### PR TITLE
When doing targeted refresh of a volume, refresh any attached VMs

### DIFF
--- a/app/models/manageiq/providers/openstack/inventory/collector/target_collection.rb
+++ b/app/models/manageiq/providers/openstack/inventory/collector/target_collection.rb
@@ -246,6 +246,8 @@ class ManageIQ::Providers::Openstack::Inventory::Collector::TargetCollection < M
         add_simple_target!(:cloud_tenants, t.ems_ref)
       when OrchestrationStack
         add_simple_target!(:orchestration_stacks, t.ems_ref)
+      when CloudVolume
+        add_simple_target!(:cloud_volumes, t.ems_ref)
       end
     end
   end
@@ -272,6 +274,10 @@ class ManageIQ::Providers::Openstack::Inventory::Collector::TargetCollection < M
       infer_related_orchestration_stacks_ems_refs_db!
       infer_related_orchestration_stacks_ems_refs_api!
     end
+    unless references(:cloud_volumes).blank?
+      infer_related_orchestration_stacks_ems_refs_db!
+      infer_related_cloud_volumes_ems_refs_api!
+    end
   end
 
   def infer_related_orchestration_stacks_ems_refs_db!
@@ -286,6 +292,27 @@ class ManageIQ::Providers::Openstack::Inventory::Collector::TargetCollection < M
     orchestration_stacks.each do |stack|
       add_simple_target!(:orchestration_stacks, stack.parent, :tenant_id => stack.service.current_tenant["id"]) unless stack.parent.blank?
       add_simple_target!(:cloud_tenants, stack.service.current_tenant["id"]) unless stack.service.current_tenant["id"].blank?
+    end
+  end
+
+  def infer_related_cloud_volumes_ems_refs_db!
+    changed_volumes = manager.cloud_volumes.where(:ems_ref => references(:cloud_volumes))
+    changed_volumes.each do |volume|
+      add_simple_target!(:cloud_tenants, volume.cloud_tenant.ems_ref) unless volume.cloud_tenant.nil?
+      volume.vms.each do |vm|
+        add_simple_target!(:vms, vm.ems_ref, :tenant_id => vm.cloud_tenant.try(:ems_ref))
+      end
+    end
+  end
+
+  def infer_related_cloud_volumes_ems_refs_api!
+    cloud_volumes.each do |volume|
+      add_simple_target!(:cloud_tenants, volume.tenant_id)
+      volume.attachments.each do |attachment|
+        unless attachment['server_id'].blank?
+          add_simple_target!(:vms, attachment['server_id'], :tenant_id => volume.tenant_id)
+        end
+      end
     end
   end
 

--- a/lib/vcr_recorder.rb
+++ b/lib/vcr_recorder.rb
@@ -69,6 +69,9 @@ class VcrRecorder
 
       file_name = File.join(vcr_base_dir, "refresher_rhos_#{env_name}_port_targeted_refresh.yml")
       change_file(file_name, OBFUSCATED_PASSWORD, env["password"], OBFUSCATED_IP, env["ip"])
+
+      file_name = File.join(vcr_base_dir, "refresher_rhos_#{env_name}_volume_targeted_refresh.yml")
+      change_file(file_name, OBFUSCATED_PASSWORD, env["password"], OBFUSCATED_IP, env["ip"])
     end
   end
 
@@ -110,6 +113,9 @@ class VcrRecorder
       change_file(file_name, env["password"], OBFUSCATED_PASSWORD, env["ip"], OBFUSCATED_IP)
 
       file_name = File.join(vcr_base_dir, "refresher_rhos_#{env_name}_port_targeted_refresh.yml")
+      change_file(file_name, env["password"], OBFUSCATED_PASSWORD, env["ip"], OBFUSCATED_IP)
+
+      file_name = File.join(vcr_base_dir, "refresher_rhos_#{env_name}_volume_targeted_refresh.yml")
       change_file(file_name, env["password"], OBFUSCATED_PASSWORD, env["ip"], OBFUSCATED_IP)
     end
   end

--- a/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty.yml
+++ b/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty.yml
@@ -17,13 +17,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:19:28 GMT
+      - Thu, 01 Nov 2018 18:34:24 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-dfe2f966-1328-485f-b6b8-de577b134be3
+      - req-91036b57-b824-4b02-825e-19fe3f10f5fb
       Content-Length:
       - '4170'
       Connection:
@@ -32,10 +32,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:19:28.560846", "expires":
-        "2018-10-25T19:19:28Z", "id": "990191f2aff540768d3e06afc6378301", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:34:24.743514", "expires":
+        "2018-11-01T19:34:24Z", "id": "ca0ba8975f684c158d388a183ca197a2", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["bA4PEmKeRAKx6hmqSsOIUA"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["iUEY7mjhTweZ8R40EcRtSA"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -80,7 +80,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:28 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:24 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -95,7 +95,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 990191f2aff540768d3e06afc6378301
+      - ca0ba8975f684c158d388a183ca197a2
   response:
     status:
       code: 200
@@ -106,7 +106,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Thu, 25 Oct 2018 18:19:28 GMT
+      - Thu, 01 Nov 2018 18:34:24 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -115,7 +115,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:28 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:24 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-availability-zone
@@ -130,7 +130,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 990191f2aff540768d3e06afc6378301
+      - ca0ba8975f684c158d388a183ca197a2
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -143,15 +143,15 @@ http_interactions:
       Content-Length:
       - '97'
       X-Compute-Request-Id:
-      - req-42b19087-bfdb-41b6-be0d-8015837081c5
+      - req-802df149-7dfb-41f1-9c07-bca822c98026
       Date:
-      - Thu, 25 Oct 2018 18:19:28 GMT
+      - Thu, 01 Nov 2018 18:34:25 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"availabilityZoneInfo": [{"zoneState": {"available": true}, "hosts":
         null, "zoneName": "nova"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:28 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:25 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -169,13 +169,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:19:28 GMT
+      - Thu, 01 Nov 2018 18:34:25 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-28c0465f-8b89-4324-bf76-f424c33de2f4
+      - req-add49e48-2add-4afb-b720-915f10f62fcc
       Content-Length:
       - '4170'
       Connection:
@@ -184,10 +184,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:19:28.998949", "expires":
-        "2018-10-25T19:19:28Z", "id": "66d4b59653ae4f3a8a0747c66b8bf73c", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:34:25.208815", "expires":
+        "2018-11-01T19:34:25Z", "id": "f874154d59e140cdb691fb7d17bedd0a", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["nXtfVuOIQJKNhNxs5DJtrA"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["XTfXum5XQQyvQbTSkr0mLw"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -232,7 +232,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:29 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:25 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-availability-zone.json
@@ -247,28 +247,28 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 66d4b59653ae4f3a8a0747c66b8bf73c
+      - f874154d59e140cdb691fb7d17bedd0a
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-b5f3daa4-3cb9-424b-bcc0-72f65bfe08cc
+      - req-e4d279a3-2c31-48c7-a76c-30d3fc632c22
       Content-Type:
       - application/json
       Content-Length:
       - '82'
       X-Openstack-Request-Id:
-      - req-b5f3daa4-3cb9-424b-bcc0-72f65bfe08cc
+      - req-e4d279a3-2c31-48c7-a76c-30d3fc632c22
       Date:
-      - Thu, 25 Oct 2018 18:19:29 GMT
+      - Thu, 01 Nov 2018 18:34:25 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"availabilityZoneInfo": [{"zoneState": {"available": true}, "zoneName":
         "nova"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:29 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:25 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -286,13 +286,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:19:29 GMT
+      - Thu, 01 Nov 2018 18:34:25 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-345eda1f-c216-4d1f-b88b-57aeb4ba00d9
+      - req-9352a35a-b9f9-438b-8178-f335873b366a
       Content-Length:
       - '370'
       Connection:
@@ -301,13 +301,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:19:29.322728", "expires":
-        "2018-10-25T19:19:29Z", "id": "a2b5ef1f411b4aea8353fb8ded174b3a", "audit_ids":
-        ["5pTzIKx6T3a_8FYGRA4nLA"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:34:25.520946", "expires":
+        "2018-11-01T19:34:25Z", "id": "926530208f78444483be79473709a9ab", "audit_ids":
+        ["llmO9CycTvOe_Mf9AmMArw"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:29 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:25 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -322,20 +322,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a2b5ef1f411b4aea8353fb8ded174b3a
+      - 926530208f78444483be79473709a9ab
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:19:29 GMT
+      - Thu, 01 Nov 2018 18:34:25 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-9b4c74a6-1b89-4566-8815-ccc9ff0f2c66
+      - req-2af30aed-794d-4d5d-8c6d-7c8942aef45c
       Content-Length:
       - '500'
       Connection:
@@ -352,7 +352,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:29 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:25 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -370,13 +370,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:19:29 GMT
+      - Thu, 01 Nov 2018 18:34:25 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-357aba57-5dd2-4b20-925d-c20309434378
+      - req-90385a7d-d22a-4f42-9060-41d3ffc7e871
       Content-Length:
       - '4117'
       Connection:
@@ -385,10 +385,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:19:29.699054", "expires":
-        "2018-10-25T19:19:29Z", "id": "c58e8a13f5a74f689e201a76d15d1464", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:34:25.850836", "expires":
+        "2018-11-01T19:34:25Z", "id": "839d90ee589d4c54b92750b9909b21ed", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["A_cZ1xgQS2CMwhVKqaElZQ"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["FErdEbc4RY2olBjGV8BK0Q"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -432,7 +432,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:29 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:25 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -447,7 +447,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c58e8a13f5a74f689e201a76d15d1464
+      - 839d90ee589d4c54b92750b9909b21ed
   response:
     status:
       code: 200
@@ -458,7 +458,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Thu, 25 Oct 2018 18:19:29 GMT
+      - Thu, 01 Nov 2018 18:34:25 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -467,7 +467,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:29 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:25 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -485,13 +485,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:19:29 GMT
+      - Thu, 01 Nov 2018 18:34:26 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-d63d46e6-aaa4-4bc3-97ee-0c25611e8ff1
+      - req-56150bc0-08f7-4178-9236-57a7de1ca6ce
       Content-Length:
       - '4131'
       Connection:
@@ -500,10 +500,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:19:29.958689", "expires":
-        "2018-10-25T19:19:29Z", "id": "9e8fd7d982f24f90941bdcf1a03a7b1c", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:34:26.158403", "expires":
+        "2018-11-01T19:34:26Z", "id": "17c070b019eb44af8a0739d270a9670d", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["fxaxJkrvR5q1eR9Dn9-v3g"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["jYpLX0ixSx-RF6MHSEy3SA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -547,7 +547,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:29 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:26 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -562,7 +562,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9e8fd7d982f24f90941bdcf1a03a7b1c
+      - 17c070b019eb44af8a0739d270a9670d
   response:
     status:
       code: 200
@@ -573,7 +573,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Thu, 25 Oct 2018 18:19:30 GMT
+      - Thu, 01 Nov 2018 18:34:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -582,7 +582,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:30 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:26 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -600,13 +600,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:19:30 GMT
+      - Thu, 01 Nov 2018 18:34:26 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-1aa2a21c-f481-4c28-b5fc-ca1f4d99b34f
+      - req-59c449b6-ac7a-4f73-a06f-dda4db084c5e
       Content-Length:
       - '4118'
       Connection:
@@ -615,10 +615,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:19:30.224020", "expires":
-        "2018-10-25T19:19:30Z", "id": "8dd483cf8db54c58999e0cd4859df746", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:34:26.449742", "expires":
+        "2018-11-01T19:34:26Z", "id": "8bc23eb188c046ad8ff9248bb1de011c", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["WAXOh8PaQceovhICA_Z7lg"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["rnC9OcgDT02HbGH6SgoxpA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -662,7 +662,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:30 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:26 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -677,7 +677,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8dd483cf8db54c58999e0cd4859df746
+      - 8bc23eb188c046ad8ff9248bb1de011c
   response:
     status:
       code: 200
@@ -688,7 +688,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Thu, 25 Oct 2018 18:19:30 GMT
+      - Thu, 01 Nov 2018 18:34:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -697,7 +697,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:30 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:26 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-services?limit=1000
@@ -712,7 +712,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c58e8a13f5a74f689e201a76d15d1464
+      - 839d90ee589d4c54b92750b9909b21ed
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -725,26 +725,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-581ff0c8-6dc8-4ce1-878e-131e91a779cb
+      - req-ae4cc5b7-4538-4cec-a04f-cb35c0de889e
       Date:
-      - Thu, 25 Oct 2018 18:19:30 GMT
+      - Thu, 01 Nov 2018 18:34:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-10-25T18:19:21.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-11-01T18:34:22.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-10-25T18:19:27.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-11-01T18:34:19.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-10-25T18:19:28.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-11-01T18:34:21.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2018-10-25T18:19:21.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-11-01T18:34:17.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-10-25T18:19:22.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-11-01T18:34:23.000000"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:30 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:26 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-services?limit=1000&marker=5
@@ -759,7 +759,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c58e8a13f5a74f689e201a76d15d1464
+      - 839d90ee589d4c54b92750b9909b21ed
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -772,26 +772,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-7a728a3c-eb56-4ddc-8072-114612826170
+      - req-6ca8ed88-00a4-4735-a59b-33ae1f15babf
       Date:
-      - Thu, 25 Oct 2018 18:19:30 GMT
+      - Thu, 01 Nov 2018 18:34:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-10-25T18:19:21.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-11-01T18:34:22.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-10-25T18:19:27.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-11-01T18:34:19.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-10-25T18:19:28.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-11-01T18:34:21.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2018-10-25T18:19:21.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-11-01T18:34:17.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-10-25T18:19:22.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-11-01T18:34:23.000000"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:30 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:26 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8/os-services?limit=1000
@@ -806,7 +806,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9e8fd7d982f24f90941bdcf1a03a7b1c
+      - 17c070b019eb44af8a0739d270a9670d
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -819,26 +819,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-9d8c161b-8ac6-4f29-b115-0b580fe5b5e6
+      - req-1e1c88d2-d9b2-4f11-b4ed-7c33eb80e89c
       Date:
-      - Thu, 25 Oct 2018 18:19:30 GMT
+      - Thu, 01 Nov 2018 18:34:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-10-25T18:19:21.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-11-01T18:34:22.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-10-25T18:19:27.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-11-01T18:34:19.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-10-25T18:19:28.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-11-01T18:34:21.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2018-10-25T18:19:21.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-11-01T18:34:17.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-10-25T18:19:22.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-11-01T18:34:23.000000"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:30 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:27 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8/os-services?limit=1000&marker=5
@@ -853,7 +853,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9e8fd7d982f24f90941bdcf1a03a7b1c
+      - 17c070b019eb44af8a0739d270a9670d
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -866,26 +866,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-1e26d446-bce4-4a0e-bf27-1ad100bcbe93
+      - req-bb2faa38-dd48-41ef-a2e0-bf77285a71b6
       Date:
-      - Thu, 25 Oct 2018 18:19:30 GMT
+      - Thu, 01 Nov 2018 18:34:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-10-25T18:19:21.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-11-01T18:34:22.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-10-25T18:19:27.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-11-01T18:34:19.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-10-25T18:19:28.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-11-01T18:34:21.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2018-10-25T18:19:21.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-11-01T18:34:17.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-10-25T18:19:22.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-11-01T18:34:23.000000"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:30 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:27 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-services?limit=1000
@@ -900,7 +900,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 990191f2aff540768d3e06afc6378301
+      - ca0ba8975f684c158d388a183ca197a2
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -913,26 +913,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-0497c70c-1391-4104-930c-cce20352c376
+      - req-bd5ebbeb-e26c-4dd7-a244-70f8fe7c4509
       Date:
-      - Thu, 25 Oct 2018 18:19:31 GMT
+      - Thu, 01 Nov 2018 18:34:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-10-25T18:19:21.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-11-01T18:34:22.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-10-25T18:19:27.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-11-01T18:34:19.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-10-25T18:19:28.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-11-01T18:34:21.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2018-10-25T18:19:21.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-11-01T18:34:27.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-10-25T18:19:22.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-11-01T18:34:23.000000"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:31 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:27 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-services?limit=1000&marker=5
@@ -947,7 +947,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 990191f2aff540768d3e06afc6378301
+      - ca0ba8975f684c158d388a183ca197a2
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -960,26 +960,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-6d616b47-67a8-46a5-80f7-4e9650c368d4
+      - req-ecaedaa3-ea02-45a4-9045-0e5bb987ecf7
       Date:
-      - Thu, 25 Oct 2018 18:19:31 GMT
+      - Thu, 01 Nov 2018 18:34:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-10-25T18:19:21.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-11-01T18:34:22.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-10-25T18:19:27.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-11-01T18:34:19.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-10-25T18:19:28.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-11-01T18:34:21.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2018-10-25T18:19:21.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-11-01T18:34:27.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-10-25T18:19:22.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-11-01T18:34:23.000000"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:31 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:27 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608/os-services?limit=1000
@@ -994,7 +994,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8dd483cf8db54c58999e0cd4859df746
+      - 8bc23eb188c046ad8ff9248bb1de011c
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1007,26 +1007,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-55c8a589-c196-4ade-be1a-aa53021e79ca
+      - req-bcde10f2-995f-4b33-aa2c-dae3ba649bf7
       Date:
-      - Thu, 25 Oct 2018 18:19:31 GMT
+      - Thu, 01 Nov 2018 18:34:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-10-25T18:19:31.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-11-01T18:34:22.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-10-25T18:19:27.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-11-01T18:34:19.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-10-25T18:19:28.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-11-01T18:34:21.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2018-10-25T18:19:21.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-11-01T18:34:27.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-10-25T18:19:22.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-11-01T18:34:23.000000"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:31 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:27 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608/os-services?limit=1000&marker=5
@@ -1041,7 +1041,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8dd483cf8db54c58999e0cd4859df746
+      - 8bc23eb188c046ad8ff9248bb1de011c
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1054,26 +1054,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-819058a3-d075-4e36-b3c8-698b3a101dec
+      - req-2c5df7c0-f498-4fc5-bf7c-9b8c0420e5e8
       Date:
-      - Thu, 25 Oct 2018 18:19:31 GMT
+      - Thu, 01 Nov 2018 18:34:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-10-25T18:19:31.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-11-01T18:34:22.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-10-25T18:19:27.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-11-01T18:34:19.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-10-25T18:19:28.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-11-01T18:34:21.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2018-10-25T18:19:31.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-11-01T18:34:27.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-10-25T18:19:22.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-11-01T18:34:23.000000"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:31 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:27 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000
@@ -1088,7 +1088,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 990191f2aff540768d3e06afc6378301
+      - ca0ba8975f684c158d388a183ca197a2
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1101,9 +1101,9 @@ http_interactions:
       Content-Length:
       - '1010'
       X-Compute-Request-Id:
-      - req-371bc40f-0d48-4c04-908a-0681494daa15
+      - req-1f55c7c8-e5ab-43e5-9273-ebd27d397aa5
       Date:
-      - Thu, 25 Oct 2018 18:19:31 GMT
+      - Thu, 01 Nov 2018 18:34:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.tiny", "links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/1",
@@ -1117,7 +1117,7 @@ http_interactions:
         0, "disk": 20, "id": "2"}], "flavors_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=2",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:31 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:27 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=2
@@ -1132,7 +1132,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 990191f2aff540768d3e06afc6378301
+      - ca0ba8975f684c158d388a183ca197a2
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1145,9 +1145,9 @@ http_interactions:
       Content-Length:
       - '1014'
       X-Compute-Request-Id:
-      - req-b34990a2-821c-4a3b-b84f-7e26fb5e261c
+      - req-ec2e342d-21ee-4b71-a38f-1d124f571fbb
       Date:
-      - Thu, 25 Oct 2018 18:19:31 GMT
+      - Thu, 01 Nov 2018 18:34:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.medium", "links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/3",
@@ -1161,7 +1161,7 @@ http_interactions:
         0, "disk": 80, "id": "4"}], "flavors_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=4",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:31 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:27 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=4
@@ -1176,7 +1176,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 990191f2aff540768d3e06afc6378301
+      - ca0ba8975f684c158d388a183ca197a2
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1189,9 +1189,9 @@ http_interactions:
       Content-Length:
       - '1026'
       X-Compute-Request-Id:
-      - req-15072573-b1a3-4212-944d-494b120224bf
+      - req-f47ae0a9-52d0-40d1-a0f8-b413aa8c8c60
       Date:
-      - Thu, 25 Oct 2018 18:19:31 GMT
+      - Thu, 01 Nov 2018 18:34:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.xlarge", "links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/5",
@@ -1206,7 +1206,7 @@ http_interactions:
         1, "disk": 1, "id": "6"}], "flavors_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=6",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:31 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:28 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=6
@@ -1221,7 +1221,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 990191f2aff540768d3e06afc6378301
+      - ca0ba8975f684c158d388a183ca197a2
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1234,9 +1234,9 @@ http_interactions:
       Content-Length:
       - '448'
       X-Compute-Request-Id:
-      - req-180ef6fa-966c-4be7-bae0-6d80dfaab13a
+      - req-98b23525-fdae-4506-a1f7-7fc89af85fff
       Date:
-      - Thu, 25 Oct 2018 18:19:31 GMT
+      - Thu, 01 Nov 2018 18:34:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.ems_refresh_spec_private", "links": [{"href":
@@ -1246,7 +1246,7 @@ http_interactions:
         8, "swap": "", "os-flavor-access:is_public": false, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         0, "disk": 160, "id": "7"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:31 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:28 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/7/os-flavor-access
@@ -1261,7 +1261,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 990191f2aff540768d3e06afc6378301
+      - ca0ba8975f684c158d388a183ca197a2
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1274,15 +1274,15 @@ http_interactions:
       Content-Length:
       - '88'
       X-Compute-Request-Id:
-      - req-b3fb3868-56c3-4808-9f81-feb42c9ef6cb
+      - req-1f8f88bb-c643-4cec-917e-d5ba5b32c55e
       Date:
-      - Thu, 25 Oct 2018 18:19:31 GMT
+      - Thu, 01 Nov 2018 18:34:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavor_access": [{"tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "flavor_id": "7"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:31 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:28 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1300,13 +1300,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:19:32 GMT
+      - Thu, 01 Nov 2018 18:34:28 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-a0cd636f-e2b2-4363-8e8a-9538f4abb8d0
+      - req-fd8555de-3283-46a8-b274-3dbf28989512
       Content-Length:
       - '4170'
       Connection:
@@ -1315,10 +1315,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:19:32.087749", "expires":
-        "2018-10-25T19:19:32Z", "id": "5d015f67b4dc445a85233039ce14544d", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:34:28.446499", "expires":
+        "2018-11-01T19:34:28Z", "id": "70d2c92b9a5145128f29e6cd1971f251", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["A8I85HB0TIWQp-_0ajsQfw"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["WhoeI5phTMGZlqyRMqX-9A"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -1363,7 +1363,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:32 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:28 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1381,13 +1381,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:19:32 GMT
+      - Thu, 01 Nov 2018 18:34:28 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-5411952e-c451-4102-882e-b2edf32e047a
+      - req-0c283e84-7feb-4a7b-9234-1057f53d72e3
       Content-Length:
       - '4117'
       Connection:
@@ -1396,10 +1396,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:19:32.281562", "expires":
-        "2018-10-25T19:19:32Z", "id": "0c5533a065424f2cac14800ce74fbd51", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:34:28.631132", "expires":
+        "2018-11-01T19:34:28Z", "id": "0ab2ece4722f4e3bbe8b7598573b3078", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["uitttIXBT12odG0dCT8lxw"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["W4a9MnVKTB6w9GAXRgqP1w"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -1443,7 +1443,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:32 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:28 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images?limit=1000
@@ -1458,7 +1458,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0c5533a065424f2cac14800ce74fbd51
+      - 0ab2ece4722f4e3bbe8b7598573b3078
   response:
     status:
       code: 200
@@ -1469,9 +1469,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-df4f3f4b-6ab4-4add-a9cd-d4404504dc66
+      - req-5b8102d7-208a-42bf-ba59-c78b74791f93
       Date:
-      - Thu, 25 Oct 2018 18:19:32 GMT
+      - Thu, 01 Nov 2018 18:34:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -1513,7 +1513,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:32 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:28 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images?limit=1000&marker=bb799f70-5e02-461b-8324-17ee88259c7b
@@ -1528,7 +1528,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0c5533a065424f2cac14800ce74fbd51
+      - 0ab2ece4722f4e3bbe8b7598573b3078
   response:
     status:
       code: 200
@@ -1539,14 +1539,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-302384b7-78b6-45b6-b4ce-897f9ee74a38
+      - req-d91662b7-7728-427d-bb5f-886cbc7faa94
       Date:
-      - Thu, 25 Oct 2018 18:19:32 GMT
+      - Thu, 01 Nov 2018 18:34:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:32 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:28 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1564,13 +1564,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:19:32 GMT
+      - Thu, 01 Nov 2018 18:34:29 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-5237edf0-7307-4c6f-a33f-7d563e1f977c
+      - req-bacbd3e0-f4ac-47ad-9782-57a50ae8faa8
       Content-Length:
       - '4131'
       Connection:
@@ -1579,10 +1579,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:19:32.913408", "expires":
-        "2018-10-25T19:19:32Z", "id": "1244d26528594e1294914a2f06e269c5", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:34:29.112526", "expires":
+        "2018-11-01T19:34:29Z", "id": "1406307faf1f41459fb78713a07b4efd", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["fCwkL8H1QVWiiYUXK3fCfA"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["TLtI3WFQTXuYSHmbrDcNhg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -1626,7 +1626,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:32 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:29 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images?limit=1000
@@ -1641,7 +1641,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1244d26528594e1294914a2f06e269c5
+      - 1406307faf1f41459fb78713a07b4efd
   response:
     status:
       code: 200
@@ -1652,9 +1652,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-e245297c-8bc5-4cf9-b45c-fddeb582a46c
+      - req-ff8a0f13-5d10-4811-b84c-3233a4f615be
       Date:
-      - Thu, 25 Oct 2018 18:19:33 GMT
+      - Thu, 01 Nov 2018 18:34:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -1696,7 +1696,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:33 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:29 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images?limit=1000&marker=bb799f70-5e02-461b-8324-17ee88259c7b
@@ -1711,7 +1711,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1244d26528594e1294914a2f06e269c5
+      - 1406307faf1f41459fb78713a07b4efd
   response:
     status:
       code: 200
@@ -1722,14 +1722,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-37474057-d49f-4093-ad36-43666c826dac
+      - req-c854becf-5e96-4eea-9b7c-f3f6d52d91c0
       Date:
-      - Thu, 25 Oct 2018 18:19:33 GMT
+      - Thu, 01 Nov 2018 18:34:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:33 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:29 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images?limit=1000
@@ -1744,7 +1744,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5d015f67b4dc445a85233039ce14544d
+      - 70d2c92b9a5145128f29e6cd1971f251
   response:
     status:
       code: 200
@@ -1755,9 +1755,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-0c809ad0-89c5-4def-8485-338c71091f90
+      - req-5bbc1210-8abc-4dbb-9dde-c3b348527e20
       Date:
-      - Thu, 25 Oct 2018 18:19:33 GMT
+      - Thu, 01 Nov 2018 18:34:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -1799,7 +1799,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:33 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:29 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images?limit=1000&marker=bb799f70-5e02-461b-8324-17ee88259c7b
@@ -1814,7 +1814,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5d015f67b4dc445a85233039ce14544d
+      - 70d2c92b9a5145128f29e6cd1971f251
   response:
     status:
       code: 200
@@ -1825,14 +1825,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-d8edbba8-4094-4c87-9a2a-613221647d1a
+      - req-8661d440-fbe6-48a5-9dc8-a5da6730c44d
       Date:
-      - Thu, 25 Oct 2018 18:19:33 GMT
+      - Thu, 01 Nov 2018 18:34:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:33 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:29 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1850,13 +1850,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:19:33 GMT
+      - Thu, 01 Nov 2018 18:34:29 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-828c91aa-d37d-4ef3-aaa2-eccdf6550d6c
+      - req-aa3def22-35af-4ec0-bd7c-b9352c20b46d
       Content-Length:
       - '4118'
       Connection:
@@ -1865,10 +1865,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:19:33.796802", "expires":
-        "2018-10-25T19:19:33Z", "id": "243929abf8a64a7f8be41114f3bd9606", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:34:29.987306", "expires":
+        "2018-11-01T19:34:29Z", "id": "35385eecd4464e9fb4c544be4a23f3f1", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["5FjpT4WKSRKBft24ilO3iw"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["7BEmL7C5TZ2ARFKQ0UL9yA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -1912,7 +1912,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:33 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:30 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images?limit=1000
@@ -1927,7 +1927,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 243929abf8a64a7f8be41114f3bd9606
+      - 35385eecd4464e9fb4c544be4a23f3f1
   response:
     status:
       code: 200
@@ -1938,9 +1938,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-45e6b0a7-d13a-489d-a9fe-6d655464aa98
+      - req-34304d07-1374-4ac9-a0e8-7e37e4c6c76e
       Date:
-      - Thu, 25 Oct 2018 18:19:33 GMT
+      - Thu, 01 Nov 2018 18:34:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -1982,7 +1982,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:33 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:30 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images?limit=1000&marker=bb799f70-5e02-461b-8324-17ee88259c7b
@@ -1997,7 +1997,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 243929abf8a64a7f8be41114f3bd9606
+      - 35385eecd4464e9fb4c544be4a23f3f1
   response:
     status:
       code: 200
@@ -2008,14 +2008,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-1f16e7d6-1931-4360-9ee8-91d650a77b95
+      - req-f64af808-3304-457f-820d-a03cd5cec2b4
       Date:
-      - Thu, 25 Oct 2018 18:19:34 GMT
+      - Thu, 01 Nov 2018 18:34:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:34 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:30 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-keypairs?limit=1000
@@ -2030,7 +2030,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c58e8a13f5a74f689e201a76d15d1464
+      - 839d90ee589d4c54b92750b9909b21ed
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2043,9 +2043,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-63792062-2982-4cd2-9e6d-73af82cc8991
+      - req-4f7c1f58-55f3-429c-8992-cc3162187be8
       Date:
-      - Thu, 25 Oct 2018 18:19:34 GMT
+      - Thu, 01 Nov 2018 18:34:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -2055,7 +2055,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:34 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:30 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -2070,7 +2070,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c58e8a13f5a74f689e201a76d15d1464
+      - 839d90ee589d4c54b92750b9909b21ed
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2083,9 +2083,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-da2094a6-6e50-4560-ad29-f0fb5fbd0653
+      - req-3f3408c4-91aa-4121-a6e2-006b9188a674
       Date:
-      - Thu, 25 Oct 2018 18:19:34 GMT
+      - Thu, 01 Nov 2018 18:34:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -2095,7 +2095,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:34 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:30 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8/os-keypairs?limit=1000
@@ -2110,7 +2110,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9e8fd7d982f24f90941bdcf1a03a7b1c
+      - 17c070b019eb44af8a0739d270a9670d
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2123,9 +2123,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-02ee77bb-c5a4-4d9f-8805-72e78dd123f6
+      - req-27f42c9e-2e45-4e25-b97b-785b1e030889
       Date:
-      - Thu, 25 Oct 2018 18:19:34 GMT
+      - Thu, 01 Nov 2018 18:34:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -2135,7 +2135,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:34 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:30 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -2150,7 +2150,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9e8fd7d982f24f90941bdcf1a03a7b1c
+      - 17c070b019eb44af8a0739d270a9670d
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2163,9 +2163,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-bfc167d1-694c-48f7-b6b6-306664c25b87
+      - req-e4788135-1396-47d1-a896-0a729682d950
       Date:
-      - Thu, 25 Oct 2018 18:19:34 GMT
+      - Thu, 01 Nov 2018 18:34:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -2175,7 +2175,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:34 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:30 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-keypairs?limit=1000
@@ -2190,7 +2190,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 990191f2aff540768d3e06afc6378301
+      - ca0ba8975f684c158d388a183ca197a2
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2203,9 +2203,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-5fa092ce-c119-499f-80ab-936f94e2fcf0
+      - req-f4a9a06a-9eaa-4753-a9cd-d5ec12e9d034
       Date:
-      - Thu, 25 Oct 2018 18:19:34 GMT
+      - Thu, 01 Nov 2018 18:34:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -2215,7 +2215,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:34 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:30 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -2230,7 +2230,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 990191f2aff540768d3e06afc6378301
+      - ca0ba8975f684c158d388a183ca197a2
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2243,9 +2243,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-726b8dbc-3acc-4785-a6f3-a2fcf192e8ae
+      - req-8ca09bf1-1a29-4123-8b5b-4b13ed51171a
       Date:
-      - Thu, 25 Oct 2018 18:19:34 GMT
+      - Thu, 01 Nov 2018 18:34:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -2255,7 +2255,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:34 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:31 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608/os-keypairs?limit=1000
@@ -2270,7 +2270,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8dd483cf8db54c58999e0cd4859df746
+      - 8bc23eb188c046ad8ff9248bb1de011c
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2283,9 +2283,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-07528758-0f07-4537-b908-aabb8bc18217
+      - req-f7598022-a988-494b-8cee-97f9685c5f81
       Date:
-      - Thu, 25 Oct 2018 18:19:34 GMT
+      - Thu, 01 Nov 2018 18:34:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -2295,7 +2295,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:34 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:31 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -2310,7 +2310,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8dd483cf8db54c58999e0cd4859df746
+      - 8bc23eb188c046ad8ff9248bb1de011c
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2323,9 +2323,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-9d4fbb9a-d8a4-414a-bd33-931ca367e9ee
+      - req-83e26262-ac8e-4923-a2f3-51ceba687955
       Date:
-      - Thu, 25 Oct 2018 18:19:34 GMT
+      - Thu, 01 Nov 2018 18:34:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -2335,7 +2335,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:34 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:31 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -2353,13 +2353,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:19:35 GMT
+      - Thu, 01 Nov 2018 18:34:31 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-166c8f95-45f9-47ee-9ed1-7b067e400551
+      - req-6a43b623-aaeb-4d08-ba02-2ab6c3e920ed
       Content-Length:
       - '4170'
       Connection:
@@ -2368,10 +2368,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:19:35.173024", "expires":
-        "2018-10-25T19:19:35Z", "id": "73a30794b94e48a9923a774aeb9c6cda", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:34:31.443960", "expires":
+        "2018-11-01T19:34:31Z", "id": "6cfaa31f2e6446c5a3438df8f0ef060b", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["gW8w3I0TT1KuYRtJhDLDzA"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["lkoU0CJpQs2g4WpFnSn8yA"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -2416,7 +2416,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:35 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:31 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -2434,13 +2434,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:19:35 GMT
+      - Thu, 01 Nov 2018 18:34:31 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-28e95448-3ba4-48f5-8062-017e8760a204
+      - req-ccd19502-9cf6-4384-bb5b-26c6d9c4bd57
       Content-Length:
       - '4117'
       Connection:
@@ -2449,10 +2449,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:19:35.365316", "expires":
-        "2018-10-25T19:19:35Z", "id": "c94e2e913e964a9eb171c6cb4ee2ef93", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:34:31.633239", "expires":
+        "2018-11-01T19:34:31Z", "id": "988e1b42b7c24a989f205f316f656dbc", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["PxKJJx20QviK6JVY-hYp9w"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["qGAZdzE0T1mzQYuwPn1QXg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -2496,7 +2496,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:35 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:31 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks?limit=1000&show_nested=true
@@ -2511,7 +2511,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c94e2e913e964a9eb171c6cb4ee2ef93
+      - 988e1b42b7c24a989f205f316f656dbc
   response:
     status:
       code: 200
@@ -2522,9 +2522,9 @@ http_interactions:
       Content-Length:
       - '2559'
       X-Openstack-Request-Id:
-      - req-33ac45f4-ea1f-4047-a0ad-d13cafa186ca
+      - req-1b1f5f9b-6577-4192-9921-1e76eedc7ca0
       Date:
-      - Thu, 25 Oct 2018 18:19:35 GMT
+      - Thu, 01 Nov 2018 18:34:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": [{"description": "Heat WordPress template to support F20,
@@ -2558,7 +2558,7 @@ http_interactions:
         "rel": "self"}], "updated_time": null, "stack_owner": null, "stack_status":
         "CREATE_COMPLETE", "id": "091e1e54-e01c-4ec5-a0ab-b00bee4d425c"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:35 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:31 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks?limit=1000&marker=091e1e54-e01c-4ec5-a0ab-b00bee4d425c&show_nested=true
@@ -2573,7 +2573,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c94e2e913e964a9eb171c6cb4ee2ef93
+      - 988e1b42b7c24a989f205f316f656dbc
   response:
     status:
       code: 200
@@ -2584,14 +2584,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-dd38b4a5-d4df-4076-a11f-6de3c29a4bc5
+      - req-56608fe9-8e96-4be2-a63e-67c467da3680
       Date:
-      - Thu, 25 Oct 2018 18:19:35 GMT
+      - Thu, 01 Nov 2018 18:34:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:35 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:31 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -2609,13 +2609,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:19:35 GMT
+      - Thu, 01 Nov 2018 18:34:32 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-8516f588-316a-4d4b-a158-4bd4248635b9
+      - req-32dd6f84-0034-4f5a-8ff2-a3770dabbde8
       Content-Length:
       - '4131'
       Connection:
@@ -2624,10 +2624,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:19:35.848824", "expires":
-        "2018-10-25T19:19:35Z", "id": "bbe5d86d541645189779118e8123c59d", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:34:32.169603", "expires":
+        "2018-11-01T19:34:32Z", "id": "aaeb21dbcba24c489c897f2e867a1108", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["5SUF8aZoSRaXF5bqomkxlg"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["c6MH-kEbR0GtEs9BShH0Bg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -2671,7 +2671,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:35 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:32 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/b458a5c25c3749758f4c0661940b3ba8/stacks?limit=1000&show_nested=true
@@ -2686,7 +2686,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bbe5d86d541645189779118e8123c59d
+      - aaeb21dbcba24c489c897f2e867a1108
   response:
     status:
       code: 200
@@ -2697,14 +2697,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-d8e5fa2c-e16c-4d23-b9da-445f5d569c46
+      - req-ff4066b3-206d-4641-bd19-e5a44cdc9c34
       Date:
-      - Thu, 25 Oct 2018 18:19:36 GMT
+      - Thu, 01 Nov 2018 18:34:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:36 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:32 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/e54e5c3c19e34720b05661f2ea1ea00a/stacks?limit=1000&show_nested=true
@@ -2719,7 +2719,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 73a30794b94e48a9923a774aeb9c6cda
+      - 6cfaa31f2e6446c5a3438df8f0ef060b
   response:
     status:
       code: 200
@@ -2730,14 +2730,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-8761b290-e56a-445e-9ab4-9b52ef3def0d
+      - req-fb37f983-0cc7-46b7-98f2-ad33e92c6e36
       Date:
-      - Thu, 25 Oct 2018 18:19:36 GMT
+      - Thu, 01 Nov 2018 18:34:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:36 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:32 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -2755,13 +2755,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:19:36 GMT
+      - Thu, 01 Nov 2018 18:34:32 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-2ac50de9-6f60-4f14-921f-24dcedb25a9a
+      - req-37eeb1be-e6c3-44c4-8070-4ec99c0de221
       Content-Length:
       - '4118'
       Connection:
@@ -2770,10 +2770,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:19:36.338316", "expires":
-        "2018-10-25T19:19:36Z", "id": "3f633ada54f74d3eb444ae900a7b38bf", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:34:32.673955", "expires":
+        "2018-11-01T19:34:32Z", "id": "dedcf17b3eed4fea83d10f09188ae7d7", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["AUCaDI95SMesmfuFg6YkFA"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["RdbtqZ4YRuW9CQ1WcXDmjQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -2817,7 +2817,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:36 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:32 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/e8f744b1fc6a487681d35fb275252608/stacks?limit=1000&show_nested=true
@@ -2832,7 +2832,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3f633ada54f74d3eb444ae900a7b38bf
+      - dedcf17b3eed4fea83d10f09188ae7d7
   response:
     status:
       code: 200
@@ -2843,14 +2843,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-035ccb77-a4b1-4eba-8468-49e5cbb1b516
+      - req-96ea179b-9689-4e75-8b45-7c36f562c6f6
       Date:
-      - Thu, 25 Oct 2018 18:19:36 GMT
+      - Thu, 01 Nov 2018 18:34:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:36 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:32 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack3/45d2af82-eff9-4483-a1f0-f19c44d96146
@@ -2865,7 +2865,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c94e2e913e964a9eb171c6cb4ee2ef93
+      - 988e1b42b7c24a989f205f316f656dbc
   response:
     status:
       code: 200
@@ -2876,9 +2876,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-0812159c-8b4b-497f-a19d-fa9dd2bdf512
+      - req-309630de-954f-472a-922e-706fb751dc70
       Date:
-      - Thu, 25 Oct 2018 18:19:36 GMT
+      - Thu, 01 Nov 2018 18:34:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -2905,7 +2905,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:36 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:33 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack2/4cf24b12-29fc-4529-a8ed-6b079dea7c17
@@ -2920,7 +2920,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c94e2e913e964a9eb171c6cb4ee2ef93
+      - 988e1b42b7c24a989f205f316f656dbc
   response:
     status:
       code: 200
@@ -2931,9 +2931,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-1320fc76-7a0f-4c0c-a595-c89eac23495e
+      - req-862c2604-cd06-481c-9448-2857e4f7d004
       Date:
-      - Thu, 25 Oct 2018 18:19:37 GMT
+      - Thu, 01 Nov 2018 18:34:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -2960,7 +2960,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:37 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:34 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c
@@ -2975,7 +2975,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c94e2e913e964a9eb171c6cb4ee2ef93
+      - 988e1b42b7c24a989f205f316f656dbc
   response:
     status:
       code: 200
@@ -2986,9 +2986,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-ee9e445b-d9ab-4542-b025-6398f24108c2
+      - req-62763631-a1d4-4839-a81a-128226d977eb
       Date:
-      - Thu, 25 Oct 2018 18:19:37 GMT
+      - Thu, 01 Nov 2018 18:34:34 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -3015,7 +3015,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:37 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:34 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack3/45d2af82-eff9-4483-a1f0-f19c44d96146/template
@@ -3030,7 +3030,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c94e2e913e964a9eb171c6cb4ee2ef93
+      - 988e1b42b7c24a989f205f316f656dbc
   response:
     status:
       code: 200
@@ -3041,9 +3041,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-285f4204-4f39-45aa-842f-d0cf9fb3899f
+      - req-83696fc0-ee79-4105-95b3-388b22a9d300
       Date:
-      - Thu, 25 Oct 2018 18:19:37 GMT
+      - Thu, 01 Nov 2018 18:34:34 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -3099,7 +3099,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:37 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:34 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack3/45d2af82-eff9-4483-a1f0-f19c44d96146/resources
@@ -3114,7 +3114,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c94e2e913e964a9eb171c6cb4ee2ef93
+      - 988e1b42b7c24a989f205f316f656dbc
   response:
     status:
       code: 200
@@ -3125,9 +3125,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-cc4418c5-bd71-4ee9-b0d5-43f072117b06
+      - req-53a2c539-ed2f-4854-b2c5-8f00b6734068
       Date:
-      - Thu, 25 Oct 2018 18:19:37 GMT
+      - Thu, 01 Nov 2018 18:34:34 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -3139,7 +3139,7 @@ http_interactions:
         changed", "physical_resource_id": "aa5907f3-8209-4dd0-b3ef-600431d85bac",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:37 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:34 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/detail?limit=1000
@@ -3154,7 +3154,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c58e8a13f5a74f689e201a76d15d1464
+      - 839d90ee589d4c54b92750b9909b21ed
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3167,9 +3167,9 @@ http_interactions:
       Content-Length:
       - '3981'
       X-Compute-Request-Id:
-      - req-cac7a0db-7444-4fa7-a918-8d1da041e9cf
+      - req-ad070672-0980-4e4a-b769-0ef58b805598
       Date:
-      - Thu, 25 Oct 2018 18:19:38 GMT
+      - Thu, 01 Nov 2018 18:34:34 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/detail?limit=1000&marker=96fef14f-5338-4d58-8b89-58b627b27b9b",
@@ -3215,7 +3215,7 @@ http_interactions:
         [], "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:38 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:34 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/detail?limit=1000&marker=96fef14f-5338-4d58-8b89-58b627b27b9b
@@ -3230,7 +3230,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c58e8a13f5a74f689e201a76d15d1464
+      - 839d90ee589d4c54b92750b9909b21ed
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3243,9 +3243,9 @@ http_interactions:
       Content-Length:
       - '4045'
       X-Compute-Request-Id:
-      - req-188c4a1e-517e-4745-88f9-5bc74526a2b4
+      - req-c61575ed-c030-4b58-b780-94dd34bea8c3
       Date:
-      - Thu, 25 Oct 2018 18:19:38 GMT
+      - Thu, 01 Nov 2018 18:34:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/detail?limit=1000&marker=ca1fc357-ee31-45e9-a38d-98723d6c8876",
@@ -3291,7 +3291,7 @@ http_interactions:
         [], "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 3, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:38 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:35 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/detail?limit=1000&marker=ca1fc357-ee31-45e9-a38d-98723d6c8876
@@ -3306,7 +3306,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c58e8a13f5a74f689e201a76d15d1464
+      - 839d90ee589d4c54b92750b9909b21ed
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3319,9 +3319,9 @@ http_interactions:
       Content-Length:
       - '4127'
       X-Compute-Request-Id:
-      - req-e46bb008-8a45-4dd2-af01-373c1a62a7bf
+      - req-9207e6ec-dd5a-4143-acab-a5a125487d44
       Date:
-      - Thu, 25 Oct 2018 18:19:38 GMT
+      - Thu, 01 Nov 2018 18:34:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/detail?limit=1000&marker=ca4f3a16-bae3-4407-83e9-f77b28af0f2b",
@@ -3369,7 +3369,7 @@ http_interactions:
         "", "progress": 0, "OS-EXT-STS:power_state": 1, "config_drive": "", "metadata":
         {}}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:38 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:35 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/detail?limit=1000&marker=ca4f3a16-bae3-4407-83e9-f77b28af0f2b
@@ -3384,7 +3384,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c58e8a13f5a74f689e201a76d15d1464
+      - 839d90ee589d4c54b92750b9909b21ed
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3397,9 +3397,9 @@ http_interactions:
       Content-Length:
       - '3796'
       X-Compute-Request-Id:
-      - req-eba19b30-4c5c-469e-9b0f-c02143726015
+      - req-017c6811-3eef-49d1-b7cb-de73e79e86fc
       Date:
-      - Thu, 25 Oct 2018 18:19:38 GMT
+      - Thu, 01 Nov 2018 18:34:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/detail?limit=1000&marker=aa5907f3-8209-4dd0-b3ef-600431d85bac",
@@ -3441,7 +3441,7 @@ http_interactions:
         "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:38 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:35 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/detail?limit=1000&marker=aa5907f3-8209-4dd0-b3ef-600431d85bac
@@ -3456,7 +3456,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c58e8a13f5a74f689e201a76d15d1464
+      - 839d90ee589d4c54b92750b9909b21ed
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3469,9 +3469,9 @@ http_interactions:
       Content-Length:
       - '1816'
       X-Compute-Request-Id:
-      - req-c8917590-2478-49cf-ac5f-e92c012de40e
+      - req-896b249b-d8d8-4c89-81d5-981765ff48a4
       Date:
-      - Thu, 25 Oct 2018 18:19:39 GMT
+      - Thu, 01 Nov 2018 18:34:36 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": [{"status": "SHUTOFF", "updated": "2018-01-17T14:49:17Z",
@@ -3494,7 +3494,7 @@ http_interactions:
         "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:39 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:36 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8/servers/detail?limit=1000
@@ -3509,7 +3509,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9e8fd7d982f24f90941bdcf1a03a7b1c
+      - 17c070b019eb44af8a0739d270a9670d
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3522,14 +3522,14 @@ http_interactions:
       Content-Length:
       - '15'
       X-Compute-Request-Id:
-      - req-516dcab1-b95d-439c-836e-94e4e6681a37
+      - req-c9ead9cd-f849-4587-ae9e-95c2e3078b84
       Date:
-      - Thu, 25 Oct 2018 18:19:39 GMT
+      - Thu, 01 Nov 2018 18:34:36 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:39 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:36 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?limit=1000
@@ -3544,7 +3544,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 990191f2aff540768d3e06afc6378301
+      - ca0ba8975f684c158d388a183ca197a2
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3557,14 +3557,14 @@ http_interactions:
       Content-Length:
       - '15'
       X-Compute-Request-Id:
-      - req-777342bf-be2e-4519-85c9-748ded077a87
+      - req-e21364b8-fc16-4602-8c98-53e3490252a1
       Date:
-      - Thu, 25 Oct 2018 18:19:39 GMT
+      - Thu, 01 Nov 2018 18:34:36 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:39 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:36 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608/servers/detail?limit=1000
@@ -3579,7 +3579,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8dd483cf8db54c58999e0cd4859df746
+      - 8bc23eb188c046ad8ff9248bb1de011c
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3592,14 +3592,14 @@ http_interactions:
       Content-Length:
       - '15'
       X-Compute-Request-Id:
-      - req-4e7f0eba-7465-494e-867a-13430c700e53
+      - req-2e074f45-454f-4897-93e7-1e0324dfdf81
       Date:
-      - Thu, 25 Oct 2018 18:19:39 GMT
+      - Thu, 01 Nov 2018 18:34:36 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:39 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:36 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack2/4cf24b12-29fc-4529-a8ed-6b079dea7c17/template
@@ -3614,7 +3614,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c94e2e913e964a9eb171c6cb4ee2ef93
+      - 988e1b42b7c24a989f205f316f656dbc
   response:
     status:
       code: 200
@@ -3625,9 +3625,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-fa10b37d-ed58-4e0f-bcf6-3273c9d78105
+      - req-b76094b3-35e4-489f-861d-5e36b5ba053a
       Date:
-      - Thu, 25 Oct 2018 18:19:39 GMT
+      - Thu, 01 Nov 2018 18:34:36 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -3683,7 +3683,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:39 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:36 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack2/4cf24b12-29fc-4529-a8ed-6b079dea7c17/resources
@@ -3698,7 +3698,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c94e2e913e964a9eb171c6cb4ee2ef93
+      - 988e1b42b7c24a989f205f316f656dbc
   response:
     status:
       code: 200
@@ -3709,9 +3709,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-aa087ae0-8b4a-498f-a5cd-dd53cb54828d
+      - req-9a18287c-f823-4549-821c-5db30f39c5cf
       Date:
-      - Thu, 25 Oct 2018 18:19:39 GMT
+      - Thu, 01 Nov 2018 18:34:36 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -3723,7 +3723,7 @@ http_interactions:
         changed", "physical_resource_id": "219a737c-b4ad-430d-944a-a92a4834b12d",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:39 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:36 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c/template
@@ -3738,7 +3738,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c94e2e913e964a9eb171c6cb4ee2ef93
+      - 988e1b42b7c24a989f205f316f656dbc
   response:
     status:
       code: 200
@@ -3749,9 +3749,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-4459128f-b487-46f5-a5ed-da2ced4b34bf
+      - req-718b092e-7c2c-4f94-90c6-03731a132968
       Date:
-      - Thu, 25 Oct 2018 18:19:39 GMT
+      - Thu, 01 Nov 2018 18:34:36 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -3807,7 +3807,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:39 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:36 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c/resources
@@ -3822,7 +3822,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c94e2e913e964a9eb171c6cb4ee2ef93
+      - 988e1b42b7c24a989f205f316f656dbc
   response:
     status:
       code: 200
@@ -3833,9 +3833,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-948f5d1f-b7b1-4e2f-99b8-8b422b8567da
+      - req-cb756a96-4f49-4a2e-bdd6-7b748d3bbc8b
       Date:
-      - Thu, 25 Oct 2018 18:19:39 GMT
+      - Thu, 01 Nov 2018 18:34:36 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -3847,7 +3847,7 @@ http_interactions:
         changed", "physical_resource_id": "b686353f-0da0-48bf-bc35-8ea411a67dfd",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:39 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:36 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a//os-quota-sets/69f8f7205ade4aa59084c32c83e60b5a
@@ -3862,7 +3862,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c58e8a13f5a74f689e201a76d15d1464
+      - 839d90ee589d4c54b92750b9909b21ed
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3875,9 +3875,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-b98be6c3-1f74-449d-b12b-f788d9927935
+      - req-e586cbe1-2364-4396-a26d-459c83cea7a3
       Date:
-      - Thu, 25 Oct 2018 18:19:40 GMT
+      - Thu, 01 Nov 2018 18:34:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -3886,7 +3886,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:40 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:37 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8//os-quota-sets/b458a5c25c3749758f4c0661940b3ba8
@@ -3901,7 +3901,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9e8fd7d982f24f90941bdcf1a03a7b1c
+      - 17c070b019eb44af8a0739d270a9670d
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3914,9 +3914,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-cfc9e33a-fcbc-475c-8a39-359f9616f29c
+      - req-03a02bc8-3801-45ea-b4ba-947299fff76f
       Date:
-      - Thu, 25 Oct 2018 18:19:40 GMT
+      - Thu, 01 Nov 2018 18:34:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -3925,7 +3925,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:40 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:37 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a//os-quota-sets/e54e5c3c19e34720b05661f2ea1ea00a
@@ -3940,7 +3940,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 990191f2aff540768d3e06afc6378301
+      - ca0ba8975f684c158d388a183ca197a2
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3953,9 +3953,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-7c325ac4-4c3e-4a86-abb0-5da83f690443
+      - req-69f694e7-9ae8-47da-a59f-8070ff97fac7
       Date:
-      - Thu, 25 Oct 2018 18:19:40 GMT
+      - Thu, 01 Nov 2018 18:34:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -3964,7 +3964,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:40 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:37 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608//os-quota-sets/e8f744b1fc6a487681d35fb275252608
@@ -3979,7 +3979,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8dd483cf8db54c58999e0cd4859df746
+      - 8bc23eb188c046ad8ff9248bb1de011c
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3992,9 +3992,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-82f6752a-aa61-4371-9eeb-18cfbdb44cf0
+      - req-8683b309-5ca4-4e72-a813-f140961a1361
       Date:
-      - Thu, 25 Oct 2018 18:19:40 GMT
+      - Thu, 01 Nov 2018 18:34:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -4003,7 +4003,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:40 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:37 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4021,13 +4021,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:19:40 GMT
+      - Thu, 01 Nov 2018 18:34:37 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-1440da09-fb6c-4fd7-add0-fcc0b710dbee
+      - req-d6dca8f4-ee8c-4fe4-9789-8ba5b71ece8a
       Content-Length:
       - '4117'
       Connection:
@@ -4036,10 +4036,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:19:40.492811", "expires":
-        "2018-10-25T19:19:40Z", "id": "1429ef77659a4dc4bcc8501f33cc22a0", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:34:37.534329", "expires":
+        "2018-11-01T19:34:37Z", "id": "15775418c2a54151a78b46cc095df120", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["FkyJBp8dSGi8YJVE020d8A"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["b0lsZLEbS3auT4CLsew0jw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -4083,7 +4083,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:40 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:37 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a//os-quota-sets/69f8f7205ade4aa59084c32c83e60b5a
@@ -4098,22 +4098,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1429ef77659a4dc4bcc8501f33cc22a0
+      - 15775418c2a54151a78b46cc095df120
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-d5874ef9-9be5-4c32-8263-a3d21b96c39e
+      - req-f8473da2-46ab-4fb6-96f3-2d2c704a5777
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-d5874ef9-9be5-4c32-8263-a3d21b96c39e
+      - req-f8473da2-46ab-4fb6-96f3-2d2c704a5777
       Date:
-      - Thu, 25 Oct 2018 18:19:40 GMT
+      - Thu, 01 Nov 2018 18:34:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -4123,7 +4123,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "69f8f7205ade4aa59084c32c83e60b5a"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:40 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:37 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4141,13 +4141,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:19:40 GMT
+      - Thu, 01 Nov 2018 18:34:37 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-ae8dc2b1-bc85-4878-912a-afef857bc435
+      - req-78e9448b-dffe-4933-9c45-e697a823d499
       Content-Length:
       - '4131'
       Connection:
@@ -4156,10 +4156,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:19:40.960276", "expires":
-        "2018-10-25T19:19:40Z", "id": "3d10dad5175141b2b112b02b6c6e3df2", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:34:38.050839", "expires":
+        "2018-11-01T19:34:38Z", "id": "cd5af9f82da04934b4d66fc70b4440ee", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["LzYxvDIBQWWOiFppkoeXVA"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["XOUjgZj4QWKbij0vZm_V6Q"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -4203,7 +4203,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:40 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:38 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8//os-quota-sets/b458a5c25c3749758f4c0661940b3ba8
@@ -4218,22 +4218,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3d10dad5175141b2b112b02b6c6e3df2
+      - cd5af9f82da04934b4d66fc70b4440ee
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-3afe987a-827f-48e8-9668-2ed89a1995c1
+      - req-e6289215-d6b2-43d3-94d6-845fc3f60b2a
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-3afe987a-827f-48e8-9668-2ed89a1995c1
+      - req-e6289215-d6b2-43d3-94d6-845fc3f60b2a
       Date:
-      - Thu, 25 Oct 2018 18:19:41 GMT
+      - Thu, 01 Nov 2018 18:34:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -4243,7 +4243,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "b458a5c25c3749758f4c0661940b3ba8"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:41 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:38 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a//os-quota-sets/e54e5c3c19e34720b05661f2ea1ea00a
@@ -4258,22 +4258,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 66d4b59653ae4f3a8a0747c66b8bf73c
+      - f874154d59e140cdb691fb7d17bedd0a
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-1225e5bd-4aa9-4a3d-8f8b-5626c27f17d7
+      - req-ee1121b3-e089-458b-9099-f13c8d293c7b
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-1225e5bd-4aa9-4a3d-8f8b-5626c27f17d7
+      - req-ee1121b3-e089-458b-9099-f13c8d293c7b
       Date:
-      - Thu, 25 Oct 2018 18:19:41 GMT
+      - Thu, 01 Nov 2018 18:34:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -4283,7 +4283,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "e54e5c3c19e34720b05661f2ea1ea00a"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:41 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:38 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4301,13 +4301,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:19:41 GMT
+      - Thu, 01 Nov 2018 18:34:38 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-0de16fba-b5a9-40f8-86b6-8b816d0ea943
+      - req-79c2a125-41ba-4734-8eea-dd17e3a5f47d
       Content-Length:
       - '4118'
       Connection:
@@ -4316,10 +4316,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:19:41.709364", "expires":
-        "2018-10-25T19:19:41Z", "id": "847db75874ae4d699f138892ed5706bd", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:34:38.888735", "expires":
+        "2018-11-01T19:34:38Z", "id": "c45b6386fde341e1bd59f58d168c4808", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["g-Ou0t9QQ0SRvqBhKaHAew"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["KryqRZh9Rc-dgT-7MuyWhw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -4363,7 +4363,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:41 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:38 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608//os-quota-sets/e8f744b1fc6a487681d35fb275252608
@@ -4378,22 +4378,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 847db75874ae4d699f138892ed5706bd
+      - c45b6386fde341e1bd59f58d168c4808
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-8f760f38-9ef8-4994-8c81-7111ae5865f9
+      - req-37b6e91a-e6a0-4ae3-ad1f-c3b69f3e9ca9
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-8f760f38-9ef8-4994-8c81-7111ae5865f9
+      - req-37b6e91a-e6a0-4ae3-ad1f-c3b69f3e9ca9
       Date:
-      - Thu, 25 Oct 2018 18:19:42 GMT
+      - Thu, 01 Nov 2018 18:34:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -4403,7 +4403,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "e8f744b1fc6a487681d35fb275252608"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:42 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:39 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4421,13 +4421,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:19:42 GMT
+      - Thu, 01 Nov 2018 18:34:39 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-dfcea7f5-def7-4a4e-a611-a52d7794d735
+      - req-59530298-ced1-4d15-89d0-6d63b665dea4
       Content-Length:
       - '4170'
       Connection:
@@ -4436,10 +4436,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:19:42.184342", "expires":
-        "2018-10-25T19:19:42Z", "id": "9848bf5762a04482936bd84eaf59ba8c", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:34:39.431452", "expires":
+        "2018-11-01T19:34:39Z", "id": "94ebc770bf6a4c678974c9e350c02f11", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["TqNjcZXvQNOBraeUuzZaNQ"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["_ng6Z_foS9C3CNwurQ70uA"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -4484,7 +4484,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:42 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:39 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4502,13 +4502,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:19:42 GMT
+      - Thu, 01 Nov 2018 18:34:39 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-6211a279-557b-4058-9a13-95349330a7ae
+      - req-15651c6c-f3e8-4884-99a0-d01e34f59ad8
       Content-Length:
       - '4117'
       Connection:
@@ -4517,10 +4517,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:19:42.364199", "expires":
-        "2018-10-25T19:19:42Z", "id": "417ff1e09d39416cae1bccc3d85a4fab", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:34:39.614272", "expires":
+        "2018-11-01T19:34:39Z", "id": "03dcf0b0a0df419aa8861858fb9823f6", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["72V5VFspQ2KZTxK9WAnvBw"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["ur1UtzB2SEeVW_TyWxuNqQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -4564,7 +4564,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:42 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:39 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0//quotas/69f8f7205ade4aa59084c32c83e60b5a
@@ -4579,7 +4579,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 417ff1e09d39416cae1bccc3d85a4fab
+      - 03dcf0b0a0df419aa8861858fb9823f6
   response:
     status:
       code: 200
@@ -4590,16 +4590,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-8aeebe31-3912-430d-bea9-2f276a5368ec
+      - req-8ef5aead-956c-47bf-9086-ba7b8647be7f
       Date:
-      - Thu, 25 Oct 2018 18:19:42 GMT
+      - Thu, 01 Nov 2018 18:34:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 20, "network": 20, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:42 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:39 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4617,13 +4617,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:19:42 GMT
+      - Thu, 01 Nov 2018 18:34:39 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-c1ac610d-5d79-4644-8d28-c48c4fb15d0e
+      - req-f9335d8c-7cc2-464c-834e-392069fb1e3d
       Content-Length:
       - '4131'
       Connection:
@@ -4632,10 +4632,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:19:42.700075", "expires":
-        "2018-10-25T19:19:42Z", "id": "27da6f029ffe43909fc07629b24aab7a", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:34:40.058499", "expires":
+        "2018-11-01T19:34:40Z", "id": "c7824cfbe5fb487182f4fd4bcff2bf50", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["qtgDSMvWSCaAYrJG5nz8nw"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["CjXjqFm_RfK7fYv9gWyh1w"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -4679,7 +4679,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:42 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:40 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0//quotas/b458a5c25c3749758f4c0661940b3ba8
@@ -4694,7 +4694,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 27da6f029ffe43909fc07629b24aab7a
+      - c7824cfbe5fb487182f4fd4bcff2bf50
   response:
     status:
       code: 200
@@ -4705,16 +4705,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-b5c867e2-2d8e-4014-9893-603b7c7d3010
+      - req-dd8264cf-c92d-4efb-b833-f0cf7c4b12ad
       Date:
-      - Thu, 25 Oct 2018 18:19:42 GMT
+      - Thu, 01 Nov 2018 18:34:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:42 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:40 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0//quotas/e54e5c3c19e34720b05661f2ea1ea00a
@@ -4729,7 +4729,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9848bf5762a04482936bd84eaf59ba8c
+      - 94ebc770bf6a4c678974c9e350c02f11
   response:
     status:
       code: 200
@@ -4740,16 +4740,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-89de824f-7b27-4293-8f6d-121ee35e8ef0
+      - req-ca7c6185-04d2-4448-82b4-a6561a05d136
       Date:
-      - Thu, 25 Oct 2018 18:19:42 GMT
+      - Thu, 01 Nov 2018 18:34:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:43 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:40 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4767,13 +4767,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:19:43 GMT
+      - Thu, 01 Nov 2018 18:34:40 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-240dff17-34e7-40ea-84b8-408c5ea7cfdf
+      - req-2a92be26-8cd1-4ab2-adcd-17d3ef93334b
       Content-Length:
       - '4118'
       Connection:
@@ -4782,10 +4782,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:19:43.194472", "expires":
-        "2018-10-25T19:19:43Z", "id": "f710da17d1ef48bd9e1f5a20889bba6a", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:34:40.622999", "expires":
+        "2018-11-01T19:34:40Z", "id": "72a36d8ef56d4228a388010a34a6542c", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["oZms89HFSiCKyOxBDZaWBg"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["UQjRsWF5Rtevf82OOUz4tw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -4829,7 +4829,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:43 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:40 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0//quotas/e8f744b1fc6a487681d35fb275252608
@@ -4844,7 +4844,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f710da17d1ef48bd9e1f5a20889bba6a
+      - 72a36d8ef56d4228a388010a34a6542c
   response:
     status:
       code: 200
@@ -4855,16 +4855,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-04521a33-6b0b-444d-a7d5-b48245be0522
+      - req-296b9274-d3c0-4850-ac1b-edfc645d2b14
       Date:
-      - Thu, 25 Oct 2018 18:19:43 GMT
+      - Thu, 01 Nov 2018 18:34:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:43 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:40 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-floating-ips
@@ -4879,7 +4879,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c58e8a13f5a74f689e201a76d15d1464
+      - 839d90ee589d4c54b92750b9909b21ed
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4892,9 +4892,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-bc521be6-c510-4ef2-bcd8-812b949b4f96
+      - req-520c9e8b-1cfc-485a-99d8-daf40a772f7c
       Date:
-      - Thu, 25 Oct 2018 18:19:43 GMT
+      - Thu, 01 Nov 2018 18:34:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": null, "ip": "172.16.17.13", "fixed_ip":
@@ -4917,7 +4917,7 @@ http_interactions:
         "ip": "172.16.17.6", "fixed_ip": "192.168.1.4", "id": "ee601a91-f6ac-4a46-a599-87cfd83094a3",
         "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:43 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:41 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-floating-ips
@@ -4932,7 +4932,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c58e8a13f5a74f689e201a76d15d1464
+      - 839d90ee589d4c54b92750b9909b21ed
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4945,9 +4945,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-b68990dd-40d7-4d26-b40a-985699f4ba32
+      - req-1af9236a-2ef8-4761-86d6-006356f015e6
       Date:
-      - Thu, 25 Oct 2018 18:19:43 GMT
+      - Thu, 01 Nov 2018 18:34:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": null, "ip": "172.16.17.13", "fixed_ip":
@@ -4970,7 +4970,7 @@ http_interactions:
         "ip": "172.16.17.6", "fixed_ip": "192.168.1.4", "id": "ee601a91-f6ac-4a46-a599-87cfd83094a3",
         "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:43 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:41 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-floating-ips
@@ -4985,7 +4985,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c58e8a13f5a74f689e201a76d15d1464
+      - 839d90ee589d4c54b92750b9909b21ed
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4998,9 +4998,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-fcdc6369-35b7-42a1-8e28-54f986a82d88
+      - req-9157c7ac-844c-4fb2-b3bf-7c2ba3dce769
       Date:
-      - Thu, 25 Oct 2018 18:19:43 GMT
+      - Thu, 01 Nov 2018 18:34:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": null, "ip": "172.16.17.13", "fixed_ip":
@@ -5023,7 +5023,7 @@ http_interactions:
         "ip": "172.16.17.6", "fixed_ip": "192.168.1.4", "id": "ee601a91-f6ac-4a46-a599-87cfd83094a3",
         "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:43 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:41 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-floating-ips
@@ -5038,7 +5038,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c58e8a13f5a74f689e201a76d15d1464
+      - 839d90ee589d4c54b92750b9909b21ed
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5051,9 +5051,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-2e9826a7-8d97-4958-ae39-19b3ec61f6e3
+      - req-70bb4437-a50d-4546-9702-d4308cf7d1c4
       Date:
-      - Thu, 25 Oct 2018 18:19:44 GMT
+      - Thu, 01 Nov 2018 18:34:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": null, "ip": "172.16.17.13", "fixed_ip":
@@ -5076,7 +5076,7 @@ http_interactions:
         "ip": "172.16.17.6", "fixed_ip": "192.168.1.4", "id": "ee601a91-f6ac-4a46-a599-87cfd83094a3",
         "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:44 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:41 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-floating-ips
@@ -5091,7 +5091,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c58e8a13f5a74f689e201a76d15d1464
+      - 839d90ee589d4c54b92750b9909b21ed
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5104,9 +5104,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-0df84143-a043-4e21-b04f-b46ddc14151d
+      - req-7c581ac3-47eb-4d87-a46b-611c4c43a9a0
       Date:
-      - Thu, 25 Oct 2018 18:19:44 GMT
+      - Thu, 01 Nov 2018 18:34:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": null, "ip": "172.16.17.13", "fixed_ip":
@@ -5129,7 +5129,7 @@ http_interactions:
         "ip": "172.16.17.6", "fixed_ip": "192.168.1.4", "id": "ee601a91-f6ac-4a46-a599-87cfd83094a3",
         "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:44 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:42 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/4bb36934-fd61-4a19-ab9d-28fbbda0c7f0/os-volume_attachments
@@ -5144,7 +5144,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c58e8a13f5a74f689e201a76d15d1464
+      - 839d90ee589d4c54b92750b9909b21ed
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5157,15 +5157,15 @@ http_interactions:
       Content-Length:
       - '197'
       X-Compute-Request-Id:
-      - req-42900de8-6694-47c7-ac5c-697a512c275b
+      - req-16f3f880-e35f-4469-9a93-843ba0ac22ca
       Date:
-      - Thu, 25 Oct 2018 18:19:44 GMT
+      - Thu, 01 Nov 2018 18:34:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumeAttachments": [{"device": "/dev/vda", "serverId": "4bb36934-fd61-4a19-ab9d-28fbbda0c7f0",
         "id": "b124469d-a857-4b39-abe9-d0e63985f834", "volumeId": "b124469d-a857-4b39-abe9-d0e63985f834"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:44 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:42 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-floating-ips
@@ -5180,7 +5180,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c58e8a13f5a74f689e201a76d15d1464
+      - 839d90ee589d4c54b92750b9909b21ed
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5193,9 +5193,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-0b9ba3be-bb7a-488b-b6d0-9644fb12e69a
+      - req-583b67c3-5fce-419a-9f9c-338e8e07bb8a
       Date:
-      - Thu, 25 Oct 2018 18:19:44 GMT
+      - Thu, 01 Nov 2018 18:34:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": null, "ip": "172.16.17.13", "fixed_ip":
@@ -5218,7 +5218,7 @@ http_interactions:
         "ip": "172.16.17.6", "fixed_ip": "192.168.1.4", "id": "ee601a91-f6ac-4a46-a599-87cfd83094a3",
         "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:44 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:42 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/ca4f3a16-bae3-4407-83e9-f77b28af0f2b/os-volume_attachments
@@ -5233,7 +5233,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c58e8a13f5a74f689e201a76d15d1464
+      - 839d90ee589d4c54b92750b9909b21ed
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5246,15 +5246,15 @@ http_interactions:
       Content-Length:
       - '197'
       X-Compute-Request-Id:
-      - req-1ec94ce0-3507-4ba1-8597-9d5fc619f56c
+      - req-754cc516-3019-4181-a362-5697c17219af
       Date:
-      - Thu, 25 Oct 2018 18:19:44 GMT
+      - Thu, 01 Nov 2018 18:34:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumeAttachments": [{"device": "/dev/vdd", "serverId": "ca4f3a16-bae3-4407-83e9-f77b28af0f2b",
         "id": "0a55c0d5-c780-4e7d-9d09-47f5520c7448", "volumeId": "0a55c0d5-c780-4e7d-9d09-47f5520c7448"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:44 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:42 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-floating-ips
@@ -5269,7 +5269,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c58e8a13f5a74f689e201a76d15d1464
+      - 839d90ee589d4c54b92750b9909b21ed
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5282,9 +5282,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-d1ddbef0-0251-41b6-982c-e044a4418f90
+      - req-2233751e-6bcf-4863-b3ed-9b42de3a590d
       Date:
-      - Thu, 25 Oct 2018 18:19:44 GMT
+      - Thu, 01 Nov 2018 18:34:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": null, "ip": "172.16.17.13", "fixed_ip":
@@ -5307,7 +5307,7 @@ http_interactions:
         "ip": "172.16.17.6", "fixed_ip": "192.168.1.4", "id": "ee601a91-f6ac-4a46-a599-87cfd83094a3",
         "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:44 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:42 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-floating-ips
@@ -5322,7 +5322,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c58e8a13f5a74f689e201a76d15d1464
+      - 839d90ee589d4c54b92750b9909b21ed
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5335,9 +5335,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-123cd4be-0005-474c-b635-3ff083a15389
+      - req-8b80f92b-d4e5-4ea9-85ca-d8705b333378
       Date:
-      - Thu, 25 Oct 2018 18:19:45 GMT
+      - Thu, 01 Nov 2018 18:34:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": null, "ip": "172.16.17.13", "fixed_ip":
@@ -5360,7 +5360,7 @@ http_interactions:
         "ip": "172.16.17.6", "fixed_ip": "192.168.1.4", "id": "ee601a91-f6ac-4a46-a599-87cfd83094a3",
         "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:45 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:42 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-floating-ips
@@ -5375,7 +5375,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c58e8a13f5a74f689e201a76d15d1464
+      - 839d90ee589d4c54b92750b9909b21ed
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5388,9 +5388,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-312a92c9-3b57-475c-9554-5385937535b2
+      - req-0348e048-68ec-449c-bd10-dc3f6ec86af0
       Date:
-      - Thu, 25 Oct 2018 18:19:45 GMT
+      - Thu, 01 Nov 2018 18:34:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": null, "ip": "172.16.17.13", "fixed_ip":
@@ -5413,7 +5413,7 @@ http_interactions:
         "ip": "172.16.17.6", "fixed_ip": "192.168.1.4", "id": "ee601a91-f6ac-4a46-a599-87cfd83094a3",
         "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:45 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:43 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -5431,13 +5431,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:19:45 GMT
+      - Thu, 01 Nov 2018 18:34:43 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-9acb7212-3143-4aad-a5d1-32513aebcfd4
+      - req-1086e60d-3232-4b99-a094-e082498e3f41
       Content-Length:
       - '4170'
       Connection:
@@ -5446,10 +5446,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:19:45.574470", "expires":
-        "2018-10-25T19:19:45Z", "id": "47f1898e7b6f4276a3cbbf888e1bb040", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:34:43.367332", "expires":
+        "2018-11-01T19:34:43Z", "id": "d5fcf2f8db364b088647b794cc3c2c0e", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["i6N4YH0uSBOcinppNCpmMA"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["49ur8zMmSBu5--UF1ESH5A"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -5494,7 +5494,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:45 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:43 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -5512,13 +5512,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:19:45 GMT
+      - Thu, 01 Nov 2018 18:34:43 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-7b7590c3-d23c-4e3a-b55d-2cd20c020161
+      - req-52639e3e-49b1-4351-b3c4-0169395838e5
       Content-Length:
       - '4170'
       Connection:
@@ -5527,10 +5527,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:19:45.754274", "expires":
-        "2018-10-25T19:19:45Z", "id": "9154d25fb7e04f4b9067367a5b5b661e", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:34:43.565257", "expires":
+        "2018-11-01T19:34:43Z", "id": "2218ac3435204a65bf2950da9c831f16", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["InChE46TRmKIFL3OCXdA-g"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["-CYZNBYYSJmcLyXNjy9Xdw"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -5575,7 +5575,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:45 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:43 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-aggregates
@@ -5590,7 +5590,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 990191f2aff540768d3e06afc6378301
+      - ca0ba8975f684c158d388a183ca197a2
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5603,14 +5603,14 @@ http_interactions:
       Content-Length:
       - '18'
       X-Compute-Request-Id:
-      - req-8ab9c33f-4599-4508-ad7e-cf649e24ef58
+      - req-b7e866ce-5e74-4763-9338-94c1973eccb9
       Date:
-      - Thu, 25 Oct 2018 18:19:45 GMT
+      - Thu, 01 Nov 2018 18:34:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"aggregates": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:45 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:43 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&status=available
@@ -5625,22 +5625,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1429ef77659a4dc4bcc8501f33cc22a0
+      - 15775418c2a54151a78b46cc095df120
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-f040d3f6-7fda-4b23-a0c4-0f3ecd9f4795
+      - req-931ef7ac-0c54-49b9-bf88-b14f1995112c
       Content-Type:
       - application/json
       Content-Length:
       - '2723'
       X-Openstack-Request-Id:
-      - req-f040d3f6-7fda-4b23-a0c4-0f3ecd9f4795
+      - req-931ef7ac-0c54-49b9-bf88-b14f1995112c
       Date:
-      - Thu, 25 Oct 2018 18:19:46 GMT
+      - Thu, 01 Nov 2018 18:34:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&status=available&marker=9bb99818-b339-4e31-b87f-e4181ec48acd",
@@ -5673,7 +5673,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-4", "bootable": "true", "created_at":
         "2016-11-11T13:49:53.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:46 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:43 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=9bb99818-b339-4e31-b87f-e4181ec48acd&status=available
@@ -5688,22 +5688,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1429ef77659a4dc4bcc8501f33cc22a0
+      - 15775418c2a54151a78b46cc095df120
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-29b87bea-1d2f-400f-87ca-b7d484c655ac
+      - req-cad89b5c-4429-485c-9170-d7174a809910
       Content-Type:
       - application/json
       Content-Length:
       - '1180'
       X-Openstack-Request-Id:
-      - req-29b87bea-1d2f-400f-87ca-b7d484c655ac
+      - req-cad89b5c-4429-485c-9170-d7174a809910
       Date:
-      - Thu, 25 Oct 2018 18:19:46 GMT
+      - Thu, 01 Nov 2018 18:34:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": [{"migration_status": null, "attachments": [], "links":
@@ -5720,7 +5720,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-FromSnapshot", "bootable": "false", "created_at":
         "2016-11-11T13:49:26.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:46 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:44 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/volumes/detail?limit=1000&status=available
@@ -5735,27 +5735,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3d10dad5175141b2b112b02b6c6e3df2
+      - cd5af9f82da04934b4d66fc70b4440ee
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-b6e9fea7-b0f3-4b63-91c1-64f258efc31e
+      - req-963ca1ee-8ef7-4ea2-b185-4d38f39e10c5
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-b6e9fea7-b0f3-4b63-91c1-64f258efc31e
+      - req-963ca1ee-8ef7-4ea2-b185-4d38f39e10c5
       Date:
-      - Thu, 25 Oct 2018 18:19:46 GMT
+      - Thu, 01 Nov 2018 18:34:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:46 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:44 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/volumes/detail?limit=1000&status=available
@@ -5770,27 +5770,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 66d4b59653ae4f3a8a0747c66b8bf73c
+      - f874154d59e140cdb691fb7d17bedd0a
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-165ce7c8-f25e-4450-89a8-d7e8f61adab8
+      - req-033dab06-7ed0-4c71-9235-8655308b6d50
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-165ce7c8-f25e-4450-89a8-d7e8f61adab8
+      - req-033dab06-7ed0-4c71-9235-8655308b6d50
       Date:
-      - Thu, 25 Oct 2018 18:19:46 GMT
+      - Thu, 01 Nov 2018 18:34:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:46 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:44 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/volumes/detail?limit=1000&status=available
@@ -5805,27 +5805,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 847db75874ae4d699f138892ed5706bd
+      - c45b6386fde341e1bd59f58d168c4808
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-bcd500a8-3b85-4e41-b9d5-7c2787718a34
+      - req-b9d8f7a9-1f52-477b-a907-e2e95f3f988f
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-bcd500a8-3b85-4e41-b9d5-7c2787718a34
+      - req-b9d8f7a9-1f52-477b-a907-e2e95f3f988f
       Date:
-      - Thu, 25 Oct 2018 18:19:46 GMT
+      - Thu, 01 Nov 2018 18:34:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:46 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:44 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail
@@ -5840,22 +5840,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1429ef77659a4dc4bcc8501f33cc22a0
+      - 15775418c2a54151a78b46cc095df120
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-ff68979a-80bb-4d9d-abf6-210493b78331
+      - req-5069d48e-f31f-492e-a936-587ce3122330
       Content-Type:
       - application/json
       Content-Length:
       - '1053'
       X-Openstack-Request-Id:
-      - req-ff68979a-80bb-4d9d-abf6-210493b78331
+      - req-5069d48e-f31f-492e-a936-587ce3122330
       Date:
-      - Thu, 25 Oct 2018 18:19:46 GMT
+      - Thu, 01 Nov 2018 18:34:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?marker=76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
@@ -5870,7 +5870,7 @@ http_interactions:
         "created_at": "2016-11-11T13:49:36.000000", "size": 1, "id": "76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:46 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:44 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?limit=1000&status=available
@@ -5885,22 +5885,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1429ef77659a4dc4bcc8501f33cc22a0
+      - 15775418c2a54151a78b46cc095df120
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-2e7e0463-058a-4196-9402-0dfb71785ea6
+      - req-a7d9fc96-9973-42d9-bddf-3b577a83c160
       Content-Type:
       - application/json
       Content-Length:
       - '1081'
       X-Openstack-Request-Id:
-      - req-2e7e0463-058a-4196-9402-0dfb71785ea6
+      - req-a7d9fc96-9973-42d9-bddf-3b577a83c160
       Date:
-      - Thu, 25 Oct 2018 18:19:46 GMT
+      - Thu, 01 Nov 2018 18:34:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?limit=1000&status=available&marker=76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
@@ -5915,7 +5915,7 @@ http_interactions:
         "created_at": "2016-11-11T13:49:36.000000", "size": 1, "id": "76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:46 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:44 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/snapshots/detail
@@ -5930,27 +5930,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3d10dad5175141b2b112b02b6c6e3df2
+      - cd5af9f82da04934b4d66fc70b4440ee
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-3a8b84e2-82ee-495a-9f05-f5b2ff723af1
+      - req-25d814e0-4e7c-4317-a095-458b4c0128b3
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-3a8b84e2-82ee-495a-9f05-f5b2ff723af1
+      - req-25d814e0-4e7c-4317-a095-458b4c0128b3
       Date:
-      - Thu, 25 Oct 2018 18:19:46 GMT
+      - Thu, 01 Nov 2018 18:34:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:46 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:44 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/snapshots/detail?limit=1000&status=available
@@ -5965,27 +5965,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3d10dad5175141b2b112b02b6c6e3df2
+      - cd5af9f82da04934b4d66fc70b4440ee
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-5c4d610f-a542-4072-8317-692f554678a4
+      - req-7e109f57-ba43-4561-ad25-5999366b659a
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-5c4d610f-a542-4072-8317-692f554678a4
+      - req-7e109f57-ba43-4561-ad25-5999366b659a
       Date:
-      - Thu, 25 Oct 2018 18:19:47 GMT
+      - Thu, 01 Nov 2018 18:34:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:47 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:44 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/snapshots/detail
@@ -6000,27 +6000,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 66d4b59653ae4f3a8a0747c66b8bf73c
+      - f874154d59e140cdb691fb7d17bedd0a
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-e19d5267-202a-471d-850c-f9fd840fde83
+      - req-c9e2d339-d023-4e61-8639-25e8ef59f9c1
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-e19d5267-202a-471d-850c-f9fd840fde83
+      - req-c9e2d339-d023-4e61-8639-25e8ef59f9c1
       Date:
-      - Thu, 25 Oct 2018 18:19:47 GMT
+      - Thu, 01 Nov 2018 18:34:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:47 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:45 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/snapshots/detail?limit=1000&status=available
@@ -6035,27 +6035,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 66d4b59653ae4f3a8a0747c66b8bf73c
+      - f874154d59e140cdb691fb7d17bedd0a
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-e7a7210a-62d9-4de5-84a6-78b9b7699775
+      - req-73c23b6b-0543-46fc-98e3-56e2074ddf6a
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-e7a7210a-62d9-4de5-84a6-78b9b7699775
+      - req-73c23b6b-0543-46fc-98e3-56e2074ddf6a
       Date:
-      - Thu, 25 Oct 2018 18:19:47 GMT
+      - Thu, 01 Nov 2018 18:34:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:47 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:45 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/snapshots/detail
@@ -6070,27 +6070,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 847db75874ae4d699f138892ed5706bd
+      - c45b6386fde341e1bd59f58d168c4808
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-2af5e7cd-8190-4a8d-9aa7-e5e840998398
+      - req-0ebe1fa3-b8ba-484c-9e51-92fba8e7c33f
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-2af5e7cd-8190-4a8d-9aa7-e5e840998398
+      - req-0ebe1fa3-b8ba-484c-9e51-92fba8e7c33f
       Date:
-      - Thu, 25 Oct 2018 18:19:47 GMT
+      - Thu, 01 Nov 2018 18:34:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:47 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:45 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/snapshots/detail?limit=1000&status=available
@@ -6105,27 +6105,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 847db75874ae4d699f138892ed5706bd
+      - c45b6386fde341e1bd59f58d168c4808
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-29d1928a-6513-42b5-8ee3-f7285dd1d465
+      - req-bd95fc66-0c56-4a2e-ab7c-5803cf1029f3
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-29d1928a-6513-42b5-8ee3-f7285dd1d465
+      - req-bd95fc66-0c56-4a2e-ab7c-5803cf1029f3
       Date:
-      - Thu, 25 Oct 2018 18:19:47 GMT
+      - Thu, 01 Nov 2018 18:34:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:47 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:45 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000
@@ -6140,22 +6140,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1429ef77659a4dc4bcc8501f33cc22a0
+      - 15775418c2a54151a78b46cc095df120
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-7bd55177-bb96-4bf5-938b-a53f9b936dd5
+      - req-53b3fe18-60d6-4afe-8774-78a46f6cf317
       Content-Type:
       - application/json
       Content-Length:
       - '2706'
       X-Openstack-Request-Id:
-      - req-7bd55177-bb96-4bf5-938b-a53f9b936dd5
+      - req-53b3fe18-60d6-4afe-8774-78a46f6cf317
       Date:
-      - Thu, 25 Oct 2018 18:19:47 GMT
+      - Thu, 01 Nov 2018 18:34:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=9bb99818-b339-4e31-b87f-e4181ec48acd",
@@ -6188,7 +6188,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-4", "bootable": "true", "created_at":
         "2016-11-11T13:49:53.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:47 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:45 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=9bb99818-b339-4e31-b87f-e4181ec48acd
@@ -6203,22 +6203,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1429ef77659a4dc4bcc8501f33cc22a0
+      - 15775418c2a54151a78b46cc095df120
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-117bdd00-6a7a-47f5-8446-09be01b3f360
+      - req-54e7a742-299f-43d3-b8de-88c07a9d931e
       Content-Type:
       - application/json
       Content-Length:
       - '3284'
       X-Openstack-Request-Id:
-      - req-117bdd00-6a7a-47f5-8446-09be01b3f360
+      - req-54e7a742-299f-43d3-b8de-88c07a9d931e
       Date:
-      - Thu, 25 Oct 2018 18:19:47 GMT
+      - Thu, 01 Nov 2018 18:34:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=2c774148-c11a-434c-aabb-7fa9c82c37ce",
@@ -6259,7 +6259,7 @@ http_interactions:
         "name": "EmsRefreshSpec-Volume-2", "bootable": "false", "created_at": "2016-11-11T13:49:43.000000",
         "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:47 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:45 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=2c774148-c11a-434c-aabb-7fa9c82c37ce
@@ -6274,22 +6274,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1429ef77659a4dc4bcc8501f33cc22a0
+      - 15775418c2a54151a78b46cc095df120
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-39d4b8e0-3c70-450d-be7e-1480c794d9ad
+      - req-69cd3a9a-cf9c-4b87-b304-38324a29cd01
       Content-Type:
       - application/json
       Content-Length:
       - '2753'
       X-Openstack-Request-Id:
-      - req-39d4b8e0-3c70-450d-be7e-1480c794d9ad
+      - req-69cd3a9a-cf9c-4b87-b304-38324a29cd01
       Date:
-      - Thu, 25 Oct 2018 18:19:47 GMT
+      - Thu, 01 Nov 2018 18:34:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=0a55c0d5-c780-4e7d-9d09-47f5520c7448",
@@ -6323,7 +6323,7 @@ http_interactions:
         "bootable": "false", "created_at": "2016-11-11T13:49:20.000000", "volume_type":
         "iscsi"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:47 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:45 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=0a55c0d5-c780-4e7d-9d09-47f5520c7448
@@ -6338,27 +6338,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1429ef77659a4dc4bcc8501f33cc22a0
+      - 15775418c2a54151a78b46cc095df120
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-2ea19b36-e72e-4831-9d9a-73f6d72b2c9b
+      - req-6899cb67-2321-4179-8e3b-59e7fc912890
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-2ea19b36-e72e-4831-9d9a-73f6d72b2c9b
+      - req-6899cb67-2321-4179-8e3b-59e7fc912890
       Date:
-      - Thu, 25 Oct 2018 18:19:48 GMT
+      - Thu, 01 Nov 2018 18:34:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:48 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:46 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/volumes/detail?limit=1000
@@ -6373,27 +6373,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3d10dad5175141b2b112b02b6c6e3df2
+      - cd5af9f82da04934b4d66fc70b4440ee
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-69c22ddd-607b-4be9-a013-fe9c3f5f686a
+      - req-27553018-4dea-439e-a973-a509977281f2
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-69c22ddd-607b-4be9-a013-fe9c3f5f686a
+      - req-27553018-4dea-439e-a973-a509977281f2
       Date:
-      - Thu, 25 Oct 2018 18:19:48 GMT
+      - Thu, 01 Nov 2018 18:34:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:48 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:46 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/volumes/detail?limit=1000
@@ -6408,27 +6408,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 66d4b59653ae4f3a8a0747c66b8bf73c
+      - f874154d59e140cdb691fb7d17bedd0a
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-dd473d98-b9e3-4f11-b9de-d71d9ed7d0af
+      - req-9ac433fc-e2c7-4b84-bdc5-a487738cfc6b
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-dd473d98-b9e3-4f11-b9de-d71d9ed7d0af
+      - req-9ac433fc-e2c7-4b84-bdc5-a487738cfc6b
       Date:
-      - Thu, 25 Oct 2018 18:19:48 GMT
+      - Thu, 01 Nov 2018 18:34:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:48 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:46 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/volumes/detail?limit=1000
@@ -6443,27 +6443,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 847db75874ae4d699f138892ed5706bd
+      - c45b6386fde341e1bd59f58d168c4808
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-8a3d4058-bddd-4e0a-973d-7acab3f6a4b6
+      - req-bc99c2b6-d254-4e14-9692-36687c7b318b
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-8a3d4058-bddd-4e0a-973d-7acab3f6a4b6
+      - req-bc99c2b6-d254-4e14-9692-36687c7b318b
       Date:
-      - Thu, 25 Oct 2018 18:19:48 GMT
+      - Thu, 01 Nov 2018 18:34:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:48 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:46 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -6481,13 +6481,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:19:49 GMT
+      - Thu, 01 Nov 2018 18:34:47 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-706ab195-1133-49a5-93df-754688904412
+      - req-f3fd6ee0-5c81-47d1-9b17-66b05d629088
       Content-Length:
       - '4170'
       Connection:
@@ -6496,10 +6496,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:19:49.633596", "expires":
-        "2018-10-25T19:19:49Z", "id": "c710bf5a31284eed950c2975bd5accf8", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:34:47.673063", "expires":
+        "2018-11-01T19:34:47Z", "id": "2f148ad1ac784d6b98dd4aba17f54056", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["iSi0RhTsSAyuh_-O04JGXA"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["e78DFp3yT0amyUmrPaGs-w"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -6544,7 +6544,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:49 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:47 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -6562,13 +6562,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:19:49 GMT
+      - Thu, 01 Nov 2018 18:34:47 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-17c6d2d4-3bee-4b88-9ca1-39a1d3fe482d
+      - req-b8d25bb4-b831-4bf4-8859-2261741066ce
       Content-Length:
       - '4170'
       Connection:
@@ -6577,10 +6577,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:19:49.820691", "expires":
-        "2018-10-25T19:19:49Z", "id": "c00676f2a36b4711afb2e2883cf4f448", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:34:47.884001", "expires":
+        "2018-11-01T19:34:47Z", "id": "db39214686914cf794fa96f1d40a782d", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["84aEVbnJS0GwAyDROTg2QQ"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["zTHdWzIUTdaSPGoY4LAq0w"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -6625,7 +6625,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:49 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:48 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/networks
@@ -6640,7 +6640,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c00676f2a36b4711afb2e2883cf4f448
+      - db39214686914cf794fa96f1d40a782d
   response:
     status:
       code: 200
@@ -6651,47 +6651,22 @@ http_interactions:
       Content-Length:
       - '5330'
       X-Openstack-Request-Id:
-      - req-dbb430f9-28e1-4d68-88db-09ab24ff3d3e
+      - req-d0339276-65fb-48ea-b252-b94fdc6de9a8
       Date:
-      - Thu, 25 Oct 2018 18:19:49 GMT
+      - Thu, 01 Nov 2018 18:34:48 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"networks": [{"status": "ACTIVE", "subnets": ["448a986a-19a9-4684-ab6e-25cbf19ae30d"],
-        "name": "EmsRefreshSpec-IsolatedNetworkPrivate_1", "provider:physical_network":
-        null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
-        "vxlan", "id": "560b4210-2b5a-4439-8d24-203e09478f48", "provider:segmentation_id":
-        54}, {"status": "ACTIVE", "subnets": ["68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "d71653c5-34d2-47bd-9cd2-d93330a34d44"], "name": "EmsRefreshSpec-NetworkPublic_50",
-        "provider:physical_network": "public_net_5", "admin_state_up": true, "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "mtu": 0, "router:external": true, "shared":
-        false, "provider:network_type": "flat", "id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "provider:segmentation_id": null}, {"status": "ACTIVE", "subnets": ["bb23bb48-804d-4416-bac3-231db23841e8"],
-        "name": "EmsRefreshSpec-NetworkPrivate_2", "provider:physical_network": null,
-        "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
-        0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
-        "id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "provider:segmentation_id":
-        53}, {"status": "ACTIVE", "subnets": ["841b5584-f86f-4abd-9bc2-f445b8bc860b",
-        "39628ee0-d5ff-4a88-ae66-80442e5feefd"], "name": "EmsRefreshSpec-NetworkPrivate_30",
-        "provider:physical_network": null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
-        "vxlan", "id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "provider:segmentation_id":
-        79}, {"status": "ACTIVE", "subnets": ["edfcb49b-e917-4897-b8ae-859ef3dae2de",
-        "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4"], "name": "EmsRefreshSpec-IsolatedNetworkPrivate_2",
-        "provider:physical_network": null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
-        "vxlan", "id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "provider:segmentation_id":
-        57}, {"status": "ACTIVE", "subnets": ["33da95a6-bded-44d8-be36-6cc97f3d72bd"],
-        "name": "EmsRefreshSpec-NetworkPublic", "provider:physical_network": "public_net_0",
-        "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
-        0, "router:external": true, "shared": false, "provider:network_type": "flat",
-        "id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "provider:segmentation_id":
-        null}, {"status": "ACTIVE", "subnets": ["2092b802-1034-4fb8-9c5e-1ec61d1e463f"],
+      string: '{"networks": [{"status": "ACTIVE", "subnets": ["2092b802-1034-4fb8-9c5e-1ec61d1e463f"],
         "name": "EmsRefreshSpec-NetworkPrivate_20", "provider:physical_network": null,
         "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
         0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
         "id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "provider:segmentation_id":
-        98}, {"status": "ACTIVE", "subnets": ["82ca5926-43cb-4312-a23f-727d5c0f5bae"],
+        98}, {"status": "ACTIVE", "subnets": ["826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
+        "edfcb49b-e917-4897-b8ae-859ef3dae2de"], "name": "EmsRefreshSpec-IsolatedNetworkPrivate_2",
+        "provider:physical_network": null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
+        "vxlan", "id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "provider:segmentation_id":
+        57}, {"status": "ACTIVE", "subnets": ["82ca5926-43cb-4312-a23f-727d5c0f5bae"],
         "name": "EmsRefreshSpec-NetworkPrivate_3", "provider:physical_network": null,
         "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
         0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
@@ -6716,14 +6691,39 @@ http_interactions:
         "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
         0, "router:external": true, "shared": false, "provider:network_type": "flat",
         "id": "64bf0546-b600-4bd7-a519-9353bde2e235", "provider:segmentation_id":
-        null}, {"status": "ACTIVE", "subnets": ["104c081f-97dd-42b7-8930-98abbd015c74",
-        "d53802a5-f0f6-48ba-9207-dbd9b13acac3"], "name": "EmsRefreshSpec-NetworkPrivate",
+        null}, {"status": "ACTIVE", "subnets": ["d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2"], "name": "EmsRefreshSpec-NetworkPublic_50",
+        "provider:physical_network": "public_net_5", "admin_state_up": true, "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "mtu": 0, "router:external": true, "shared":
+        false, "provider:network_type": "flat", "id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "provider:segmentation_id": null}, {"status": "ACTIVE", "subnets": ["448a986a-19a9-4684-ab6e-25cbf19ae30d"],
+        "name": "EmsRefreshSpec-IsolatedNetworkPrivate_1", "provider:physical_network":
+        null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
+        "vxlan", "id": "560b4210-2b5a-4439-8d24-203e09478f48", "provider:segmentation_id":
+        54}, {"status": "ACTIVE", "subnets": ["bb23bb48-804d-4416-bac3-231db23841e8"],
+        "name": "EmsRefreshSpec-NetworkPrivate_2", "provider:physical_network": null,
+        "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
+        0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
+        "id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "provider:segmentation_id":
+        53}, {"status": "ACTIVE", "subnets": ["841b5584-f86f-4abd-9bc2-f445b8bc860b",
+        "39628ee0-d5ff-4a88-ae66-80442e5feefd"], "name": "EmsRefreshSpec-NetworkPrivate_30",
+        "provider:physical_network": null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
+        "vxlan", "id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "provider:segmentation_id":
+        79}, {"status": "ACTIVE", "subnets": ["33da95a6-bded-44d8-be36-6cc97f3d72bd"],
+        "name": "EmsRefreshSpec-NetworkPublic", "provider:physical_network": "public_net_0",
+        "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
+        0, "router:external": true, "shared": false, "provider:network_type": "flat",
+        "id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "provider:segmentation_id":
+        null}, {"status": "ACTIVE", "subnets": ["d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "104c081f-97dd-42b7-8930-98abbd015c74"], "name": "EmsRefreshSpec-NetworkPrivate",
         "provider:physical_network": null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
         "vxlan", "id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "provider:segmentation_id":
         14}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:50 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:48 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -6741,13 +6741,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:19:50 GMT
+      - Thu, 01 Nov 2018 18:34:48 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-6f171535-ab54-4d7b-9393-f1aab731e954
+      - req-ec27a256-4f85-4768-9e7c-4cfe09afd39f
       Content-Length:
       - '4170'
       Connection:
@@ -6756,10 +6756,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:19:50.167206", "expires":
-        "2018-10-25T19:19:50Z", "id": "515b816976994cc883878b5f57d3ca9f", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:34:48.531111", "expires":
+        "2018-11-01T19:34:48Z", "id": "017c6e0859f8439e8c43b23799550eb6", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["YGZFPvPCRryapxW7vnDcqA"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["JoDc6Tb7QsmiblosymBQsA"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -6804,7 +6804,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:50 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:48 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -6822,13 +6822,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:19:50 GMT
+      - Thu, 01 Nov 2018 18:34:48 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-827a96c7-db72-4567-ab8d-c1ff405491f1
+      - req-7656418b-4b2f-4a4c-9d98-67b932aa1bf6
       Content-Length:
       - '370'
       Connection:
@@ -6837,13 +6837,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:19:50.338461", "expires":
-        "2018-10-25T19:19:50Z", "id": "1afae9d4979a4dcc8a5c9963d393e875", "audit_ids":
-        ["wVu9KUfiTuqSaV2ThvYayA"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:34:48.699286", "expires":
+        "2018-11-01T19:34:48Z", "id": "ef8939c7c2e9421d8cf1d2fa4daca3aa", "audit_ids":
+        ["9VUlGXV9SwiwdjKcEQa30Q"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:50 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:48 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -6858,20 +6858,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1afae9d4979a4dcc8a5c9963d393e875
+      - ef8939c7c2e9421d8cf1d2fa4daca3aa
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:19:50 GMT
+      - Thu, 01 Nov 2018 18:34:48 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-769503c2-d4cd-4642-9a08-adb6e2aac6d3
+      - req-f73580cd-4030-4baa-9d0e-832a93e1b1b4
       Content-Length:
       - '500'
       Connection:
@@ -6888,7 +6888,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:50 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:48 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -6906,13 +6906,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:19:50 GMT
+      - Thu, 01 Nov 2018 18:34:48 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-746fe68a-d6f1-4dd4-893c-2d5fc07a3c12
+      - req-858707a3-2471-4ac1-bc23-009aff433d40
       Content-Length:
       - '4117'
       Connection:
@@ -6921,10 +6921,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:19:50.640027", "expires":
-        "2018-10-25T19:19:50Z", "id": "2e5730110bca4db18e5fdb3fa3e97031", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:34:49.023084", "expires":
+        "2018-11-01T19:34:49Z", "id": "219d4f6086914b4f867a81f253ec86e1", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["sWyfOqydRq6pOmpMpZpLFw"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["AIpugJvET6KHRtbXDTaJkQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -6968,7 +6968,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:50 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:49 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -6986,13 +6986,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:19:50 GMT
+      - Thu, 01 Nov 2018 18:34:49 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-86571cd1-7dc4-4cae-a1fc-0aaac07482ad
+      - req-42339f1e-0bcd-42ed-a46b-dc9e839dbe47
       Content-Length:
       - '4131'
       Connection:
@@ -7001,10 +7001,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:19:50.839234", "expires":
-        "2018-10-25T19:19:50Z", "id": "7f9846d0695b499eba361131cc233a7e", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:34:49.207729", "expires":
+        "2018-11-01T19:34:49Z", "id": "55f7cef5aa6b452ba1f6e6afb14a050a", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["FXd9UtR_SBmhFuVFc35Fhw"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["-sHuWI0MQUiBnC7nsstQ0A"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -7048,7 +7048,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:50 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:49 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -7066,13 +7066,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:19:50 GMT
+      - Thu, 01 Nov 2018 18:34:49 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-9145744a-0607-4503-86e4-3fda11213a04
+      - req-ccc70e14-c049-4250-90fa-2b70f480d850
       Content-Length:
       - '4118'
       Connection:
@@ -7081,10 +7081,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:19:51.012569", "expires":
-        "2018-10-25T19:19:50Z", "id": "40da4be3ef4f4f5787bc3612db63aaf2", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:34:49.392488", "expires":
+        "2018-11-01T19:34:49Z", "id": "392017797fad424081cc4a5ba73a7287", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["1B_D2mHrS9Ck65QuqshFlQ"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["k-zZgivJSgKMmlbKJeKscw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -7128,7 +7128,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:51 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:49 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -7146,13 +7146,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:19:51 GMT
+      - Thu, 01 Nov 2018 18:34:49 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-ca6d7cb9-a08a-42c9-bbe2-a440082a3bfa
+      - req-126bdf6f-b68f-466c-af2e-2329bf03cf48
       Content-Length:
       - '4117'
       Connection:
@@ -7161,10 +7161,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:19:51.206661", "expires":
-        "2018-10-25T19:19:51Z", "id": "c0b5a41f987844e9b2e595b1426af26f", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:34:49.581659", "expires":
+        "2018-11-01T19:34:49Z", "id": "0fe5a5cbfb4e401cbaebac7d8b5c9bd0", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["B653Hiz8Sby-PGtgcu5cZw"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["rMbqGwsJSlGaIHMOm9aq5w"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -7208,7 +7208,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:51 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:49 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks?limit=1000&show_nested=true
@@ -7223,7 +7223,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c0b5a41f987844e9b2e595b1426af26f
+      - 0fe5a5cbfb4e401cbaebac7d8b5c9bd0
   response:
     status:
       code: 200
@@ -7234,9 +7234,9 @@ http_interactions:
       Content-Length:
       - '2559'
       X-Openstack-Request-Id:
-      - req-c1f927a3-799b-4d23-9b91-bec09b23b584
+      - req-d68a41c5-081b-4336-a20a-f919303bd8fe
       Date:
-      - Thu, 25 Oct 2018 18:19:51 GMT
+      - Thu, 01 Nov 2018 18:34:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": [{"description": "Heat WordPress template to support F20,
@@ -7270,7 +7270,7 @@ http_interactions:
         "rel": "self"}], "updated_time": null, "stack_owner": null, "stack_status":
         "CREATE_COMPLETE", "id": "091e1e54-e01c-4ec5-a0ab-b00bee4d425c"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:51 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:49 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks?limit=1000&marker=091e1e54-e01c-4ec5-a0ab-b00bee4d425c&show_nested=true
@@ -7285,7 +7285,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c0b5a41f987844e9b2e595b1426af26f
+      - 0fe5a5cbfb4e401cbaebac7d8b5c9bd0
   response:
     status:
       code: 200
@@ -7296,14 +7296,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-088beae6-16a1-4de0-a2cb-4b5f0956aeab
+      - req-e2ae2883-e95e-4b66-a322-390476eefa77
       Date:
-      - Thu, 25 Oct 2018 18:19:51 GMT
+      - Thu, 01 Nov 2018 18:34:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:51 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:49 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -7321,13 +7321,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:19:51 GMT
+      - Thu, 01 Nov 2018 18:34:50 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-04cafaea-3881-4e20-affb-1724bbb47d77
+      - req-8c8db87f-7366-4df1-830b-8f860d0661ed
       Content-Length:
       - '4131'
       Connection:
@@ -7336,10 +7336,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:19:51.695623", "expires":
-        "2018-10-25T19:19:51Z", "id": "1e65171cf4dd41648a2a879bf1465e2b", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:34:50.090432", "expires":
+        "2018-11-01T19:34:50Z", "id": "326175ccfcb5416e83a58668564686d5", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["D1snxlNqSUi7Bp1CjiGOKA"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["ebPnuojxScywDUXTTZCuFw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -7383,7 +7383,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:51 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:50 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/b458a5c25c3749758f4c0661940b3ba8/stacks?limit=1000&show_nested=true
@@ -7398,7 +7398,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1e65171cf4dd41648a2a879bf1465e2b
+      - 326175ccfcb5416e83a58668564686d5
   response:
     status:
       code: 200
@@ -7409,14 +7409,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-6ea27e57-9078-4279-a266-44bc3471aa35
+      - req-dfa649a6-3f4c-48ae-857f-5a16837c416f
       Date:
-      - Thu, 25 Oct 2018 18:19:51 GMT
+      - Thu, 01 Nov 2018 18:34:50 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:51 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:50 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/e54e5c3c19e34720b05661f2ea1ea00a/stacks?limit=1000&show_nested=true
@@ -7431,7 +7431,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 515b816976994cc883878b5f57d3ca9f
+      - 017c6e0859f8439e8c43b23799550eb6
   response:
     status:
       code: 200
@@ -7442,14 +7442,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-05bb874d-d6bf-4646-9b22-e83d8f81af7a
+      - req-a62c2043-41b2-43a2-a756-2f89afc81588
       Date:
-      - Thu, 25 Oct 2018 18:19:52 GMT
+      - Thu, 01 Nov 2018 18:34:50 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:52 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:50 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -7467,13 +7467,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:19:52 GMT
+      - Thu, 01 Nov 2018 18:34:50 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-2873bdf2-0be4-4c99-94f9-ba54f9edc5be
+      - req-679f1614-b95a-4249-8d86-4ca66d9a76fb
       Content-Length:
       - '4118'
       Connection:
@@ -7482,10 +7482,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:19:52.202145", "expires":
-        "2018-10-25T19:19:52Z", "id": "a4cdc680cfe944cabb1a7ccc0d372a29", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:34:50.614587", "expires":
+        "2018-11-01T19:34:50Z", "id": "aaed8132780e4700a8763586648dd7c3", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["35bQ-PsnSTaZ35DtKJI1Vg"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["7Vo7Pc8bS1eYbHex_LzcEw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -7529,7 +7529,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:52 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:50 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/e8f744b1fc6a487681d35fb275252608/stacks?limit=1000&show_nested=true
@@ -7544,7 +7544,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a4cdc680cfe944cabb1a7ccc0d372a29
+      - aaed8132780e4700a8763586648dd7c3
   response:
     status:
       code: 200
@@ -7555,14 +7555,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-8217e89b-b8bb-41ba-8a5c-b9368c4f702d
+      - req-1e63b23f-c01f-415c-819b-b2b522f61e8a
       Date:
-      - Thu, 25 Oct 2018 18:19:52 GMT
+      - Thu, 01 Nov 2018 18:34:50 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:52 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:50 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack3/45d2af82-eff9-4483-a1f0-f19c44d96146
@@ -7577,7 +7577,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c0b5a41f987844e9b2e595b1426af26f
+      - 0fe5a5cbfb4e401cbaebac7d8b5c9bd0
   response:
     status:
       code: 200
@@ -7588,9 +7588,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-7327f1d6-d68a-4bc0-a44e-913ac83c843c
+      - req-d7fc5987-3996-48df-b005-47258a50d908
       Date:
-      - Thu, 25 Oct 2018 18:19:52 GMT
+      - Thu, 01 Nov 2018 18:34:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -7617,7 +7617,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:52 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:51 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack2/4cf24b12-29fc-4529-a8ed-6b079dea7c17
@@ -7632,7 +7632,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c0b5a41f987844e9b2e595b1426af26f
+      - 0fe5a5cbfb4e401cbaebac7d8b5c9bd0
   response:
     status:
       code: 200
@@ -7643,9 +7643,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-e899aeb8-0e8e-48dd-a9ae-d924571d7812
+      - req-a1af832d-aa1c-4ab1-800a-53f67bf25d18
       Date:
-      - Thu, 25 Oct 2018 18:19:53 GMT
+      - Thu, 01 Nov 2018 18:34:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -7672,7 +7672,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:53 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:51 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c
@@ -7687,7 +7687,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c0b5a41f987844e9b2e595b1426af26f
+      - 0fe5a5cbfb4e401cbaebac7d8b5c9bd0
   response:
     status:
       code: 200
@@ -7698,9 +7698,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-40bc8db4-3c04-49e6-ac45-7a77d78b1d64
+      - req-6085dcac-7086-410e-8647-6ebbd1267a3b
       Date:
-      - Thu, 25 Oct 2018 18:19:53 GMT
+      - Thu, 01 Nov 2018 18:34:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -7727,7 +7727,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:53 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:51 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack3/45d2af82-eff9-4483-a1f0-f19c44d96146/resources
@@ -7742,7 +7742,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c0b5a41f987844e9b2e595b1426af26f
+      - 0fe5a5cbfb4e401cbaebac7d8b5c9bd0
   response:
     status:
       code: 200
@@ -7753,9 +7753,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-edee0b0a-22fc-41c5-9f81-ba94f32215c4
+      - req-3b81d225-dd16-4db2-a306-63c628a0e01a
       Date:
-      - Thu, 25 Oct 2018 18:19:53 GMT
+      - Thu, 01 Nov 2018 18:34:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -7767,7 +7767,7 @@ http_interactions:
         changed", "physical_resource_id": "aa5907f3-8209-4dd0-b3ef-600431d85bac",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:53 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:52 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack2/4cf24b12-29fc-4529-a8ed-6b079dea7c17/resources
@@ -7782,7 +7782,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c0b5a41f987844e9b2e595b1426af26f
+      - 0fe5a5cbfb4e401cbaebac7d8b5c9bd0
   response:
     status:
       code: 200
@@ -7793,9 +7793,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-48f512d4-a8dd-4531-be32-fc37c348506f
+      - req-112b3b6a-735a-4aa0-8073-1a4ee2c26d5f
       Date:
-      - Thu, 25 Oct 2018 18:19:53 GMT
+      - Thu, 01 Nov 2018 18:34:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -7807,7 +7807,7 @@ http_interactions:
         changed", "physical_resource_id": "219a737c-b4ad-430d-944a-a92a4834b12d",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:53 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:52 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c/resources
@@ -7822,7 +7822,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c0b5a41f987844e9b2e595b1426af26f
+      - 0fe5a5cbfb4e401cbaebac7d8b5c9bd0
   response:
     status:
       code: 200
@@ -7833,9 +7833,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-219018b4-7c2f-486d-90b9-2cb1d96ba196
+      - req-0ac0e934-3719-4b39-9038-535f0cd4a5b6
       Date:
-      - Thu, 25 Oct 2018 18:19:53 GMT
+      - Thu, 01 Nov 2018 18:34:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -7847,7 +7847,7 @@ http_interactions:
         changed", "physical_resource_id": "b686353f-0da0-48bf-bc35-8ea411a67dfd",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:53 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:52 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -7865,13 +7865,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:19:53 GMT
+      - Thu, 01 Nov 2018 18:34:52 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-4d3960b3-234d-4a3d-8506-4a32c54c4c70
+      - req-5eec7c4b-7edb-42c9-83a1-dcc8834918a6
       Content-Length:
       - '4117'
       Connection:
@@ -7880,10 +7880,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:19:53.903407", "expires":
-        "2018-10-25T19:19:53Z", "id": "b14072875c534709aa7e0b490b9bb464", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:34:52.473871", "expires":
+        "2018-11-01T19:34:52Z", "id": "f33e43b955eb43e69dbf6d7756595151", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["0AwPuKr2S0ma4TtD_tourw"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["WR1o0ayXS9SeOsok_AXcfw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -7927,7 +7927,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:53 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:52 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -7942,7 +7942,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b14072875c534709aa7e0b490b9bb464
+      - f33e43b955eb43e69dbf6d7756595151
   response:
     status:
       code: 200
@@ -7953,17 +7953,167 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-f36f29e3-bcc2-44f8-abd1-49aadf7ec33e
+      - req-507d834f-c13a-45ab-b055-dc4270df8389
       Date:
-      - Thu, 25 Oct 2018 18:19:54 GMT
+      - Thu, 01 Nov 2018 18:34:52 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.50.4", "end": "192.168.50.4"}, {"start":
-        "192.168.50.2", "end": "192.168.50.2"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 01 Nov 2018 18:34:52 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - f33e43b955eb43e69dbf6d7756595151
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-1c3bce99-eb44-4b3c-a506-0e11684c3b1a
+      Date:
+      - Thu, 01 Nov 2018 18:34:52 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2",
+        "end": "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
         true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
@@ -8028,24 +8178,6 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
         "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
-        false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
-        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
@@ -8059,7 +8191,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:54 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:52 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
@@ -8074,7 +8206,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b14072875c534709aa7e0b490b9bb464
+      - f33e43b955eb43e69dbf6d7756595151
   response:
     status:
       code: 200
@@ -8085,9 +8217,669 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-c737967a-264e-4d35-9cd0-c3b4983b4e4a
+      - req-dd3fbcaf-fb7c-45bf-87a7-ef420d5800a5
       Date:
-      - Thu, 25 Oct 2018 18:19:54 GMT
+      - Thu, 01 Nov 2018 18:34:52 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 01 Nov 2018 18:34:53 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - f33e43b955eb43e69dbf6d7756595151
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-f5836017-cb36-40f4-bf0d-b97978814062
+      Date:
+      - Thu, 01 Nov 2018 18:34:53 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2",
+        "end": "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 01 Nov 2018 18:34:53 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - f33e43b955eb43e69dbf6d7756595151
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-591369a4-2b1a-47a9-9103-03dec89350c7
+      Date:
+      - Thu, 01 Nov 2018 18:34:53 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 01 Nov 2018 18:34:53 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - f33e43b955eb43e69dbf6d7756595151
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-52b02ce2-0152-4e68-9c80-78f04e1ca561
+      Date:
+      - Thu, 01 Nov 2018 18:34:53 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2",
+        "end": "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 01 Nov 2018 18:34:53 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - f33e43b955eb43e69dbf6d7756595151
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-24c1bd01-e11f-4920-96fb-f70d09c1ee9b
+      Date:
+      - Thu, 01 Nov 2018 18:34:53 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 01 Nov 2018 18:34:53 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - f33e43b955eb43e69dbf6d7756595151
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-ee1f0bf3-645a-4003-9aa7-b8b8f837c15a
+      Date:
+      - Thu, 01 Nov 2018 18:34:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
@@ -8191,535 +8983,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
         "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:54 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - b14072875c534709aa7e0b490b9bb464
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-a75cd3b8-ed60-49e4-a3a1-0a09da1656d6
-      Date:
-      - Thu, 25 Oct 2018 18:19:54 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2",
-        "end": "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:54 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - b14072875c534709aa7e0b490b9bb464
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-0c0d9616-01ab-4a15-9e06-a59f19947f18
-      Date:
-      - Thu, 25 Oct 2018 18:19:54 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp":
-        true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:54 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - b14072875c534709aa7e0b490b9bb464
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-98645e4e-70c2-43b4-9251-c34efbe9e941
-      Date:
-      - Thu, 25 Oct 2018 18:19:54 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.50.4", "end": "192.168.50.4"}, {"start":
-        "192.168.50.2", "end": "192.168.50.2"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
-        false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
-        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:54 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - b14072875c534709aa7e0b490b9bb464
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-d1ac5085-dc64-4f63-a4b9-91f97734ae93
-      Date:
-      - Thu, 25 Oct 2018 18:19:54 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2",
-        "end": "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:54 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:53 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -8737,13 +9001,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:19:55 GMT
+      - Thu, 01 Nov 2018 18:34:54 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-1dc3ef0b-af91-4815-b296-29123a73a6ca
+      - req-19c980ca-ae4b-4d40-b2c2-0ecc17bf4641
       Content-Length:
       - '4131'
       Connection:
@@ -8752,10 +9016,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:19:55.160109", "expires":
-        "2018-10-25T19:19:55Z", "id": "05b69b73edb74f5f90b6052c63aed25f", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:34:54.073678", "expires":
+        "2018-11-01T19:34:54Z", "id": "59c9705af20542b29bf1e7fa152f9ca1", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["XcX_b2VdRwiw1X4prQlzyA"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["a0hGTwUmRzeBXkZexArQ6Q"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -8799,7 +9063,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:55 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:54 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -8814,7 +9078,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 05b69b73edb74f5f90b6052c63aed25f
+      - 59c9705af20542b29bf1e7fa152f9ca1
   response:
     status:
       code: 200
@@ -8825,141 +9089,9 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-9a068cbd-aa68-4cc0-804f-562f545414c9
+      - req-31f7ceb8-d313-45f5-8e02-96eebe108f9b
       Date:
-      - Thu, 25 Oct 2018 18:19:55 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.50.4", "end": "192.168.50.4"}, {"start":
-        "192.168.50.2", "end": "192.168.50.2"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
-        false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
-        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:55 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 05b69b73edb74f5f90b6052c63aed25f
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-446492fb-2442-4bdb-8d96-c7861666471b
-      Date:
-      - Thu, 25 Oct 2018 18:19:55 GMT
+      - Thu, 01 Nov 2018 18:34:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
@@ -9063,10 +9195,10 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:55 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:54 GMT
 - request:
     method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
     body:
       encoding: US-ASCII
       string: ''
@@ -9078,7 +9210,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c00676f2a36b4711afb2e2883cf4f448
+      - 59c9705af20542b29bf1e7fa152f9ca1
   response:
     status:
       code: 200
@@ -9089,17 +9221,52 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-7dffae33-e074-4efc-b0f7-db085ca2728d
+      - req-23741fa6-594e-409f-8d01-8e920f81f24b
       Date:
-      - Thu, 25 Oct 2018 18:19:55 GMT
+      - Thu, 01 Nov 2018 18:34:54 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.50.4", "end": "192.168.50.4"}, {"start":
-        "192.168.50.2", "end": "192.168.50.2"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
         true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
@@ -9147,23 +9314,67 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
         "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 01 Nov 2018 18:34:54 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 59c9705af20542b29bf1e7fa152f9ca1
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-8768fefe-e63d-4847-a971-f3eaf372122a
+      Date:
+      - Thu, 01 Nov 2018 18:34:54 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
@@ -9176,29 +9387,82 @@ http_interactions:
         "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
         "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
-        false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
-        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
         "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:55 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:54 GMT
 - request:
     method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
     body:
       encoding: US-ASCII
       string: ''
@@ -9210,7 +9474,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c00676f2a36b4711afb2e2883cf4f448
+      - db39214686914cf794fa96f1d40a782d
   response:
     status:
       code: 200
@@ -9221,9 +9485,9 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-400bf2ff-d98d-4c47-a538-b83da158a40d
+      - req-ef470955-a862-45b0-a4e8-1dac74643071
       Date:
-      - Thu, 25 Oct 2018 18:19:55 GMT
+      - Thu, 01 Nov 2018 18:34:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
@@ -9327,90 +9591,10 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:55 GMT
-- request:
-    method: post
-    uri: http://11.22.33.44:5000/v2.0/tokens
-    body:
-      encoding: UTF-8
-      string: '{"auth":{"passwordCredentials":{"username":"admin","password":"password_2WpEraURh"},"tenantName":"EmsRefreshSpec-Project2"}}'
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 25 Oct 2018 18:19:56 GMT
-      Server:
-      - Apache/2.4.6 (Red Hat Enterprise Linux)
-      Vary:
-      - X-Auth-Token,Accept-Encoding
-      X-Openstack-Request-Id:
-      - req-067f65cb-d092-45f0-9702-771a640b86a0
-      Content-Length:
-      - '4118'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:19:56.089454", "expires":
-        "2018-10-25T19:19:56Z", "id": "32c84fe7b8934b1ab14b2edd8e75269b", "tenant":
-        {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["yT5RIpZhRJ2prS1189dYag"]},
-        "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
-        "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
-        "endpoints_links": [], "type": "compute", "name": "nova"}, {"endpoints": [{"adminURL":
-        "http://10.8.99.233:9696", "region": "RegionOne", "internalURL": "http://10.8.99.233:9696",
-        "id": "5b097055aff24a40aa4cd2d7317c9108", "publicURL": "http://10.8.99.233:9696"}],
-        "endpoints_links": [], "type": "network", "name": "neutron"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608",
-        "id": "13c4208d548d4bcdaedfe8296b6559ee", "publicURL": "http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608"}],
-        "endpoints_links": [], "type": "volumev2", "name": "cinderv2"}, {"endpoints":
-        [{"adminURL": "http://127.0.0.1:8774/v3", "region": "RegionOne", "internalURL":
-        "http://127.0.0.1:8774/v3", "id": "3874f107e1a0461596883a12743dbcc0", "publicURL":
-        "http://127.0.0.1:8774/v3"}], "endpoints_links": [], "type": "computev3",
-        "name": "novav3"}, {"endpoints": [{"adminURL": "http://10.8.99.233:9292",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:9292", "id": "75fcb24891654062ae1703e6b92f6018",
-        "publicURL": "http://10.8.99.233:9292"}], "endpoints_links": [], "type": "image",
-        "name": "glance"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8777",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8777", "id": "2c972a2880d1453aad86104dcda88a55",
-        "publicURL": "http://10.8.99.233:8777"}], "endpoints_links": [], "type": "metering",
-        "name": "ceilometer"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8776/v1/e8f744b1fc6a487681d35fb275252608",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v1/e8f744b1fc6a487681d35fb275252608",
-        "id": "410c753013fb430c9998f22f68c4cb18", "publicURL": "http://10.8.99.233:8776/v1/e8f744b1fc6a487681d35fb275252608"}],
-        "endpoints_links": [], "type": "volume", "name": "cinder"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8773/services/Admin", "region": "RegionOne",
-        "internalURL": "http://10.8.99.233:8773/services/Cloud", "id": "2833b001aa814ddf9216479d379cdac1",
-        "publicURL": "http://10.8.99.233:8773/services/Cloud"}], "endpoints_links":
-        [], "type": "ec2", "name": "nova_ec2"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8004/v1/e8f744b1fc6a487681d35fb275252608",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8004/v1/e8f744b1fc6a487681d35fb275252608",
-        "id": "a29a931a5667478c8b3724506a286144", "publicURL": "http://10.8.99.233:8004/v1/e8f744b1fc6a487681d35fb275252608"}],
-        "endpoints_links": [], "type": "orchestration", "name": "heat"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8080", "region": "RegionOne", "internalURL":
-        "http://10.8.99.233:8080/v1/AUTH_e8f744b1fc6a487681d35fb275252608", "id":
-        "7a2262abf515414ea08b3beedc87e51e", "publicURL": "http://10.8.99.233:8080/v1/AUTH_e8f744b1fc6a487681d35fb275252608"}],
-        "endpoints_links": [], "type": "object-store", "name": "swift"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:35357/v2.0", "region": "RegionOne", "internalURL":
-        "http://10.8.99.233:5000/v2.0", "id": "5d1b7edf24e14ce29abaeee69e84e529",
-        "publicURL": "http://10.8.99.233:5000/v2.0"}], "endpoints_links": [], "type":
-        "identity", "name": "keystone"}], "user": {"username": "admin", "roles_links":
-        [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
-        {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
-        0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:56 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:54 GMT
 - request:
     method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
     body:
       encoding: US-ASCII
       string: ''
@@ -9422,7 +9606,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 32c84fe7b8934b1ab14b2edd8e75269b
+      - db39214686914cf794fa96f1d40a782d
   response:
     status:
       code: 200
@@ -9433,9 +9617,9 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-23b6ddbc-66fd-40d2-bbe5-d66ea8f59799
+      - req-aa6afba8-099d-4226-a40f-82c8e66dc9c3
       Date:
-      - Thu, 25 Oct 2018 18:19:56 GMT
+      - Thu, 01 Nov 2018 18:34:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
@@ -9539,7 +9723,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
         "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:56 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:55 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
@@ -9554,7 +9738,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 32c84fe7b8934b1ab14b2edd8e75269b
+      - db39214686914cf794fa96f1d40a782d
   response:
     status:
       code: 200
@@ -9565,13 +9749,243 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-bca64676-ef58-428a-8ac1-cbd6cab9caca
+      - req-f1db24fd-3500-43ac-850d-14af79b2c2b2
       Date:
-      - Thu, 25 Oct 2018 18:19:56 GMT
+      - Thu, 01 Nov 2018 18:34:55 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp":
-        true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 01 Nov 2018 18:34:55 GMT
+- request:
+    method: post
+    uri: http://11.22.33.44:5000/v2.0/tokens
+    body:
+      encoding: UTF-8
+      string: '{"auth":{"passwordCredentials":{"username":"admin","password":"password_2WpEraURh"},"tenantName":"EmsRefreshSpec-Project2"}}'
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 01 Nov 2018 18:34:55 GMT
+      Server:
+      - Apache/2.4.6 (Red Hat Enterprise Linux)
+      Vary:
+      - X-Auth-Token,Accept-Encoding
+      X-Openstack-Request-Id:
+      - req-bf61401b-dcaa-4917-a2f8-cfeb3c471aa2
+      Content-Length:
+      - '4118'
+      Connection:
+      - close
+      Content-Type:
+      - application/json
+    body:
+      encoding: ASCII-8BIT
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:34:55.420623", "expires":
+        "2018-11-01T19:34:55Z", "id": "7199b530fd514749b7ae7e06dc997112", "tenant":
+        {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["mJRNHpvaRqCpx76MvwK93Q"]},
+        "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
+        "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
+        "endpoints_links": [], "type": "compute", "name": "nova"}, {"endpoints": [{"adminURL":
+        "http://10.8.99.233:9696", "region": "RegionOne", "internalURL": "http://10.8.99.233:9696",
+        "id": "5b097055aff24a40aa4cd2d7317c9108", "publicURL": "http://10.8.99.233:9696"}],
+        "endpoints_links": [], "type": "network", "name": "neutron"}, {"endpoints":
+        [{"adminURL": "http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608",
+        "id": "13c4208d548d4bcdaedfe8296b6559ee", "publicURL": "http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608"}],
+        "endpoints_links": [], "type": "volumev2", "name": "cinderv2"}, {"endpoints":
+        [{"adminURL": "http://127.0.0.1:8774/v3", "region": "RegionOne", "internalURL":
+        "http://127.0.0.1:8774/v3", "id": "3874f107e1a0461596883a12743dbcc0", "publicURL":
+        "http://127.0.0.1:8774/v3"}], "endpoints_links": [], "type": "computev3",
+        "name": "novav3"}, {"endpoints": [{"adminURL": "http://10.8.99.233:9292",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:9292", "id": "75fcb24891654062ae1703e6b92f6018",
+        "publicURL": "http://10.8.99.233:9292"}], "endpoints_links": [], "type": "image",
+        "name": "glance"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8777",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:8777", "id": "2c972a2880d1453aad86104dcda88a55",
+        "publicURL": "http://10.8.99.233:8777"}], "endpoints_links": [], "type": "metering",
+        "name": "ceilometer"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8776/v1/e8f744b1fc6a487681d35fb275252608",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v1/e8f744b1fc6a487681d35fb275252608",
+        "id": "410c753013fb430c9998f22f68c4cb18", "publicURL": "http://10.8.99.233:8776/v1/e8f744b1fc6a487681d35fb275252608"}],
+        "endpoints_links": [], "type": "volume", "name": "cinder"}, {"endpoints":
+        [{"adminURL": "http://10.8.99.233:8773/services/Admin", "region": "RegionOne",
+        "internalURL": "http://10.8.99.233:8773/services/Cloud", "id": "2833b001aa814ddf9216479d379cdac1",
+        "publicURL": "http://10.8.99.233:8773/services/Cloud"}], "endpoints_links":
+        [], "type": "ec2", "name": "nova_ec2"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8004/v1/e8f744b1fc6a487681d35fb275252608",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:8004/v1/e8f744b1fc6a487681d35fb275252608",
+        "id": "a29a931a5667478c8b3724506a286144", "publicURL": "http://10.8.99.233:8004/v1/e8f744b1fc6a487681d35fb275252608"}],
+        "endpoints_links": [], "type": "orchestration", "name": "heat"}, {"endpoints":
+        [{"adminURL": "http://10.8.99.233:8080", "region": "RegionOne", "internalURL":
+        "http://10.8.99.233:8080/v1/AUTH_e8f744b1fc6a487681d35fb275252608", "id":
+        "7a2262abf515414ea08b3beedc87e51e", "publicURL": "http://10.8.99.233:8080/v1/AUTH_e8f744b1fc6a487681d35fb275252608"}],
+        "endpoints_links": [], "type": "object-store", "name": "swift"}, {"endpoints":
+        [{"adminURL": "http://10.8.99.233:35357/v2.0", "region": "RegionOne", "internalURL":
+        "http://10.8.99.233:5000/v2.0", "id": "5d1b7edf24e14ce29abaeee69e84e529",
+        "publicURL": "http://10.8.99.233:5000/v2.0"}], "endpoints_links": [], "type":
+        "identity", "name": "keystone"}], "user": {"username": "admin", "roles_links":
+        [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
+        {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
+        0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
+    http_version: 
+  recorded_at: Thu, 01 Nov 2018 18:34:55 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 7199b530fd514749b7ae7e06dc997112
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-1067f59d-c67a-4036-939b-0d6ec97b6e96
+      Date:
+      - Thu, 01 Nov 2018 18:34:55 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
@@ -9640,6 +10054,114 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
         "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 01 Nov 2018 18:34:55 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 7199b530fd514749b7ae7e06dc997112
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-cb8ded42-73d3-41a3-a8ac-1c292307773e
+      Date:
+      - Thu, 01 Nov 2018 18:34:55 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
         false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
@@ -9658,6 +10180,12 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
         "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
         "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
@@ -9671,7 +10199,7 @@ http_interactions:
         4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
         "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:56 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:55 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?limit=1000
@@ -9686,7 +10214,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b14072875c534709aa7e0b490b9bb464
+      - f33e43b955eb43e69dbf6d7756595151
   response:
     status:
       code: 200
@@ -9697,9 +10225,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-669d20ec-b3eb-41b9-9aaa-d9651a983244
+      - req-d80a801a-5629-4fed-9bdc-061921ee30db
       Date:
-      - Thu, 25 Oct 2018 18:19:56 GMT
+      - Thu, 01 Nov 2018 18:34:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -9741,7 +10269,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:56 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:55 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?limit=1000&marker=ee601a91-f6ac-4a46-a599-87cfd83094a3
@@ -9756,7 +10284,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b14072875c534709aa7e0b490b9bb464
+      - f33e43b955eb43e69dbf6d7756595151
   response:
     status:
       code: 200
@@ -9767,9 +10295,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-482ee67d-03c9-47d2-8810-c8a04d2432d1
+      - req-269b659b-3a53-4d51-9a68-663f744af18c
       Date:
-      - Thu, 25 Oct 2018 18:19:56 GMT
+      - Thu, 01 Nov 2018 18:34:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -9811,7 +10339,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:56 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:56 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?limit=1000
@@ -9826,7 +10354,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 05b69b73edb74f5f90b6052c63aed25f
+      - 59c9705af20542b29bf1e7fa152f9ca1
   response:
     status:
       code: 200
@@ -9837,9 +10365,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-e08da2ea-93df-4249-98ed-a0397d7b862a
+      - req-29f65385-3a70-4c56-8da3-00503e139f06
       Date:
-      - Thu, 25 Oct 2018 18:19:56 GMT
+      - Thu, 01 Nov 2018 18:34:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -9881,7 +10409,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:56 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:56 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?limit=1000&marker=ee601a91-f6ac-4a46-a599-87cfd83094a3
@@ -9896,7 +10424,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 05b69b73edb74f5f90b6052c63aed25f
+      - 59c9705af20542b29bf1e7fa152f9ca1
   response:
     status:
       code: 200
@@ -9907,9 +10435,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-ec6ed3b7-9358-4b91-9bfb-94e15619cb22
+      - req-5ba301a8-11c9-48dd-9117-6a8b23c458e8
       Date:
-      - Thu, 25 Oct 2018 18:19:56 GMT
+      - Thu, 01 Nov 2018 18:34:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -9951,7 +10479,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:56 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:56 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?limit=1000
@@ -9966,7 +10494,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c00676f2a36b4711afb2e2883cf4f448
+      - db39214686914cf794fa96f1d40a782d
   response:
     status:
       code: 200
@@ -9977,9 +10505,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-1d3baa5b-56e2-468b-bb70-7101f0dc546d
+      - req-e348bdd3-ee80-43b3-8974-99e78b42cbfd
       Date:
-      - Thu, 25 Oct 2018 18:19:56 GMT
+      - Thu, 01 Nov 2018 18:34:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -10021,7 +10549,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:56 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:56 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?limit=1000&marker=ee601a91-f6ac-4a46-a599-87cfd83094a3
@@ -10036,7 +10564,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c00676f2a36b4711afb2e2883cf4f448
+      - db39214686914cf794fa96f1d40a782d
   response:
     status:
       code: 200
@@ -10047,9 +10575,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-2e409eee-6640-41f2-9eec-a0371ce3296e
+      - req-16f2819a-29cb-49b1-99d9-213dc6da6bc9
       Date:
-      - Thu, 25 Oct 2018 18:19:57 GMT
+      - Thu, 01 Nov 2018 18:34:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -10091,7 +10619,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:57 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:56 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?limit=1000
@@ -10106,7 +10634,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 32c84fe7b8934b1ab14b2edd8e75269b
+      - 7199b530fd514749b7ae7e06dc997112
   response:
     status:
       code: 200
@@ -10117,9 +10645,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-edb4a9fa-5ec9-4bb5-8589-35fdd99e5960
+      - req-a548b6b7-3367-4a66-8fbf-4221b42eed8a
       Date:
-      - Thu, 25 Oct 2018 18:19:57 GMT
+      - Thu, 01 Nov 2018 18:34:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -10161,7 +10689,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:57 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:56 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?limit=1000&marker=ee601a91-f6ac-4a46-a599-87cfd83094a3
@@ -10176,7 +10704,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 32c84fe7b8934b1ab14b2edd8e75269b
+      - 7199b530fd514749b7ae7e06dc997112
   response:
     status:
       code: 200
@@ -10187,9 +10715,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-edbd9ef5-4017-4da5-9092-5cdb746af183
+      - req-3a6d970d-8a61-463a-bc98-00b6b242d011
       Date:
-      - Thu, 25 Oct 2018 18:19:57 GMT
+      - Thu, 01 Nov 2018 18:34:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -10231,7 +10759,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:57 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:56 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?limit=1000
@@ -10246,7 +10774,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b14072875c534709aa7e0b490b9bb464
+      - f33e43b955eb43e69dbf6d7756595151
   response:
     status:
       code: 200
@@ -10257,9 +10785,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-fa2d88d3-121a-409e-855d-d9b7077c5a82
+      - req-32a97c0b-03b9-42b7-8600-e64a0a8fa887
       Date:
-      - Thu, 25 Oct 2018 18:19:57 GMT
+      - Thu, 01 Nov 2018 18:34:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -10662,7 +11190,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:57 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:56 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?limit=1000&marker=dee8791c-23b3-4e65-846d-49aeaba18036
@@ -10677,7 +11205,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b14072875c534709aa7e0b490b9bb464
+      - f33e43b955eb43e69dbf6d7756595151
   response:
     status:
       code: 200
@@ -10688,9 +11216,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-6fdbb830-46a2-4994-94ee-68e6c3e42da8
+      - req-e2d90ecd-a4bc-4461-9447-9c0f210ab8b5
       Date:
-      - Thu, 25 Oct 2018 18:19:57 GMT
+      - Thu, 01 Nov 2018 18:34:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -11093,7 +11621,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:57 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:57 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?limit=1000
@@ -11108,7 +11636,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 05b69b73edb74f5f90b6052c63aed25f
+      - 59c9705af20542b29bf1e7fa152f9ca1
   response:
     status:
       code: 200
@@ -11119,9 +11647,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-72a92c85-eecc-44e2-8416-975470c735a9
+      - req-daa65d50-4ada-4487-bfae-d2ae5fd058bc
       Date:
-      - Thu, 25 Oct 2018 18:19:57 GMT
+      - Thu, 01 Nov 2018 18:34:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -11524,7 +12052,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:57 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:57 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?limit=1000&marker=dee8791c-23b3-4e65-846d-49aeaba18036
@@ -11539,7 +12067,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 05b69b73edb74f5f90b6052c63aed25f
+      - 59c9705af20542b29bf1e7fa152f9ca1
   response:
     status:
       code: 200
@@ -11550,9 +12078,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-c714a13e-32b8-46cf-8ecc-8897c7f1aab6
+      - req-2ddee4de-d2c1-403e-b290-9a7ebef6994d
       Date:
-      - Thu, 25 Oct 2018 18:19:57 GMT
+      - Thu, 01 Nov 2018 18:34:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -11955,7 +12483,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:58 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:57 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?limit=1000
@@ -11970,7 +12498,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c00676f2a36b4711afb2e2883cf4f448
+      - db39214686914cf794fa96f1d40a782d
   response:
     status:
       code: 200
@@ -11981,9 +12509,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-dd27990d-945e-4a50-ac9b-e694e2a935a5
+      - req-706226ab-7ef9-4d45-8c90-4c60d9d3add7
       Date:
-      - Thu, 25 Oct 2018 18:19:58 GMT
+      - Thu, 01 Nov 2018 18:34:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -12386,7 +12914,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:58 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:57 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?limit=1000&marker=dee8791c-23b3-4e65-846d-49aeaba18036
@@ -12401,7 +12929,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c00676f2a36b4711afb2e2883cf4f448
+      - db39214686914cf794fa96f1d40a782d
   response:
     status:
       code: 200
@@ -12412,9 +12940,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-a88f9555-e355-4320-bd31-b6bb28d3b880
+      - req-ea52206e-45bd-4271-81bd-8aa13cdb8fc8
       Date:
-      - Thu, 25 Oct 2018 18:19:58 GMT
+      - Thu, 01 Nov 2018 18:34:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -12817,7 +13345,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:58 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:57 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?limit=1000
@@ -12832,7 +13360,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 32c84fe7b8934b1ab14b2edd8e75269b
+      - 7199b530fd514749b7ae7e06dc997112
   response:
     status:
       code: 200
@@ -12843,9 +13371,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-ce486ac3-4aa2-4671-bf6a-01a475feba70
+      - req-77ffba4d-8ff8-4e36-a572-a881967b010f
       Date:
-      - Thu, 25 Oct 2018 18:19:58 GMT
+      - Thu, 01 Nov 2018 18:34:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -13248,7 +13776,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:58 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:58 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?limit=1000&marker=dee8791c-23b3-4e65-846d-49aeaba18036
@@ -13263,7 +13791,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 32c84fe7b8934b1ab14b2edd8e75269b
+      - 7199b530fd514749b7ae7e06dc997112
   response:
     status:
       code: 200
@@ -13274,9 +13802,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-3137a566-9038-4e84-8bc3-5113165679f8
+      - req-492c1d13-6d3d-4091-9219-1e847b34ef1d
       Date:
-      - Thu, 25 Oct 2018 18:19:59 GMT
+      - Thu, 01 Nov 2018 18:34:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -13679,7 +14207,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:59 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:58 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?limit=1000
@@ -13694,7 +14222,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b14072875c534709aa7e0b490b9bb464
+      - f33e43b955eb43e69dbf6d7756595151
   response:
     status:
       code: 200
@@ -13705,9 +14233,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-3171b301-1333-4ff5-b5de-16d5038e6c1e
+      - req-74139585-babb-4ef8-af36-98f83dfbab18
       Date:
-      - Thu, 25 Oct 2018 18:19:59 GMT
+      - Thu, 01 Nov 2018 18:34:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -13739,7 +14267,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:59 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:58 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?limit=1000&marker=a41c036a-c34e-454b-851d-5eefd03888cb
@@ -13754,7 +14282,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b14072875c534709aa7e0b490b9bb464
+      - f33e43b955eb43e69dbf6d7756595151
   response:
     status:
       code: 200
@@ -13765,9 +14293,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-35684edf-cbbf-4603-b0e1-e0c6973ace13
+      - req-612f3bbe-64ff-4e18-921d-58714216ff29
       Date:
-      - Thu, 25 Oct 2018 18:19:59 GMT
+      - Thu, 01 Nov 2018 18:34:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -13799,7 +14327,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:59 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:58 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?limit=1000
@@ -13814,7 +14342,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 05b69b73edb74f5f90b6052c63aed25f
+      - 59c9705af20542b29bf1e7fa152f9ca1
   response:
     status:
       code: 200
@@ -13825,9 +14353,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-f845a0e0-8600-41bf-a751-11d8c1551c53
+      - req-4dd38460-209f-4075-8281-4e9a07e60d52
       Date:
-      - Thu, 25 Oct 2018 18:19:59 GMT
+      - Thu, 01 Nov 2018 18:34:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -13859,7 +14387,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:59 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:58 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?limit=1000&marker=a41c036a-c34e-454b-851d-5eefd03888cb
@@ -13874,7 +14402,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 05b69b73edb74f5f90b6052c63aed25f
+      - 59c9705af20542b29bf1e7fa152f9ca1
   response:
     status:
       code: 200
@@ -13885,9 +14413,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-ef2605d2-71e6-47b7-bdb4-757cc7b385af
+      - req-27d56c4e-8750-4cda-babe-d89233a6c901
       Date:
-      - Thu, 25 Oct 2018 18:19:59 GMT
+      - Thu, 01 Nov 2018 18:34:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -13919,7 +14447,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:59 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:58 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?limit=1000
@@ -13934,7 +14462,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c00676f2a36b4711afb2e2883cf4f448
+      - db39214686914cf794fa96f1d40a782d
   response:
     status:
       code: 200
@@ -13945,9 +14473,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-1c5cbd5c-e6c0-4455-8688-65bb779491ce
+      - req-4b7c8c6b-6298-477e-957b-d79f3b11ec26
       Date:
-      - Thu, 25 Oct 2018 18:19:59 GMT
+      - Thu, 01 Nov 2018 18:34:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -13979,7 +14507,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:59 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:58 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?limit=1000&marker=a41c036a-c34e-454b-851d-5eefd03888cb
@@ -13994,7 +14522,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c00676f2a36b4711afb2e2883cf4f448
+      - db39214686914cf794fa96f1d40a782d
   response:
     status:
       code: 200
@@ -14005,9 +14533,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-a9de086a-512f-4cc3-8333-054755540c53
+      - req-288ccb3e-d3c9-4b1a-afd0-c04430cf1ebd
       Date:
-      - Thu, 25 Oct 2018 18:19:59 GMT
+      - Thu, 01 Nov 2018 18:34:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -14039,7 +14567,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:59 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:59 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?limit=1000
@@ -14054,7 +14582,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 32c84fe7b8934b1ab14b2edd8e75269b
+      - 7199b530fd514749b7ae7e06dc997112
   response:
     status:
       code: 200
@@ -14065,9 +14593,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-80557530-9ffa-471c-b7d9-f5ab6d79af3e
+      - req-4716c979-efa7-466e-ae44-687a37dcc2a5
       Date:
-      - Thu, 25 Oct 2018 18:19:59 GMT
+      - Thu, 01 Nov 2018 18:34:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -14099,7 +14627,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:59 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:59 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?limit=1000&marker=a41c036a-c34e-454b-851d-5eefd03888cb
@@ -14114,7 +14642,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 32c84fe7b8934b1ab14b2edd8e75269b
+      - 7199b530fd514749b7ae7e06dc997112
   response:
     status:
       code: 200
@@ -14125,9 +14653,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-b47d3514-692f-4d18-b08a-d1f799f3db89
+      - req-8db73766-044d-48ea-8dcb-ec63f873c75e
       Date:
-      - Thu, 25 Oct 2018 18:20:00 GMT
+      - Thu, 01 Nov 2018 18:34:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -14159,7 +14687,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:00 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:59 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000
@@ -14174,7 +14702,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b14072875c534709aa7e0b490b9bb464
+      - f33e43b955eb43e69dbf6d7756595151
   response:
     status:
       code: 200
@@ -14185,9 +14713,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-7beea1a2-7de9-4f2f-a95c-2d70ad3d03e4
+      - req-ebfcfc7e-b9de-4917-9484-86bcf8d21367
       Date:
-      - Thu, 25 Oct 2018 18:20:00 GMT
+      - Thu, 01 Nov 2018 18:34:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef",
@@ -14229,7 +14757,7 @@ http_interactions:
         null, "port_range_min": null, "id": "ff24dfac-169a-4238-b78b-ed1536a0bf06",
         "security_group_id": "5b2b42a6-1271-4c4a-b062-8e8ba299acef"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:00 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:59 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef
@@ -14244,7 +14772,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b14072875c534709aa7e0b490b9bb464
+      - f33e43b955eb43e69dbf6d7756595151
   response:
     status:
       code: 200
@@ -14255,9 +14783,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-d7ab0aab-e4bb-4b96-b1e7-a1f68a84bce3
+      - req-4c5ae68d-1b0d-474c-8f0f-f80fb543aea6
       Date:
-      - Thu, 25 Oct 2018 18:20:00 GMT
+      - Thu, 01 Nov 2018 18:34:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab",
@@ -14300,7 +14828,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "c06c0e71-2c18-43a9-ace9-91242f0251e2",
         "security_group_id": "98bfc20c-a897-42c5-b33c-f0d8317667ab"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:00 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:59 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab
@@ -14315,7 +14843,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b14072875c534709aa7e0b490b9bb464
+      - f33e43b955eb43e69dbf6d7756595151
   response:
     status:
       code: 200
@@ -14326,9 +14854,9 @@ http_interactions:
       Content-Length:
       - '2717'
       X-Openstack-Request-Id:
-      - req-65b6407b-cfb0-4a88-aaf1-21e7090478a1
+      - req-fb155687-ed49-49f3-bb77-1fe17549baad
       Date:
-      - Thu, 25 Oct 2018 18:20:00 GMT
+      - Thu, 01 Nov 2018 18:34:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4",
@@ -14363,7 +14891,7 @@ http_interactions:
         null, "port_range_min": null, "id": "75924ebc-4758-4042-ad04-4ef3c9189098",
         "security_group_id": "e4836528-d0df-425e-a117-ae8ec6f356d4"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:00 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:59 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4
@@ -14378,7 +14906,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b14072875c534709aa7e0b490b9bb464
+      - f33e43b955eb43e69dbf6d7756595151
   response:
     status:
       code: 200
@@ -14389,9 +14917,9 @@ http_interactions:
       Content-Length:
       - '7080'
       X-Openstack-Request-Id:
-      - req-884f56d9-948e-456c-8c36-33153e798585
+      - req-1824fd30-472c-414b-8c96-8a0db31650a1
       Date:
-      - Thu, 25 Oct 2018 18:20:00 GMT
+      - Thu, 01 Nov 2018 18:34:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=fd147cb7-7456-43d9-a01f-c06e21b4e6fb&page_reverse=True",
@@ -14478,7 +15006,7 @@ http_interactions:
         "port_range_max": 80, "port_range_min": 80, "id": "f79f0e32-b186-4778-952e-20827a60ef73",
         "security_group_id": "fd147cb7-7456-43d9-a01f-c06e21b4e6fb"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:00 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:59 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000
@@ -14493,7 +15021,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 05b69b73edb74f5f90b6052c63aed25f
+      - 59c9705af20542b29bf1e7fa152f9ca1
   response:
     status:
       code: 200
@@ -14504,9 +15032,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-4d5ab7b2-edec-4b8f-92b1-da2634293742
+      - req-d3f70875-a279-4c2c-a214-1868d6216bcb
       Date:
-      - Thu, 25 Oct 2018 18:20:00 GMT
+      - Thu, 01 Nov 2018 18:34:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef",
@@ -14548,7 +15076,7 @@ http_interactions:
         null, "port_range_min": null, "id": "ff24dfac-169a-4238-b78b-ed1536a0bf06",
         "security_group_id": "5b2b42a6-1271-4c4a-b062-8e8ba299acef"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:00 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:59 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef
@@ -14563,7 +15091,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 05b69b73edb74f5f90b6052c63aed25f
+      - 59c9705af20542b29bf1e7fa152f9ca1
   response:
     status:
       code: 200
@@ -14574,9 +15102,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-74feb4f4-5c80-4977-8240-889dafe0fa3b
+      - req-0c27e8b6-d780-4fd1-b140-0558592b0998
       Date:
-      - Thu, 25 Oct 2018 18:20:00 GMT
+      - Thu, 01 Nov 2018 18:34:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab",
@@ -14619,7 +15147,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "c06c0e71-2c18-43a9-ace9-91242f0251e2",
         "security_group_id": "98bfc20c-a897-42c5-b33c-f0d8317667ab"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:00 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:59 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab
@@ -14634,7 +15162,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 05b69b73edb74f5f90b6052c63aed25f
+      - 59c9705af20542b29bf1e7fa152f9ca1
   response:
     status:
       code: 200
@@ -14645,9 +15173,9 @@ http_interactions:
       Content-Length:
       - '2717'
       X-Openstack-Request-Id:
-      - req-a25d288d-6c6d-4919-98a1-9fc19c8ae940
+      - req-e5596afe-b186-4433-864e-499f10653767
       Date:
-      - Thu, 25 Oct 2018 18:20:00 GMT
+      - Thu, 01 Nov 2018 18:35:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4",
@@ -14682,7 +15210,7 @@ http_interactions:
         null, "port_range_min": null, "id": "75924ebc-4758-4042-ad04-4ef3c9189098",
         "security_group_id": "e4836528-d0df-425e-a117-ae8ec6f356d4"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:00 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:00 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4
@@ -14697,7 +15225,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 05b69b73edb74f5f90b6052c63aed25f
+      - 59c9705af20542b29bf1e7fa152f9ca1
   response:
     status:
       code: 200
@@ -14708,9 +15236,9 @@ http_interactions:
       Content-Length:
       - '7080'
       X-Openstack-Request-Id:
-      - req-495db763-8c92-4687-b696-3108bac831a7
+      - req-4ebfa6e8-ecad-484d-8017-9f809b645a61
       Date:
-      - Thu, 25 Oct 2018 18:20:00 GMT
+      - Thu, 01 Nov 2018 18:35:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=fd147cb7-7456-43d9-a01f-c06e21b4e6fb&page_reverse=True",
@@ -14797,7 +15325,7 @@ http_interactions:
         "port_range_max": 80, "port_range_min": 80, "id": "f79f0e32-b186-4778-952e-20827a60ef73",
         "security_group_id": "fd147cb7-7456-43d9-a01f-c06e21b4e6fb"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:00 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:00 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000
@@ -14812,7 +15340,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c00676f2a36b4711afb2e2883cf4f448
+      - db39214686914cf794fa96f1d40a782d
   response:
     status:
       code: 200
@@ -14823,9 +15351,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-6b0fe4fe-1d46-4a56-9811-976bd36f3aa9
+      - req-3d6083c0-fbef-45cb-906b-e8852b89ba28
       Date:
-      - Thu, 25 Oct 2018 18:20:00 GMT
+      - Thu, 01 Nov 2018 18:35:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef",
@@ -14867,7 +15395,7 @@ http_interactions:
         null, "port_range_min": null, "id": "ff24dfac-169a-4238-b78b-ed1536a0bf06",
         "security_group_id": "5b2b42a6-1271-4c4a-b062-8e8ba299acef"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:01 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:00 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef
@@ -14882,7 +15410,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c00676f2a36b4711afb2e2883cf4f448
+      - db39214686914cf794fa96f1d40a782d
   response:
     status:
       code: 200
@@ -14893,9 +15421,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-1c039fc9-9077-4d8b-a9d1-b142345bffc3
+      - req-ea26c0b8-867b-4d8e-88cd-cd1eeb74fe72
       Date:
-      - Thu, 25 Oct 2018 18:20:01 GMT
+      - Thu, 01 Nov 2018 18:35:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab",
@@ -14938,7 +15466,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "c06c0e71-2c18-43a9-ace9-91242f0251e2",
         "security_group_id": "98bfc20c-a897-42c5-b33c-f0d8317667ab"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:01 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:00 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab
@@ -14953,7 +15481,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c00676f2a36b4711afb2e2883cf4f448
+      - db39214686914cf794fa96f1d40a782d
   response:
     status:
       code: 200
@@ -14964,9 +15492,9 @@ http_interactions:
       Content-Length:
       - '2717'
       X-Openstack-Request-Id:
-      - req-e1b891c0-0e0b-4e22-a8a8-c0742b061dc3
+      - req-a6bb15e8-4c6e-46d5-aaf6-8d55d4dd8f4f
       Date:
-      - Thu, 25 Oct 2018 18:20:01 GMT
+      - Thu, 01 Nov 2018 18:35:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4",
@@ -15001,7 +15529,7 @@ http_interactions:
         null, "port_range_min": null, "id": "75924ebc-4758-4042-ad04-4ef3c9189098",
         "security_group_id": "e4836528-d0df-425e-a117-ae8ec6f356d4"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:01 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:00 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4
@@ -15016,7 +15544,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c00676f2a36b4711afb2e2883cf4f448
+      - db39214686914cf794fa96f1d40a782d
   response:
     status:
       code: 200
@@ -15027,9 +15555,9 @@ http_interactions:
       Content-Length:
       - '7080'
       X-Openstack-Request-Id:
-      - req-5d7cd456-f3e1-4c4f-87a3-9331c4de633f
+      - req-f7cedd65-3165-48d9-9697-34d46df9b46a
       Date:
-      - Thu, 25 Oct 2018 18:20:01 GMT
+      - Thu, 01 Nov 2018 18:35:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=fd147cb7-7456-43d9-a01f-c06e21b4e6fb&page_reverse=True",
@@ -15116,7 +15644,7 @@ http_interactions:
         "port_range_max": 80, "port_range_min": 80, "id": "f79f0e32-b186-4778-952e-20827a60ef73",
         "security_group_id": "fd147cb7-7456-43d9-a01f-c06e21b4e6fb"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:01 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:00 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000
@@ -15131,7 +15659,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 32c84fe7b8934b1ab14b2edd8e75269b
+      - 7199b530fd514749b7ae7e06dc997112
   response:
     status:
       code: 200
@@ -15142,9 +15670,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-a5639366-e668-4c38-b838-607f630cd06a
+      - req-1142cbee-70f9-4268-b53d-c20c07eae53d
       Date:
-      - Thu, 25 Oct 2018 18:20:01 GMT
+      - Thu, 01 Nov 2018 18:35:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef",
@@ -15186,7 +15714,7 @@ http_interactions:
         null, "port_range_min": null, "id": "ff24dfac-169a-4238-b78b-ed1536a0bf06",
         "security_group_id": "5b2b42a6-1271-4c4a-b062-8e8ba299acef"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:01 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:00 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef
@@ -15201,7 +15729,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 32c84fe7b8934b1ab14b2edd8e75269b
+      - 7199b530fd514749b7ae7e06dc997112
   response:
     status:
       code: 200
@@ -15212,9 +15740,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-cbea2104-b0d1-4272-9469-fdc9e0aec6a0
+      - req-23161808-8618-48e4-af9e-da3ebc529097
       Date:
-      - Thu, 25 Oct 2018 18:20:01 GMT
+      - Thu, 01 Nov 2018 18:35:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab",
@@ -15257,7 +15785,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "c06c0e71-2c18-43a9-ace9-91242f0251e2",
         "security_group_id": "98bfc20c-a897-42c5-b33c-f0d8317667ab"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:01 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:00 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab
@@ -15272,7 +15800,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 32c84fe7b8934b1ab14b2edd8e75269b
+      - 7199b530fd514749b7ae7e06dc997112
   response:
     status:
       code: 200
@@ -15283,9 +15811,9 @@ http_interactions:
       Content-Length:
       - '2717'
       X-Openstack-Request-Id:
-      - req-7fdc58da-ee12-4bdb-a675-614a9e00e1ec
+      - req-c0250340-8e51-48bf-8b5c-64a7e67e54f8
       Date:
-      - Thu, 25 Oct 2018 18:20:01 GMT
+      - Thu, 01 Nov 2018 18:35:01 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4",
@@ -15320,7 +15848,7 @@ http_interactions:
         null, "port_range_min": null, "id": "75924ebc-4758-4042-ad04-4ef3c9189098",
         "security_group_id": "e4836528-d0df-425e-a117-ae8ec6f356d4"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:01 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:01 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4
@@ -15335,7 +15863,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 32c84fe7b8934b1ab14b2edd8e75269b
+      - 7199b530fd514749b7ae7e06dc997112
   response:
     status:
       code: 200
@@ -15346,9 +15874,9 @@ http_interactions:
       Content-Length:
       - '7080'
       X-Openstack-Request-Id:
-      - req-c8f041aa-0cb4-44d6-a075-bfba62d2d8a9
+      - req-cd6f0b1c-d217-4d47-be9a-5e1f247a624c
       Date:
-      - Thu, 25 Oct 2018 18:20:01 GMT
+      - Thu, 01 Nov 2018 18:35:01 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=fd147cb7-7456-43d9-a01f-c06e21b4e6fb&page_reverse=True",
@@ -15435,7 +15963,7 @@ http_interactions:
         "port_range_max": 80, "port_range_min": 80, "id": "f79f0e32-b186-4778-952e-20827a60ef73",
         "security_group_id": "fd147cb7-7456-43d9-a01f-c06e21b4e6fb"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:01 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:01 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -15453,13 +15981,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:20:02 GMT
+      - Thu, 01 Nov 2018 18:35:01 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-ddfb9a49-3b58-43e9-9914-ec13e35ba6ff
+      - req-10db83b3-c170-4d93-92f9-d5c29fddbc03
       Content-Length:
       - '4170'
       Connection:
@@ -15468,10 +15996,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:20:02.375868", "expires":
-        "2018-10-25T19:20:02Z", "id": "4ba95255bff440f886e14ed6c6584868", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:35:01.824226", "expires":
+        "2018-11-01T19:35:01Z", "id": "635260c99a814478ab56e185cbdfda4f", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["oKd6qb8SRR-bA0a-hxoXwg"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["NmosbStnQwKiMamaCFZwpw"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -15516,7 +16044,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:02 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:01 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -15534,13 +16062,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:20:02 GMT
+      - Thu, 01 Nov 2018 18:35:01 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-d9226080-d166-488b-a09c-80ad579917cd
+      - req-4ad3b37b-7f75-415e-af4a-4f41312257cf
       Content-Length:
       - '4170'
       Connection:
@@ -15549,10 +16077,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:20:02.558463", "expires":
-        "2018-10-25T19:20:02Z", "id": "c77da5f543fa41b79305756854f0596f", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:35:02.016433", "expires":
+        "2018-11-01T19:35:01Z", "id": "2723dab1f55549a7be94595acd48ea67", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["QPSyKX5BR4uaONPhYP6d_w"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["zWop6WJPT5W4f7Uda77Izw"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -15597,7 +16125,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:02 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:02 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -15615,13 +16143,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:20:02 GMT
+      - Thu, 01 Nov 2018 18:35:02 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-216b62d0-1eb7-4b24-a668-d2becd551cf6
+      - req-35aa7290-100a-4593-9eea-51a3955e3ab7
       Content-Length:
       - '370'
       Connection:
@@ -15630,13 +16158,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:20:02.707911", "expires":
-        "2018-10-25T19:20:02Z", "id": "f5e26a602b3549f6a19e760c860d2cb8", "audit_ids":
-        ["0N9q07wSTNGnm8VNeMZDeQ"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:35:02.182033", "expires":
+        "2018-11-01T19:35:02Z", "id": "b042bad859f941ef8363a8a03502c305", "audit_ids":
+        ["pocCtbV_Sm6-wU94fj9tqw"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:02 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:02 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -15651,20 +16179,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f5e26a602b3549f6a19e760c860d2cb8
+      - b042bad859f941ef8363a8a03502c305
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:20:02 GMT
+      - Thu, 01 Nov 2018 18:35:02 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-54230161-0b5c-404b-a9c2-74410b034ac5
+      - req-2a667d02-4a3b-4ede-bed8-1e3121696a69
       Content-Length:
       - '500'
       Connection:
@@ -15681,7 +16209,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:02 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:02 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -15699,13 +16227,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:20:02 GMT
+      - Thu, 01 Nov 2018 18:35:02 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-a2f7bdbd-8b5d-4c7d-929e-91b03bcf7630
+      - req-d02a5c96-a5f4-4a99-aa69-e56e4fa0545d
       Content-Length:
       - '4117'
       Connection:
@@ -15714,10 +16242,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:20:03.018099", "expires":
-        "2018-10-25T19:20:03Z", "id": "756f037c0c8f490caa3259e6cc1c0db8", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:35:02.508870", "expires":
+        "2018-11-01T19:35:02Z", "id": "7227957177c0494da1fe171804736aa7", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["4UfbOF12RIeM0i37Z8N91A"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["A_mCrVgTSeWcSRnJukf4Kw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -15761,7 +16289,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:03 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:02 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -15779,13 +16307,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:20:03 GMT
+      - Thu, 01 Nov 2018 18:35:02 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-675b4a24-b216-4c0c-bc15-1ff722aeb11d
+      - req-e08b8d72-f0ad-4105-9fa4-fd7610775729
       Content-Length:
       - '4131'
       Connection:
@@ -15794,10 +16322,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:20:03.202304", "expires":
-        "2018-10-25T19:20:03Z", "id": "9f9f337b8fd4447eb97b59ccbc0d77f3", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:35:02.696050", "expires":
+        "2018-11-01T19:35:02Z", "id": "fe2da59d79294d068f3e611729dbe152", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["vgnMznEdQmCNVMywBH0bng"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["yy28c5FzT7KwO48UgJUgig"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -15841,7 +16369,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:03 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:02 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -15859,13 +16387,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:20:03 GMT
+      - Thu, 01 Nov 2018 18:35:02 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-517d50f0-6403-4bac-a103-b799e177077f
+      - req-93dbec9b-506c-4aa1-a4a8-7b7bac06de1b
       Content-Length:
       - '4118'
       Connection:
@@ -15874,10 +16402,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:20:03.387316", "expires":
-        "2018-10-25T19:20:03Z", "id": "663085c875fc44118b1e370d6a77209a", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:35:02.883575", "expires":
+        "2018-11-01T19:35:02Z", "id": "07b31b408d1046fb8770688b249b41cb", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["5alg6UjtQiGG6_m6v2BqTw"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["WM62ng2xSiqyZ99NackCew"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -15921,7 +16449,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:03 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:02 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -15939,13 +16467,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:20:03 GMT
+      - Thu, 01 Nov 2018 18:35:03 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-cae31ab5-2274-4c01-8820-02754d5c1c8f
+      - req-03fd1f9e-d268-4cf5-b584-d7fac9c22885
       Content-Length:
       - '4117'
       Connection:
@@ -15954,10 +16482,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:20:03.564540", "expires":
-        "2018-10-25T19:20:03Z", "id": "c75bff773d9e4bb2858839789339749c", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:35:03.076666", "expires":
+        "2018-11-01T19:35:03Z", "id": "1aaf2c1927294fe5b7dd1494bf1e35a1", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["W0f4am1NRVCijGhcoN49sw"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["p3Isok3ERpuKsA8Ut0rpDQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -16001,7 +16529,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:03 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:03 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000
@@ -16016,22 +16544,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c75bff773d9e4bb2858839789339749c
+      - 1aaf2c1927294fe5b7dd1494bf1e35a1
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-47e38866-1283-4340-8860-9099a8d841b0
+      - req-526d53a1-daa9-4aa2-ab85-57617e221bca
       Content-Type:
       - application/json
       Content-Length:
       - '2706'
       X-Openstack-Request-Id:
-      - req-47e38866-1283-4340-8860-9099a8d841b0
+      - req-526d53a1-daa9-4aa2-ab85-57617e221bca
       Date:
-      - Thu, 25 Oct 2018 18:20:03 GMT
+      - Thu, 01 Nov 2018 18:35:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=9bb99818-b339-4e31-b87f-e4181ec48acd",
@@ -16064,7 +16592,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-4", "bootable": "true", "created_at":
         "2016-11-11T13:49:53.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:03 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:03 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=9bb99818-b339-4e31-b87f-e4181ec48acd
@@ -16079,22 +16607,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c75bff773d9e4bb2858839789339749c
+      - 1aaf2c1927294fe5b7dd1494bf1e35a1
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-b6e1b5a4-2d53-4741-a4a6-7c08b196442f
+      - req-c1157d57-09f9-4e3d-a015-54ed8c5fdcc4
       Content-Type:
       - application/json
       Content-Length:
       - '3284'
       X-Openstack-Request-Id:
-      - req-b6e1b5a4-2d53-4741-a4a6-7c08b196442f
+      - req-c1157d57-09f9-4e3d-a015-54ed8c5fdcc4
       Date:
-      - Thu, 25 Oct 2018 18:20:03 GMT
+      - Thu, 01 Nov 2018 18:35:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=2c774148-c11a-434c-aabb-7fa9c82c37ce",
@@ -16135,7 +16663,7 @@ http_interactions:
         "name": "EmsRefreshSpec-Volume-2", "bootable": "false", "created_at": "2016-11-11T13:49:43.000000",
         "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:03 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:03 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=2c774148-c11a-434c-aabb-7fa9c82c37ce
@@ -16150,22 +16678,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c75bff773d9e4bb2858839789339749c
+      - 1aaf2c1927294fe5b7dd1494bf1e35a1
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-1b882b90-414b-48e2-bb33-da34224e121a
+      - req-657fcf8e-47da-4c33-819c-9fe5e02171bb
       Content-Type:
       - application/json
       Content-Length:
       - '2753'
       X-Openstack-Request-Id:
-      - req-1b882b90-414b-48e2-bb33-da34224e121a
+      - req-657fcf8e-47da-4c33-819c-9fe5e02171bb
       Date:
-      - Thu, 25 Oct 2018 18:20:04 GMT
+      - Thu, 01 Nov 2018 18:35:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=0a55c0d5-c780-4e7d-9d09-47f5520c7448",
@@ -16199,7 +16727,7 @@ http_interactions:
         "bootable": "false", "created_at": "2016-11-11T13:49:20.000000", "volume_type":
         "iscsi"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:04 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:03 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=0a55c0d5-c780-4e7d-9d09-47f5520c7448
@@ -16214,27 +16742,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c75bff773d9e4bb2858839789339749c
+      - 1aaf2c1927294fe5b7dd1494bf1e35a1
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-a0c8f07e-5eb2-45f1-bf97-d10c652fd41f
+      - req-0ddd4f9b-cce6-4b23-b926-5dd1b9b654f1
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-a0c8f07e-5eb2-45f1-bf97-d10c652fd41f
+      - req-0ddd4f9b-cce6-4b23-b926-5dd1b9b654f1
       Date:
-      - Thu, 25 Oct 2018 18:20:04 GMT
+      - Thu, 01 Nov 2018 18:35:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:04 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:03 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -16252,13 +16780,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:20:04 GMT
+      - Thu, 01 Nov 2018 18:35:03 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-36686746-f1cc-44f6-a4d1-f7697d07f457
+      - req-0ddc319b-b279-4b25-94a6-8d7370f09ca3
       Content-Length:
       - '4131'
       Connection:
@@ -16267,10 +16795,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:20:04.408704", "expires":
-        "2018-10-25T19:20:04Z", "id": "88b62c8f2d0c48b2aaa00404076323fa", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:35:03.943758", "expires":
+        "2018-11-01T19:35:03Z", "id": "89de6e8c45a746a3b1724cda26af500f", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["MGP1kXIKQZyE3Lp8PgxKug"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["si6Ap0h1TD-nWAe95ZGMng"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -16314,7 +16842,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:04 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:03 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/volumes/detail?limit=1000
@@ -16329,27 +16857,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 88b62c8f2d0c48b2aaa00404076323fa
+      - 89de6e8c45a746a3b1724cda26af500f
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-fbb48d08-cfb4-44fd-a0ca-340496e84f17
+      - req-92c46763-7b90-4cc5-99b9-97e7e420e71f
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-fbb48d08-cfb4-44fd-a0ca-340496e84f17
+      - req-92c46763-7b90-4cc5-99b9-97e7e420e71f
       Date:
-      - Thu, 25 Oct 2018 18:20:04 GMT
+      - Thu, 01 Nov 2018 18:35:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:04 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:04 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/volumes/detail?limit=1000
@@ -16364,27 +16892,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c77da5f543fa41b79305756854f0596f
+      - 2723dab1f55549a7be94595acd48ea67
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-9e4912c1-dde4-4bfa-8b85-d8e095de49c3
+      - req-6b92912c-15ea-478d-85fc-404a82b3c2ad
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-9e4912c1-dde4-4bfa-8b85-d8e095de49c3
+      - req-6b92912c-15ea-478d-85fc-404a82b3c2ad
       Date:
-      - Thu, 25 Oct 2018 18:20:04 GMT
+      - Thu, 01 Nov 2018 18:35:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:04 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:04 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -16402,13 +16930,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:20:04 GMT
+      - Thu, 01 Nov 2018 18:35:04 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-00e628a6-9f3d-459c-9138-40964330baaa
+      - req-3b60f8a2-a24f-4d9f-91fe-7265ca839da3
       Content-Length:
       - '4118'
       Connection:
@@ -16417,10 +16945,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:20:04.963404", "expires":
-        "2018-10-25T19:20:04Z", "id": "1090e54eb1c34cdd884890c1352aef8e", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:35:04.519279", "expires":
+        "2018-11-01T19:35:04Z", "id": "34ed82d7c774464993a4ded5acb13e0f", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["2-z-AoPwTSCTgI2Qe0jCUQ"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["QfJYn5AoR1CtK4ad9D0exQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -16464,7 +16992,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:04 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:04 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/volumes/detail?limit=1000
@@ -16479,27 +17007,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1090e54eb1c34cdd884890c1352aef8e
+      - 34ed82d7c774464993a4ded5acb13e0f
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-de9634eb-2c19-42b9-a905-291ebacb55c8
+      - req-90e8a23b-65fd-4b0a-a1be-d62226d97042
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-de9634eb-2c19-42b9-a905-291ebacb55c8
+      - req-90e8a23b-65fd-4b0a-a1be-d62226d97042
       Date:
-      - Thu, 25 Oct 2018 18:20:05 GMT
+      - Thu, 01 Nov 2018 18:35:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:05 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:04 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail
@@ -16514,22 +17042,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c75bff773d9e4bb2858839789339749c
+      - 1aaf2c1927294fe5b7dd1494bf1e35a1
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-c4dd1987-aba4-46ce-ad21-1152d4c3d2fa
+      - req-ec92a12f-15ff-4e15-be22-de7707bf4615
       Content-Type:
       - application/json
       Content-Length:
       - '1053'
       X-Openstack-Request-Id:
-      - req-c4dd1987-aba4-46ce-ad21-1152d4c3d2fa
+      - req-ec92a12f-15ff-4e15-be22-de7707bf4615
       Date:
-      - Thu, 25 Oct 2018 18:20:05 GMT
+      - Thu, 01 Nov 2018 18:35:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?marker=76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
@@ -16544,7 +17072,7 @@ http_interactions:
         "created_at": "2016-11-11T13:49:36.000000", "size": 1, "id": "76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:05 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:04 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?limit=1000
@@ -16559,22 +17087,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c75bff773d9e4bb2858839789339749c
+      - 1aaf2c1927294fe5b7dd1494bf1e35a1
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-63988c5d-abcc-4e00-9650-fbbfc99ee3d9
+      - req-a041bdd1-5658-47f0-8eb6-696e3dd5e9e0
       Content-Type:
       - application/json
       Content-Length:
       - '1064'
       X-Openstack-Request-Id:
-      - req-63988c5d-abcc-4e00-9650-fbbfc99ee3d9
+      - req-a041bdd1-5658-47f0-8eb6-696e3dd5e9e0
       Date:
-      - Thu, 25 Oct 2018 18:20:05 GMT
+      - Thu, 01 Nov 2018 18:35:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?limit=1000&marker=76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
@@ -16589,7 +17117,7 @@ http_interactions:
         "created_at": "2016-11-11T13:49:36.000000", "size": 1, "id": "76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:05 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:04 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/snapshots/detail
@@ -16604,27 +17132,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 88b62c8f2d0c48b2aaa00404076323fa
+      - 89de6e8c45a746a3b1724cda26af500f
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-ad2acffd-488a-4bc6-abf1-a04a3f030f3f
+      - req-410044b7-dc77-4ec6-ac32-219220b540fa
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-ad2acffd-488a-4bc6-abf1-a04a3f030f3f
+      - req-410044b7-dc77-4ec6-ac32-219220b540fa
       Date:
-      - Thu, 25 Oct 2018 18:20:05 GMT
+      - Thu, 01 Nov 2018 18:35:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:05 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:05 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/snapshots/detail?limit=1000
@@ -16639,27 +17167,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 88b62c8f2d0c48b2aaa00404076323fa
+      - 89de6e8c45a746a3b1724cda26af500f
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-9c656468-7282-4c69-820e-a9ae23f3483a
+      - req-5d73caa7-6d28-46a1-932c-b6cddc1177ae
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-9c656468-7282-4c69-820e-a9ae23f3483a
+      - req-5d73caa7-6d28-46a1-932c-b6cddc1177ae
       Date:
-      - Thu, 25 Oct 2018 18:20:05 GMT
+      - Thu, 01 Nov 2018 18:35:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:05 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:05 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/snapshots/detail
@@ -16674,27 +17202,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c77da5f543fa41b79305756854f0596f
+      - 2723dab1f55549a7be94595acd48ea67
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-190dad8b-1530-403e-9a74-5dc7345be64e
+      - req-7faaa58e-a541-4ce5-b70a-49a1eb677e63
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-190dad8b-1530-403e-9a74-5dc7345be64e
+      - req-7faaa58e-a541-4ce5-b70a-49a1eb677e63
       Date:
-      - Thu, 25 Oct 2018 18:20:05 GMT
+      - Thu, 01 Nov 2018 18:35:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:05 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:05 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/snapshots/detail?limit=1000
@@ -16709,27 +17237,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c77da5f543fa41b79305756854f0596f
+      - 2723dab1f55549a7be94595acd48ea67
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-888fb413-b32e-4a96-9aaa-e630d6c600c5
+      - req-f0d9a43f-3c73-4a2b-a13e-056116529aba
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-888fb413-b32e-4a96-9aaa-e630d6c600c5
+      - req-f0d9a43f-3c73-4a2b-a13e-056116529aba
       Date:
-      - Thu, 25 Oct 2018 18:20:05 GMT
+      - Thu, 01 Nov 2018 18:35:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:05 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:05 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/snapshots/detail
@@ -16744,27 +17272,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1090e54eb1c34cdd884890c1352aef8e
+      - 34ed82d7c774464993a4ded5acb13e0f
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-8b9192ae-042c-43b5-aa71-9492676a7c92
+      - req-06bf92ae-d6da-425d-8653-075c05bc7210
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-8b9192ae-042c-43b5-aa71-9492676a7c92
+      - req-06bf92ae-d6da-425d-8653-075c05bc7210
       Date:
-      - Thu, 25 Oct 2018 18:20:05 GMT
+      - Thu, 01 Nov 2018 18:35:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:05 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:05 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/snapshots/detail?limit=1000
@@ -16779,27 +17307,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1090e54eb1c34cdd884890c1352aef8e
+      - 34ed82d7c774464993a4ded5acb13e0f
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-9aaab778-21f9-42c1-8238-987dd1fcf03a
+      - req-e1725a1d-2439-4398-a980-67633a87ee8e
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-9aaab778-21f9-42c1-8238-987dd1fcf03a
+      - req-e1725a1d-2439-4398-a980-67633a87ee8e
       Date:
-      - Thu, 25 Oct 2018 18:20:06 GMT
+      - Thu, 01 Nov 2018 18:35:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:06 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:05 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/backups/detail
@@ -16814,27 +17342,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c75bff773d9e4bb2858839789339749c
+      - 1aaf2c1927294fe5b7dd1494bf1e35a1
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-64df119b-64af-43df-9996-6b0ae75373fc
+      - req-ee5d13d2-98af-49e6-895d-a0e5d88581ef
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-64df119b-64af-43df-9996-6b0ae75373fc
+      - req-ee5d13d2-98af-49e6-895d-a0e5d88581ef
       Date:
-      - Thu, 25 Oct 2018 18:20:06 GMT
+      - Thu, 01 Nov 2018 18:35:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:06 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:05 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/backups/detail?limit=1000
@@ -16849,27 +17377,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c75bff773d9e4bb2858839789339749c
+      - 1aaf2c1927294fe5b7dd1494bf1e35a1
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-7e3ddbf4-1f96-42c6-b092-26510bf72ea6
+      - req-03301330-1c2d-46fd-92aa-b438abe7c161
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-7e3ddbf4-1f96-42c6-b092-26510bf72ea6
+      - req-03301330-1c2d-46fd-92aa-b438abe7c161
       Date:
-      - Thu, 25 Oct 2018 18:20:06 GMT
+      - Thu, 01 Nov 2018 18:35:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:06 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:05 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/backups/detail
@@ -16884,27 +17412,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 88b62c8f2d0c48b2aaa00404076323fa
+      - 89de6e8c45a746a3b1724cda26af500f
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-197bda6a-7d5a-4c8e-9f7c-cbb0bf3979e4
+      - req-0ae27550-3539-40b4-86b5-55c546c82f23
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-197bda6a-7d5a-4c8e-9f7c-cbb0bf3979e4
+      - req-0ae27550-3539-40b4-86b5-55c546c82f23
       Date:
-      - Thu, 25 Oct 2018 18:20:06 GMT
+      - Thu, 01 Nov 2018 18:35:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:06 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:06 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/backups/detail?limit=1000
@@ -16919,27 +17447,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 88b62c8f2d0c48b2aaa00404076323fa
+      - 89de6e8c45a746a3b1724cda26af500f
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-84432365-4b87-4261-b284-55d9d09cb0f5
+      - req-8e0f3a6c-398b-44a3-b07d-ed45097557a2
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-84432365-4b87-4261-b284-55d9d09cb0f5
+      - req-8e0f3a6c-398b-44a3-b07d-ed45097557a2
       Date:
-      - Thu, 25 Oct 2018 18:20:06 GMT
+      - Thu, 01 Nov 2018 18:35:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:06 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:06 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/backups/detail
@@ -16954,27 +17482,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c77da5f543fa41b79305756854f0596f
+      - 2723dab1f55549a7be94595acd48ea67
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-68c14337-e0d7-49f7-b622-fec014590e1a
+      - req-2e7a85a5-953e-45b3-95f8-6b1a0d30d48d
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-68c14337-e0d7-49f7-b622-fec014590e1a
+      - req-2e7a85a5-953e-45b3-95f8-6b1a0d30d48d
       Date:
-      - Thu, 25 Oct 2018 18:20:06 GMT
+      - Thu, 01 Nov 2018 18:35:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:06 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:06 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/backups/detail?limit=1000
@@ -16989,27 +17517,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c77da5f543fa41b79305756854f0596f
+      - 2723dab1f55549a7be94595acd48ea67
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-6149056a-0ae8-4128-aff4-1ebce015c015
+      - req-a44d315b-7e75-43eb-a2ff-a5a2d53ed191
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-6149056a-0ae8-4128-aff4-1ebce015c015
+      - req-a44d315b-7e75-43eb-a2ff-a5a2d53ed191
       Date:
-      - Thu, 25 Oct 2018 18:20:06 GMT
+      - Thu, 01 Nov 2018 18:35:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:06 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:06 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/backups/detail
@@ -17024,27 +17552,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1090e54eb1c34cdd884890c1352aef8e
+      - 34ed82d7c774464993a4ded5acb13e0f
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-496ceebd-e95b-434a-8cff-1c95d5ac9802
+      - req-fb31fe7a-b302-463c-87a5-4d32ce3005cf
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-496ceebd-e95b-434a-8cff-1c95d5ac9802
+      - req-fb31fe7a-b302-463c-87a5-4d32ce3005cf
       Date:
-      - Thu, 25 Oct 2018 18:20:06 GMT
+      - Thu, 01 Nov 2018 18:35:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:06 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:06 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/backups/detail?limit=1000
@@ -17059,27 +17587,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1090e54eb1c34cdd884890c1352aef8e
+      - 34ed82d7c774464993a4ded5acb13e0f
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-27964a2d-4a99-4085-a13f-e4657de79c3e
+      - req-a57e8356-5e46-4afb-ade6-b03a8b66a39d
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-27964a2d-4a99-4085-a13f-e4657de79c3e
+      - req-a57e8356-5e46-4afb-ade6-b03a8b66a39d
       Date:
-      - Thu, 25 Oct 2018 18:20:06 GMT
+      - Thu, 01 Nov 2018 18:35:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:06 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:06 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/types?limit=1000
@@ -17094,22 +17622,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c75bff773d9e4bb2858839789339749c
+      - 1aaf2c1927294fe5b7dd1494bf1e35a1
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-d292f469-5e21-4bec-bbf9-becda6576c26
+      - req-e9dc7f10-052c-4c2f-898f-91c1ddcb737d
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-d292f469-5e21-4bec-bbf9-becda6576c26
+      - req-e9dc7f10-052c-4c2f-898f-91c1ddcb737d
       Date:
-      - Thu, 25 Oct 2018 18:20:07 GMT
+      - Thu, 01 Nov 2018 18:35:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -17121,7 +17649,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:07 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:06 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/types?limit=1000&marker=0d07f8c3-f295-48c7-b632-6b7d8bd860eb
@@ -17136,22 +17664,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c75bff773d9e4bb2858839789339749c
+      - 1aaf2c1927294fe5b7dd1494bf1e35a1
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-f208aadc-7dcd-4933-94ca-e6f180b20c76
+      - req-a5b2911a-6b1b-43a2-a4d1-e8c021a09120
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-f208aadc-7dcd-4933-94ca-e6f180b20c76
+      - req-a5b2911a-6b1b-43a2-a4d1-e8c021a09120
       Date:
-      - Thu, 25 Oct 2018 18:20:07 GMT
+      - Thu, 01 Nov 2018 18:35:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -17163,7 +17691,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:07 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:06 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/types?limit=1000
@@ -17178,22 +17706,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 88b62c8f2d0c48b2aaa00404076323fa
+      - 89de6e8c45a746a3b1724cda26af500f
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-c7ca38b4-81b2-4f0f-9cd3-3df98be5b890
+      - req-a83cddf3-ff0e-4f52-a8f9-4e14debb1e58
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-c7ca38b4-81b2-4f0f-9cd3-3df98be5b890
+      - req-a83cddf3-ff0e-4f52-a8f9-4e14debb1e58
       Date:
-      - Thu, 25 Oct 2018 18:20:07 GMT
+      - Thu, 01 Nov 2018 18:35:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -17205,7 +17733,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:07 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:06 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/types?limit=1000&marker=0d07f8c3-f295-48c7-b632-6b7d8bd860eb
@@ -17220,22 +17748,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 88b62c8f2d0c48b2aaa00404076323fa
+      - 89de6e8c45a746a3b1724cda26af500f
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-12ba3af7-be15-4664-8d31-a1e86a0cf121
+      - req-bb34cc2e-4842-48cc-94f5-d462c3651232
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-12ba3af7-be15-4664-8d31-a1e86a0cf121
+      - req-bb34cc2e-4842-48cc-94f5-d462c3651232
       Date:
-      - Thu, 25 Oct 2018 18:20:07 GMT
+      - Thu, 01 Nov 2018 18:35:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -17247,7 +17775,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:07 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:06 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/types?limit=1000
@@ -17262,22 +17790,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c77da5f543fa41b79305756854f0596f
+      - 2723dab1f55549a7be94595acd48ea67
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-918473c6-c60f-4614-9c2d-06bbaffea3d2
+      - req-d76f18b0-ce8f-4a30-9731-37ddc897d092
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-918473c6-c60f-4614-9c2d-06bbaffea3d2
+      - req-d76f18b0-ce8f-4a30-9731-37ddc897d092
       Date:
-      - Thu, 25 Oct 2018 18:20:07 GMT
+      - Thu, 01 Nov 2018 18:35:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -17289,7 +17817,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:07 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:07 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/types?limit=1000&marker=0d07f8c3-f295-48c7-b632-6b7d8bd860eb
@@ -17304,22 +17832,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c77da5f543fa41b79305756854f0596f
+      - 2723dab1f55549a7be94595acd48ea67
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-9aec9c15-9c11-4f7d-adff-a2a64a27c6ab
+      - req-e2a5b2cf-9d25-4792-a2e2-f4dea7c3407b
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-9aec9c15-9c11-4f7d-adff-a2a64a27c6ab
+      - req-e2a5b2cf-9d25-4792-a2e2-f4dea7c3407b
       Date:
-      - Thu, 25 Oct 2018 18:20:07 GMT
+      - Thu, 01 Nov 2018 18:35:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -17331,7 +17859,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:07 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:07 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/types?limit=1000
@@ -17346,22 +17874,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1090e54eb1c34cdd884890c1352aef8e
+      - 34ed82d7c774464993a4ded5acb13e0f
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-4cc51750-6721-49a0-99cc-a89813b1be16
+      - req-ff5d441b-7c82-4bac-8ea2-aa733af1b04e
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-4cc51750-6721-49a0-99cc-a89813b1be16
+      - req-ff5d441b-7c82-4bac-8ea2-aa733af1b04e
       Date:
-      - Thu, 25 Oct 2018 18:20:07 GMT
+      - Thu, 01 Nov 2018 18:35:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -17373,7 +17901,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:07 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:07 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/types?limit=1000&marker=0d07f8c3-f295-48c7-b632-6b7d8bd860eb
@@ -17388,22 +17916,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1090e54eb1c34cdd884890c1352aef8e
+      - 34ed82d7c774464993a4ded5acb13e0f
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-71e2ff90-061a-4891-ae04-727316fcf113
+      - req-4923e775-8504-47ba-892f-c6e8778b379e
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-71e2ff90-061a-4891-ae04-727316fcf113
+      - req-4923e775-8504-47ba-892f-c6e8778b379e
       Date:
-      - Thu, 25 Oct 2018 18:20:07 GMT
+      - Thu, 01 Nov 2018 18:35:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -17415,7 +17943,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:07 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:07 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -17433,13 +17961,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:20:07 GMT
+      - Thu, 01 Nov 2018 18:35:07 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-7bd1e04c-5e38-4754-89d4-d8d6609a9f1c
+      - req-fd411c47-81f2-46d3-883d-eb64eb7e2ae4
       Content-Length:
       - '4170'
       Connection:
@@ -17448,10 +17976,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:20:07.990830", "expires":
-        "2018-10-25T19:20:07Z", "id": "33220baeabfc4108b1ed6af68c15ce4b", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:35:07.616338", "expires":
+        "2018-11-01T19:35:07Z", "id": "460d6914f6764719a721e56e21d97db4", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["_iDnarn9QlC-_uAmklzMeA"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["kiddh4R4QMy47H6mLkq-dg"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -17496,7 +18024,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:08 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:07 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -17514,13 +18042,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:20:08 GMT
+      - Thu, 01 Nov 2018 18:35:07 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-2553bb8f-1c11-49ba-adee-589cbf98e3be
+      - req-ad3c955c-6eb1-44e6-a990-e880d1fb8510
       Content-Length:
       - '4170'
       Connection:
@@ -17529,10 +18057,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:20:08.177226", "expires":
-        "2018-10-25T19:20:08Z", "id": "bccac69028e8432f861b9103fea8df39", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:35:07.814332", "expires":
+        "2018-11-01T19:35:07Z", "id": "5bf90f52abf14c3da0c4e6b3bd713282", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["LRw3wZfQTx-PFp-W9I5OzQ"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["mhcNhedYROeEmJCfE2vNoQ"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -17577,7 +18105,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:08 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:07 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -17595,13 +18123,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:20:08 GMT
+      - Thu, 01 Nov 2018 18:35:07 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-ea019f32-405c-4105-b58e-604d2da2b321
+      - req-a6e3db12-0dfb-4599-9620-aa763866e326
       Content-Length:
       - '370'
       Connection:
@@ -17610,13 +18138,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:20:08.329334", "expires":
-        "2018-10-25T19:20:08Z", "id": "245c5bb42ead4781a333211c41c5a705", "audit_ids":
-        ["96a7vH4qRbSY0q5yig_TcA"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:35:07.974944", "expires":
+        "2018-11-01T19:35:07Z", "id": "c1d8a1f7acda4006a694fca2914ca69b", "audit_ids":
+        ["w9IllqLcRhKaVEZSe1dPHg"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:08 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:07 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -17631,20 +18159,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 245c5bb42ead4781a333211c41c5a705
+      - c1d8a1f7acda4006a694fca2914ca69b
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:20:08 GMT
+      - Thu, 01 Nov 2018 18:35:08 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-0df66463-f70a-44f9-ba08-985137d923ad
+      - req-d7c39708-e169-40c3-a7d3-7cb1651a0694
       Content-Length:
       - '500'
       Connection:
@@ -17661,7 +18189,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:08 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:08 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -17679,13 +18207,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:20:08 GMT
+      - Thu, 01 Nov 2018 18:35:08 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-7771800d-7f6e-450b-8f8d-a2d328487fcf
+      - req-30928c24-37e3-41a3-a795-726f1be26c57
       Content-Length:
       - '4117'
       Connection:
@@ -17694,10 +18222,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:20:08.635128", "expires":
-        "2018-10-25T19:20:08Z", "id": "e33b73b552ef45a8a0bc63d84ebcbb61", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:35:08.330593", "expires":
+        "2018-11-01T19:35:08Z", "id": "27869bc6d9764b6a954c9a9ebf1c17c2", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["OzVVmkHmQAie5G8dTN-AdA"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["4DpFEAazSSGB5qDlbXtZ8w"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -17741,7 +18269,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:08 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:08 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -17759,13 +18287,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:20:08 GMT
+      - Thu, 01 Nov 2018 18:35:08 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-cbf1ad54-7980-4433-acd5-63b67bddb456
+      - req-b8a60ee2-5b4b-42d1-83cd-b133bee1c622
       Content-Length:
       - '4131'
       Connection:
@@ -17774,10 +18302,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:20:08.830872", "expires":
-        "2018-10-25T19:20:08Z", "id": "7758aa6420c94742a0241910bd3fec1f", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:35:08.524839", "expires":
+        "2018-11-01T19:35:08Z", "id": "424209118b9148a3b1e6ca4095c344d8", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["ufXYkTh0T4CFWgVdcWet3w"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["mGKm3DPvSK-5OXcBzHCqyg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -17821,7 +18349,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:08 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:08 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -17839,13 +18367,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:20:08 GMT
+      - Thu, 01 Nov 2018 18:35:08 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-41d4c645-c2c3-45a8-bea5-da83f964d1fa
+      - req-67d6bf29-a512-4385-be52-4f3ec1d13a82
       Content-Length:
       - '4118'
       Connection:
@@ -17854,10 +18382,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:20:09.015203", "expires":
-        "2018-10-25T19:20:08Z", "id": "61bac17a64f04423bbcc7767a4eac9c8", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:35:08.716674", "expires":
+        "2018-11-01T19:35:08Z", "id": "7f442483e3be40d0add176273db5db4d", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["gAA0ZtLoSwC81D0DW6Uf9g"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["0mvZHy-_TVe0pl8qw7aA-Q"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -17901,7 +18429,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:09 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:08 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -17919,13 +18447,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:20:09 GMT
+      - Thu, 01 Nov 2018 18:35:08 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-d082669e-17be-44df-a9b5-9fa9c4a7511a
+      - req-4b17c225-068f-400a-9634-55dd399fb48d
       Content-Length:
       - '4117'
       Connection:
@@ -17934,10 +18462,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:20:09.212575", "expires":
-        "2018-10-25T19:20:09Z", "id": "9256c11a79724e05af605de6f1f69e72", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:35:08.914557", "expires":
+        "2018-11-01T19:35:08Z", "id": "adb6dde2f7c34d12b4661564b2284847", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["VrQYF_lYS4eaFvcesBY-Rg"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["uaYGwxBzTOuLKbk4AOHKjg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -17981,7 +18509,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:09 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:08 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/?format=json&limit=1000
@@ -17996,7 +18524,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9256c11a79724e05af605de6f1f69e72
+      - adb6dde2f7c34d12b4661564b2284847
   response:
     status:
       code: 200
@@ -18025,15 +18553,15 @@ http_interactions:
       X-Account-Project-Domain-Id:
       - default
       X-Trans-Id:
-      - tx5318a84fb1ce4b0bae3d6-005bd20959
+      - tx92eff0784d514ba0bf4ab-005bdb475d
       Date:
-      - Thu, 25 Oct 2018 18:20:09 GMT
+      - Thu, 01 Nov 2018 18:35:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '[{"count": 3, "bytes": 33, "name": "dir_1"}, {"count": 0, "bytes":
         0, "name": "dir_2"}, {"count": 0, "bytes": 0, "name": "dir_3"}]'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:09 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:09 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/?format=json&limit=1000&marker=dir_3
@@ -18048,7 +18576,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9256c11a79724e05af605de6f1f69e72
+      - adb6dde2f7c34d12b4661564b2284847
   response:
     status:
       code: 200
@@ -18077,14 +18605,14 @@ http_interactions:
       X-Account-Project-Domain-Id:
       - default
       X-Trans-Id:
-      - txe965f49fcf644c6da85f9-005bd20959
+      - tx8923dfb718ba4f2d85169-005bdb475d
       Date:
-      - Thu, 25 Oct 2018 18:20:09 GMT
+      - Thu, 01 Nov 2018 18:35:09 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:09 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:09 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -18102,13 +18630,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:20:09 GMT
+      - Thu, 01 Nov 2018 18:35:09 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-b30044db-a701-4443-9403-5e07096a0366
+      - req-05440d05-9cb5-4ef3-ac65-dd634946b0eb
       Content-Length:
       - '4131'
       Connection:
@@ -18117,10 +18645,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:20:09.640716", "expires":
-        "2018-10-25T19:20:09Z", "id": "f8c3789898a44a5db359c2b7570c8b9e", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:35:09.371245", "expires":
+        "2018-11-01T19:35:09Z", "id": "c180ac0d29f44118a2dca040586fe7f4", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["jG3dhi3sRP-5O1vD4cRIiw"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["2TjDrTNsTqeTxYSzy4UfeQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -18164,7 +18692,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:09 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:09 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_b458a5c25c3749758f4c0661940b3ba8/?format=json&limit=1000
@@ -18179,7 +18707,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f8c3789898a44a5db359c2b7570c8b9e
+      - c180ac0d29f44118a2dca040586fe7f4
   response:
     status:
       code: 200
@@ -18192,22 +18720,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1540491609.80645'
+      - '1541097309.53483'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1540491609.80645'
+      - '1541097309.53483'
       X-Trans-Id:
-      - txc63bb348a29f4096aa755-005bd20959
+      - tx0798429d2d154874ad310-005bdb475d
       Date:
-      - Thu, 25 Oct 2018 18:20:09 GMT
+      - Thu, 01 Nov 2018 18:35:09 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:09 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:09 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_e54e5c3c19e34720b05661f2ea1ea00a/?format=json&limit=1000
@@ -18222,7 +18750,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bccac69028e8432f861b9103fea8df39
+      - 5bf90f52abf14c3da0c4e6b3bd713282
   response:
     status:
       code: 200
@@ -18235,22 +18763,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1540491609.95514'
+      - '1541097309.68482'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1540491609.95514'
+      - '1541097309.68482'
       X-Trans-Id:
-      - tx1754d1c3e33d4394b8373-005bd20959
+      - tx7733f82030de453c97c58-005bdb475d
       Date:
-      - Thu, 25 Oct 2018 18:20:09 GMT
+      - Thu, 01 Nov 2018 18:35:09 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:09 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:09 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -18268,13 +18796,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:20:10 GMT
+      - Thu, 01 Nov 2018 18:35:09 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-096dabf9-a20d-47f0-9d42-05f1805a53f0
+      - req-cc3ed6ee-6875-4d4d-a229-1d5a5ddc4fc3
       Content-Length:
       - '4118'
       Connection:
@@ -18283,10 +18811,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:20:10.133220", "expires":
-        "2018-10-25T19:20:10Z", "id": "6a396c6a2b21454d84bde20cbbd67352", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:35:09.874695", "expires":
+        "2018-11-01T19:35:09Z", "id": "ce67ddf4a7b440dc9b18cadd7dbb718c", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["MjQDwvtbTB6zW9O9-f5irQ"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["BJRd-TCEQ3qvzIizxB5sWw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -18330,7 +18858,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:10 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:09 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_e8f744b1fc6a487681d35fb275252608/?format=json&limit=1000
@@ -18345,7 +18873,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6a396c6a2b21454d84bde20cbbd67352
+      - ce67ddf4a7b440dc9b18cadd7dbb718c
   response:
     status:
       code: 200
@@ -18358,22 +18886,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1540491610.29686'
+      - '1541097310.04227'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1540491610.29686'
+      - '1541097310.04227'
       X-Trans-Id:
-      - tx91ad9403799d481ca6676-005bd2095a
+      - txa29587fe8cce4c5f8a4d2-005bdb475d
       Date:
-      - Thu, 25 Oct 2018 18:20:10 GMT
+      - Thu, 01 Nov 2018 18:35:10 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:10 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:10 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/dir_1?format=json
@@ -18388,7 +18916,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9256c11a79724e05af605de6f1f69e72
+      - adb6dde2f7c34d12b4661564b2284847
   response:
     status:
       code: 200
@@ -18409,9 +18937,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - tx4ab34f2f5a964d669986e-005bd2095a
+      - tx8d2e25c7d62a46acac462-005bdb475e
       Date:
-      - Thu, 25 Oct 2018 18:20:10 GMT
+      - Thu, 01 Nov 2018 18:35:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '[{"hash": "61257bf228e2f6802a196c9a460d19a8", "last_modified": "2016-11-11T13:50:03.869630",
@@ -18421,7 +18949,7 @@ http_interactions:
         {"hash": "1727a9b61bddf85bbe7a5710c9f45691", "last_modified": "2016-11-11T13:50:04.495640",
         "bytes": 11, "name": "file_3", "content_type": "application/octet-stream"}]'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:10 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:10 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/dir_2?format=json
@@ -18436,7 +18964,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9256c11a79724e05af605de6f1f69e72
+      - adb6dde2f7c34d12b4661564b2284847
   response:
     status:
       code: 200
@@ -18457,14 +18985,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - tx837da472430a453fb710a-005bd2095a
+      - tx7891567be6644a6999d0a-005bdb475e
       Date:
-      - Thu, 25 Oct 2018 18:20:10 GMT
+      - Thu, 01 Nov 2018 18:35:10 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:10 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:10 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/dir_3?format=json
@@ -18479,7 +19007,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9256c11a79724e05af605de6f1f69e72
+      - adb6dde2f7c34d12b4661564b2284847
   response:
     status:
       code: 200
@@ -18500,12 +19028,12 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - tx81d3a2fdda504aaba0933-005bd2095a
+      - txfb660c1a5a97471090f8d-005bdb475e
       Date:
-      - Thu, 25 Oct 2018 18:20:10 GMT
+      - Thu, 01 Nov 2018 18:35:10 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:10 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:10 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_fast_refresh.yml
+++ b/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_fast_refresh.yml
@@ -17,13 +17,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:21:44 GMT
+      - Thu, 01 Nov 2018 18:37:06 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-33443050-5f42-4e45-b594-b7dc7fe9d261
+      - req-029f5c94-9f63-4075-955f-9735f0faf297
       Content-Length:
       - '4170'
       Connection:
@@ -32,10 +32,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:44.538125", "expires":
-        "2018-10-25T19:21:44Z", "id": "374009d19f954a2d8b1de1a56b39e97d", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:37:06.843562", "expires":
+        "2018-11-01T19:37:06Z", "id": "9fa685d3d4a44ca18af344bd9c072eeb", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["q7FmTaD_TGG8UyXRW8mxnw"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["bqCl0B5BQcOz6oX5eiM9pA"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -80,7 +80,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:44 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:06 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -95,7 +95,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 374009d19f954a2d8b1de1a56b39e97d
+      - 9fa685d3d4a44ca18af344bd9c072eeb
   response:
     status:
       code: 200
@@ -106,7 +106,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Thu, 25 Oct 2018 18:21:44 GMT
+      - Thu, 01 Nov 2018 18:37:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -115,7 +115,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:44 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:06 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-availability-zone
@@ -130,7 +130,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 374009d19f954a2d8b1de1a56b39e97d
+      - 9fa685d3d4a44ca18af344bd9c072eeb
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -143,15 +143,15 @@ http_interactions:
       Content-Length:
       - '97'
       X-Compute-Request-Id:
-      - req-168504ab-340a-405f-bdf4-b8bf676760b4
+      - req-29b13954-f0df-4784-8ad6-706e015c784e
       Date:
-      - Thu, 25 Oct 2018 18:21:44 GMT
+      - Thu, 01 Nov 2018 18:37:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"availabilityZoneInfo": [{"zoneState": {"available": true}, "hosts":
         null, "zoneName": "nova"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:44 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:07 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -169,13 +169,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:21:44 GMT
+      - Thu, 01 Nov 2018 18:37:07 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-ba7dd181-9a2f-47e3-ae13-4d6379b3a531
+      - req-35762481-c098-4854-b137-72d14648e0be
       Content-Length:
       - '4170'
       Connection:
@@ -184,10 +184,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:44.968388", "expires":
-        "2018-10-25T19:21:44Z", "id": "31a100b4e77e4d8cbda2b3abf0a3d069", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:37:07.333144", "expires":
+        "2018-11-01T19:37:07Z", "id": "fd7a3dbff41f4bf49fd0d9b0bf46b4b4", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["l1DRaEfMRhGzFKVPstblEg"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["vSc2QS5MR7Gt3YdqaxiK7g"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -232,7 +232,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:44 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:07 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-availability-zone.json
@@ -247,28 +247,28 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 31a100b4e77e4d8cbda2b3abf0a3d069
+      - fd7a3dbff41f4bf49fd0d9b0bf46b4b4
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-550dd436-f59f-4087-9aec-58a4f50da742
+      - req-f7c9e34e-bcb4-48c5-9a09-ce8a01edcdb3
       Content-Type:
       - application/json
       Content-Length:
       - '82'
       X-Openstack-Request-Id:
-      - req-550dd436-f59f-4087-9aec-58a4f50da742
+      - req-f7c9e34e-bcb4-48c5-9a09-ce8a01edcdb3
       Date:
-      - Thu, 25 Oct 2018 18:21:45 GMT
+      - Thu, 01 Nov 2018 18:37:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"availabilityZoneInfo": [{"zoneState": {"available": true}, "zoneName":
         "nova"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:45 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:07 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-services?all_tenants=True&limit=1000
@@ -283,7 +283,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 374009d19f954a2d8b1de1a56b39e97d
+      - 9fa685d3d4a44ca18af344bd9c072eeb
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -296,26 +296,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-4942d4ed-4fa2-4e32-b9b1-84dbb6fec923
+      - req-78af2047-5913-4e13-bac6-ad393c2ed44b
       Date:
-      - Thu, 25 Oct 2018 18:21:45 GMT
+      - Thu, 01 Nov 2018 18:37:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-10-25T18:21:41.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-11-01T18:37:02.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-10-25T18:21:37.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-11-01T18:36:59.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-10-25T18:21:38.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-11-01T18:37:01.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2018-10-25T18:21:41.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-11-01T18:37:07.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-10-25T18:21:42.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-11-01T18:37:03.000000"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:45 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:07 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-services?all_tenants=True&limit=1000&marker=5
@@ -330,7 +330,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 374009d19f954a2d8b1de1a56b39e97d
+      - 9fa685d3d4a44ca18af344bd9c072eeb
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -343,26 +343,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-f041594c-b1b0-4dba-a5cc-27c1f129e546
+      - req-07775761-88e3-4002-9ac9-4085024b7514
       Date:
-      - Thu, 25 Oct 2018 18:21:45 GMT
+      - Thu, 01 Nov 2018 18:37:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-10-25T18:21:41.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-11-01T18:37:02.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-10-25T18:21:37.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-11-01T18:36:59.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-10-25T18:21:38.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-11-01T18:37:01.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2018-10-25T18:21:41.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-11-01T18:37:07.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-10-25T18:21:42.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-11-01T18:37:03.000000"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:45 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:07 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000
@@ -377,7 +377,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 374009d19f954a2d8b1de1a56b39e97d
+      - 9fa685d3d4a44ca18af344bd9c072eeb
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -390,9 +390,9 @@ http_interactions:
       Content-Length:
       - '1010'
       X-Compute-Request-Id:
-      - req-b203a531-af99-4bd5-a460-e6fc1e24d82e
+      - req-a917efe6-5ed9-435d-9187-8f8952175408
       Date:
-      - Thu, 25 Oct 2018 18:21:45 GMT
+      - Thu, 01 Nov 2018 18:37:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.tiny", "links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/1",
@@ -406,7 +406,7 @@ http_interactions:
         0, "disk": 20, "id": "2"}], "flavors_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=2",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:45 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:07 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=2
@@ -421,7 +421,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 374009d19f954a2d8b1de1a56b39e97d
+      - 9fa685d3d4a44ca18af344bd9c072eeb
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -434,9 +434,9 @@ http_interactions:
       Content-Length:
       - '1014'
       X-Compute-Request-Id:
-      - req-0e894291-48a6-4bd0-9db2-5c1f33ca15d6
+      - req-7841a00f-d5c6-4a18-9a39-e22289eefa32
       Date:
-      - Thu, 25 Oct 2018 18:21:45 GMT
+      - Thu, 01 Nov 2018 18:37:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.medium", "links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/3",
@@ -450,7 +450,7 @@ http_interactions:
         0, "disk": 80, "id": "4"}], "flavors_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=4",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:45 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:08 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=4
@@ -465,7 +465,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 374009d19f954a2d8b1de1a56b39e97d
+      - 9fa685d3d4a44ca18af344bd9c072eeb
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -478,9 +478,9 @@ http_interactions:
       Content-Length:
       - '1026'
       X-Compute-Request-Id:
-      - req-afedc1dc-e7b8-458d-9ac2-5565dc43b9ac
+      - req-73a3b98d-7513-45b0-9fe3-6a6c41ed8c92
       Date:
-      - Thu, 25 Oct 2018 18:21:45 GMT
+      - Thu, 01 Nov 2018 18:37:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.xlarge", "links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/5",
@@ -495,7 +495,7 @@ http_interactions:
         1, "disk": 1, "id": "6"}], "flavors_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=6",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:45 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:08 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=6
@@ -510,7 +510,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 374009d19f954a2d8b1de1a56b39e97d
+      - 9fa685d3d4a44ca18af344bd9c072eeb
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -523,9 +523,9 @@ http_interactions:
       Content-Length:
       - '448'
       X-Compute-Request-Id:
-      - req-40870cda-cdd3-4c2b-a53a-6746feaf9e6f
+      - req-bda0530d-0f3b-4ffb-ab32-e7b8a0bbf191
       Date:
-      - Thu, 25 Oct 2018 18:21:45 GMT
+      - Thu, 01 Nov 2018 18:37:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.ems_refresh_spec_private", "links": [{"href":
@@ -535,7 +535,7 @@ http_interactions:
         8, "swap": "", "os-flavor-access:is_public": false, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         0, "disk": 160, "id": "7"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:45 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:08 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -553,13 +553,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:21:45 GMT
+      - Thu, 01 Nov 2018 18:37:08 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-4c6e2a21-cbcf-41c7-a200-fe631d03ad0e
+      - req-4aa1d3b4-bc31-42bb-ba77-4e1ae599b8de
       Content-Length:
       - '4170'
       Connection:
@@ -568,10 +568,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:45.997911", "expires":
-        "2018-10-25T19:21:45Z", "id": "314b2f10e623463ba33f21e329ee6b7f", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:37:08.420885", "expires":
+        "2018-11-01T19:37:08Z", "id": "86cbe3beb55847038dca08df708b4b71", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["UAqNZuihSKieRQPbFm6I5g"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["0ONsVkczRO6j1HELJbUH-A"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -616,7 +616,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:46 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:08 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -631,20 +631,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 314b2f10e623463ba33f21e329ee6b7f
+      - 86cbe3beb55847038dca08df708b4b71
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:21:46 GMT
+      - Thu, 01 Nov 2018 18:37:08 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-3f131a86-acae-4004-9efa-d33c4b854d38
+      - req-eafefb70-3d3e-4426-9ebd-0337c11184d5
       Content-Length:
       - '500'
       Connection:
@@ -661,7 +661,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:46 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:08 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/7/os-flavor-access
@@ -676,7 +676,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 374009d19f954a2d8b1de1a56b39e97d
+      - 9fa685d3d4a44ca18af344bd9c072eeb
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -689,15 +689,15 @@ http_interactions:
       Content-Length:
       - '88'
       X-Compute-Request-Id:
-      - req-2db5b4e5-fb15-49b1-90c8-4744bf45aea4
+      - req-0bd1ed49-747b-4433-ba68-18431f207fd4
       Date:
-      - Thu, 25 Oct 2018 18:21:46 GMT
+      - Thu, 01 Nov 2018 18:37:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavor_access": [{"tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "flavor_id": "7"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:46 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:08 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -715,13 +715,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:21:46 GMT
+      - Thu, 01 Nov 2018 18:37:08 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-b9b8d9da-3ff1-457d-bcc5-94dab6d3633e
+      - req-1fd84e6c-55d9-4736-8a90-e8931161203d
       Content-Length:
       - '4170'
       Connection:
@@ -730,10 +730,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:46.410346", "expires":
-        "2018-10-25T19:21:46Z", "id": "2993cdfdae83436193a319a558c60daa", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:37:08.853297", "expires":
+        "2018-11-01T19:37:08Z", "id": "4b3aa314f450480881c57747a762e06b", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["G8k7TQn1QvGNH09XCfpQqQ"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["a0qKDi3mTZeBK8nLsdCqfQ"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -778,7 +778,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:46 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:08 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images
@@ -793,7 +793,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2993cdfdae83436193a319a558c60daa
+      - 4b3aa314f450480881c57747a762e06b
   response:
     status:
       code: 200
@@ -804,9 +804,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-818c0a20-8e09-4050-ae66-d35c5d0e8f7b
+      - req-2b8adebf-afdc-4a61-82ae-3b91dbe28cf8
       Date:
-      - Thu, 25 Oct 2018 18:21:46 GMT
+      - Thu, 01 Nov 2018 18:37:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -848,7 +848,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images"}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:46 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:09 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images?marker=bb799f70-5e02-461b-8324-17ee88259c7b
@@ -863,7 +863,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2993cdfdae83436193a319a558c60daa
+      - 4b3aa314f450480881c57747a762e06b
   response:
     status:
       code: 200
@@ -874,14 +874,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-0ba093e4-101a-4852-a93f-cb82d287a517
+      - req-af1e03ac-03e0-42cf-ba31-6fc53475b13c
       Date:
-      - Thu, 25 Oct 2018 18:21:46 GMT
+      - Thu, 01 Nov 2018 18:37:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images"}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:46 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:09 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-keypairs?all_tenants=True&limit=1000
@@ -896,7 +896,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 374009d19f954a2d8b1de1a56b39e97d
+      - 9fa685d3d4a44ca18af344bd9c072eeb
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -909,9 +909,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-dc8a74d3-3b39-4f73-9421-6205f4c78fdd
+      - req-8eba079d-89ca-4396-8b92-8f5d0c1e2d41
       Date:
-      - Thu, 25 Oct 2018 18:21:46 GMT
+      - Thu, 01 Nov 2018 18:37:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -921,7 +921,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:46 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:09 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-keypairs?all_tenants=True&limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -936,7 +936,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 374009d19f954a2d8b1de1a56b39e97d
+      - 9fa685d3d4a44ca18af344bd9c072eeb
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -949,9 +949,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-ed829455-e719-4b56-b07c-526b3a0f2c85
+      - req-1e3b8efb-a96d-4ffa-b6cf-54e66ef7e0b9
       Date:
-      - Thu, 25 Oct 2018 18:21:46 GMT
+      - Thu, 01 Nov 2018 18:37:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -961,7 +961,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:46 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:09 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -979,13 +979,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:21:47 GMT
+      - Thu, 01 Nov 2018 18:37:09 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-6aaab10b-b948-4f13-b524-766310b2f645
+      - req-c381331f-4ce3-43d7-ae67-b93cc8ca72bb
       Content-Length:
       - '4170'
       Connection:
@@ -994,10 +994,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:47.141468", "expires":
-        "2018-10-25T19:21:47Z", "id": "27cc04e96ab3401dbbdc240d5a399e6d", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:37:09.649276", "expires":
+        "2018-11-01T19:37:09Z", "id": "e1d1526984994b68ba671f6050ff1050", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["zRarSxS0S7anQYAwnjjsZw"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["h9QdtSkhTOKaQ2-yzamEwg"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -1042,7 +1042,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:47 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:09 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1060,13 +1060,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:21:47 GMT
+      - Thu, 01 Nov 2018 18:37:09 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-344e4627-0ab6-4476-9336-852f6f593974
+      - req-cab5384b-daf6-4a30-87a6-5f30da097c5e
       Content-Length:
       - '370'
       Connection:
@@ -1075,13 +1075,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:47.315605", "expires":
-        "2018-10-25T19:21:47Z", "id": "e7d03da584a44b20a44dc39cd0cf4f4e", "audit_ids":
-        ["nOtnWf7iTz6tGmW1KFAhEg"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:37:09.818573", "expires":
+        "2018-11-01T19:37:09Z", "id": "0cac5ed4bea743babf4f5558dacd144e", "audit_ids":
+        ["UY3c1y4HSe28ITqUiNtfDw"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:47 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:09 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -1096,20 +1096,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e7d03da584a44b20a44dc39cd0cf4f4e
+      - 0cac5ed4bea743babf4f5558dacd144e
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:21:47 GMT
+      - Thu, 01 Nov 2018 18:37:09 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-e5bca8c8-249a-4e94-b1b4-777dfaf4d6df
+      - req-889213e2-ecec-4523-92d4-5506f5da70a1
       Content-Length:
       - '500'
       Connection:
@@ -1126,7 +1126,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:47 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:09 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1144,13 +1144,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:21:47 GMT
+      - Thu, 01 Nov 2018 18:37:10 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-165390bb-ac4c-4018-8bc7-35a7dd4816c7
+      - req-d814f403-85c5-413c-8de9-ae9301a54abc
       Content-Length:
       - '4117'
       Connection:
@@ -1159,10 +1159,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:47.623559", "expires":
-        "2018-10-25T19:21:47Z", "id": "59bdf2d92cc9422996b2578739f2ba8c", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:37:10.161076", "expires":
+        "2018-11-01T19:37:10Z", "id": "1ab801b64a4a4e69ba84b9843b9cd599", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["CZgQPIFaTBGRDtAEYjhIXQ"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["HKU4GrH6QsO9Ww9a9UGt9A"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -1206,7 +1206,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:47 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:10 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -1221,7 +1221,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 59bdf2d92cc9422996b2578739f2ba8c
+      - 1ab801b64a4a4e69ba84b9843b9cd599
   response:
     status:
       code: 200
@@ -1232,7 +1232,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Thu, 25 Oct 2018 18:21:47 GMT
+      - Thu, 01 Nov 2018 18:37:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -1241,7 +1241,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:47 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:10 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1259,13 +1259,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:21:47 GMT
+      - Thu, 01 Nov 2018 18:37:10 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-32b6bb81-043a-4bff-84d2-85ae36e0c992
+      - req-b571f7fd-47ec-4189-a10b-9974fec5212e
       Content-Length:
       - '4131'
       Connection:
@@ -1274,10 +1274,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:47.884554", "expires":
-        "2018-10-25T19:21:47Z", "id": "9279da89caed4ba08613476e7f4c5622", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:37:10.448239", "expires":
+        "2018-11-01T19:37:10Z", "id": "0a90669b56214297aaa2ac7974667fa1", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["dh_K0k9IRZ2TAGjUCl1GQw"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["Hne9NEhDSYmrORNi5FJC6w"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -1321,7 +1321,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:47 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:10 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -1336,7 +1336,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9279da89caed4ba08613476e7f4c5622
+      - 0a90669b56214297aaa2ac7974667fa1
   response:
     status:
       code: 200
@@ -1347,7 +1347,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Thu, 25 Oct 2018 18:21:47 GMT
+      - Thu, 01 Nov 2018 18:37:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -1356,7 +1356,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:47 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:10 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1374,13 +1374,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:21:48 GMT
+      - Thu, 01 Nov 2018 18:37:10 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-2255ae32-db1d-4bb2-80f9-f0e2c8bffb81
+      - req-b159475d-f965-4e71-a704-c21c8798f871
       Content-Length:
       - '4118'
       Connection:
@@ -1389,10 +1389,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:48.142379", "expires":
-        "2018-10-25T19:21:48Z", "id": "7f7cafd5301545f1814f68dc40fcb64f", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:37:10.737399", "expires":
+        "2018-11-01T19:37:10Z", "id": "4a8623b5468f49b2b4acf08554b53b2b", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["7944VoHTQ4mz9GP8BIfOPg"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["vXGzxwiMRp20UrJ3OMixfg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -1436,7 +1436,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:48 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:10 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -1451,7 +1451,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7f7cafd5301545f1814f68dc40fcb64f
+      - 4a8623b5468f49b2b4acf08554b53b2b
   response:
     status:
       code: 200
@@ -1462,7 +1462,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Thu, 25 Oct 2018 18:21:48 GMT
+      - Thu, 01 Nov 2018 18:37:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -1471,7 +1471,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:48 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:10 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1489,13 +1489,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:21:48 GMT
+      - Thu, 01 Nov 2018 18:37:10 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-86e24925-b18b-4507-81fe-0ce5e2e344e8
+      - req-6b5e455e-9558-494e-8f2d-e3055404ec63
       Content-Length:
       - '4117'
       Connection:
@@ -1504,10 +1504,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:48.398311", "expires":
-        "2018-10-25T19:21:48Z", "id": "e5a79af6c3fc4433bfbbbcc61c24b317", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:37:11.009327", "expires":
+        "2018-11-01T19:37:10Z", "id": "925b6ed1046142b18b771ef9d72cba52", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["lOAhQ9vSShaIQrS-KVyt2g"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["cP347l0bQ3GxpS3ZaZuRnA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -1551,7 +1551,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:48 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:11 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks?limit=1000&show_nested=true
@@ -1566,7 +1566,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e5a79af6c3fc4433bfbbbcc61c24b317
+      - 925b6ed1046142b18b771ef9d72cba52
   response:
     status:
       code: 200
@@ -1577,9 +1577,9 @@ http_interactions:
       Content-Length:
       - '2559'
       X-Openstack-Request-Id:
-      - req-f3a1161a-0b28-47f2-b5eb-cb838432411d
+      - req-ddfc1923-3058-4ade-9925-6bb4b83e8483
       Date:
-      - Thu, 25 Oct 2018 18:21:48 GMT
+      - Thu, 01 Nov 2018 18:37:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": [{"description": "Heat WordPress template to support F20,
@@ -1613,7 +1613,7 @@ http_interactions:
         "rel": "self"}], "updated_time": null, "stack_owner": null, "stack_status":
         "CREATE_COMPLETE", "id": "091e1e54-e01c-4ec5-a0ab-b00bee4d425c"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:48 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:11 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks?limit=1000&marker=091e1e54-e01c-4ec5-a0ab-b00bee4d425c&show_nested=true
@@ -1628,7 +1628,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e5a79af6c3fc4433bfbbbcc61c24b317
+      - 925b6ed1046142b18b771ef9d72cba52
   response:
     status:
       code: 200
@@ -1639,14 +1639,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-d56d641d-7d9c-4cb2-b0ff-9699ca30a201
+      - req-7f4da66e-3ea5-41fb-9df6-04d8f2b550d2
       Date:
-      - Thu, 25 Oct 2018 18:21:48 GMT
+      - Thu, 01 Nov 2018 18:37:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:48 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:11 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1664,13 +1664,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:21:48 GMT
+      - Thu, 01 Nov 2018 18:37:11 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-2d66e76a-7a05-48e1-ad36-0ca5765b0d15
+      - req-2da9bbce-da88-4fd8-9ccb-1546c956224f
       Content-Length:
       - '4131'
       Connection:
@@ -1679,10 +1679,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:48.859219", "expires":
-        "2018-10-25T19:21:48Z", "id": "3abb6524eac54039abc5681a7ee24992", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:37:11.509034", "expires":
+        "2018-11-01T19:37:11Z", "id": "d5f526b073c9435baa2992c8e7178f8c", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["V4b4QFoZQnGIQfftyIhF-Q"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["TfUxyBiuRfCBXtmJIsOQRA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -1726,7 +1726,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:48 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:11 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/b458a5c25c3749758f4c0661940b3ba8/stacks?limit=1000&show_nested=true
@@ -1741,7 +1741,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3abb6524eac54039abc5681a7ee24992
+      - d5f526b073c9435baa2992c8e7178f8c
   response:
     status:
       code: 200
@@ -1752,14 +1752,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-0e5b9df2-fa32-460f-8125-a84d642e1faf
+      - req-e79ce9a1-3807-4e9c-9fe3-6650c239fe44
       Date:
-      - Thu, 25 Oct 2018 18:21:49 GMT
+      - Thu, 01 Nov 2018 18:37:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:49 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:11 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/e54e5c3c19e34720b05661f2ea1ea00a/stacks?limit=1000&show_nested=true
@@ -1774,7 +1774,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 27cc04e96ab3401dbbdc240d5a399e6d
+      - e1d1526984994b68ba671f6050ff1050
   response:
     status:
       code: 200
@@ -1785,14 +1785,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-8b9179ba-8608-47aa-b2a9-5d7e99e9a28b
+      - req-2098016a-288d-4f5b-8f35-e186a2a00238
       Date:
-      - Thu, 25 Oct 2018 18:21:49 GMT
+      - Thu, 01 Nov 2018 18:37:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:49 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:11 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1810,13 +1810,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:21:49 GMT
+      - Thu, 01 Nov 2018 18:37:11 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-c3456ebd-d6a1-4d1c-b805-0a2b57196174
+      - req-cb720169-c4e1-40e1-892c-2df95516e127
       Content-Length:
       - '4118'
       Connection:
@@ -1825,10 +1825,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:49.389601", "expires":
-        "2018-10-25T19:21:49Z", "id": "d4a581e1433645b6b84eefe9ac60ba3b", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:37:12.015223", "expires":
+        "2018-11-01T19:37:12Z", "id": "0ba8d9f41fbd4e579480349b16d06404", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["EXZ4m5hjQgGQS_-MZtWSOA"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["LnoTrLq1RvOpc3MOnzN6tQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -1872,7 +1872,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:49 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:12 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/e8f744b1fc6a487681d35fb275252608/stacks?limit=1000&show_nested=true
@@ -1887,7 +1887,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d4a581e1433645b6b84eefe9ac60ba3b
+      - 0ba8d9f41fbd4e579480349b16d06404
   response:
     status:
       code: 200
@@ -1898,14 +1898,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-103f84f1-70d0-4a1d-847e-7c7068f28ca9
+      - req-fb64e976-1070-408e-8fca-cb98a8690603
       Date:
-      - Thu, 25 Oct 2018 18:21:49 GMT
+      - Thu, 01 Nov 2018 18:37:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:49 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:12 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack3/45d2af82-eff9-4483-a1f0-f19c44d96146
@@ -1920,7 +1920,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e5a79af6c3fc4433bfbbbcc61c24b317
+      - 925b6ed1046142b18b771ef9d72cba52
   response:
     status:
       code: 200
@@ -1931,9 +1931,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-576602b9-47ff-403c-8b7d-92edaa4dcd82
+      - req-38d8a2e7-4ebe-4344-a22e-aa70d03a52f0
       Date:
-      - Thu, 25 Oct 2018 18:21:49 GMT
+      - Thu, 01 Nov 2018 18:37:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -1960,7 +1960,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:49 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:12 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack2/4cf24b12-29fc-4529-a8ed-6b079dea7c17
@@ -1975,7 +1975,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e5a79af6c3fc4433bfbbbcc61c24b317
+      - 925b6ed1046142b18b771ef9d72cba52
   response:
     status:
       code: 200
@@ -1986,9 +1986,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-e4333c73-0a19-45fc-8faf-a7381a5352db
+      - req-ea10cb2c-86a2-4a93-ba37-b4117a0cdeea
       Date:
-      - Thu, 25 Oct 2018 18:21:50 GMT
+      - Thu, 01 Nov 2018 18:37:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -2015,7 +2015,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:50 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:12 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c
@@ -2030,7 +2030,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e5a79af6c3fc4433bfbbbcc61c24b317
+      - 925b6ed1046142b18b771ef9d72cba52
   response:
     status:
       code: 200
@@ -2041,9 +2041,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-09063e4f-16b6-4b5c-b43a-b99913603271
+      - req-311af64a-90bf-4dd9-a23e-ff5fc90a3c22
       Date:
-      - Thu, 25 Oct 2018 18:21:50 GMT
+      - Thu, 01 Nov 2018 18:37:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -2070,7 +2070,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:50 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:13 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack3/45d2af82-eff9-4483-a1f0-f19c44d96146/template
@@ -2085,7 +2085,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e5a79af6c3fc4433bfbbbcc61c24b317
+      - 925b6ed1046142b18b771ef9d72cba52
   response:
     status:
       code: 200
@@ -2096,9 +2096,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-ce2e281e-0c26-496a-b946-ccd49fdb1ace
+      - req-14aa0e34-0213-43c7-bbbd-5a62b476bbda
       Date:
-      - Thu, 25 Oct 2018 18:21:50 GMT
+      - Thu, 01 Nov 2018 18:37:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -2154,7 +2154,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:50 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:13 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack3/45d2af82-eff9-4483-a1f0-f19c44d96146/resources
@@ -2169,7 +2169,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e5a79af6c3fc4433bfbbbcc61c24b317
+      - 925b6ed1046142b18b771ef9d72cba52
   response:
     status:
       code: 200
@@ -2180,9 +2180,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-aba39358-70c5-44a3-9c77-398b6138c966
+      - req-2a7f2bba-7e2e-4a78-a837-d8e90e58f1b1
       Date:
-      - Thu, 25 Oct 2018 18:21:50 GMT
+      - Thu, 01 Nov 2018 18:37:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -2194,7 +2194,7 @@ http_interactions:
         changed", "physical_resource_id": "aa5907f3-8209-4dd0-b3ef-600431d85bac",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:50 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:13 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?all_tenants=True&limit=1000
@@ -2209,7 +2209,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 374009d19f954a2d8b1de1a56b39e97d
+      - 9fa685d3d4a44ca18af344bd9c072eeb
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2222,9 +2222,9 @@ http_interactions:
       Content-Length:
       - '3998'
       X-Compute-Request-Id:
-      - req-5ff8231d-a152-40d0-98a9-45e59e126e38
+      - req-7a0df779-fe71-4f33-bb64-53b8533fc74c
       Date:
-      - Thu, 25 Oct 2018 18:21:51 GMT
+      - Thu, 01 Nov 2018 18:37:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?all_tenants=True&limit=1000&marker=96fef14f-5338-4d58-8b89-58b627b27b9b",
@@ -2270,7 +2270,7 @@ http_interactions:
         [], "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:51 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:13 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?all_tenants=True&limit=1000&marker=96fef14f-5338-4d58-8b89-58b627b27b9b
@@ -2285,7 +2285,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 374009d19f954a2d8b1de1a56b39e97d
+      - 9fa685d3d4a44ca18af344bd9c072eeb
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2298,9 +2298,9 @@ http_interactions:
       Content-Length:
       - '4062'
       X-Compute-Request-Id:
-      - req-b4db3a05-3740-4b9f-8354-384032480298
+      - req-88b1b452-8f2f-4c3f-99ee-d091f5e4739e
       Date:
-      - Thu, 25 Oct 2018 18:21:51 GMT
+      - Thu, 01 Nov 2018 18:37:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?all_tenants=True&limit=1000&marker=ca1fc357-ee31-45e9-a38d-98723d6c8876",
@@ -2346,7 +2346,7 @@ http_interactions:
         [], "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 3, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:51 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:14 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?all_tenants=True&limit=1000&marker=ca1fc357-ee31-45e9-a38d-98723d6c8876
@@ -2361,7 +2361,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 374009d19f954a2d8b1de1a56b39e97d
+      - 9fa685d3d4a44ca18af344bd9c072eeb
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2374,9 +2374,9 @@ http_interactions:
       Content-Length:
       - '4144'
       X-Compute-Request-Id:
-      - req-68a40955-934f-417e-a353-eff6aa687604
+      - req-db98cf2e-ee2f-498a-b032-cdc79c95e0a8
       Date:
-      - Thu, 25 Oct 2018 18:21:51 GMT
+      - Thu, 01 Nov 2018 18:37:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?all_tenants=True&limit=1000&marker=ca4f3a16-bae3-4407-83e9-f77b28af0f2b",
@@ -2424,7 +2424,7 @@ http_interactions:
         "", "progress": 0, "OS-EXT-STS:power_state": 1, "config_drive": "", "metadata":
         {}}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:51 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:14 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?all_tenants=True&limit=1000&marker=ca4f3a16-bae3-4407-83e9-f77b28af0f2b
@@ -2439,7 +2439,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 374009d19f954a2d8b1de1a56b39e97d
+      - 9fa685d3d4a44ca18af344bd9c072eeb
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2452,9 +2452,9 @@ http_interactions:
       Content-Length:
       - '3813'
       X-Compute-Request-Id:
-      - req-c938489e-f93b-4dfc-8aa3-51e270a6782b
+      - req-fadc2065-4e35-4105-9d79-2f5a93100da2
       Date:
-      - Thu, 25 Oct 2018 18:21:51 GMT
+      - Thu, 01 Nov 2018 18:37:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?all_tenants=True&limit=1000&marker=aa5907f3-8209-4dd0-b3ef-600431d85bac",
@@ -2496,7 +2496,7 @@ http_interactions:
         "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:51 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:14 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?all_tenants=True&limit=1000&marker=aa5907f3-8209-4dd0-b3ef-600431d85bac
@@ -2511,7 +2511,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 374009d19f954a2d8b1de1a56b39e97d
+      - 9fa685d3d4a44ca18af344bd9c072eeb
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2524,9 +2524,9 @@ http_interactions:
       Content-Length:
       - '1816'
       X-Compute-Request-Id:
-      - req-bd2ca756-ad79-4622-9679-5ec4b677b842
+      - req-12c4c6ad-3473-4c8a-a93d-0fdecc2d04d1
       Date:
-      - Thu, 25 Oct 2018 18:21:52 GMT
+      - Thu, 01 Nov 2018 18:37:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": [{"status": "SHUTOFF", "updated": "2018-01-17T14:49:17Z",
@@ -2549,7 +2549,7 @@ http_interactions:
         "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:52 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:14 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack2/4cf24b12-29fc-4529-a8ed-6b079dea7c17/template
@@ -2564,7 +2564,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e5a79af6c3fc4433bfbbbcc61c24b317
+      - 925b6ed1046142b18b771ef9d72cba52
   response:
     status:
       code: 200
@@ -2575,9 +2575,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-234fe85f-76cf-4481-9e3f-e8efd32a3b97
+      - req-73f66384-8d09-44bd-a18d-5cde010edbb2
       Date:
-      - Thu, 25 Oct 2018 18:21:52 GMT
+      - Thu, 01 Nov 2018 18:37:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -2633,7 +2633,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:52 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:15 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack2/4cf24b12-29fc-4529-a8ed-6b079dea7c17/resources
@@ -2648,7 +2648,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e5a79af6c3fc4433bfbbbcc61c24b317
+      - 925b6ed1046142b18b771ef9d72cba52
   response:
     status:
       code: 200
@@ -2659,9 +2659,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-e0d4c128-b587-451e-8489-8d9be3d6b2c6
+      - req-241f9bd6-e82b-4b59-86d2-c70c478b4483
       Date:
-      - Thu, 25 Oct 2018 18:21:52 GMT
+      - Thu, 01 Nov 2018 18:37:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -2673,7 +2673,7 @@ http_interactions:
         changed", "physical_resource_id": "219a737c-b4ad-430d-944a-a92a4834b12d",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:52 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:15 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c/template
@@ -2688,7 +2688,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e5a79af6c3fc4433bfbbbcc61c24b317
+      - 925b6ed1046142b18b771ef9d72cba52
   response:
     status:
       code: 200
@@ -2699,9 +2699,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-09bb5641-fdc2-43cb-991b-13aa46c6b6a7
+      - req-61b0ea68-5e6b-4f0d-abc2-8b8070413e34
       Date:
-      - Thu, 25 Oct 2018 18:21:52 GMT
+      - Thu, 01 Nov 2018 18:37:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -2757,7 +2757,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:52 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:15 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c/resources
@@ -2772,7 +2772,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e5a79af6c3fc4433bfbbbcc61c24b317
+      - 925b6ed1046142b18b771ef9d72cba52
   response:
     status:
       code: 200
@@ -2783,9 +2783,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-1bc9ba60-4adb-4d09-bdc1-2cb1b3e4e41d
+      - req-ec137629-5925-4287-9f87-e7d184edb3fc
       Date:
-      - Thu, 25 Oct 2018 18:21:52 GMT
+      - Thu, 01 Nov 2018 18:37:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -2797,7 +2797,7 @@ http_interactions:
         changed", "physical_resource_id": "b686353f-0da0-48bf-bc35-8ea411a67dfd",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:52 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:15 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a//os-quota-sets/69f8f7205ade4aa59084c32c83e60b5a
@@ -2812,7 +2812,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 59bdf2d92cc9422996b2578739f2ba8c
+      - 1ab801b64a4a4e69ba84b9843b9cd599
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2825,9 +2825,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-3a96e4a5-8597-4562-b4c4-2a1f0d108219
+      - req-0ea4d052-eda2-45b8-b70a-28d3d912b92d
       Date:
-      - Thu, 25 Oct 2018 18:21:52 GMT
+      - Thu, 01 Nov 2018 18:37:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -2836,7 +2836,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:52 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:15 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8//os-quota-sets/b458a5c25c3749758f4c0661940b3ba8
@@ -2851,7 +2851,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9279da89caed4ba08613476e7f4c5622
+      - 0a90669b56214297aaa2ac7974667fa1
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2864,9 +2864,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-2685ba93-5898-4c29-b772-f8bdec453582
+      - req-85f05523-712c-4902-9b7a-57ed2e42d868
       Date:
-      - Thu, 25 Oct 2018 18:21:52 GMT
+      - Thu, 01 Nov 2018 18:37:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -2875,7 +2875,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:52 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:15 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a//os-quota-sets/e54e5c3c19e34720b05661f2ea1ea00a
@@ -2890,7 +2890,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 374009d19f954a2d8b1de1a56b39e97d
+      - 9fa685d3d4a44ca18af344bd9c072eeb
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2903,9 +2903,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-9e15092d-e2c2-4d08-a9dc-60cbe7cf8f8a
+      - req-1c1f068a-379e-403a-951a-9c23da8033c1
       Date:
-      - Thu, 25 Oct 2018 18:21:52 GMT
+      - Thu, 01 Nov 2018 18:37:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -2914,7 +2914,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:53 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:15 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608//os-quota-sets/e8f744b1fc6a487681d35fb275252608
@@ -2929,7 +2929,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7f7cafd5301545f1814f68dc40fcb64f
+      - 4a8623b5468f49b2b4acf08554b53b2b
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2942,9 +2942,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-e400ad04-6885-4f2c-bd72-3a57f8cbad21
+      - req-d8a2fa5c-3e04-48ac-bb4d-745ae9c3803f
       Date:
-      - Thu, 25 Oct 2018 18:21:53 GMT
+      - Thu, 01 Nov 2018 18:37:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -2953,7 +2953,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:53 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:15 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -2971,13 +2971,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:21:53 GMT
+      - Thu, 01 Nov 2018 18:37:16 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-5cfa7f16-e428-4b40-a745-8fc9650b0c51
+      - req-157b0f45-4e3d-4be2-88f1-75aea1ad2b27
       Content-Length:
       - '4117'
       Connection:
@@ -2986,10 +2986,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:53.367120", "expires":
-        "2018-10-25T19:21:53Z", "id": "a104e5847238444bb8a8adaa78d1108d", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:37:16.167622", "expires":
+        "2018-11-01T19:37:16Z", "id": "175ccf7cc7e8488b98bd0e38b2037ce9", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["IQi7wRFFQLi457BFaPY6VA"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["FMsNoIHCQeqFWW7dcVRtOQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -3033,7 +3033,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:53 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:16 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a//os-quota-sets/69f8f7205ade4aa59084c32c83e60b5a
@@ -3048,22 +3048,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a104e5847238444bb8a8adaa78d1108d
+      - 175ccf7cc7e8488b98bd0e38b2037ce9
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-9269cf97-388c-4a96-a236-be63e8e17ddd
+      - req-5747f7ac-8e74-4237-b95b-99842eef44f1
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-9269cf97-388c-4a96-a236-be63e8e17ddd
+      - req-5747f7ac-8e74-4237-b95b-99842eef44f1
       Date:
-      - Thu, 25 Oct 2018 18:21:53 GMT
+      - Thu, 01 Nov 2018 18:37:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -3073,7 +3073,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "69f8f7205ade4aa59084c32c83e60b5a"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:53 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:16 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -3091,13 +3091,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:21:53 GMT
+      - Thu, 01 Nov 2018 18:37:16 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-b9a699a6-9186-4475-9d64-b8c0adf40ece
+      - req-a6232e02-4d38-4671-bfdf-d2514dcf1d70
       Content-Length:
       - '4131'
       Connection:
@@ -3106,10 +3106,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:53.854864", "expires":
-        "2018-10-25T19:21:53Z", "id": "00d5243ff75c4829b3766828f2c20e83", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:37:16.666130", "expires":
+        "2018-11-01T19:37:16Z", "id": "983ae17fd60949b0ae85380830c41f6f", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["CRdbeHGGR16NO6HWnpg7XQ"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["shqziH_VR2q4B-jGIqP3Ug"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -3153,7 +3153,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:53 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:16 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8//os-quota-sets/b458a5c25c3749758f4c0661940b3ba8
@@ -3168,22 +3168,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 00d5243ff75c4829b3766828f2c20e83
+      - 983ae17fd60949b0ae85380830c41f6f
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-c424cb74-7811-4ecb-816c-6cb4675ea240
+      - req-d089106d-ea9e-4585-873f-918a37abbebf
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-c424cb74-7811-4ecb-816c-6cb4675ea240
+      - req-d089106d-ea9e-4585-873f-918a37abbebf
       Date:
-      - Thu, 25 Oct 2018 18:21:54 GMT
+      - Thu, 01 Nov 2018 18:37:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -3193,7 +3193,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "b458a5c25c3749758f4c0661940b3ba8"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:54 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:16 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a//os-quota-sets/e54e5c3c19e34720b05661f2ea1ea00a
@@ -3208,22 +3208,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 31a100b4e77e4d8cbda2b3abf0a3d069
+      - fd7a3dbff41f4bf49fd0d9b0bf46b4b4
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-c4a40e76-2998-464e-aaaa-8d27a05bc9d6
+      - req-16c23a84-cce8-4c5b-a533-3d8a04e1f62c
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-c4a40e76-2998-464e-aaaa-8d27a05bc9d6
+      - req-16c23a84-cce8-4c5b-a533-3d8a04e1f62c
       Date:
-      - Thu, 25 Oct 2018 18:21:54 GMT
+      - Thu, 01 Nov 2018 18:37:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -3233,7 +3233,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "e54e5c3c19e34720b05661f2ea1ea00a"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:54 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:17 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -3251,13 +3251,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:21:54 GMT
+      - Thu, 01 Nov 2018 18:37:17 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-8459c8ff-8865-497a-a9db-3d2a41a0ba5e
+      - req-1c2d3d9d-2b43-4fcd-8c76-364810bbbb23
       Content-Length:
       - '4118'
       Connection:
@@ -3266,10 +3266,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:54.582989", "expires":
-        "2018-10-25T19:21:54Z", "id": "832a14367cc3401dacbf9bd609f630ea", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:37:17.427208", "expires":
+        "2018-11-01T19:37:17Z", "id": "55fc8f34e85b482fbb5a7832bdbbccb6", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["E_BeDUeJQMmQuBvdH4W1yQ"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["xDrtpzgeRPCWa_IJeiDC5w"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -3313,7 +3313,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:54 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:17 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608//os-quota-sets/e8f744b1fc6a487681d35fb275252608
@@ -3328,22 +3328,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 832a14367cc3401dacbf9bd609f630ea
+      - 55fc8f34e85b482fbb5a7832bdbbccb6
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-e22efc3b-3ff6-407a-a44f-ffb0dd8d3e2c
+      - req-ca06c75b-b633-40ab-8abf-c5951359fdb2
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-e22efc3b-3ff6-407a-a44f-ffb0dd8d3e2c
+      - req-ca06c75b-b633-40ab-8abf-c5951359fdb2
       Date:
-      - Thu, 25 Oct 2018 18:21:54 GMT
+      - Thu, 01 Nov 2018 18:37:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -3353,7 +3353,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "e8f744b1fc6a487681d35fb275252608"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:54 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:17 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -3371,13 +3371,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:21:55 GMT
+      - Thu, 01 Nov 2018 18:37:17 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-1e1b85ef-2572-43b9-8b0a-7deb3d1ac1bc
+      - req-2483847a-c711-43a6-b63f-119d472c9bb3
       Content-Length:
       - '4170'
       Connection:
@@ -3386,10 +3386,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:55.064690", "expires":
-        "2018-10-25T19:21:55Z", "id": "f8b4cdfad19149cba575d2e18ae194ef", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:37:17.908079", "expires":
+        "2018-11-01T19:37:17Z", "id": "b019cdc3031c400594c4eae822712c23", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["_7q4StL0Qx2lUfNGEvPFtg"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["559qhHN-QFajfJv8Rm4DEA"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -3434,7 +3434,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:55 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:17 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -3452,13 +3452,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:21:55 GMT
+      - Thu, 01 Nov 2018 18:37:18 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-f22c5074-0ba1-4f33-ad7d-2cda4e86d78c
+      - req-0671ce8e-ed23-4d14-93d4-525f291956ee
       Content-Length:
       - '4117'
       Connection:
@@ -3467,10 +3467,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:55.259844", "expires":
-        "2018-10-25T19:21:55Z", "id": "8682288d4dfc4b9886bfd646e212f37b", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:37:18.112313", "expires":
+        "2018-11-01T19:37:18Z", "id": "16b9fcfcbf394ce1bb04e620ba506ab6", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["mSB7Q-qVTlufNd_QfiMNeQ"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["21qa_z_VQLWCQNkIkYkneA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -3514,7 +3514,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:55 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:18 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0//quotas/69f8f7205ade4aa59084c32c83e60b5a
@@ -3529,7 +3529,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8682288d4dfc4b9886bfd646e212f37b
+      - 16b9fcfcbf394ce1bb04e620ba506ab6
   response:
     status:
       code: 200
@@ -3540,16 +3540,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-c1bfc241-80cd-4129-ab85-5cefd626ddd8
+      - req-888a0e50-db94-4a97-a9fb-2e796b24b866
       Date:
-      - Thu, 25 Oct 2018 18:21:55 GMT
+      - Thu, 01 Nov 2018 18:37:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 20, "network": 20, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:55 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:18 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -3567,13 +3567,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:21:55 GMT
+      - Thu, 01 Nov 2018 18:37:18 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-2c6937ba-ebc4-451d-9c43-d77c385187f9
+      - req-e0d64ace-1373-4069-8a7c-83335818d5aa
       Content-Length:
       - '4131'
       Connection:
@@ -3582,10 +3582,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:55.590840", "expires":
-        "2018-10-25T19:21:55Z", "id": "6afe6276dff14ca9bfbbdcb8dd118500", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:37:18.454449", "expires":
+        "2018-11-01T19:37:18Z", "id": "f3ff1efa91214466b018b24918e4e378", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["sSCI25S8R1SthQh10Xj9UQ"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["yJEzgGGWTKmhk4L6qTrQAw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -3629,7 +3629,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:55 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:18 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0//quotas/b458a5c25c3749758f4c0661940b3ba8
@@ -3644,7 +3644,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6afe6276dff14ca9bfbbdcb8dd118500
+      - f3ff1efa91214466b018b24918e4e378
   response:
     status:
       code: 200
@@ -3655,16 +3655,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-fc50c9bb-633a-4b2c-bcc6-05bb038504a0
+      - req-c791fc38-8f77-480a-ad49-57cbc4416f2e
       Date:
-      - Thu, 25 Oct 2018 18:21:55 GMT
+      - Thu, 01 Nov 2018 18:37:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:55 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:18 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0//quotas/e54e5c3c19e34720b05661f2ea1ea00a
@@ -3679,7 +3679,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f8b4cdfad19149cba575d2e18ae194ef
+      - b019cdc3031c400594c4eae822712c23
   response:
     status:
       code: 200
@@ -3690,16 +3690,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-10eb4e61-c5ad-4346-b34b-b8097f82ff16
+      - req-45ff025f-6d58-4a6d-9508-eaf6a882c914
       Date:
-      - Thu, 25 Oct 2018 18:21:55 GMT
+      - Thu, 01 Nov 2018 18:37:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:55 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:18 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -3717,13 +3717,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:21:56 GMT
+      - Thu, 01 Nov 2018 18:37:18 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-7d2851ac-1627-49b6-8894-2abc4818095d
+      - req-1b813f71-e004-41d1-ba35-fac112d902c9
       Content-Length:
       - '4118'
       Connection:
@@ -3732,10 +3732,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:56.075933", "expires":
-        "2018-10-25T19:21:56Z", "id": "42c079e30b744af6b9c11ced8f577e81", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:37:18.991321", "expires":
+        "2018-11-01T19:37:18Z", "id": "131cde7f33fa42e6a2b76f7c12452022", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["ziYNY1v-QqCt19GKDOb0Ow"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["yDdb0-4ITIy0jFZUKxMWLw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -3779,7 +3779,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:56 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:19 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0//quotas/e8f744b1fc6a487681d35fb275252608
@@ -3794,7 +3794,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 42c079e30b744af6b9c11ced8f577e81
+      - 131cde7f33fa42e6a2b76f7c12452022
   response:
     status:
       code: 200
@@ -3805,16 +3805,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-98ad0fef-cead-4759-a172-a9e8cca65412
+      - req-1582bfbd-4b8c-4da2-ad55-dce3739dfd83
       Date:
-      - Thu, 25 Oct 2018 18:21:56 GMT
+      - Thu, 01 Nov 2018 18:37:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:56 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:19 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-floating-ips
@@ -3829,7 +3829,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 374009d19f954a2d8b1de1a56b39e97d
+      - 9fa685d3d4a44ca18af344bd9c072eeb
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3842,14 +3842,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-73c49171-c1d0-449d-95d3-0a8b323fe4eb
+      - req-b87efc7f-f7a8-406c-97c7-0fd9317f7406
       Date:
-      - Thu, 25 Oct 2018 18:21:56 GMT
+      - Thu, 01 Nov 2018 18:37:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:56 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:19 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-floating-ips
@@ -3864,7 +3864,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 374009d19f954a2d8b1de1a56b39e97d
+      - 9fa685d3d4a44ca18af344bd9c072eeb
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3877,14 +3877,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-b5baa1ab-001b-480e-b794-1a75a0d59006
+      - req-9644e90b-5922-4114-851c-326389512708
       Date:
-      - Thu, 25 Oct 2018 18:21:56 GMT
+      - Thu, 01 Nov 2018 18:37:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:56 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:19 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-floating-ips
@@ -3899,7 +3899,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 374009d19f954a2d8b1de1a56b39e97d
+      - 9fa685d3d4a44ca18af344bd9c072eeb
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3912,14 +3912,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-7cbb8c07-6376-43be-a227-e3bcc825480c
+      - req-8875ee9b-21e1-4131-8e14-140a3d16a88b
       Date:
-      - Thu, 25 Oct 2018 18:21:56 GMT
+      - Thu, 01 Nov 2018 18:37:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:56 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:19 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-floating-ips
@@ -3934,7 +3934,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 374009d19f954a2d8b1de1a56b39e97d
+      - 9fa685d3d4a44ca18af344bd9c072eeb
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3947,14 +3947,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-bb8009ab-3f8e-4b4b-a7fe-2ef0e9df225d
+      - req-799e91eb-2ade-4fea-96ef-0b453af5a33d
       Date:
-      - Thu, 25 Oct 2018 18:21:56 GMT
+      - Thu, 01 Nov 2018 18:37:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:56 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:19 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-floating-ips
@@ -3969,7 +3969,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 374009d19f954a2d8b1de1a56b39e97d
+      - 9fa685d3d4a44ca18af344bd9c072eeb
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3982,14 +3982,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-4737eae5-f4f2-4278-b2d4-8b4e7b390c82
+      - req-97e2ae3f-dbba-4daa-a6d0-5793cf78d5c6
       Date:
-      - Thu, 25 Oct 2018 18:21:56 GMT
+      - Thu, 01 Nov 2018 18:37:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:57 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:19 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/4bb36934-fd61-4a19-ab9d-28fbbda0c7f0/os-volume_attachments
@@ -4004,7 +4004,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 374009d19f954a2d8b1de1a56b39e97d
+      - 9fa685d3d4a44ca18af344bd9c072eeb
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4017,15 +4017,15 @@ http_interactions:
       Content-Length:
       - '197'
       X-Compute-Request-Id:
-      - req-80e897da-3b92-4d98-9f4c-cfd689715283
+      - req-9b826f40-fd50-4297-ba7b-06418bcfefd6
       Date:
-      - Thu, 25 Oct 2018 18:21:57 GMT
+      - Thu, 01 Nov 2018 18:37:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumeAttachments": [{"device": "/dev/vda", "serverId": "4bb36934-fd61-4a19-ab9d-28fbbda0c7f0",
         "id": "b124469d-a857-4b39-abe9-d0e63985f834", "volumeId": "b124469d-a857-4b39-abe9-d0e63985f834"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:57 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:20 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-floating-ips
@@ -4040,7 +4040,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 374009d19f954a2d8b1de1a56b39e97d
+      - 9fa685d3d4a44ca18af344bd9c072eeb
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4053,14 +4053,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-c7fbb0c5-5c25-48ec-8605-99240341b1af
+      - req-021c0997-f3ab-4fd2-a454-5f9edc4c25d1
       Date:
-      - Thu, 25 Oct 2018 18:21:57 GMT
+      - Thu, 01 Nov 2018 18:37:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:57 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:20 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/ca4f3a16-bae3-4407-83e9-f77b28af0f2b/os-volume_attachments
@@ -4075,7 +4075,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 374009d19f954a2d8b1de1a56b39e97d
+      - 9fa685d3d4a44ca18af344bd9c072eeb
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4088,15 +4088,15 @@ http_interactions:
       Content-Length:
       - '197'
       X-Compute-Request-Id:
-      - req-6302f3d1-efb4-4d50-90a9-3e81a55df33b
+      - req-14f0dd15-0a84-4085-9dc1-17c267f3ef73
       Date:
-      - Thu, 25 Oct 2018 18:21:57 GMT
+      - Thu, 01 Nov 2018 18:37:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumeAttachments": [{"device": "/dev/vdd", "serverId": "ca4f3a16-bae3-4407-83e9-f77b28af0f2b",
         "id": "0a55c0d5-c780-4e7d-9d09-47f5520c7448", "volumeId": "0a55c0d5-c780-4e7d-9d09-47f5520c7448"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:57 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:20 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-floating-ips
@@ -4111,7 +4111,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 374009d19f954a2d8b1de1a56b39e97d
+      - 9fa685d3d4a44ca18af344bd9c072eeb
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4124,14 +4124,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-0ac8f660-6a04-4fbb-971f-15cd05c282df
+      - req-c1ee481e-d929-4657-a55a-f85ed38e1cf2
       Date:
-      - Thu, 25 Oct 2018 18:21:57 GMT
+      - Thu, 01 Nov 2018 18:37:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:57 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:20 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-floating-ips
@@ -4146,7 +4146,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 374009d19f954a2d8b1de1a56b39e97d
+      - 9fa685d3d4a44ca18af344bd9c072eeb
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4159,14 +4159,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-d3bc389a-dcc9-4a9a-8351-1fa7fadef0d7
+      - req-985b9995-08a1-4667-b8bf-e2471be16bb0
       Date:
-      - Thu, 25 Oct 2018 18:21:57 GMT
+      - Thu, 01 Nov 2018 18:37:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:57 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:20 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-floating-ips
@@ -4181,7 +4181,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 374009d19f954a2d8b1de1a56b39e97d
+      - 9fa685d3d4a44ca18af344bd9c072eeb
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4194,14 +4194,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-d8daec8d-050b-47d7-8840-027e956cad88
+      - req-87544a95-1cfe-4f73-8e53-1a4582d8ebab
       Date:
-      - Thu, 25 Oct 2018 18:21:57 GMT
+      - Thu, 01 Nov 2018 18:37:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:57 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:20 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4219,13 +4219,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:21:57 GMT
+      - Thu, 01 Nov 2018 18:37:20 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-c092d697-e55c-4ec0-9794-67c2073b8eee
+      - req-ac661757-e835-4f50-9c17-f320d7d40077
       Content-Length:
       - '4170'
       Connection:
@@ -4234,10 +4234,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:58.011134", "expires":
-        "2018-10-25T19:21:57Z", "id": "f8677356e2c841f7b63dd744739ade07", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:37:20.972726", "expires":
+        "2018-11-01T19:37:20Z", "id": "e0e32fb359964211be88609a695dfa75", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["RL30h1R9QZKKtvr-4-acqg"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["pOhBAM8iSSK30UZAl7OQ6A"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -4282,7 +4282,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:58 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:20 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4300,13 +4300,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:21:58 GMT
+      - Thu, 01 Nov 2018 18:37:21 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-10f43867-ee3d-4b6e-a5b1-5e547958e0ac
+      - req-4145af2d-a947-466b-84ab-88ed84db4a57
       Content-Length:
       - '4170'
       Connection:
@@ -4315,10 +4315,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:58.197491", "expires":
-        "2018-10-25T19:21:58Z", "id": "6e4ffc50fc43453b9b1f7a8b07673823", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:37:21.174284", "expires":
+        "2018-11-01T19:37:21Z", "id": "a081df40ba6e49e8828ef0b662b7b313", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["_HTFxLreT9G-kvoU6EQbwg"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["MQrFyQYxQDuEVTond27C7g"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -4363,7 +4363,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:58 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:21 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-aggregates
@@ -4378,7 +4378,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 374009d19f954a2d8b1de1a56b39e97d
+      - 9fa685d3d4a44ca18af344bd9c072eeb
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4391,14 +4391,14 @@ http_interactions:
       Content-Length:
       - '18'
       X-Compute-Request-Id:
-      - req-d181cecf-0117-47e6-be6c-1b2303c9e145
+      - req-91e0abe7-50e5-48b9-819c-f73162a56c9f
       Date:
-      - Thu, 25 Oct 2018 18:21:58 GMT
+      - Thu, 01 Nov 2018 18:37:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"aggregates": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:58 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:21 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/volumes/detail?all_tenants=True&limit=1000&status=available
@@ -4413,22 +4413,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 31a100b4e77e4d8cbda2b3abf0a3d069
+      - fd7a3dbff41f4bf49fd0d9b0bf46b4b4
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-ab8ab383-4b56-4978-98b4-98ae2e243417
+      - req-448fab5a-4113-495a-a108-7f3e95c6ced4
       Content-Type:
       - application/json
       Content-Length:
       - '2740'
       X-Openstack-Request-Id:
-      - req-ab8ab383-4b56-4978-98b4-98ae2e243417
+      - req-448fab5a-4113-495a-a108-7f3e95c6ced4
       Date:
-      - Thu, 25 Oct 2018 18:21:58 GMT
+      - Thu, 01 Nov 2018 18:37:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/volumes/detail?all_tenants=True&limit=1000&status=available&marker=9bb99818-b339-4e31-b87f-e4181ec48acd",
@@ -4461,7 +4461,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-4", "bootable": "true", "created_at":
         "2016-11-11T13:49:53.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:58 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:21 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/volumes/detail?all_tenants=True&limit=1000&marker=9bb99818-b339-4e31-b87f-e4181ec48acd&status=available
@@ -4476,22 +4476,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 31a100b4e77e4d8cbda2b3abf0a3d069
+      - fd7a3dbff41f4bf49fd0d9b0bf46b4b4
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-de132cb3-998b-4ec3-8ff3-c03fbadaac55
+      - req-754834ca-ec83-42d1-a34f-22af16ef7601
       Content-Type:
       - application/json
       Content-Length:
       - '1180'
       X-Openstack-Request-Id:
-      - req-de132cb3-998b-4ec3-8ff3-c03fbadaac55
+      - req-754834ca-ec83-42d1-a34f-22af16ef7601
       Date:
-      - Thu, 25 Oct 2018 18:21:58 GMT
+      - Thu, 01 Nov 2018 18:37:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": [{"migration_status": null, "attachments": [], "links":
@@ -4508,7 +4508,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-FromSnapshot", "bootable": "false", "created_at":
         "2016-11-11T13:49:26.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:58 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:21 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/snapshots/detail
@@ -4523,27 +4523,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 31a100b4e77e4d8cbda2b3abf0a3d069
+      - fd7a3dbff41f4bf49fd0d9b0bf46b4b4
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-0d6e9b4c-843e-4ec0-b975-d800d98c9f8e
+      - req-bc016ab4-b806-4c7b-ad10-707ff136202a
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-0d6e9b4c-843e-4ec0-b975-d800d98c9f8e
+      - req-bc016ab4-b806-4c7b-ad10-707ff136202a
       Date:
-      - Thu, 25 Oct 2018 18:21:58 GMT
+      - Thu, 01 Nov 2018 18:37:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:58 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:21 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/snapshots/detail?all_tenants=True&limit=1000&status=available
@@ -4558,22 +4558,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 31a100b4e77e4d8cbda2b3abf0a3d069
+      - fd7a3dbff41f4bf49fd0d9b0bf46b4b4
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-903acaf8-8fb1-4bff-bba2-d4dfc2613e54
+      - req-a270251e-62f5-484a-8e8f-324b11ec2fb4
       Content-Type:
       - application/json
       Content-Length:
       - '1098'
       X-Openstack-Request-Id:
-      - req-903acaf8-8fb1-4bff-bba2-d4dfc2613e54
+      - req-a270251e-62f5-484a-8e8f-324b11ec2fb4
       Date:
-      - Thu, 25 Oct 2018 18:21:58 GMT
+      - Thu, 01 Nov 2018 18:37:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/snapshots/detail?all_tenants=True&limit=1000&status=available&marker=76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
@@ -4588,7 +4588,7 @@ http_interactions:
         "created_at": "2016-11-11T13:49:36.000000", "size": 1, "id": "76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:58 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:21 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/volumes/detail?all_tenants=True&limit=1000
@@ -4603,22 +4603,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 31a100b4e77e4d8cbda2b3abf0a3d069
+      - fd7a3dbff41f4bf49fd0d9b0bf46b4b4
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-91037f16-490d-4a26-97d0-39a528775565
+      - req-80703819-de81-4f69-8237-a85e467d0ced
       Content-Type:
       - application/json
       Content-Length:
       - '2723'
       X-Openstack-Request-Id:
-      - req-91037f16-490d-4a26-97d0-39a528775565
+      - req-80703819-de81-4f69-8237-a85e467d0ced
       Date:
-      - Thu, 25 Oct 2018 18:21:58 GMT
+      - Thu, 01 Nov 2018 18:37:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/volumes/detail?all_tenants=True&limit=1000&marker=9bb99818-b339-4e31-b87f-e4181ec48acd",
@@ -4651,7 +4651,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-4", "bootable": "true", "created_at":
         "2016-11-11T13:49:53.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:59 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:21 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/volumes/detail?all_tenants=True&limit=1000&marker=9bb99818-b339-4e31-b87f-e4181ec48acd
@@ -4666,22 +4666,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 31a100b4e77e4d8cbda2b3abf0a3d069
+      - fd7a3dbff41f4bf49fd0d9b0bf46b4b4
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-8d61a941-0f13-47e4-9c93-32ec9da557f5
+      - req-cc6e241d-12e2-46b8-8897-29922a873f97
       Content-Type:
       - application/json
       Content-Length:
       - '3301'
       X-Openstack-Request-Id:
-      - req-8d61a941-0f13-47e4-9c93-32ec9da557f5
+      - req-cc6e241d-12e2-46b8-8897-29922a873f97
       Date:
-      - Thu, 25 Oct 2018 18:21:59 GMT
+      - Thu, 01 Nov 2018 18:37:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/volumes/detail?all_tenants=True&limit=1000&marker=2c774148-c11a-434c-aabb-7fa9c82c37ce",
@@ -4722,7 +4722,7 @@ http_interactions:
         "name": "EmsRefreshSpec-Volume-2", "bootable": "false", "created_at": "2016-11-11T13:49:43.000000",
         "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:59 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:22 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/volumes/detail?all_tenants=True&limit=1000&marker=2c774148-c11a-434c-aabb-7fa9c82c37ce
@@ -4737,22 +4737,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 31a100b4e77e4d8cbda2b3abf0a3d069
+      - fd7a3dbff41f4bf49fd0d9b0bf46b4b4
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-d1ca28b1-ac96-4b8d-bab8-72c0284948a4
+      - req-509babac-2fee-4881-856d-16e52a4fef96
       Content-Type:
       - application/json
       Content-Length:
       - '2770'
       X-Openstack-Request-Id:
-      - req-d1ca28b1-ac96-4b8d-bab8-72c0284948a4
+      - req-509babac-2fee-4881-856d-16e52a4fef96
       Date:
-      - Thu, 25 Oct 2018 18:21:59 GMT
+      - Thu, 01 Nov 2018 18:37:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/volumes/detail?all_tenants=True&limit=1000&marker=0a55c0d5-c780-4e7d-9d09-47f5520c7448",
@@ -4786,7 +4786,7 @@ http_interactions:
         "bootable": "false", "created_at": "2016-11-11T13:49:20.000000", "volume_type":
         "iscsi"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:59 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:22 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/volumes/detail?all_tenants=True&limit=1000&marker=0a55c0d5-c780-4e7d-9d09-47f5520c7448
@@ -4801,27 +4801,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 31a100b4e77e4d8cbda2b3abf0a3d069
+      - fd7a3dbff41f4bf49fd0d9b0bf46b4b4
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-f4e5f39c-69a6-4878-b7a7-3b80f0c94606
+      - req-8512a509-306f-4e95-8e3e-5f56e26e28dd
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-f4e5f39c-69a6-4878-b7a7-3b80f0c94606
+      - req-8512a509-306f-4e95-8e3e-5f56e26e28dd
       Date:
-      - Thu, 25 Oct 2018 18:21:59 GMT
+      - Thu, 01 Nov 2018 18:37:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:59 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:22 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4839,13 +4839,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:22:00 GMT
+      - Thu, 01 Nov 2018 18:37:23 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-b1ffd685-d9a5-4ce3-af6c-5ec99d3f59ec
+      - req-fe1ec9fd-6e44-4780-8eaa-27823bd2482a
       Content-Length:
       - '4170'
       Connection:
@@ -4854,10 +4854,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:22:00.718380", "expires":
-        "2018-10-25T19:22:00Z", "id": "d559d641642e4f8988f3db4e402863b6", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:37:23.590593", "expires":
+        "2018-11-01T19:37:23Z", "id": "f639cc9653e947ddafa42621b3d225da", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["tFbQ8UgDSFqw6bnEj2lERA"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["vxJiNP7-SxqkUXRTDn5GoQ"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -4902,7 +4902,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:00 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:23 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4920,13 +4920,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:22:00 GMT
+      - Thu, 01 Nov 2018 18:37:23 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-7dd8fe7f-7a16-4507-98a7-f9c8969cf872
+      - req-7315e118-5043-4e67-a9b9-1703857b7841
       Content-Length:
       - '4170'
       Connection:
@@ -4935,10 +4935,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:22:00.899293", "expires":
-        "2018-10-25T19:22:00Z", "id": "0ed9a3aba33d4553aadce38156cee447", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:37:23.783637", "expires":
+        "2018-11-01T19:37:23Z", "id": "e92f6adaa928438a99678a1002a2a0b2", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["1UDaVH11RXeBjZGB3i0zDQ"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["AOj-MMuVQlmy_PRgHx5APQ"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -4983,7 +4983,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:00 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:23 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/networks
@@ -4998,7 +4998,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0ed9a3aba33d4553aadce38156cee447
+      - e92f6adaa928438a99678a1002a2a0b2
   response:
     status:
       code: 200
@@ -5009,42 +5009,22 @@ http_interactions:
       Content-Length:
       - '5330'
       X-Openstack-Request-Id:
-      - req-67cdca60-31a4-4abf-b12e-49d3b8d5a8a7
+      - req-96779801-d158-49e4-b849-13ae56449a96
       Date:
-      - Thu, 25 Oct 2018 18:22:01 GMT
+      - Thu, 01 Nov 2018 18:37:23 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"networks": [{"status": "ACTIVE", "subnets": ["d0065ae4-dffb-4dcc-9e44-a0b1166337f3"],
-        "name": "EmsRefreshSpec-NetworkPublic_40", "provider:physical_network": "public_net_4",
-        "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
-        0, "router:external": true, "shared": false, "provider:network_type": "flat",
-        "id": "68259081-a5ca-425f-9d9b-816eb62148a3", "provider:segmentation_id":
-        null}, {"status": "ACTIVE", "subnets": ["82ca5926-43cb-4312-a23f-727d5c0f5bae"],
-        "name": "EmsRefreshSpec-NetworkPrivate_3", "provider:physical_network": null,
-        "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
-        0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
-        "id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "provider:segmentation_id":
-        87}, {"status": "ACTIVE", "subnets": ["93c2f53c-df39-491e-b45b-ce8b36b29437"],
-        "name": "EmsRefreshSpec-NetworkPublic_10", "provider:physical_network": "public_net_1",
-        "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
-        0, "router:external": true, "shared": false, "provider:network_type": "flat",
-        "id": "83e63648-5a43-4db0-907c-cf9ca0150336", "provider:segmentation_id":
-        null}, {"status": "ACTIVE", "subnets": ["4d8b0801-addf-4ad4-8f46-e5bffa6a1002"],
-        "name": "EmsRefreshSpec-NetworkPublic_30", "provider:physical_network": "public_net_3",
-        "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
-        0, "router:external": true, "shared": false, "provider:network_type": "flat",
-        "id": "64bf0546-b600-4bd7-a519-9353bde2e235", "provider:segmentation_id":
-        null}, {"status": "ACTIVE", "subnets": ["d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2"], "name": "EmsRefreshSpec-NetworkPublic_50",
-        "provider:physical_network": "public_net_5", "admin_state_up": true, "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "mtu": 0, "router:external": true, "shared":
-        false, "provider:network_type": "flat", "id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "provider:segmentation_id": null}, {"status": "ACTIVE", "subnets": ["448a986a-19a9-4684-ab6e-25cbf19ae30d"],
+      string: '{"networks": [{"status": "ACTIVE", "subnets": ["448a986a-19a9-4684-ab6e-25cbf19ae30d"],
         "name": "EmsRefreshSpec-IsolatedNetworkPrivate_1", "provider:physical_network":
         null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
         "vxlan", "id": "560b4210-2b5a-4439-8d24-203e09478f48", "provider:segmentation_id":
-        54}, {"status": "ACTIVE", "subnets": ["bb23bb48-804d-4416-bac3-231db23841e8"],
+        54}, {"status": "ACTIVE", "subnets": ["68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "d71653c5-34d2-47bd-9cd2-d93330a34d44"], "name": "EmsRefreshSpec-NetworkPublic_50",
+        "provider:physical_network": "public_net_5", "admin_state_up": true, "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "mtu": 0, "router:external": true, "shared":
+        false, "provider:network_type": "flat", "id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "provider:segmentation_id": null}, {"status": "ACTIVE", "subnets": ["bb23bb48-804d-4416-bac3-231db23841e8"],
         "name": "EmsRefreshSpec-NetworkPrivate_2", "provider:physical_network": null,
         "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
         0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
@@ -5069,19 +5049,39 @@ http_interactions:
         "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
         0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
         "id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "provider:segmentation_id":
-        98}, {"status": "ACTIVE", "subnets": ["c68ac5c0-9d9e-438b-a10f-6d0faeee0790"],
+        98}, {"status": "ACTIVE", "subnets": ["82ca5926-43cb-4312-a23f-727d5c0f5bae"],
+        "name": "EmsRefreshSpec-NetworkPrivate_3", "provider:physical_network": null,
+        "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
+        0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
+        "id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "provider:segmentation_id":
+        87}, {"status": "ACTIVE", "subnets": ["c68ac5c0-9d9e-438b-a10f-6d0faeee0790"],
         "name": "EmsRefreshSpec-NetworkPublic_20", "provider:physical_network": "public_net_2",
         "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
         0, "router:external": true, "shared": false, "provider:network_type": "flat",
         "id": "8da920f8-705d-4777-a938-e081b01ad41c", "provider:segmentation_id":
-        null}, {"status": "ACTIVE", "subnets": ["d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "104c081f-97dd-42b7-8930-98abbd015c74"], "name": "EmsRefreshSpec-NetworkPrivate",
+        null}, {"status": "ACTIVE", "subnets": ["d0065ae4-dffb-4dcc-9e44-a0b1166337f3"],
+        "name": "EmsRefreshSpec-NetworkPublic_40", "provider:physical_network": "public_net_4",
+        "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
+        0, "router:external": true, "shared": false, "provider:network_type": "flat",
+        "id": "68259081-a5ca-425f-9d9b-816eb62148a3", "provider:segmentation_id":
+        null}, {"status": "ACTIVE", "subnets": ["93c2f53c-df39-491e-b45b-ce8b36b29437"],
+        "name": "EmsRefreshSpec-NetworkPublic_10", "provider:physical_network": "public_net_1",
+        "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
+        0, "router:external": true, "shared": false, "provider:network_type": "flat",
+        "id": "83e63648-5a43-4db0-907c-cf9ca0150336", "provider:segmentation_id":
+        null}, {"status": "ACTIVE", "subnets": ["4d8b0801-addf-4ad4-8f46-e5bffa6a1002"],
+        "name": "EmsRefreshSpec-NetworkPublic_30", "provider:physical_network": "public_net_3",
+        "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
+        0, "router:external": true, "shared": false, "provider:network_type": "flat",
+        "id": "64bf0546-b600-4bd7-a519-9353bde2e235", "provider:segmentation_id":
+        null}, {"status": "ACTIVE", "subnets": ["104c081f-97dd-42b7-8930-98abbd015c74",
+        "d53802a5-f0f6-48ba-9207-dbd9b13acac3"], "name": "EmsRefreshSpec-NetworkPrivate",
         "provider:physical_network": null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
         "vxlan", "id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "provider:segmentation_id":
         14}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:01 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:23 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -5099,13 +5099,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:22:01 GMT
+      - Thu, 01 Nov 2018 18:37:24 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-f94dee84-666b-4c7e-a478-c21c2040cc8b
+      - req-aeb408cb-b9f3-42a2-a444-40c9021d5d94
       Content-Length:
       - '4170'
       Connection:
@@ -5114,10 +5114,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:22:01.282157", "expires":
-        "2018-10-25T19:22:01Z", "id": "b83f3bae09974b8f90f0cc72e80c1564", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:37:24.151050", "expires":
+        "2018-11-01T19:37:24Z", "id": "534a1d5b2017414d8aeaf9ef846d6cf6", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["D3QV6ti1QhW64b4ze1lwaA"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["9JxfHr8OQF2bZFqMP-84SA"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -5162,7 +5162,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:01 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:24 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -5180,13 +5180,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:22:01 GMT
+      - Thu, 01 Nov 2018 18:37:24 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-720a6e07-cb22-4bb3-a7eb-9a929a2c0780
+      - req-3d35e392-dee1-4f02-a871-1cca5841bb67
       Content-Length:
       - '370'
       Connection:
@@ -5195,13 +5195,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:22:01.434234", "expires":
-        "2018-10-25T19:22:01Z", "id": "f9badf0a407d48cf8c9070512b828210", "audit_ids":
-        ["UOW9-_k8SLKi0TCAE79aOg"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:37:24.320761", "expires":
+        "2018-11-01T19:37:24Z", "id": "25a5db5155174e9e93c596e597db5728", "audit_ids":
+        ["RsJWPanpRy6FF3oD2YoFSQ"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:01 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:24 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -5216,20 +5216,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f9badf0a407d48cf8c9070512b828210
+      - 25a5db5155174e9e93c596e597db5728
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:22:01 GMT
+      - Thu, 01 Nov 2018 18:37:24 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-2d7a5bdb-d63e-4448-8cf6-ecf982b55366
+      - req-530692ab-5cb8-4e14-8eb2-fc373a643cb7
       Content-Length:
       - '500'
       Connection:
@@ -5246,7 +5246,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:01 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:24 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -5264,13 +5264,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:22:01 GMT
+      - Thu, 01 Nov 2018 18:37:24 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-fbd1edfa-0423-40e3-9f5b-448d9e3e6aad
+      - req-75a1eea9-a410-41ff-97fa-361ca2348e39
       Content-Length:
       - '4117'
       Connection:
@@ -5279,10 +5279,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:22:01.744661", "expires":
-        "2018-10-25T19:22:01Z", "id": "e3788a94e2a04eebb664ec878aee2ace", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:37:24.645715", "expires":
+        "2018-11-01T19:37:24Z", "id": "40419debb6754381ab85e89ddbaf3a37", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["JjNIOd4dS6iDlcz8it9ckA"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["-ZL5Qwb4Rk6BHeQhehMWAw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -5326,7 +5326,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:01 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:24 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -5344,13 +5344,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:22:01 GMT
+      - Thu, 01 Nov 2018 18:37:24 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-d636c0c6-952a-4f08-a089-b4d41c827b3c
+      - req-a3e1f04f-d7fb-47f7-83cc-fa2f379608ef
       Content-Length:
       - '4131'
       Connection:
@@ -5359,10 +5359,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:22:01.924033", "expires":
-        "2018-10-25T19:22:01Z", "id": "124a11c2cd124da1b3a7dcbff1b9f381", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:37:24.843657", "expires":
+        "2018-11-01T19:37:24Z", "id": "f82be200321f43a8b1d82bda3a0a8001", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["gL4ksq-zQrCq8rwF-N8u8Q"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["fr0ZMg6jRraYb3kDjSPXbQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -5406,7 +5406,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:01 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:24 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -5424,13 +5424,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:22:02 GMT
+      - Thu, 01 Nov 2018 18:37:24 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-24dde1d1-b2c2-4ccc-b0e3-d01cd9bdbfc0
+      - req-abfe5aa9-7e76-4c97-a1d2-22f86eab03ba
       Content-Length:
       - '4118'
       Connection:
@@ -5439,10 +5439,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:22:02.109178", "expires":
-        "2018-10-25T19:22:02Z", "id": "52a09656b9554b45a5826254ba9023ec", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:37:25.040342", "expires":
+        "2018-11-01T19:37:25Z", "id": "ee5fd879084a45188713f1bd6bcfd5e2", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["lUUs-t6OSxGt3VTSBVmk4w"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["j2XHLDXSQpW-kqmD7odllw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -5486,7 +5486,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:02 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:25 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -5504,13 +5504,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:22:02 GMT
+      - Thu, 01 Nov 2018 18:37:25 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-16a97239-57e9-4ea6-b615-eb05fdbc08f9
+      - req-9f25c3dc-4e1e-4a63-b42d-fe0bb1816796
       Content-Length:
       - '4117'
       Connection:
@@ -5519,10 +5519,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:22:02.298073", "expires":
-        "2018-10-25T19:22:02Z", "id": "81b1f5a3cfff42f5a4749d06bc72f482", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:37:25.238993", "expires":
+        "2018-11-01T19:37:25Z", "id": "06a2391a8c4b4ba5baad159fad001e4a", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["XJZ7q5gPQFKcG0pMJ86pyA"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["vjPkz2cGRS--BRmXfzaGGQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -5566,7 +5566,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:02 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:25 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks?limit=1000&show_nested=true
@@ -5581,7 +5581,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 81b1f5a3cfff42f5a4749d06bc72f482
+      - 06a2391a8c4b4ba5baad159fad001e4a
   response:
     status:
       code: 200
@@ -5592,9 +5592,9 @@ http_interactions:
       Content-Length:
       - '2559'
       X-Openstack-Request-Id:
-      - req-249f6ce9-3630-489d-9a8a-7d1c3f1fca6a
+      - req-aee8852e-77d2-4035-beb1-537c8c9b5953
       Date:
-      - Thu, 25 Oct 2018 18:22:02 GMT
+      - Thu, 01 Nov 2018 18:37:25 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": [{"description": "Heat WordPress template to support F20,
@@ -5628,7 +5628,7 @@ http_interactions:
         "rel": "self"}], "updated_time": null, "stack_owner": null, "stack_status":
         "CREATE_COMPLETE", "id": "091e1e54-e01c-4ec5-a0ab-b00bee4d425c"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:02 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:25 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks?limit=1000&marker=091e1e54-e01c-4ec5-a0ab-b00bee4d425c&show_nested=true
@@ -5643,7 +5643,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 81b1f5a3cfff42f5a4749d06bc72f482
+      - 06a2391a8c4b4ba5baad159fad001e4a
   response:
     status:
       code: 200
@@ -5654,14 +5654,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-800c83e7-2e29-4373-9c50-f42b5e9e6ac5
+      - req-2b31df7c-2d83-4c1d-b7af-9da51fe5ddaf
       Date:
-      - Thu, 25 Oct 2018 18:22:02 GMT
+      - Thu, 01 Nov 2018 18:37:25 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:02 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:25 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -5679,13 +5679,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:22:02 GMT
+      - Thu, 01 Nov 2018 18:37:25 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-10fb2987-7932-44e6-88c2-776a30f8733d
+      - req-c8ca3ba4-277c-4ce4-875a-dbc2a6211f29
       Content-Length:
       - '4131'
       Connection:
@@ -5694,10 +5694,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:22:02.773419", "expires":
-        "2018-10-25T19:22:02Z", "id": "b9de25f845374d529bdef4d07eb7c9df", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:37:25.747479", "expires":
+        "2018-11-01T19:37:25Z", "id": "ccaa36702d704a36be21f4cefe3309ab", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["DNglwAA3Q0C0zmPMNTXinw"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["6wMFkOxFRZ-LTmTwfG3oSw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -5741,7 +5741,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:02 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:25 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/b458a5c25c3749758f4c0661940b3ba8/stacks?limit=1000&show_nested=true
@@ -5756,7 +5756,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b9de25f845374d529bdef4d07eb7c9df
+      - ccaa36702d704a36be21f4cefe3309ab
   response:
     status:
       code: 200
@@ -5767,14 +5767,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-ff2b95de-c186-4187-83c2-85ef826ae27f
+      - req-a6cc1676-83e5-46e9-baf1-efb79bec6234
       Date:
-      - Thu, 25 Oct 2018 18:22:02 GMT
+      - Thu, 01 Nov 2018 18:37:25 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:02 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:25 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/e54e5c3c19e34720b05661f2ea1ea00a/stacks?limit=1000&show_nested=true
@@ -5789,7 +5789,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b83f3bae09974b8f90f0cc72e80c1564
+      - 534a1d5b2017414d8aeaf9ef846d6cf6
   response:
     status:
       code: 200
@@ -5800,14 +5800,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-f79053b3-0e8c-4efb-8b72-46895ac5fb6d
+      - req-3b46bfec-ea9b-40a2-88ee-cc475d13f0e5
       Date:
-      - Thu, 25 Oct 2018 18:22:03 GMT
+      - Thu, 01 Nov 2018 18:37:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:03 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:26 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -5825,13 +5825,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:22:03 GMT
+      - Thu, 01 Nov 2018 18:37:26 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-71894746-14e4-44ce-8ba4-1491a3add4c6
+      - req-aa6d5fa4-36ef-4817-b6e7-915b23a74947
       Content-Length:
       - '4118'
       Connection:
@@ -5840,10 +5840,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:22:03.275358", "expires":
-        "2018-10-25T19:22:03Z", "id": "2e64cc4f9ecf4685bb47a090231bed61", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:37:26.296947", "expires":
+        "2018-11-01T19:37:26Z", "id": "eab3179a62e4453cbe4ed844f26d8e9e", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["vPg1hqWsTsaUWVyIPlVAAg"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["QqT52pDwQMyjAYLYLW7IUA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -5887,7 +5887,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:03 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:26 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/e8f744b1fc6a487681d35fb275252608/stacks?limit=1000&show_nested=true
@@ -5902,7 +5902,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2e64cc4f9ecf4685bb47a090231bed61
+      - eab3179a62e4453cbe4ed844f26d8e9e
   response:
     status:
       code: 200
@@ -5913,14 +5913,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-d6b4d709-ddef-48ba-a736-66ccc6970841
+      - req-31d38af1-929d-4612-b2da-a1c55ce346a9
       Date:
-      - Thu, 25 Oct 2018 18:22:03 GMT
+      - Thu, 01 Nov 2018 18:37:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:03 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:26 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack3/45d2af82-eff9-4483-a1f0-f19c44d96146
@@ -5935,7 +5935,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 81b1f5a3cfff42f5a4749d06bc72f482
+      - 06a2391a8c4b4ba5baad159fad001e4a
   response:
     status:
       code: 200
@@ -5946,9 +5946,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-17d9643d-8feb-4b67-85c7-fcaccc93cb72
+      - req-d94796e7-f941-4925-b4a4-74a391cb37c8
       Date:
-      - Thu, 25 Oct 2018 18:22:03 GMT
+      - Thu, 01 Nov 2018 18:37:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -5975,7 +5975,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:03 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:26 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack2/4cf24b12-29fc-4529-a8ed-6b079dea7c17
@@ -5990,7 +5990,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 81b1f5a3cfff42f5a4749d06bc72f482
+      - 06a2391a8c4b4ba5baad159fad001e4a
   response:
     status:
       code: 200
@@ -6001,9 +6001,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-7f593e43-1764-43d4-b497-c7b0d0d3091e
+      - req-8545caa1-6d66-4de8-a4da-7c9446af3308
       Date:
-      - Thu, 25 Oct 2018 18:22:04 GMT
+      - Thu, 01 Nov 2018 18:37:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -6030,7 +6030,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:04 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:27 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c
@@ -6045,7 +6045,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 81b1f5a3cfff42f5a4749d06bc72f482
+      - 06a2391a8c4b4ba5baad159fad001e4a
   response:
     status:
       code: 200
@@ -6056,9 +6056,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-f0ac3f75-19cd-4646-872f-4a94734ffaa9
+      - req-9398c2e7-c43e-45a1-ae47-8234dd02d06c
       Date:
-      - Thu, 25 Oct 2018 18:22:04 GMT
+      - Thu, 01 Nov 2018 18:37:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -6085,7 +6085,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:04 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:27 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack3/45d2af82-eff9-4483-a1f0-f19c44d96146/resources
@@ -6100,7 +6100,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 81b1f5a3cfff42f5a4749d06bc72f482
+      - 06a2391a8c4b4ba5baad159fad001e4a
   response:
     status:
       code: 200
@@ -6111,9 +6111,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-25f38973-5c85-4146-aa98-aa3d2bd0bdef
+      - req-e0bb48fe-d3b6-4233-9729-4dfe2c452bdb
       Date:
-      - Thu, 25 Oct 2018 18:22:04 GMT
+      - Thu, 01 Nov 2018 18:37:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -6125,7 +6125,7 @@ http_interactions:
         changed", "physical_resource_id": "aa5907f3-8209-4dd0-b3ef-600431d85bac",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:04 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:27 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack2/4cf24b12-29fc-4529-a8ed-6b079dea7c17/resources
@@ -6140,7 +6140,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 81b1f5a3cfff42f5a4749d06bc72f482
+      - 06a2391a8c4b4ba5baad159fad001e4a
   response:
     status:
       code: 200
@@ -6151,9 +6151,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-1c4d44c2-ad37-43d7-b64d-1d1b84bcf0b2
+      - req-c13472ea-022c-4911-a319-b6246195e3b2
       Date:
-      - Thu, 25 Oct 2018 18:22:04 GMT
+      - Thu, 01 Nov 2018 18:37:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -6165,7 +6165,7 @@ http_interactions:
         changed", "physical_resource_id": "219a737c-b4ad-430d-944a-a92a4834b12d",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:04 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:27 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c/resources
@@ -6180,7 +6180,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 81b1f5a3cfff42f5a4749d06bc72f482
+      - 06a2391a8c4b4ba5baad159fad001e4a
   response:
     status:
       code: 200
@@ -6191,9 +6191,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-fefc64f6-94b1-4c37-ba4a-9ebcf1d4ee69
+      - req-2f20e815-aefa-4b42-9743-bc860af54e3c
       Date:
-      - Thu, 25 Oct 2018 18:22:04 GMT
+      - Thu, 01 Nov 2018 18:37:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -6205,7 +6205,7 @@ http_interactions:
         changed", "physical_resource_id": "b686353f-0da0-48bf-bc35-8ea411a67dfd",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:04 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:28 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?all_tenants=True&limit=1000
@@ -6220,7 +6220,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0ed9a3aba33d4553aadce38156cee447
+      - e92f6adaa928438a99678a1002a2a0b2
   response:
     status:
       code: 200
@@ -6231,28 +6231,16 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-0362e04f-8dc0-4a82-bbc6-e2d022b2c943
+      - req-0f5c695a-eda0-40b9-b722-00238ad1a546
       Date:
-      - Thu, 25 Oct 2018 18:22:04 GMT
+      - Thu, 01 Nov 2018 18:37:28 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
         "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
@@ -6261,6 +6249,12 @@ http_interactions:
         "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
         "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2",
+        "end": "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
         "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
@@ -6313,6 +6307,12 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
         "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
         "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
@@ -6337,7 +6337,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:04 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:28 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?all_tenants=True&limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
@@ -6352,7 +6352,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0ed9a3aba33d4553aadce38156cee447
+      - e92f6adaa928438a99678a1002a2a0b2
   response:
     status:
       code: 200
@@ -6363,45 +6363,51 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-63255bd1-10a5-4502-9099-b37ceac62c71
+      - req-e16b4c45-f9d3-4408-a896-4a99aee57a7c
       Date:
-      - Thu, 25 Oct 2018 18:22:05 GMT
+      - Thu, 01 Nov 2018 18:37:28 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
-        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2",
+        "end": "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
         "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
         "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
         "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.4",
-        "end": "192.168.50.4"}, {"start": "192.168.50.2", "end": "192.168.50.2"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
-        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.20.0/24", "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
-        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
         false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
@@ -6450,12 +6456,6 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
         "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
@@ -6469,7 +6469,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:05 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:28 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?all_tenants=True&limit=1000
@@ -6484,7 +6484,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0ed9a3aba33d4553aadce38156cee447
+      - e92f6adaa928438a99678a1002a2a0b2
   response:
     status:
       code: 200
@@ -6495,9 +6495,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-5bee0512-2a36-4e06-8957-061a8bcb2bda
+      - req-d8c6576a-e2e5-4d3f-aada-bbcbe517f6a6
       Date:
-      - Thu, 25 Oct 2018 18:22:05 GMT
+      - Thu, 01 Nov 2018 18:37:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -6539,7 +6539,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:05 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:28 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?all_tenants=True&limit=1000&marker=ee601a91-f6ac-4a46-a599-87cfd83094a3
@@ -6554,7 +6554,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0ed9a3aba33d4553aadce38156cee447
+      - e92f6adaa928438a99678a1002a2a0b2
   response:
     status:
       code: 200
@@ -6565,9 +6565,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-56d08ec3-2ef8-4996-be21-361bebc2262d
+      - req-4506db4d-8b16-4219-8db3-cd5393560351
       Date:
-      - Thu, 25 Oct 2018 18:22:05 GMT
+      - Thu, 01 Nov 2018 18:37:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -6609,7 +6609,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:05 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:28 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?all_tenants=True&limit=1000
@@ -6624,7 +6624,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0ed9a3aba33d4553aadce38156cee447
+      - e92f6adaa928438a99678a1002a2a0b2
   response:
     status:
       code: 200
@@ -6635,9 +6635,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-3d4a343f-b83a-4981-8508-a70a20f8681d
+      - req-2fc37758-6af5-461c-9248-b966d2fef217
       Date:
-      - Thu, 25 Oct 2018 18:22:05 GMT
+      - Thu, 01 Nov 2018 18:37:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -7040,7 +7040,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:05 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:28 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?all_tenants=True&limit=1000&marker=dee8791c-23b3-4e65-846d-49aeaba18036
@@ -7055,7 +7055,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0ed9a3aba33d4553aadce38156cee447
+      - e92f6adaa928438a99678a1002a2a0b2
   response:
     status:
       code: 200
@@ -7066,9 +7066,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-4a8b4f1f-8e9c-4351-8783-7c4b7cd93716
+      - req-f34d2e2c-7f9c-4bda-bbe6-22e3f6b7af94
       Date:
-      - Thu, 25 Oct 2018 18:22:05 GMT
+      - Thu, 01 Nov 2018 18:37:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -7471,7 +7471,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:05 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:29 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?all_tenants=True&limit=1000
@@ -7486,7 +7486,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0ed9a3aba33d4553aadce38156cee447
+      - e92f6adaa928438a99678a1002a2a0b2
   response:
     status:
       code: 200
@@ -7497,9 +7497,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-59026bbf-e484-4e65-9e47-639f77aa4434
+      - req-1fc62ec5-4fbf-4bd4-90b0-194c450f82b7
       Date:
-      - Thu, 25 Oct 2018 18:22:05 GMT
+      - Thu, 01 Nov 2018 18:37:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -7531,7 +7531,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:05 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:29 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?all_tenants=True&limit=1000&marker=a41c036a-c34e-454b-851d-5eefd03888cb
@@ -7546,7 +7546,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0ed9a3aba33d4553aadce38156cee447
+      - e92f6adaa928438a99678a1002a2a0b2
   response:
     status:
       code: 200
@@ -7557,9 +7557,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-f53f3109-5335-4f10-bd9e-d0bfd79606b1
+      - req-dde4d264-ab41-43e6-aaf3-cf5b9b9b4dc8
       Date:
-      - Thu, 25 Oct 2018 18:22:06 GMT
+      - Thu, 01 Nov 2018 18:37:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -7591,7 +7591,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:06 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:29 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?all_tenants=True&limit=1000
@@ -7606,7 +7606,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0ed9a3aba33d4553aadce38156cee447
+      - e92f6adaa928438a99678a1002a2a0b2
   response:
     status:
       code: 200
@@ -7617,9 +7617,9 @@ http_interactions:
       Content-Length:
       - '3418'
       X-Openstack-Request-Id:
-      - req-d4f04f23-66e7-4fc2-967a-65125715209c
+      - req-9be99001-81a0-480d-a1f1-4eeecaa5a6f0
       Date:
-      - Thu, 25 Oct 2018 18:22:06 GMT
+      - Thu, 01 Nov 2018 18:37:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef",
@@ -7661,7 +7661,7 @@ http_interactions:
         null, "port_range_min": null, "id": "ff24dfac-169a-4238-b78b-ed1536a0bf06",
         "security_group_id": "5b2b42a6-1271-4c4a-b062-8e8ba299acef"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:06 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:29 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef
@@ -7676,7 +7676,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0ed9a3aba33d4553aadce38156cee447
+      - e92f6adaa928438a99678a1002a2a0b2
   response:
     status:
       code: 200
@@ -7687,9 +7687,9 @@ http_interactions:
       Content-Length:
       - '3418'
       X-Openstack-Request-Id:
-      - req-515b5c35-5905-4e73-b110-552abafde889
+      - req-e4bea1a0-e98d-4a5c-a213-b880da3c613b
       Date:
-      - Thu, 25 Oct 2018 18:22:06 GMT
+      - Thu, 01 Nov 2018 18:37:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab",
@@ -7732,7 +7732,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "c06c0e71-2c18-43a9-ace9-91242f0251e2",
         "security_group_id": "98bfc20c-a897-42c5-b33c-f0d8317667ab"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:06 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:29 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab
@@ -7747,7 +7747,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0ed9a3aba33d4553aadce38156cee447
+      - e92f6adaa928438a99678a1002a2a0b2
   response:
     status:
       code: 200
@@ -7758,9 +7758,9 @@ http_interactions:
       Content-Length:
       - '2751'
       X-Openstack-Request-Id:
-      - req-bae36b1a-3d99-4e11-91b2-5abe3c0f2eb5
+      - req-fcf77fe6-1885-4ca9-a291-554a5afec4aa
       Date:
-      - Thu, 25 Oct 2018 18:22:06 GMT
+      - Thu, 01 Nov 2018 18:37:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4",
@@ -7795,7 +7795,7 @@ http_interactions:
         null, "port_range_min": null, "id": "75924ebc-4758-4042-ad04-4ef3c9189098",
         "security_group_id": "e4836528-d0df-425e-a117-ae8ec6f356d4"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:06 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:29 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4
@@ -7810,7 +7810,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0ed9a3aba33d4553aadce38156cee447
+      - e92f6adaa928438a99678a1002a2a0b2
   response:
     status:
       code: 200
@@ -7821,9 +7821,9 @@ http_interactions:
       Content-Length:
       - '7097'
       X-Openstack-Request-Id:
-      - req-52cd4bd3-2877-4e01-b2fd-8963c07c9761
+      - req-f4e4f8e6-5371-464d-830d-bab375ab159b
       Date:
-      - Thu, 25 Oct 2018 18:22:06 GMT
+      - Thu, 01 Nov 2018 18:37:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=fd147cb7-7456-43d9-a01f-c06e21b4e6fb&page_reverse=True",
@@ -7910,7 +7910,7 @@ http_interactions:
         "port_range_max": 80, "port_range_min": 80, "id": "f79f0e32-b186-4778-952e-20827a60ef73",
         "security_group_id": "fd147cb7-7456-43d9-a01f-c06e21b4e6fb"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:06 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:30 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -7928,13 +7928,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:22:06 GMT
+      - Thu, 01 Nov 2018 18:37:30 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-f582f747-768d-4d3f-9081-3adf9f15ff8a
+      - req-0b420414-4932-46c4-b00c-0f3fb7615d50
       Content-Length:
       - '4170'
       Connection:
@@ -7943,10 +7943,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:22:07.009338", "expires":
-        "2018-10-25T19:22:06Z", "id": "f30099fa62aa49cb9b12ebf81c346667", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:37:30.686748", "expires":
+        "2018-11-01T19:37:30Z", "id": "78cd9fbecd81472ea625486bf79886f3", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["Dpggue_YRpyrRONNKJSp5w"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["7_FxX-llSzKbwOM3dfEFvg"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -7991,7 +7991,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:07 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:30 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -8009,13 +8009,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:22:07 GMT
+      - Thu, 01 Nov 2018 18:37:30 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-37571635-6ee0-4cc6-ab9c-4c43c3a1ac91
+      - req-d9bccc8a-c169-45bb-8aea-bdc46739dac8
       Content-Length:
       - '4170'
       Connection:
@@ -8024,10 +8024,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:22:07.217316", "expires":
-        "2018-10-25T19:22:07Z", "id": "35f284e8281d419c910a0b906151c422", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:37:30.879621", "expires":
+        "2018-11-01T19:37:30Z", "id": "ca41e934d425493699987846b683ddeb", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["QFoWV-YoR8enQeMNgJixhA"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["dFFExuLcRNWOFNvg3GlzHg"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -8072,7 +8072,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:07 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:30 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -8090,13 +8090,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:22:07 GMT
+      - Thu, 01 Nov 2018 18:37:31 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-e3934b4f-40c1-4fbd-ad83-08174e07b418
+      - req-d708d05e-4d34-4b85-9b4b-63a9c5b383d2
       Content-Length:
       - '370'
       Connection:
@@ -8105,13 +8105,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:22:07.387029", "expires":
-        "2018-10-25T19:22:07Z", "id": "87b9b1dafd184049b1421a449a7ee269", "audit_ids":
-        ["C6KS9Eh_TkSshX1Zof7Rdw"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:37:31.036618", "expires":
+        "2018-11-01T19:37:31Z", "id": "7907f098cc8449659fe49a47042acd9d", "audit_ids":
+        ["9sxXRKJET2qBMWtTozXvag"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:07 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:31 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -8126,20 +8126,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 87b9b1dafd184049b1421a449a7ee269
+      - 7907f098cc8449659fe49a47042acd9d
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:22:07 GMT
+      - Thu, 01 Nov 2018 18:37:31 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-a56795eb-61ac-4f9b-aecf-188f0289d7ee
+      - req-1386e44f-cbad-4a42-b7c4-c49dd310b28f
       Content-Length:
       - '500'
       Connection:
@@ -8156,7 +8156,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:07 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:31 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -8174,13 +8174,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:22:07 GMT
+      - Thu, 01 Nov 2018 18:37:31 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-58c46a28-7ce0-4572-8a09-9f852d3953ed
+      - req-311585c1-52b8-4b23-bdcf-b9c2e15cb8ac
       Content-Length:
       - '4117'
       Connection:
@@ -8189,10 +8189,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:22:07.709394", "expires":
-        "2018-10-25T19:22:07Z", "id": "fa9ccd306ef24c8aa4d72c12d3d1a4b9", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:37:31.366611", "expires":
+        "2018-11-01T19:37:31Z", "id": "552715fde95b4aad9b180177d65cf502", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["xeoI1BScTIu52ToKqJevfQ"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["7shQQQV-SMCF7MjlWBTiBQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -8236,7 +8236,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:07 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:31 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -8254,13 +8254,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:22:07 GMT
+      - Thu, 01 Nov 2018 18:37:31 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-91ee1fab-f925-43ac-a1cf-66e695177ddd
+      - req-b700ae34-7a9b-4c90-a4e1-42b148dfce0f
       Content-Length:
       - '4131'
       Connection:
@@ -8269,10 +8269,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:22:07.894804", "expires":
-        "2018-10-25T19:22:07Z", "id": "9c3bae55f68a4731a0b4e1e47aa36a2b", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:37:31.548290", "expires":
+        "2018-11-01T19:37:31Z", "id": "4084885781f243e5965e1aed56822369", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["nvpbF0OKQhG5BNbv3pSpuQ"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["Ibfhx0GvSF-BIWXIt3eOGA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -8316,7 +8316,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:07 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:31 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -8334,13 +8334,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:22:08 GMT
+      - Thu, 01 Nov 2018 18:37:31 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-ee06f0a1-8f7d-4f72-95f9-23c12f08980d
+      - req-2262140b-2c32-4d77-8733-ba60d0c00b8b
       Content-Length:
       - '4118'
       Connection:
@@ -8349,10 +8349,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:22:08.081710", "expires":
-        "2018-10-25T19:22:08Z", "id": "4dcb5a3ba50144d58cba3e3aa2b5e25c", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:37:31.731600", "expires":
+        "2018-11-01T19:37:31Z", "id": "9c5b2b1ff89040de87b1d919882f5d3a", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["wtBdHaMKR8OedWxK14GwxA"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["caPFmoRETY2gYlQf6YlkEQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -8396,7 +8396,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:08 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:31 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -8414,13 +8414,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:22:08 GMT
+      - Thu, 01 Nov 2018 18:37:31 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-ec0fa6d9-af75-442a-8d56-927436be1796
+      - req-0eb5357c-7525-4410-9bb7-9fb21e0a90cd
       Content-Length:
       - '4117'
       Connection:
@@ -8429,10 +8429,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:22:08.259661", "expires":
-        "2018-10-25T19:22:08Z", "id": "23637d656704468c944d32fa43493eff", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:37:31.924118", "expires":
+        "2018-11-01T19:37:31Z", "id": "29a97abd92ae44a0b29f44d353b48483", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["Hh-29SVSTBOJvxWL1qbyKQ"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["dOWe2xEpTeuhLgEFDcXwdg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -8476,7 +8476,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:08 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:31 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000
@@ -8491,22 +8491,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 23637d656704468c944d32fa43493eff
+      - 29a97abd92ae44a0b29f44d353b48483
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-86913854-c856-42c7-bd13-2d62101844b7
+      - req-9cccce15-ec90-4afa-b8e7-b037dc877205
       Content-Type:
       - application/json
       Content-Length:
       - '2706'
       X-Openstack-Request-Id:
-      - req-86913854-c856-42c7-bd13-2d62101844b7
+      - req-9cccce15-ec90-4afa-b8e7-b037dc877205
       Date:
-      - Thu, 25 Oct 2018 18:22:08 GMT
+      - Thu, 01 Nov 2018 18:37:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=9bb99818-b339-4e31-b87f-e4181ec48acd",
@@ -8539,7 +8539,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-4", "bootable": "true", "created_at":
         "2016-11-11T13:49:53.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:08 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:32 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=9bb99818-b339-4e31-b87f-e4181ec48acd
@@ -8554,22 +8554,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 23637d656704468c944d32fa43493eff
+      - 29a97abd92ae44a0b29f44d353b48483
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-2ddc233a-376d-4d2e-9fe8-8498e0535d7d
+      - req-903036aa-937e-4088-bda7-5e5503d6ba11
       Content-Type:
       - application/json
       Content-Length:
       - '3284'
       X-Openstack-Request-Id:
-      - req-2ddc233a-376d-4d2e-9fe8-8498e0535d7d
+      - req-903036aa-937e-4088-bda7-5e5503d6ba11
       Date:
-      - Thu, 25 Oct 2018 18:22:08 GMT
+      - Thu, 01 Nov 2018 18:37:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=2c774148-c11a-434c-aabb-7fa9c82c37ce",
@@ -8610,7 +8610,7 @@ http_interactions:
         "name": "EmsRefreshSpec-Volume-2", "bootable": "false", "created_at": "2016-11-11T13:49:43.000000",
         "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:08 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:32 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=2c774148-c11a-434c-aabb-7fa9c82c37ce
@@ -8625,22 +8625,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 23637d656704468c944d32fa43493eff
+      - 29a97abd92ae44a0b29f44d353b48483
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-d9c42910-f0ef-40b6-b6a1-86a054a3d5a8
+      - req-06d34466-5703-48db-97e5-07db637e58fd
       Content-Type:
       - application/json
       Content-Length:
       - '2753'
       X-Openstack-Request-Id:
-      - req-d9c42910-f0ef-40b6-b6a1-86a054a3d5a8
+      - req-06d34466-5703-48db-97e5-07db637e58fd
       Date:
-      - Thu, 25 Oct 2018 18:22:08 GMT
+      - Thu, 01 Nov 2018 18:37:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=0a55c0d5-c780-4e7d-9d09-47f5520c7448",
@@ -8674,7 +8674,7 @@ http_interactions:
         "bootable": "false", "created_at": "2016-11-11T13:49:20.000000", "volume_type":
         "iscsi"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:08 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:32 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=0a55c0d5-c780-4e7d-9d09-47f5520c7448
@@ -8689,27 +8689,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 23637d656704468c944d32fa43493eff
+      - 29a97abd92ae44a0b29f44d353b48483
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-89a9cefe-464d-447c-b757-577d88c924db
+      - req-cf59d421-8a23-471e-8cf9-59f63795a083
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-89a9cefe-464d-447c-b757-577d88c924db
+      - req-cf59d421-8a23-471e-8cf9-59f63795a083
       Date:
-      - Thu, 25 Oct 2018 18:22:08 GMT
+      - Thu, 01 Nov 2018 18:37:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:09 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:32 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -8727,13 +8727,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:22:09 GMT
+      - Thu, 01 Nov 2018 18:37:32 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-87115fe0-4973-4c6e-8207-11abd0351cf4
+      - req-9d279b04-4e8b-41d0-9906-4a7db38bc658
       Content-Length:
       - '4131'
       Connection:
@@ -8742,10 +8742,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:22:09.179745", "expires":
-        "2018-10-25T19:22:09Z", "id": "2ed768347bb44056ac46df60ea4f81a3", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:37:32.822747", "expires":
+        "2018-11-01T19:37:32Z", "id": "2a1dc04a3b7e4a53b1129624d0911729", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["42_UhXEERYGjaRcCti_JIw"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["KhLSMut_RN6gVICw-kZTGA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -8789,7 +8789,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:09 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:32 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/volumes/detail?limit=1000
@@ -8804,27 +8804,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2ed768347bb44056ac46df60ea4f81a3
+      - 2a1dc04a3b7e4a53b1129624d0911729
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-7ce37cf1-25f8-4c52-b984-1eeca6bbfb96
+      - req-d63d08ef-6a0a-4208-ba28-f06f527fc5c5
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-7ce37cf1-25f8-4c52-b984-1eeca6bbfb96
+      - req-d63d08ef-6a0a-4208-ba28-f06f527fc5c5
       Date:
-      - Thu, 25 Oct 2018 18:22:09 GMT
+      - Thu, 01 Nov 2018 18:37:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:09 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:33 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/volumes/detail?limit=1000
@@ -8839,27 +8839,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 35f284e8281d419c910a0b906151c422
+      - ca41e934d425493699987846b683ddeb
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-987a3694-8637-4d9b-ada0-2ae7ca4d9e12
+      - req-e1bd29c9-0936-46d1-885b-9cff31936ffd
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-987a3694-8637-4d9b-ada0-2ae7ca4d9e12
+      - req-e1bd29c9-0936-46d1-885b-9cff31936ffd
       Date:
-      - Thu, 25 Oct 2018 18:22:09 GMT
+      - Thu, 01 Nov 2018 18:37:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:09 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:33 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -8877,13 +8877,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:22:09 GMT
+      - Thu, 01 Nov 2018 18:37:33 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-9930afc3-b6c2-4c03-847c-925650064613
+      - req-11fd6e79-939e-4904-8c55-16f99734736c
       Content-Length:
       - '4118'
       Connection:
@@ -8892,10 +8892,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:22:09.765883", "expires":
-        "2018-10-25T19:22:09Z", "id": "0dee90b269d8407ea43e476ffa743ba7", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:37:33.396621", "expires":
+        "2018-11-01T19:37:33Z", "id": "0bf09455d39440edb4b61526ea618709", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["6fv-MTphSlmYr3qLBCMHnw"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["L5htWqI5SNuDzMr6-skScQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -8939,7 +8939,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:09 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:33 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/volumes/detail?limit=1000
@@ -8954,27 +8954,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0dee90b269d8407ea43e476ffa743ba7
+      - 0bf09455d39440edb4b61526ea618709
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-eaa29a80-b09f-4c7a-8e91-ed974fa96c97
+      - req-849f4d3d-3c66-43a7-a71e-aa34f9d64e61
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-eaa29a80-b09f-4c7a-8e91-ed974fa96c97
+      - req-849f4d3d-3c66-43a7-a71e-aa34f9d64e61
       Date:
-      - Thu, 25 Oct 2018 18:22:09 GMT
+      - Thu, 01 Nov 2018 18:37:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:09 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:33 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail
@@ -8989,22 +8989,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 23637d656704468c944d32fa43493eff
+      - 29a97abd92ae44a0b29f44d353b48483
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-7b5fbc9f-0203-4810-b048-f9fb533d7351
+      - req-d1490591-cc06-450a-84ec-4124f697995d
       Content-Type:
       - application/json
       Content-Length:
       - '1053'
       X-Openstack-Request-Id:
-      - req-7b5fbc9f-0203-4810-b048-f9fb533d7351
+      - req-d1490591-cc06-450a-84ec-4124f697995d
       Date:
-      - Thu, 25 Oct 2018 18:22:10 GMT
+      - Thu, 01 Nov 2018 18:37:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?marker=76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
@@ -9019,7 +9019,7 @@ http_interactions:
         "created_at": "2016-11-11T13:49:36.000000", "size": 1, "id": "76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:10 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:33 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?limit=1000
@@ -9034,22 +9034,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 23637d656704468c944d32fa43493eff
+      - 29a97abd92ae44a0b29f44d353b48483
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-69f0d76f-cad6-426a-9421-f863470c032f
+      - req-f0de04f7-2ce6-4420-91f4-e940fb063d7a
       Content-Type:
       - application/json
       Content-Length:
       - '1064'
       X-Openstack-Request-Id:
-      - req-69f0d76f-cad6-426a-9421-f863470c032f
+      - req-f0de04f7-2ce6-4420-91f4-e940fb063d7a
       Date:
-      - Thu, 25 Oct 2018 18:22:10 GMT
+      - Thu, 01 Nov 2018 18:37:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?limit=1000&marker=76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
@@ -9064,7 +9064,7 @@ http_interactions:
         "created_at": "2016-11-11T13:49:36.000000", "size": 1, "id": "76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:10 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:33 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/snapshots/detail
@@ -9079,27 +9079,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2ed768347bb44056ac46df60ea4f81a3
+      - 2a1dc04a3b7e4a53b1129624d0911729
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-51b3a511-d052-43d4-b300-9e5b597182ea
+      - req-5598817f-727d-42d3-977a-d8878e417b8a
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-51b3a511-d052-43d4-b300-9e5b597182ea
+      - req-5598817f-727d-42d3-977a-d8878e417b8a
       Date:
-      - Thu, 25 Oct 2018 18:22:10 GMT
+      - Thu, 01 Nov 2018 18:37:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:10 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:33 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/snapshots/detail?limit=1000
@@ -9114,27 +9114,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2ed768347bb44056ac46df60ea4f81a3
+      - 2a1dc04a3b7e4a53b1129624d0911729
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-0a4e84de-2041-4498-be1f-06d02e0812be
+      - req-46b676c4-cc18-475b-880a-2852eb8800c2
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-0a4e84de-2041-4498-be1f-06d02e0812be
+      - req-46b676c4-cc18-475b-880a-2852eb8800c2
       Date:
-      - Thu, 25 Oct 2018 18:22:10 GMT
+      - Thu, 01 Nov 2018 18:37:34 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:10 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:34 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/snapshots/detail
@@ -9149,27 +9149,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 35f284e8281d419c910a0b906151c422
+      - ca41e934d425493699987846b683ddeb
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-21eacd81-9d09-4c19-8454-f1657e3609c9
+      - req-81fde828-e2d0-415e-9d60-465fc79a73d2
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-21eacd81-9d09-4c19-8454-f1657e3609c9
+      - req-81fde828-e2d0-415e-9d60-465fc79a73d2
       Date:
-      - Thu, 25 Oct 2018 18:22:10 GMT
+      - Thu, 01 Nov 2018 18:37:34 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:10 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:34 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/snapshots/detail?limit=1000
@@ -9184,27 +9184,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 35f284e8281d419c910a0b906151c422
+      - ca41e934d425493699987846b683ddeb
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-d66e5e9b-9eda-4a87-9f6d-ff33c9f23fad
+      - req-38ac6181-97cf-4d6e-909e-f0962a89456a
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-d66e5e9b-9eda-4a87-9f6d-ff33c9f23fad
+      - req-38ac6181-97cf-4d6e-909e-f0962a89456a
       Date:
-      - Thu, 25 Oct 2018 18:22:10 GMT
+      - Thu, 01 Nov 2018 18:37:34 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:10 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:34 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/snapshots/detail
@@ -9219,27 +9219,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0dee90b269d8407ea43e476ffa743ba7
+      - 0bf09455d39440edb4b61526ea618709
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-1e4b9a35-e5f1-403a-8736-46bfd968c6fb
+      - req-0b6af81c-f2ba-42f8-a4bf-260795b7b51a
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-1e4b9a35-e5f1-403a-8736-46bfd968c6fb
+      - req-0b6af81c-f2ba-42f8-a4bf-260795b7b51a
       Date:
-      - Thu, 25 Oct 2018 18:22:10 GMT
+      - Thu, 01 Nov 2018 18:37:34 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:10 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:34 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/snapshots/detail?limit=1000
@@ -9254,27 +9254,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0dee90b269d8407ea43e476ffa743ba7
+      - 0bf09455d39440edb4b61526ea618709
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-7940cbb3-6273-4122-bdc5-ad16acb73634
+      - req-4a511d80-4c10-496c-8c4e-887ad53234a5
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-7940cbb3-6273-4122-bdc5-ad16acb73634
+      - req-4a511d80-4c10-496c-8c4e-887ad53234a5
       Date:
-      - Thu, 25 Oct 2018 18:22:10 GMT
+      - Thu, 01 Nov 2018 18:37:34 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:10 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:34 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/backups/detail
@@ -9289,27 +9289,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 23637d656704468c944d32fa43493eff
+      - 29a97abd92ae44a0b29f44d353b48483
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-b318ea63-3d5f-491e-98f6-76cf50f39ae5
+      - req-17c1789b-5e9f-4b2f-968c-72e045dd23fa
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-b318ea63-3d5f-491e-98f6-76cf50f39ae5
+      - req-17c1789b-5e9f-4b2f-968c-72e045dd23fa
       Date:
-      - Thu, 25 Oct 2018 18:22:10 GMT
+      - Thu, 01 Nov 2018 18:37:34 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:10 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:34 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/backups/detail?limit=1000
@@ -9324,27 +9324,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 23637d656704468c944d32fa43493eff
+      - 29a97abd92ae44a0b29f44d353b48483
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-6ddfc89d-b919-4734-a87e-224e30d2c580
+      - req-0ff49965-c31c-4e7b-9078-004a52fe8ef9
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-6ddfc89d-b919-4734-a87e-224e30d2c580
+      - req-0ff49965-c31c-4e7b-9078-004a52fe8ef9
       Date:
-      - Thu, 25 Oct 2018 18:22:11 GMT
+      - Thu, 01 Nov 2018 18:37:34 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:11 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:34 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/backups/detail
@@ -9359,27 +9359,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2ed768347bb44056ac46df60ea4f81a3
+      - 2a1dc04a3b7e4a53b1129624d0911729
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-9b067222-6da9-44da-89da-0bb3b24a5fe7
+      - req-c38b8557-d82c-44ca-8617-c0d9a47f2055
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-9b067222-6da9-44da-89da-0bb3b24a5fe7
+      - req-c38b8557-d82c-44ca-8617-c0d9a47f2055
       Date:
-      - Thu, 25 Oct 2018 18:22:11 GMT
+      - Thu, 01 Nov 2018 18:37:34 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:11 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:34 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/backups/detail?limit=1000
@@ -9394,27 +9394,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2ed768347bb44056ac46df60ea4f81a3
+      - 2a1dc04a3b7e4a53b1129624d0911729
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-c2267da3-d585-49b7-bb7d-82543b2cdeeb
+      - req-77ea1669-b572-4311-9ab2-d1e538f87437
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-c2267da3-d585-49b7-bb7d-82543b2cdeeb
+      - req-77ea1669-b572-4311-9ab2-d1e538f87437
       Date:
-      - Thu, 25 Oct 2018 18:22:11 GMT
+      - Thu, 01 Nov 2018 18:37:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:11 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:35 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/backups/detail
@@ -9429,27 +9429,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 35f284e8281d419c910a0b906151c422
+      - ca41e934d425493699987846b683ddeb
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-442dab22-1823-4aa2-ac47-b2668354b7d5
+      - req-25593554-da19-4769-9d3e-8096f8ff9590
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-442dab22-1823-4aa2-ac47-b2668354b7d5
+      - req-25593554-da19-4769-9d3e-8096f8ff9590
       Date:
-      - Thu, 25 Oct 2018 18:22:11 GMT
+      - Thu, 01 Nov 2018 18:37:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:11 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:35 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/backups/detail?limit=1000
@@ -9464,27 +9464,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 35f284e8281d419c910a0b906151c422
+      - ca41e934d425493699987846b683ddeb
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-39c8921a-9eb8-4bc2-b2db-44688e783238
+      - req-65fbe58b-d2a2-48a0-b6e1-67044d391677
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-39c8921a-9eb8-4bc2-b2db-44688e783238
+      - req-65fbe58b-d2a2-48a0-b6e1-67044d391677
       Date:
-      - Thu, 25 Oct 2018 18:22:11 GMT
+      - Thu, 01 Nov 2018 18:37:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:11 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:35 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/backups/detail
@@ -9499,27 +9499,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0dee90b269d8407ea43e476ffa743ba7
+      - 0bf09455d39440edb4b61526ea618709
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-d73f48bf-a6f2-48d1-99de-d128b776afba
+      - req-ad3b6dae-5071-4d61-a44d-31be68cb0a2f
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-d73f48bf-a6f2-48d1-99de-d128b776afba
+      - req-ad3b6dae-5071-4d61-a44d-31be68cb0a2f
       Date:
-      - Thu, 25 Oct 2018 18:22:11 GMT
+      - Thu, 01 Nov 2018 18:37:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:11 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:35 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/backups/detail?limit=1000
@@ -9534,27 +9534,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0dee90b269d8407ea43e476ffa743ba7
+      - 0bf09455d39440edb4b61526ea618709
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-fabcd7fd-5494-47f6-938c-351be2fcb82d
+      - req-7c7d28d4-177a-4c72-ac9d-d0d80ac0dc9b
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-fabcd7fd-5494-47f6-938c-351be2fcb82d
+      - req-7c7d28d4-177a-4c72-ac9d-d0d80ac0dc9b
       Date:
-      - Thu, 25 Oct 2018 18:22:11 GMT
+      - Thu, 01 Nov 2018 18:37:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:11 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:35 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/types?limit=1000
@@ -9569,22 +9569,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 23637d656704468c944d32fa43493eff
+      - 29a97abd92ae44a0b29f44d353b48483
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-8f0ac54c-cd66-47d4-a8b9-f4ddd52b6329
+      - req-30588c53-dafb-4ee6-bb91-c6d250a38baf
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-8f0ac54c-cd66-47d4-a8b9-f4ddd52b6329
+      - req-30588c53-dafb-4ee6-bb91-c6d250a38baf
       Date:
-      - Thu, 25 Oct 2018 18:22:11 GMT
+      - Thu, 01 Nov 2018 18:37:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -9596,7 +9596,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:11 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:35 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/types?limit=1000&marker=0d07f8c3-f295-48c7-b632-6b7d8bd860eb
@@ -9611,22 +9611,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 23637d656704468c944d32fa43493eff
+      - 29a97abd92ae44a0b29f44d353b48483
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-4a4ddc8b-83bc-489d-8102-bea0a1f7834e
+      - req-541fc307-9e23-43a9-a00a-90881a413454
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-4a4ddc8b-83bc-489d-8102-bea0a1f7834e
+      - req-541fc307-9e23-43a9-a00a-90881a413454
       Date:
-      - Thu, 25 Oct 2018 18:22:11 GMT
+      - Thu, 01 Nov 2018 18:37:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -9638,7 +9638,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:11 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:35 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/types?limit=1000
@@ -9653,22 +9653,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2ed768347bb44056ac46df60ea4f81a3
+      - 2a1dc04a3b7e4a53b1129624d0911729
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-14287cd3-3b52-4ec9-bd40-d4e2d106f5b6
+      - req-20dc5cf5-8787-49a1-b6f4-acec9baacb08
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-14287cd3-3b52-4ec9-bd40-d4e2d106f5b6
+      - req-20dc5cf5-8787-49a1-b6f4-acec9baacb08
       Date:
-      - Thu, 25 Oct 2018 18:22:11 GMT
+      - Thu, 01 Nov 2018 18:37:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -9680,7 +9680,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:11 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:35 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/types?limit=1000&marker=0d07f8c3-f295-48c7-b632-6b7d8bd860eb
@@ -9695,22 +9695,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2ed768347bb44056ac46df60ea4f81a3
+      - 2a1dc04a3b7e4a53b1129624d0911729
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-aab4d288-7393-43c3-a84e-58c2e16d78ca
+      - req-1d9245e3-99a0-4deb-8f76-79479356da58
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-aab4d288-7393-43c3-a84e-58c2e16d78ca
+      - req-1d9245e3-99a0-4deb-8f76-79479356da58
       Date:
-      - Thu, 25 Oct 2018 18:22:12 GMT
+      - Thu, 01 Nov 2018 18:37:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -9722,7 +9722,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:12 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:35 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/types?limit=1000
@@ -9737,22 +9737,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 35f284e8281d419c910a0b906151c422
+      - ca41e934d425493699987846b683ddeb
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-6ce9b4b0-2aaa-4bf1-9598-3c7e762106e7
+      - req-936b810a-5616-4079-83b6-edda37080e50
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-6ce9b4b0-2aaa-4bf1-9598-3c7e762106e7
+      - req-936b810a-5616-4079-83b6-edda37080e50
       Date:
-      - Thu, 25 Oct 2018 18:22:12 GMT
+      - Thu, 01 Nov 2018 18:37:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -9764,7 +9764,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:12 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:35 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/types?limit=1000&marker=0d07f8c3-f295-48c7-b632-6b7d8bd860eb
@@ -9779,22 +9779,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 35f284e8281d419c910a0b906151c422
+      - ca41e934d425493699987846b683ddeb
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-1bc9b7c2-1e42-4759-b2aa-d974a2acb0bf
+      - req-a3d625bf-4e2a-42d7-8c81-88f936ae88dc
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-1bc9b7c2-1e42-4759-b2aa-d974a2acb0bf
+      - req-a3d625bf-4e2a-42d7-8c81-88f936ae88dc
       Date:
-      - Thu, 25 Oct 2018 18:22:12 GMT
+      - Thu, 01 Nov 2018 18:37:36 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -9806,7 +9806,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:12 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:36 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/types?limit=1000
@@ -9821,22 +9821,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0dee90b269d8407ea43e476ffa743ba7
+      - 0bf09455d39440edb4b61526ea618709
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-97f76c03-ae63-4c4b-a0a5-4f496ffd69a5
+      - req-461b53d3-6d76-4a52-86ab-8ed18d1473ae
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-97f76c03-ae63-4c4b-a0a5-4f496ffd69a5
+      - req-461b53d3-6d76-4a52-86ab-8ed18d1473ae
       Date:
-      - Thu, 25 Oct 2018 18:22:12 GMT
+      - Thu, 01 Nov 2018 18:37:36 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -9848,7 +9848,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:12 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:36 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/types?limit=1000&marker=0d07f8c3-f295-48c7-b632-6b7d8bd860eb
@@ -9863,22 +9863,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0dee90b269d8407ea43e476ffa743ba7
+      - 0bf09455d39440edb4b61526ea618709
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-24294153-a198-4bf0-91ef-4d6968da6a52
+      - req-a41f1a13-09fb-45ee-b70d-6f133d7791ba
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-24294153-a198-4bf0-91ef-4d6968da6a52
+      - req-a41f1a13-09fb-45ee-b70d-6f133d7791ba
       Date:
-      - Thu, 25 Oct 2018 18:22:12 GMT
+      - Thu, 01 Nov 2018 18:37:36 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -9890,7 +9890,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:12 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:36 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -9908,13 +9908,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:22:12 GMT
+      - Thu, 01 Nov 2018 18:37:36 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-8ed958f4-7a6c-427f-a8bb-076f4446b9ac
+      - req-f94dea55-3700-4bd3-b109-6b56c879e253
       Content-Length:
       - '4170'
       Connection:
@@ -9923,10 +9923,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:22:12.668619", "expires":
-        "2018-10-25T19:22:12Z", "id": "3b337a386624429480fa22fb488ff4e2", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:37:36.541076", "expires":
+        "2018-11-01T19:37:36Z", "id": "610be9495668406ea182402733b32ff7", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["b2RD-MhzQViKO-ZKL_DRCA"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["SkjUkqbZRxifaAZ7veuwVA"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -9971,7 +9971,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:12 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:36 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -9989,13 +9989,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:22:12 GMT
+      - Thu, 01 Nov 2018 18:37:36 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-98562f05-d0ed-43a9-9f80-e645d37d85ec
+      - req-eacad946-fe69-434f-8814-f05cba1865c2
       Content-Length:
       - '4170'
       Connection:
@@ -10004,10 +10004,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:22:12.861564", "expires":
-        "2018-10-25T19:22:12Z", "id": "b72e901891df431e824f6070a31fee32", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:37:36.741240", "expires":
+        "2018-11-01T19:37:36Z", "id": "32a0b45d26ef4cdead981ffa8042e71d", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["88pt2TEsRG-t0BLKNZHAYg"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["2zvlSGxQRl-rrLMl4h8X3Q"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -10052,7 +10052,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:12 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:36 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -10070,13 +10070,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:22:12 GMT
+      - Thu, 01 Nov 2018 18:37:36 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-b708573c-db87-44f6-9d98-bbe4578ad615
+      - req-bf785be0-62ef-4b5b-9cc1-fc25b31694a0
       Content-Length:
       - '370'
       Connection:
@@ -10085,13 +10085,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:22:13.012857", "expires":
-        "2018-10-25T19:22:13Z", "id": "1322a2c1388c4a949473f84bfce72541", "audit_ids":
-        ["jFaX7JYvRtuaBKKTBpB2kQ"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:37:36.904007", "expires":
+        "2018-11-01T19:37:36Z", "id": "7aa89d9429924e7d8c8573a8b2aa9bfe", "audit_ids":
+        ["vyn3IqVDRYCliUWH_zkNuQ"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:13 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:36 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -10106,20 +10106,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1322a2c1388c4a949473f84bfce72541
+      - 7aa89d9429924e7d8c8573a8b2aa9bfe
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:22:13 GMT
+      - Thu, 01 Nov 2018 18:37:37 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-91e4a8e1-43c6-46f8-9b5c-e5cfa1369488
+      - req-6a0b9795-01db-40dc-8d0d-4565d0616364
       Content-Length:
       - '500'
       Connection:
@@ -10136,7 +10136,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:13 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:37 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -10154,13 +10154,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:22:13 GMT
+      - Thu, 01 Nov 2018 18:37:37 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-55c251d8-7bd4-4bce-814c-5cb7c24f8811
+      - req-bbdb6e4e-7265-430a-860a-7092615f8781
       Content-Length:
       - '4117'
       Connection:
@@ -10169,10 +10169,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:22:13.338445", "expires":
-        "2018-10-25T19:22:13Z", "id": "2832df69794b40488dbddb92c2681dcf", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:37:37.239534", "expires":
+        "2018-11-01T19:37:37Z", "id": "be36f05bdab847369d5b46652bfafc33", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["fnug4PVdTcai_x8MMyLcbw"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["TlEMsJnBTS2GXLstKCK-Kw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -10216,7 +10216,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:13 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:37 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -10234,13 +10234,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:22:13 GMT
+      - Thu, 01 Nov 2018 18:37:37 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-dff6575e-8f5d-4c07-9a55-4dd0ee904e7d
+      - req-617138ce-7327-4fe3-9f88-25e66ada0edf
       Content-Length:
       - '4131'
       Connection:
@@ -10249,10 +10249,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:22:13.525539", "expires":
-        "2018-10-25T19:22:13Z", "id": "b5a08b5f64be4606af6e1a99b3919259", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:37:37.430423", "expires":
+        "2018-11-01T19:37:37Z", "id": "295209ab2b4e454390413b7fb10a7910", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["o8LvFS2dQqm0B1ha8pUdlg"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["N25jEQRkQ8iuyzIFzZf-0w"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -10296,7 +10296,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:13 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:37 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -10314,13 +10314,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:22:13 GMT
+      - Thu, 01 Nov 2018 18:37:37 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-97797c13-b81b-45d9-927d-98672421969e
+      - req-4bf34972-6862-46da-b4d7-2b26ae20466c
       Content-Length:
       - '4118'
       Connection:
@@ -10329,10 +10329,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:22:13.708552", "expires":
-        "2018-10-25T19:22:13Z", "id": "67cceccfb18044cfa5e271215f5c5e4e", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:37:37.618272", "expires":
+        "2018-11-01T19:37:37Z", "id": "ec4f2d7b645f4e75a5772eca02d05b30", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["jaBiB8pVTc-BRuemg8-92Q"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["W7nbL6qHQou7vVCNdmZAXQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -10376,7 +10376,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:13 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:37 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -10394,13 +10394,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:22:13 GMT
+      - Thu, 01 Nov 2018 18:37:37 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-e2df8675-8a35-4e81-a236-5126503ea6ff
+      - req-312930c4-0960-48ae-adb6-4489b1798612
       Content-Length:
       - '4117'
       Connection:
@@ -10409,10 +10409,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:22:13.898245", "expires":
-        "2018-10-25T19:22:13Z", "id": "17b6bb36ac844e8485dc8e5819efe80e", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:37:37.822257", "expires":
+        "2018-11-01T19:37:37Z", "id": "7cbf678cb904435ab7941aab90b6d2ab", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["3xfX0F-rQXKHRlQBVvdRKA"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["LVFE1P9FSQaiSYAnho-boQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -10456,7 +10456,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:13 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:37 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/?format=json&limit=1000
@@ -10471,7 +10471,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 17b6bb36ac844e8485dc8e5819efe80e
+      - 7cbf678cb904435ab7941aab90b6d2ab
   response:
     status:
       code: 200
@@ -10500,15 +10500,15 @@ http_interactions:
       X-Account-Project-Domain-Id:
       - default
       X-Trans-Id:
-      - tx5af4fb8c0c804822b14b3-005bd209d5
+      - txafc3d50ef32f42a38639e-005bdb47f1
       Date:
-      - Thu, 25 Oct 2018 18:22:14 GMT
+      - Thu, 01 Nov 2018 18:37:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '[{"count": 3, "bytes": 33, "name": "dir_1"}, {"count": 0, "bytes":
         0, "name": "dir_2"}, {"count": 0, "bytes": 0, "name": "dir_3"}]'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:14 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:38 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/?format=json&limit=1000&marker=dir_3
@@ -10523,7 +10523,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 17b6bb36ac844e8485dc8e5819efe80e
+      - 7cbf678cb904435ab7941aab90b6d2ab
   response:
     status:
       code: 200
@@ -10552,14 +10552,14 @@ http_interactions:
       X-Account-Project-Domain-Id:
       - default
       X-Trans-Id:
-      - txf24ecc0ffa9f4afd9a98f-005bd209d6
+      - txfb2d94dd46904e14b8963-005bdb47f2
       Date:
-      - Thu, 25 Oct 2018 18:22:14 GMT
+      - Thu, 01 Nov 2018 18:37:38 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:14 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:38 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -10577,13 +10577,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:22:14 GMT
+      - Thu, 01 Nov 2018 18:37:38 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-2a413752-016e-4f23-9f59-07032ed756b6
+      - req-477bb338-7b9a-4201-be5e-d1c0db15f4ca
       Content-Length:
       - '4131'
       Connection:
@@ -10592,10 +10592,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:22:14.346785", "expires":
-        "2018-10-25T19:22:14Z", "id": "a571880be8df4a9d84beed47162f368d", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:37:38.291177", "expires":
+        "2018-11-01T19:37:38Z", "id": "571b4c9b6c94415a8650482374f06506", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["42BfPQwURuCpJJZuJ_mzrw"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["yJzIz_ekQvihc0UUdyZ2mA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -10639,7 +10639,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:14 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:38 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_b458a5c25c3749758f4c0661940b3ba8/?format=json&limit=1000
@@ -10654,7 +10654,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a571880be8df4a9d84beed47162f368d
+      - 571b4c9b6c94415a8650482374f06506
   response:
     status:
       code: 200
@@ -10667,22 +10667,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1540491734.52365'
+      - '1541097458.45710'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1540491734.52365'
+      - '1541097458.45710'
       X-Trans-Id:
-      - tx6d20586908f84cf09f454-005bd209d6
+      - tx0ca957fe20a14c8198061-005bdb47f2
       Date:
-      - Thu, 25 Oct 2018 18:22:14 GMT
+      - Thu, 01 Nov 2018 18:37:38 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:14 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:38 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_e54e5c3c19e34720b05661f2ea1ea00a/?format=json&limit=1000
@@ -10697,7 +10697,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b72e901891df431e824f6070a31fee32
+      - 32a0b45d26ef4cdead981ffa8042e71d
   response:
     status:
       code: 200
@@ -10710,22 +10710,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1540491734.68964'
+      - '1541097458.61454'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1540491734.68964'
+      - '1541097458.61454'
       X-Trans-Id:
-      - tx286af2c5b1314ee797cb9-005bd209d6
+      - tx5995abce1eb945eeb81bb-005bdb47f2
       Date:
-      - Thu, 25 Oct 2018 18:22:14 GMT
+      - Thu, 01 Nov 2018 18:37:38 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:14 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:38 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -10743,13 +10743,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:22:14 GMT
+      - Thu, 01 Nov 2018 18:37:38 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-c40a5ce8-27b5-4e9e-b200-d1b6acbcfb52
+      - req-8d9d339a-0efc-46c2-9ba7-0709f9442430
       Content-Length:
       - '4118'
       Connection:
@@ -10758,10 +10758,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:22:14.872059", "expires":
-        "2018-10-25T19:22:14Z", "id": "90af07e201a44a04814897a4b987e554", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:37:38.805113", "expires":
+        "2018-11-01T19:37:38Z", "id": "16c0f757f06e4db38e8d9fe8bf991f7b", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["dmsyVdGqQb6O6x5zehBUrQ"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["F8wji5e2SsitwmO-4E27aQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -10805,7 +10805,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:14 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:38 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_e8f744b1fc6a487681d35fb275252608/?format=json&limit=1000
@@ -10820,7 +10820,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 90af07e201a44a04814897a4b987e554
+      - 16c0f757f06e4db38e8d9fe8bf991f7b
   response:
     status:
       code: 200
@@ -10833,22 +10833,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1540491735.03769'
+      - '1541097458.98019'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1540491735.03769'
+      - '1541097458.98019'
       X-Trans-Id:
-      - tx58b90e8527e74bdab03b7-005bd209d6
+      - txa8cf4a93d4eb441f832a6-005bdb47f2
       Date:
-      - Thu, 25 Oct 2018 18:22:15 GMT
+      - Thu, 01 Nov 2018 18:37:38 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:15 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:39 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/dir_1?format=json
@@ -10863,7 +10863,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 17b6bb36ac844e8485dc8e5819efe80e
+      - 7cbf678cb904435ab7941aab90b6d2ab
   response:
     status:
       code: 200
@@ -10884,9 +10884,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - tx1f9b7b307521452fadc69-005bd209d7
+      - tx27e0f50777df4ddca73e9-005bdb47f3
       Date:
-      - Thu, 25 Oct 2018 18:22:15 GMT
+      - Thu, 01 Nov 2018 18:37:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '[{"hash": "61257bf228e2f6802a196c9a460d19a8", "last_modified": "2016-11-11T13:50:03.869630",
@@ -10896,7 +10896,7 @@ http_interactions:
         {"hash": "1727a9b61bddf85bbe7a5710c9f45691", "last_modified": "2016-11-11T13:50:04.495640",
         "bytes": 11, "name": "file_3", "content_type": "application/octet-stream"}]'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:15 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:39 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/dir_2?format=json
@@ -10911,7 +10911,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 17b6bb36ac844e8485dc8e5819efe80e
+      - 7cbf678cb904435ab7941aab90b6d2ab
   response:
     status:
       code: 200
@@ -10932,14 +10932,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - tx2d7ee339a4914ec786b5a-005bd209d7
+      - tx1f56ba0195424666a89cf-005bdb47f3
       Date:
-      - Thu, 25 Oct 2018 18:22:15 GMT
+      - Thu, 01 Nov 2018 18:37:39 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:15 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:39 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/dir_3?format=json
@@ -10954,7 +10954,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 17b6bb36ac844e8485dc8e5819efe80e
+      - 7cbf678cb904435ab7941aab90b6d2ab
   response:
     status:
       code: 200
@@ -10975,12 +10975,12 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - txaab52ccef741468db4833-005bd209d7
+      - tx4abebfa15dc245caa4758-005bdb47f3
       Date:
-      - Thu, 25 Oct 2018 18:22:15 GMT
+      - Thu, 01 Nov 2018 18:37:39 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:15 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:39 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_keystone_v3.yml
+++ b/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_keystone_v3.yml
@@ -17,15 +17,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:23:05 GMT
+      - Thu, 01 Nov 2018 18:31:37 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - d5e08decea854f9d9045e427794321a4
+      - 91c772b42a324045a203d6215c73a103
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-773edac4-796e-4874-a193-3a2d0dff08c0
+      - req-f41f7fef-1ff3-4f37-b92f-ea8f547b2a54
       Content-Length:
       - '7311'
       Connection:
@@ -37,7 +37,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-10-25T19:23:05.380432Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-11-01T19:31:37.952133Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -116,10 +116,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["wW0WGSFBR7mv7Bbz40-2ig"],
-        "issued_at": "2018-10-25T18:23:05.380454Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["LkO0CfpzSzCuqITx26lnPA"],
+        "issued_at": "2018-11-01T18:31:37.952154Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:05 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:37 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -134,7 +134,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d5e08decea854f9d9045e427794321a4
+      - 91c772b42a324045a203d6215c73a103
   response:
     status:
       code: 200
@@ -145,7 +145,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Thu, 25 Oct 2018 18:23:05 GMT
+      - Thu, 01 Nov 2018 18:31:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -154,7 +154,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:05 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:38 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-availability-zone
@@ -169,7 +169,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d5e08decea854f9d9045e427794321a4
+      - 91c772b42a324045a203d6215c73a103
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -182,15 +182,15 @@ http_interactions:
       Content-Length:
       - '97'
       X-Compute-Request-Id:
-      - req-5074e502-cd48-4752-9e42-b5edfd69b41c
+      - req-65af9fd8-01b5-49e5-887c-25e653a33ead
       Date:
-      - Thu, 25 Oct 2018 18:23:05 GMT
+      - Thu, 01 Nov 2018 18:31:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"availabilityZoneInfo": [{"zoneState": {"available": true}, "hosts":
         null, "zoneName": "nova"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:05 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:38 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -208,15 +208,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:23:05 GMT
+      - Thu, 01 Nov 2018 18:31:38 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 33a0d96815174b8aa583a7ca218f6c04
+      - dbe191db653e4c6581367157a0c9475f
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-0dcaa908-8ebf-48ad-82ab-171d53bf0024
+      - req-9b0b0add-673f-494b-90f9-a451c6538adc
       Content-Length:
       - '7311'
       Connection:
@@ -228,7 +228,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-10-25T19:23:05.822184Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-11-01T19:31:38.393649Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -307,10 +307,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["eU2yiZpjQKKxZX8RmV2_mw"],
-        "issued_at": "2018-10-25T18:23:05.822205Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["CQfRdrhgSgGBYVdg0rK8ow"],
+        "issued_at": "2018-11-01T18:31:38.393671Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:05 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:38 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/os-availability-zone.json
@@ -325,28 +325,28 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 33a0d96815174b8aa583a7ca218f6c04
+      - dbe191db653e4c6581367157a0c9475f
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-fd939103-f7d5-42a5-8136-6f897c1c3045
+      - req-aeade912-28b1-4690-ae45-19fe10e8a9d8
       Content-Type:
       - application/json
       Content-Length:
       - '82'
       X-Openstack-Request-Id:
-      - req-fd939103-f7d5-42a5-8136-6f897c1c3045
+      - req-aeade912-28b1-4690-ae45-19fe10e8a9d8
       Date:
-      - Thu, 25 Oct 2018 18:23:05 GMT
+      - Thu, 01 Nov 2018 18:31:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"availabilityZoneInfo": [{"zoneState": {"available": true}, "zoneName":
         "nova"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:05 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:39 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -364,15 +364,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:23:06 GMT
+      - Thu, 01 Nov 2018 18:31:39 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - f6ac138c77be43c5891320ee3ebdd097
+      - 82af4e8d00da4a99bb0c6c2bdf7fcb00
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-c72ff87e-3700-41bb-a9c3-916dfef501f5
+      - req-8fb4217f-649b-488e-aeaf-8b8a832b5643
       Content-Length:
       - '297'
       Connection:
@@ -381,12 +381,12 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"token": {"methods": ["password"], "expires_at": "2018-10-25T19:23:06.104058Z",
+      string: '{"token": {"methods": ["password"], "expires_at": "2018-11-01T19:31:39.682851Z",
         "extras": {}, "user": {"domain": {"id": "default", "name": "Default"}, "id":
-        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Pj6-H6zWRuySLFRRVxBG1A"],
-        "issued_at": "2018-10-25T18:23:06.104079Z"}}'
+        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["fLyq3bWRRYCxhABeTlkqew"],
+        "issued_at": "2018-11-01T18:31:39.682872Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:06 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:39 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects?domain_id=default
@@ -401,20 +401,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f6ac138c77be43c5891320ee3ebdd097
+      - 82af4e8d00da4a99bb0c6c2bdf7fcb00
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:23:06 GMT
+      - Thu, 01 Nov 2018 18:31:39 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-a30459cd-9402-4c8f-be4f-df64a24b6f5f
+      - req-eb26e5aa-dcad-4913-9339-e8c89aa00578
       Content-Length:
       - '2475'
       Connection:
@@ -447,7 +447,7 @@ http_interactions:
         "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
         "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:06 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:39 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -465,15 +465,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:23:06 GMT
+      - Thu, 01 Nov 2018 18:31:39 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - f130f696cdfa428089d3a195c4b33719
+      - a56d2a9d7a0a4153aa5df041f2480d4a
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-1adac250-6dd9-4ba7-9ea2-f9b42197f316
+      - req-9080fd96-bf2f-45be-92ad-a1e5cfdfd3f3
       Content-Length:
       - '7278'
       Connection:
@@ -485,7 +485,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:23:06.430495Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:31:40.023902Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -564,10 +564,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["NfhJYt7SThC25gF9ycKGhg"],
-        "issued_at": "2018-10-25T18:23:06.430515Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["h-fhxPG4TXStufIaUF7M0A"],
+        "issued_at": "2018-11-01T18:31:40.023923Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:06 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:40 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -582,7 +582,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f130f696cdfa428089d3a195c4b33719
+      - a56d2a9d7a0a4153aa5df041f2480d4a
   response:
     status:
       code: 200
@@ -593,7 +593,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Thu, 25 Oct 2018 18:23:06 GMT
+      - Thu, 01 Nov 2018 18:31:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -602,7 +602,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:06 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:40 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -620,15 +620,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:23:06 GMT
+      - Thu, 01 Nov 2018 18:31:40 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - e9afc6b25c6a43feb9c5d51bbd84241a
+      - f9137d18297a4fd98d146990230151e2
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-d51b28d1-d160-4ce1-b411-b683a231af8e
+      - req-1775bce9-9e5c-4be9-93e9-6f7842f1871e
       Content-Length:
       - '7278'
       Connection:
@@ -640,7 +640,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:23:06.712880Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:31:40.311282Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -719,10 +719,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["2slE-xEvQy2ybU18oY_w6w"],
-        "issued_at": "2018-10-25T18:23:06.712911Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["I4yh6W71SQSz2ng3fPqr1A"],
+        "issued_at": "2018-11-01T18:31:40.311301Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:06 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:40 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -737,7 +737,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e9afc6b25c6a43feb9c5d51bbd84241a
+      - f9137d18297a4fd98d146990230151e2
   response:
     status:
       code: 200
@@ -748,7 +748,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Thu, 25 Oct 2018 18:23:06 GMT
+      - Thu, 01 Nov 2018 18:31:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -757,7 +757,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:06 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:40 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -775,15 +775,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:23:06 GMT
+      - Thu, 01 Nov 2018 18:31:40 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - f3704f32307549d9ae9d8754d49694c9
+      - 89d8021eb8c540c2b147ddb1c40e7a7b
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-d03938f5-5f18-446b-be78-8632140fd9f5
+      - req-40643724-8dc6-4ca2-8aa7-da1fcb9c20a2
       Content-Length:
       - '7264'
       Connection:
@@ -795,7 +795,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:23:07.029783Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:31:40.600256Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -874,10 +874,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["jt6C2AXgRiS-Czz4QB_qCQ"],
-        "issued_at": "2018-10-25T18:23:07.029810Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["JD0y9NIqQUC2EmMrmk8HPQ"],
+        "issued_at": "2018-11-01T18:31:40.600276Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:07 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:40 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -892,7 +892,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f3704f32307549d9ae9d8754d49694c9
+      - 89d8021eb8c540c2b147ddb1c40e7a7b
   response:
     status:
       code: 200
@@ -903,7 +903,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Thu, 25 Oct 2018 18:23:07 GMT
+      - Thu, 01 Nov 2018 18:31:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -912,7 +912,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:07 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:40 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -930,15 +930,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:23:07 GMT
+      - Thu, 01 Nov 2018 18:31:40 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 9f339daaf2b442ea94a1334e891fdbd8
+      - '08232f81c46946d0b1944a39c6b1c79a'
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-774e8edb-45e2-4760-b469-bffe72d1b219
+      - req-247c21ae-8599-4a52-a76b-619f6b02dce8
       Content-Length:
       - '7278'
       Connection:
@@ -950,7 +950,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:23:07.313887Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:31:40.891473Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -1029,10 +1029,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["7jJuzbsNQQStAimE864P7Q"],
-        "issued_at": "2018-10-25T18:23:07.313909Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["C0hZ5jjnSXy1YaOg0y3CBw"],
+        "issued_at": "2018-11-01T18:31:40.891493Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:07 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:40 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -1047,7 +1047,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9f339daaf2b442ea94a1334e891fdbd8
+      - '08232f81c46946d0b1944a39c6b1c79a'
   response:
     status:
       code: 200
@@ -1058,7 +1058,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Thu, 25 Oct 2018 18:23:07 GMT
+      - Thu, 01 Nov 2018 18:31:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -1067,7 +1067,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:07 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:41 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -1085,15 +1085,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:23:07 GMT
+      - Thu, 01 Nov 2018 18:31:41 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 822b32934d0b41cc9dc4b9cb86cdc202
+      - 6c722a2ac5f945f0a5f61fbf11ca3618
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-56908282-564f-42e1-aa89-95cde411c0f5
+      - req-0898f73e-2432-4a71-9060-cb5d17b3f28f
       Content-Length:
       - '7265'
       Connection:
@@ -1105,7 +1105,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:23:07.591424Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:31:41.180825Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -1184,10 +1184,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["CfLoxzoVRRaihLJtClbeEg"],
-        "issued_at": "2018-10-25T18:23:07.591445Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["UBMMWUrgSrWBK-SojeA_5A"],
+        "issued_at": "2018-11-01T18:31:41.180846Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:07 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:41 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -1202,7 +1202,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 822b32934d0b41cc9dc4b9cb86cdc202
+      - 6c722a2ac5f945f0a5f61fbf11ca3618
   response:
     status:
       code: 200
@@ -1213,7 +1213,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Thu, 25 Oct 2018 18:23:07 GMT
+      - Thu, 01 Nov 2018 18:31:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -1222,7 +1222,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:07 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:41 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -1240,15 +1240,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:23:07 GMT
+      - Thu, 01 Nov 2018 18:31:41 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 180af607b5ef47c8940e3c3e35de425c
+      - 5ad6db8acf29438ebc1b24e0de3f5974
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-5a35295c-f96e-4ccb-ba7d-e4272329d3af
+      - req-d417c6b1-6bd5-4672-9024-64992f1b9aa4
       Content-Length:
       - '7278'
       Connection:
@@ -1260,7 +1260,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:23:07.930638Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:31:41.468102Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -1339,10 +1339,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["fRzlsX3ESpa3lwjYnRRl3w"],
-        "issued_at": "2018-10-25T18:23:07.930663Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["rJIP_R_HRxyqRcDkgcsInQ"],
+        "issued_at": "2018-11-01T18:31:41.468121Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:07 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:41 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -1357,7 +1357,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 180af607b5ef47c8940e3c3e35de425c
+      - 5ad6db8acf29438ebc1b24e0de3f5974
   response:
     status:
       code: 200
@@ -1368,7 +1368,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Thu, 25 Oct 2018 18:23:08 GMT
+      - Thu, 01 Nov 2018 18:31:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -1377,7 +1377,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:08 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:41 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3/os-services?limit=1000
@@ -1392,7 +1392,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f130f696cdfa428089d3a195c4b33719
+      - a56d2a9d7a0a4153aa5df041f2480d4a
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1405,26 +1405,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-7666b7df-319d-43e3-af25-fbf323d7eb86
+      - req-a8886edb-ad77-412c-a960-7ceb554fd540
       Date:
-      - Thu, 25 Oct 2018 18:23:08 GMT
+      - Thu, 01 Nov 2018 18:31:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-10-25T18:23:04.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-11-01T18:31:33.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-10-25T18:23:00.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-11-01T18:31:35.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-10-25T18:23:03.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-11-01T18:31:41.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 5, "updated_at":
-        "2018-10-25T18:23:05.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-11-01T18:31:33.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-10-25T18:23:06.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-11-01T18:31:34.000000"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:08 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:41 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3/os-services?limit=1000&marker=6
@@ -1439,7 +1439,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f130f696cdfa428089d3a195c4b33719
+      - a56d2a9d7a0a4153aa5df041f2480d4a
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1452,26 +1452,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-045605ae-d51c-4148-a3d2-0875ab4b2058
+      - req-45666309-515f-4b1d-9b2f-f3779187f830
       Date:
-      - Thu, 25 Oct 2018 18:23:08 GMT
+      - Thu, 01 Nov 2018 18:31:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-10-25T18:23:04.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-11-01T18:31:33.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-10-25T18:23:00.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-11-01T18:31:35.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-10-25T18:23:03.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-11-01T18:31:41.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 5, "updated_at":
-        "2018-10-25T18:23:05.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-11-01T18:31:33.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-10-25T18:23:06.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-11-01T18:31:34.000000"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:08 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:41 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/28db8f69ba9e4305b7fad82da4c86e74/os-services?limit=1000
@@ -1486,7 +1486,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e9afc6b25c6a43feb9c5d51bbd84241a
+      - f9137d18297a4fd98d146990230151e2
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1499,26 +1499,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-d2b66a6c-8f5c-41ed-afae-afd2a383f251
+      - req-ee22ceeb-cfb5-472c-95eb-eddcac6dddbd
       Date:
-      - Thu, 25 Oct 2018 18:23:08 GMT
+      - Thu, 01 Nov 2018 18:31:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-10-25T18:23:04.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-11-01T18:31:33.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-10-25T18:23:00.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-11-01T18:31:35.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-10-25T18:23:03.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-11-01T18:31:41.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 5, "updated_at":
-        "2018-10-25T18:23:05.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-11-01T18:31:33.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-10-25T18:23:06.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-11-01T18:31:34.000000"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:08 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:41 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/28db8f69ba9e4305b7fad82da4c86e74/os-services?limit=1000&marker=6
@@ -1533,7 +1533,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e9afc6b25c6a43feb9c5d51bbd84241a
+      - f9137d18297a4fd98d146990230151e2
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1546,26 +1546,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-0c5d19d0-cce1-480d-80c3-21ffcc078d9a
+      - req-46086177-9911-40bd-957a-68d2944e1cd9
       Date:
-      - Thu, 25 Oct 2018 18:23:08 GMT
+      - Thu, 01 Nov 2018 18:31:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-10-25T18:23:04.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-11-01T18:31:33.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-10-25T18:23:00.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-11-01T18:31:35.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-10-25T18:23:03.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-11-01T18:31:41.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 5, "updated_at":
-        "2018-10-25T18:23:05.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-11-01T18:31:33.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-10-25T18:23:06.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-11-01T18:31:34.000000"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:08 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:42 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/os-services?limit=1000
@@ -1580,7 +1580,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f3704f32307549d9ae9d8754d49694c9
+      - 89d8021eb8c540c2b147ddb1c40e7a7b
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1593,26 +1593,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-9de7dc2e-82d6-497b-aaf7-f56a2eb0067e
+      - req-4cf35c14-527e-4bd2-b75a-001a38df8293
       Date:
-      - Thu, 25 Oct 2018 18:23:08 GMT
+      - Thu, 01 Nov 2018 18:31:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-10-25T18:23:04.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-11-01T18:31:33.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-10-25T18:23:00.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-11-01T18:31:35.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-10-25T18:23:03.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-11-01T18:31:41.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 5, "updated_at":
-        "2018-10-25T18:23:05.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-11-01T18:31:33.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-10-25T18:23:06.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-11-01T18:31:34.000000"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:08 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:42 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/os-services?limit=1000&marker=6
@@ -1627,7 +1627,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f3704f32307549d9ae9d8754d49694c9
+      - 89d8021eb8c540c2b147ddb1c40e7a7b
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1640,26 +1640,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-f1713f91-e8f6-4e6e-b660-fb546ecfc9ba
+      - req-637df834-8771-4b1d-aa61-c6fec0a94651
       Date:
-      - Thu, 25 Oct 2018 18:23:08 GMT
+      - Thu, 01 Nov 2018 18:31:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-10-25T18:23:04.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-11-01T18:31:33.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-10-25T18:23:00.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-11-01T18:31:35.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-10-25T18:23:03.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-11-01T18:31:41.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 5, "updated_at":
-        "2018-10-25T18:23:05.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-11-01T18:31:33.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-10-25T18:23:06.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-11-01T18:31:34.000000"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:08 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:42 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/52c452d7763a4295950527948232a3e5/os-services?limit=1000
@@ -1674,7 +1674,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9f339daaf2b442ea94a1334e891fdbd8
+      - '08232f81c46946d0b1944a39c6b1c79a'
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1687,26 +1687,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-757fbec9-63cf-4144-a0f2-d841244fa3c4
+      - req-6fe22b7e-8928-4ed5-9987-61d98f758b21
       Date:
-      - Thu, 25 Oct 2018 18:23:08 GMT
+      - Thu, 01 Nov 2018 18:31:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-10-25T18:23:04.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-11-01T18:31:33.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-10-25T18:23:00.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-11-01T18:31:35.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-10-25T18:23:03.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-11-01T18:31:41.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 5, "updated_at":
-        "2018-10-25T18:23:05.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-11-01T18:31:33.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-10-25T18:23:06.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-11-01T18:31:34.000000"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:08 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:42 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/52c452d7763a4295950527948232a3e5/os-services?limit=1000&marker=6
@@ -1721,7 +1721,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9f339daaf2b442ea94a1334e891fdbd8
+      - '08232f81c46946d0b1944a39c6b1c79a'
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1734,26 +1734,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-91115749-53ed-401e-b093-9e4e69931fd4
+      - req-708a3533-e33b-4389-808c-104611bf487a
       Date:
-      - Thu, 25 Oct 2018 18:23:09 GMT
+      - Thu, 01 Nov 2018 18:31:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-10-25T18:23:04.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-11-01T18:31:33.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-10-25T18:23:00.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-11-01T18:31:35.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-10-25T18:23:03.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-11-01T18:31:41.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 5, "updated_at":
-        "2018-10-25T18:23:05.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-11-01T18:31:33.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-10-25T18:23:06.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-11-01T18:31:34.000000"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:09 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:42 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-services?limit=1000
@@ -1768,7 +1768,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d5e08decea854f9d9045e427794321a4
+      - 91c772b42a324045a203d6215c73a103
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1781,26 +1781,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-55a141a5-7e06-4ae9-871a-e2c1140490c0
+      - req-e35ad95b-a497-4d88-99a0-5ee92814e5b3
       Date:
-      - Thu, 25 Oct 2018 18:23:09 GMT
+      - Thu, 01 Nov 2018 18:31:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-10-25T18:23:04.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-11-01T18:31:33.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-10-25T18:23:00.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-11-01T18:31:35.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-10-25T18:23:03.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-11-01T18:31:41.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 5, "updated_at":
-        "2018-10-25T18:23:05.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-11-01T18:31:33.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-10-25T18:23:06.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-11-01T18:31:34.000000"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:09 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:42 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-services?limit=1000&marker=6
@@ -1815,7 +1815,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d5e08decea854f9d9045e427794321a4
+      - 91c772b42a324045a203d6215c73a103
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1828,26 +1828,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-9fcf109b-88ef-42f0-882b-8f911fb3cb57
+      - req-9c81e3ac-8f38-4ed3-b530-b16394458d90
       Date:
-      - Thu, 25 Oct 2018 18:23:09 GMT
+      - Thu, 01 Nov 2018 18:31:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-10-25T18:23:04.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-11-01T18:31:33.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-10-25T18:23:00.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-11-01T18:31:35.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-10-25T18:23:03.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-11-01T18:31:41.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 5, "updated_at":
-        "2018-10-25T18:23:05.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-11-01T18:31:33.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-10-25T18:23:06.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-11-01T18:31:34.000000"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:09 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:42 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/d09cbe26295d47ff848ea73c74264e23/os-services?limit=1000
@@ -1862,7 +1862,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 822b32934d0b41cc9dc4b9cb86cdc202
+      - 6c722a2ac5f945f0a5f61fbf11ca3618
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1875,26 +1875,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-85d6e926-a116-4d94-95bb-f9d537d18c5c
+      - req-5ddd9203-bc67-4cb3-8c24-9590ffbe13ab
       Date:
-      - Thu, 25 Oct 2018 18:23:09 GMT
+      - Thu, 01 Nov 2018 18:31:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-10-25T18:23:04.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-11-01T18:31:33.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-10-25T18:23:00.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-11-01T18:31:35.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-10-25T18:23:03.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-11-01T18:31:41.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 5, "updated_at":
-        "2018-10-25T18:23:05.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-11-01T18:31:33.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-10-25T18:23:06.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-11-01T18:31:34.000000"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:09 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:42 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/d09cbe26295d47ff848ea73c74264e23/os-services?limit=1000&marker=6
@@ -1909,7 +1909,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 822b32934d0b41cc9dc4b9cb86cdc202
+      - 6c722a2ac5f945f0a5f61fbf11ca3618
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1922,26 +1922,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-d640cd16-40bf-49da-aeed-22fa4a588abe
+      - req-13f87fa7-378d-44ef-9b13-237e61d9d15e
       Date:
-      - Thu, 25 Oct 2018 18:23:09 GMT
+      - Thu, 01 Nov 2018 18:31:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-10-25T18:23:04.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-11-01T18:31:33.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-10-25T18:23:00.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-11-01T18:31:35.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-10-25T18:23:03.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-11-01T18:31:41.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 5, "updated_at":
-        "2018-10-25T18:23:05.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-11-01T18:31:33.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-10-25T18:23:06.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-11-01T18:31:34.000000"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:09 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:43 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/os-services?limit=1000
@@ -1956,7 +1956,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 180af607b5ef47c8940e3c3e35de425c
+      - 5ad6db8acf29438ebc1b24e0de3f5974
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1969,26 +1969,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-56bc4560-46db-4539-ab0a-14e56bcf8e77
+      - req-3ec11f18-bbbe-4249-98f3-21476d66c46f
       Date:
-      - Thu, 25 Oct 2018 18:23:09 GMT
+      - Thu, 01 Nov 2018 18:31:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-10-25T18:23:04.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-11-01T18:31:33.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-10-25T18:23:00.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-11-01T18:31:35.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-10-25T18:23:03.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-11-01T18:31:41.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 5, "updated_at":
-        "2018-10-25T18:23:05.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-11-01T18:31:43.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-10-25T18:23:06.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-11-01T18:31:34.000000"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:09 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:43 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/os-services?limit=1000&marker=6
@@ -2003,7 +2003,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 180af607b5ef47c8940e3c3e35de425c
+      - 5ad6db8acf29438ebc1b24e0de3f5974
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2016,26 +2016,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-02d77f43-2c55-4c61-bd41-add0402a5071
+      - req-390cd12d-1d61-421b-a81b-d58840a49e23
       Date:
-      - Thu, 25 Oct 2018 18:23:09 GMT
+      - Thu, 01 Nov 2018 18:31:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-10-25T18:23:04.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-11-01T18:31:43.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-10-25T18:23:00.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-11-01T18:31:35.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-10-25T18:23:03.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-11-01T18:31:41.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 5, "updated_at":
-        "2018-10-25T18:23:05.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-11-01T18:31:43.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-10-25T18:23:06.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-11-01T18:31:34.000000"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:09 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:43 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000
@@ -2050,7 +2050,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d5e08decea854f9d9045e427794321a4
+      - 91c772b42a324045a203d6215c73a103
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2063,9 +2063,9 @@ http_interactions:
       Content-Length:
       - '1010'
       X-Compute-Request-Id:
-      - req-6afd3ae0-d46c-44c4-80b3-b3df0f7d72af
+      - req-12f10b24-160f-4385-8997-0b7c0387169e
       Date:
-      - Thu, 25 Oct 2018 18:23:09 GMT
+      - Thu, 01 Nov 2018 18:31:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.tiny", "links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/1",
@@ -2079,7 +2079,7 @@ http_interactions:
         0, "disk": 20, "id": "2"}], "flavors_links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=2",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:09 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:43 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=2
@@ -2094,7 +2094,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d5e08decea854f9d9045e427794321a4
+      - 91c772b42a324045a203d6215c73a103
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2107,9 +2107,9 @@ http_interactions:
       Content-Length:
       - '1014'
       X-Compute-Request-Id:
-      - req-00684e89-8e5c-4d03-b397-a64ddf48284a
+      - req-c1e74c65-7fd3-4a8d-96b4-b3e63b745321
       Date:
-      - Thu, 25 Oct 2018 18:23:09 GMT
+      - Thu, 01 Nov 2018 18:31:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.medium", "links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/3",
@@ -2123,7 +2123,7 @@ http_interactions:
         0, "disk": 80, "id": "4"}], "flavors_links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=4",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:09 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:43 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=4
@@ -2138,7 +2138,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d5e08decea854f9d9045e427794321a4
+      - 91c772b42a324045a203d6215c73a103
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2151,9 +2151,9 @@ http_interactions:
       Content-Length:
       - '1026'
       X-Compute-Request-Id:
-      - req-d71e39c1-a2b9-4bcc-9e90-78589a216783
+      - req-4724be7d-9b2b-4764-85cb-093e57a707e5
       Date:
-      - Thu, 25 Oct 2018 18:23:10 GMT
+      - Thu, 01 Nov 2018 18:31:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.xlarge", "links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/5",
@@ -2168,7 +2168,7 @@ http_interactions:
         1, "disk": 1, "id": "6"}], "flavors_links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=6",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:10 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:43 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=6
@@ -2183,7 +2183,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d5e08decea854f9d9045e427794321a4
+      - 91c772b42a324045a203d6215c73a103
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2196,9 +2196,9 @@ http_interactions:
       Content-Length:
       - '448'
       X-Compute-Request-Id:
-      - req-7bceccdc-e269-46f3-8438-7f1adc49b742
+      - req-689aa96d-fd57-4aa0-8493-51224b06f439
       Date:
-      - Thu, 25 Oct 2018 18:23:10 GMT
+      - Thu, 01 Nov 2018 18:31:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.ems_refresh_spec_private", "links": [{"href":
@@ -2208,7 +2208,7 @@ http_interactions:
         8, "swap": "", "os-flavor-access:is_public": false, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         0, "disk": 160, "id": "7"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:10 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:43 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/7/os-flavor-access
@@ -2223,7 +2223,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d5e08decea854f9d9045e427794321a4
+      - 91c772b42a324045a203d6215c73a103
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2236,15 +2236,15 @@ http_interactions:
       Content-Length:
       - '88'
       X-Compute-Request-Id:
-      - req-d342bb4a-74d0-49eb-8195-dedeeee4ed63
+      - req-b2a629f2-3e33-4136-a6c6-34fd2f7990d5
       Date:
-      - Thu, 25 Oct 2018 18:23:10 GMT
+      - Thu, 01 Nov 2018 18:31:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavor_access": [{"tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "flavor_id": "7"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:10 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:43 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -2262,15 +2262,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:23:10 GMT
+      - Thu, 01 Nov 2018 18:31:44 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - c7401c59232747e5ab68a1a887f666d8
+      - 5063d4e186ef4a5ca027fa305b80f407
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-0163c893-f25a-4a7c-bed9-6bac78c0f920
+      - req-99dad737-ee7e-4435-a1aa-5368dd05e53f
       Content-Length:
       - '7311'
       Connection:
@@ -2282,7 +2282,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-10-25T19:23:10.499849Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-11-01T19:31:44.122240Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -2361,10 +2361,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["UKyE9KZrSFqoqdlca9Kdeg"],
-        "issued_at": "2018-10-25T18:23:10.499871Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["lCIp1TunTGWXd7Qlkmks7g"],
+        "issued_at": "2018-11-01T18:31:44.122266Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:10 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:44 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -2382,15 +2382,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:23:10 GMT
+      - Thu, 01 Nov 2018 18:31:44 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - a7e49ae42f714628b39a203354139571
+      - c4d6a95ce07245d08bd613b62b90777b
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-688776f1-4a26-4d6b-9219-5d2cd132fabf
+      - req-17b7f722-c4d5-402a-b477-9685395ef547
       Content-Length:
       - '7278'
       Connection:
@@ -2402,7 +2402,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:23:10.698483Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:31:44.332883Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -2481,10 +2481,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["yheXLfZmTTSBYwwufZ0OKw"],
-        "issued_at": "2018-10-25T18:23:10.698503Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["eFAw8JoqR8CE9d71fgdCPw"],
+        "issued_at": "2018-11-01T18:31:44.332906Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:10 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:44 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images?limit=1000
@@ -2499,7 +2499,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a7e49ae42f714628b39a203354139571
+      - c4d6a95ce07245d08bd613b62b90777b
   response:
     status:
       code: 200
@@ -2510,9 +2510,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-9e2cabda-fd5d-40a6-aba9-e25471146a4c
+      - req-2921a7b9-6928-424d-a906-469e10789d74
       Date:
-      - Thu, 25 Oct 2018 18:23:10 GMT
+      - Thu, 01 Nov 2018 18:31:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -2554,7 +2554,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:10 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:44 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images?limit=1000&marker=b672acdb-654b-41d7-963c-44a0349bd285
@@ -2569,7 +2569,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a7e49ae42f714628b39a203354139571
+      - c4d6a95ce07245d08bd613b62b90777b
   response:
     status:
       code: 200
@@ -2580,14 +2580,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-e1892aa6-2357-4635-b194-9cd939b91914
+      - req-dcb1ee33-353f-4e42-9285-58b1db950e85
       Date:
-      - Thu, 25 Oct 2018 18:23:11 GMT
+      - Thu, 01 Nov 2018 18:31:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:11 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:44 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -2605,15 +2605,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:23:11 GMT
+      - Thu, 01 Nov 2018 18:31:44 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - f5e865d6a4d1477082297ae3658f691b
+      - a562778f267c41918ab7b357576758ab
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-c0371235-86f6-4a08-9c3d-31a17f492189
+      - req-e7c3fbc6-077e-4c2a-afb2-a90ec44f0b70
       Content-Length:
       - '7278'
       Connection:
@@ -2625,7 +2625,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:23:11.189073Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:31:44.845184Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -2704,10 +2704,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["DNYR4ZSeRnqRN5gCu0JbFQ"],
-        "issued_at": "2018-10-25T18:23:11.189095Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["ei1tyg_9RAKFAd41RzLMNQ"],
+        "issued_at": "2018-11-01T18:31:44.845204Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:11 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:44 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images?limit=1000
@@ -2722,7 +2722,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f5e865d6a4d1477082297ae3658f691b
+      - a562778f267c41918ab7b357576758ab
   response:
     status:
       code: 200
@@ -2733,9 +2733,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-813e0067-1f09-453c-84fb-66b0d2383589
+      - req-6590aaec-933c-4edc-bb4e-491106c0fade
       Date:
-      - Thu, 25 Oct 2018 18:23:11 GMT
+      - Thu, 01 Nov 2018 18:31:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -2777,7 +2777,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:11 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:45 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images?limit=1000&marker=b672acdb-654b-41d7-963c-44a0349bd285
@@ -2792,7 +2792,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f5e865d6a4d1477082297ae3658f691b
+      - a562778f267c41918ab7b357576758ab
   response:
     status:
       code: 200
@@ -2803,14 +2803,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-04ecbb44-1ee4-4c2d-aa18-5a5fe2d134fd
+      - req-e943b4ee-31f2-48ed-a60d-0b52d8e53a16
       Date:
-      - Thu, 25 Oct 2018 18:23:11 GMT
+      - Thu, 01 Nov 2018 18:31:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:11 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:45 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -2828,15 +2828,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:23:11 GMT
+      - Thu, 01 Nov 2018 18:31:45 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - d05c9d6467554b32b4e2abd904b494dd
+      - '081a335188684f2cafa93a4d336ab9c7'
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-1834d413-bff3-46bb-971d-d55137dd9c21
+      - req-465df480-b538-4766-8137-3c913033f01f
       Content-Length:
       - '7264'
       Connection:
@@ -2848,7 +2848,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:23:11.634836Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:31:45.329497Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -2927,10 +2927,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["lmtEkdM7TACI1Y3rRktHFw"],
-        "issued_at": "2018-10-25T18:23:11.634860Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["LcboLKMxTWSi_BwT6NapKg"],
+        "issued_at": "2018-11-01T18:31:45.329516Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:11 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:45 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images?limit=1000
@@ -2945,7 +2945,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d05c9d6467554b32b4e2abd904b494dd
+      - '081a335188684f2cafa93a4d336ab9c7'
   response:
     status:
       code: 200
@@ -2956,9 +2956,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-cc36c919-066f-41fb-bfe1-37a337f62600
+      - req-b4d4d0e3-ec84-4313-8505-ee48e7b1f197
       Date:
-      - Thu, 25 Oct 2018 18:23:11 GMT
+      - Thu, 01 Nov 2018 18:31:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -3000,7 +3000,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:11 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:45 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images?limit=1000&marker=b672acdb-654b-41d7-963c-44a0349bd285
@@ -3015,7 +3015,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d05c9d6467554b32b4e2abd904b494dd
+      - '081a335188684f2cafa93a4d336ab9c7'
   response:
     status:
       code: 200
@@ -3026,14 +3026,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-e8271300-a00b-4709-99e1-33c3f0c4d0de
+      - req-3973e17c-382c-4636-848e-2732893606b7
       Date:
-      - Thu, 25 Oct 2018 18:23:11 GMT
+      - Thu, 01 Nov 2018 18:31:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:11 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:45 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -3051,15 +3051,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:23:12 GMT
+      - Thu, 01 Nov 2018 18:31:45 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 18c480fde27a49f1b5d61200aad9c2dc
+      - 24b7ef9cd1be47068e38891ece915510
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-10393815-3ed3-4440-a4cc-f36449612a83
+      - req-cd2b0ea3-196b-404e-a1b1-47d3e1c4d040
       Content-Length:
       - '7278'
       Connection:
@@ -3071,7 +3071,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:23:12.077712Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:31:45.802700Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -3150,10 +3150,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["ZSXOZaHZRqS1YCwQGFoKxg"],
-        "issued_at": "2018-10-25T18:23:12.077734Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["UosQhX04TKGC2O1j8zvokQ"],
+        "issued_at": "2018-11-01T18:31:45.802720Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:12 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:45 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images?limit=1000
@@ -3168,7 +3168,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 18c480fde27a49f1b5d61200aad9c2dc
+      - 24b7ef9cd1be47068e38891ece915510
   response:
     status:
       code: 200
@@ -3179,9 +3179,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-cca15f2f-266d-4d74-b2aa-a9dce21e50bd
+      - req-7484fe50-ce5b-4dea-bad1-aa486d8e0f99
       Date:
-      - Thu, 25 Oct 2018 18:23:12 GMT
+      - Thu, 01 Nov 2018 18:31:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -3223,7 +3223,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:12 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:45 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images?limit=1000&marker=b672acdb-654b-41d7-963c-44a0349bd285
@@ -3238,7 +3238,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 18c480fde27a49f1b5d61200aad9c2dc
+      - 24b7ef9cd1be47068e38891ece915510
   response:
     status:
       code: 200
@@ -3249,14 +3249,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-41f875e1-14c9-4ed5-9646-959324308787
+      - req-4e6237a7-cb9d-4777-b60a-076c008ece9f
       Date:
-      - Thu, 25 Oct 2018 18:23:12 GMT
+      - Thu, 01 Nov 2018 18:31:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:12 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:46 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images?limit=1000
@@ -3271,7 +3271,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c7401c59232747e5ab68a1a887f666d8
+      - 5063d4e186ef4a5ca027fa305b80f407
   response:
     status:
       code: 200
@@ -3282,9 +3282,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-a2aef4ba-35d5-424b-af96-44f997b35a43
+      - req-a2a10047-c2ea-4b56-8150-41cabb84c51c
       Date:
-      - Thu, 25 Oct 2018 18:23:12 GMT
+      - Thu, 01 Nov 2018 18:31:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -3326,7 +3326,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:12 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:46 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images?limit=1000&marker=b672acdb-654b-41d7-963c-44a0349bd285
@@ -3341,7 +3341,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c7401c59232747e5ab68a1a887f666d8
+      - 5063d4e186ef4a5ca027fa305b80f407
   response:
     status:
       code: 200
@@ -3352,14 +3352,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-cbc20b33-b643-4ec4-998c-3b6987214d2f
+      - req-71f052a9-7177-422c-810d-497c4d824f94
       Date:
-      - Thu, 25 Oct 2018 18:23:12 GMT
+      - Thu, 01 Nov 2018 18:31:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:12 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:46 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -3377,15 +3377,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:23:12 GMT
+      - Thu, 01 Nov 2018 18:31:46 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - facb966a41e4488b855978671daf7100
+      - 7902d4d11ed949bfbfb7962e2faaa3f2
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-f6defc26-9653-42b8-af80-90342a1b201b
+      - req-57cd9eaf-56d0-4dde-85b9-cf3179d6f91b
       Content-Length:
       - '7265'
       Connection:
@@ -3397,7 +3397,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:23:12.791978Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:31:46.578711Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -3476,10 +3476,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["OSoUYgcAT4eh3eKQYuN2tQ"],
-        "issued_at": "2018-10-25T18:23:12.791999Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["3XyDVQZDSMGKS2sKMKiuDA"],
+        "issued_at": "2018-11-01T18:31:46.578730Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:12 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:46 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images?limit=1000
@@ -3494,7 +3494,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - facb966a41e4488b855978671daf7100
+      - 7902d4d11ed949bfbfb7962e2faaa3f2
   response:
     status:
       code: 200
@@ -3505,9 +3505,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-07d2b832-6aaf-4183-86b1-c71911bbf5cd
+      - req-2f73db70-0c48-4774-b031-194ebbb51b42
       Date:
-      - Thu, 25 Oct 2018 18:23:12 GMT
+      - Thu, 01 Nov 2018 18:31:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -3549,7 +3549,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:12 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:46 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images?limit=1000&marker=b672acdb-654b-41d7-963c-44a0349bd285
@@ -3564,7 +3564,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - facb966a41e4488b855978671daf7100
+      - 7902d4d11ed949bfbfb7962e2faaa3f2
   response:
     status:
       code: 200
@@ -3575,14 +3575,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-7cc32c79-650b-46e5-a0e2-a5359c868beb
+      - req-89e572b2-1801-4980-8741-f3d89e25db17
       Date:
-      - Thu, 25 Oct 2018 18:23:13 GMT
+      - Thu, 01 Nov 2018 18:31:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:13 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:46 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -3600,15 +3600,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:23:13 GMT
+      - Thu, 01 Nov 2018 18:31:46 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - b94a9863b79947faa0510f1be62d4f73
+      - 58919bbb3b444c248c53e56f1e444ced
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-61750fc9-9560-4168-a517-44a2b2f71797
+      - req-f8814f02-877e-4543-91cd-e258155f869e
       Content-Length:
       - '7278'
       Connection:
@@ -3620,7 +3620,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:23:13.263829Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:31:47.058480Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -3699,10 +3699,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["AzCWdqbBTNKrhMVUA2-jXg"],
-        "issued_at": "2018-10-25T18:23:13.263851Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["1HEEPghyRqKMhav_5htwIA"],
+        "issued_at": "2018-11-01T18:31:47.058501Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:13 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:47 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images?limit=1000
@@ -3717,7 +3717,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b94a9863b79947faa0510f1be62d4f73
+      - 58919bbb3b444c248c53e56f1e444ced
   response:
     status:
       code: 200
@@ -3728,9 +3728,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-67093d28-6d9b-41b3-90ba-614aceada845
+      - req-0b0105a1-1f80-42fa-8000-b51ebfbccac2
       Date:
-      - Thu, 25 Oct 2018 18:23:13 GMT
+      - Thu, 01 Nov 2018 18:31:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -3772,7 +3772,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:13 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:47 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images?limit=1000&marker=b672acdb-654b-41d7-963c-44a0349bd285
@@ -3787,7 +3787,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b94a9863b79947faa0510f1be62d4f73
+      - 58919bbb3b444c248c53e56f1e444ced
   response:
     status:
       code: 200
@@ -3798,14 +3798,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-cf38b7b7-90a5-4d82-a12b-caf2a08fa70d
+      - req-e529619f-0ad9-4fdc-9b98-6b9637a2a551
       Date:
-      - Thu, 25 Oct 2018 18:23:13 GMT
+      - Thu, 01 Nov 2018 18:31:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:13 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:47 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3/os-keypairs?limit=1000
@@ -3820,7 +3820,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f130f696cdfa428089d3a195c4b33719
+      - a56d2a9d7a0a4153aa5df041f2480d4a
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3833,9 +3833,9 @@ http_interactions:
       Content-Length:
       - '1611'
       X-Compute-Request-Id:
-      - req-c8432571-d159-4203-a732-9736b0f64f44
+      - req-dff9a004-ff39-45c1-9ba6-60d3f401c43d
       Date:
-      - Thu, 25 Oct 2018 18:23:13 GMT
+      - Thu, 01 Nov 2018 18:31:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKQyhM0ECmYmB8mI4vfeTEaY90skgHYgA/5apgT+cHhKzZX59Go+LGfb98dOCYEjnV3XKdO5dy7MrSdI5QSvGJmJIQPsH4WZNpRNuEhHzcHS1fEPe9zMceRlLafkTeUKhUGMIi1gOmBRdyZtz6fJw37AK6ioM4+16IhXjNVLV09jHn2PsUjh2RsGX5TzA3eHivptzINBD8eMBkyQwS2uejY42FlIg9qBpa8KEMgyo4KLvd/99kw9wLg1D9Y5+3OxA/J6hLfjSBv7Vd7Xvwd4ZmDlkU5+yH88b2ZOte8MyfAnlVA4v8bMdSsAf1e5NvUuZsoZC8goZCHjXmTDSI+yen
@@ -3845,7 +3845,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:13 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:47 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -3860,7 +3860,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f130f696cdfa428089d3a195c4b33719
+      - a56d2a9d7a0a4153aa5df041f2480d4a
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3873,9 +3873,9 @@ http_interactions:
       Content-Length:
       - '1611'
       X-Compute-Request-Id:
-      - req-5c98bcd8-5285-4c25-aa61-56c4f381fc97
+      - req-6003f707-e572-4397-8460-f8a951b651e4
       Date:
-      - Thu, 25 Oct 2018 18:23:13 GMT
+      - Thu, 01 Nov 2018 18:31:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKQyhM0ECmYmB8mI4vfeTEaY90skgHYgA/5apgT+cHhKzZX59Go+LGfb98dOCYEjnV3XKdO5dy7MrSdI5QSvGJmJIQPsH4WZNpRNuEhHzcHS1fEPe9zMceRlLafkTeUKhUGMIi1gOmBRdyZtz6fJw37AK6ioM4+16IhXjNVLV09jHn2PsUjh2RsGX5TzA3eHivptzINBD8eMBkyQwS2uejY42FlIg9qBpa8KEMgyo4KLvd/99kw9wLg1D9Y5+3OxA/J6hLfjSBv7Vd7Xvwd4ZmDlkU5+yH88b2ZOte8MyfAnlVA4v8bMdSsAf1e5NvUuZsoZC8goZCHjXmTDSI+yen
@@ -3885,7 +3885,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:13 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:47 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/28db8f69ba9e4305b7fad82da4c86e74/os-keypairs?limit=1000
@@ -3900,7 +3900,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e9afc6b25c6a43feb9c5d51bbd84241a
+      - f9137d18297a4fd98d146990230151e2
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3913,9 +3913,9 @@ http_interactions:
       Content-Length:
       - '1611'
       X-Compute-Request-Id:
-      - req-1149c06e-cf07-48eb-aa6b-cf9e3e2e3eb9
+      - req-be0bf2ea-ac2b-422c-8994-e620a57f27ff
       Date:
-      - Thu, 25 Oct 2018 18:23:13 GMT
+      - Thu, 01 Nov 2018 18:31:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKQyhM0ECmYmB8mI4vfeTEaY90skgHYgA/5apgT+cHhKzZX59Go+LGfb98dOCYEjnV3XKdO5dy7MrSdI5QSvGJmJIQPsH4WZNpRNuEhHzcHS1fEPe9zMceRlLafkTeUKhUGMIi1gOmBRdyZtz6fJw37AK6ioM4+16IhXjNVLV09jHn2PsUjh2RsGX5TzA3eHivptzINBD8eMBkyQwS2uejY42FlIg9qBpa8KEMgyo4KLvd/99kw9wLg1D9Y5+3OxA/J6hLfjSBv7Vd7Xvwd4ZmDlkU5+yH88b2ZOte8MyfAnlVA4v8bMdSsAf1e5NvUuZsoZC8goZCHjXmTDSI+yen
@@ -3925,7 +3925,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:13 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:47 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/28db8f69ba9e4305b7fad82da4c86e74/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -3940,7 +3940,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e9afc6b25c6a43feb9c5d51bbd84241a
+      - f9137d18297a4fd98d146990230151e2
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3953,9 +3953,9 @@ http_interactions:
       Content-Length:
       - '1611'
       X-Compute-Request-Id:
-      - req-2ec4775c-6500-4b7f-acb8-c0d61904fe94
+      - req-82c53ef4-2655-448b-a180-84d24d98b00e
       Date:
-      - Thu, 25 Oct 2018 18:23:13 GMT
+      - Thu, 01 Nov 2018 18:31:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKQyhM0ECmYmB8mI4vfeTEaY90skgHYgA/5apgT+cHhKzZX59Go+LGfb98dOCYEjnV3XKdO5dy7MrSdI5QSvGJmJIQPsH4WZNpRNuEhHzcHS1fEPe9zMceRlLafkTeUKhUGMIi1gOmBRdyZtz6fJw37AK6ioM4+16IhXjNVLV09jHn2PsUjh2RsGX5TzA3eHivptzINBD8eMBkyQwS2uejY42FlIg9qBpa8KEMgyo4KLvd/99kw9wLg1D9Y5+3OxA/J6hLfjSBv7Vd7Xvwd4ZmDlkU5+yH88b2ZOte8MyfAnlVA4v8bMdSsAf1e5NvUuZsoZC8goZCHjXmTDSI+yen
@@ -3965,7 +3965,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:13 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:47 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/os-keypairs?limit=1000
@@ -3980,7 +3980,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f3704f32307549d9ae9d8754d49694c9
+      - 89d8021eb8c540c2b147ddb1c40e7a7b
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3993,9 +3993,9 @@ http_interactions:
       Content-Length:
       - '1611'
       X-Compute-Request-Id:
-      - req-86584c9b-89d2-4643-9ea5-9f367cfb9b56
+      - req-c9b4c31b-4aba-43bb-8b9f-03987912aa2f
       Date:
-      - Thu, 25 Oct 2018 18:23:14 GMT
+      - Thu, 01 Nov 2018 18:31:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKQyhM0ECmYmB8mI4vfeTEaY90skgHYgA/5apgT+cHhKzZX59Go+LGfb98dOCYEjnV3XKdO5dy7MrSdI5QSvGJmJIQPsH4WZNpRNuEhHzcHS1fEPe9zMceRlLafkTeUKhUGMIi1gOmBRdyZtz6fJw37AK6ioM4+16IhXjNVLV09jHn2PsUjh2RsGX5TzA3eHivptzINBD8eMBkyQwS2uejY42FlIg9qBpa8KEMgyo4KLvd/99kw9wLg1D9Y5+3OxA/J6hLfjSBv7Vd7Xvwd4ZmDlkU5+yH88b2ZOte8MyfAnlVA4v8bMdSsAf1e5NvUuZsoZC8goZCHjXmTDSI+yen
@@ -4005,7 +4005,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:14 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:47 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -4020,7 +4020,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f3704f32307549d9ae9d8754d49694c9
+      - 89d8021eb8c540c2b147ddb1c40e7a7b
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4033,9 +4033,9 @@ http_interactions:
       Content-Length:
       - '1611'
       X-Compute-Request-Id:
-      - req-585b116a-7e85-4adc-8dca-8cdd54b59180
+      - req-fe1d9f5d-1bf0-4ef7-a1ed-9363e601b0c9
       Date:
-      - Thu, 25 Oct 2018 18:23:14 GMT
+      - Thu, 01 Nov 2018 18:31:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKQyhM0ECmYmB8mI4vfeTEaY90skgHYgA/5apgT+cHhKzZX59Go+LGfb98dOCYEjnV3XKdO5dy7MrSdI5QSvGJmJIQPsH4WZNpRNuEhHzcHS1fEPe9zMceRlLafkTeUKhUGMIi1gOmBRdyZtz6fJw37AK6ioM4+16IhXjNVLV09jHn2PsUjh2RsGX5TzA3eHivptzINBD8eMBkyQwS2uejY42FlIg9qBpa8KEMgyo4KLvd/99kw9wLg1D9Y5+3OxA/J6hLfjSBv7Vd7Xvwd4ZmDlkU5+yH88b2ZOte8MyfAnlVA4v8bMdSsAf1e5NvUuZsoZC8goZCHjXmTDSI+yen
@@ -4045,7 +4045,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:14 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:47 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/52c452d7763a4295950527948232a3e5/os-keypairs?limit=1000
@@ -4060,7 +4060,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9f339daaf2b442ea94a1334e891fdbd8
+      - '08232f81c46946d0b1944a39c6b1c79a'
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4073,9 +4073,9 @@ http_interactions:
       Content-Length:
       - '1611'
       X-Compute-Request-Id:
-      - req-23ba6d48-912d-4bfb-8d27-1f98f57946db
+      - req-e1793b15-d09c-410e-b426-2a4626b74c30
       Date:
-      - Thu, 25 Oct 2018 18:23:14 GMT
+      - Thu, 01 Nov 2018 18:31:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKQyhM0ECmYmB8mI4vfeTEaY90skgHYgA/5apgT+cHhKzZX59Go+LGfb98dOCYEjnV3XKdO5dy7MrSdI5QSvGJmJIQPsH4WZNpRNuEhHzcHS1fEPe9zMceRlLafkTeUKhUGMIi1gOmBRdyZtz6fJw37AK6ioM4+16IhXjNVLV09jHn2PsUjh2RsGX5TzA3eHivptzINBD8eMBkyQwS2uejY42FlIg9qBpa8KEMgyo4KLvd/99kw9wLg1D9Y5+3OxA/J6hLfjSBv7Vd7Xvwd4ZmDlkU5+yH88b2ZOte8MyfAnlVA4v8bMdSsAf1e5NvUuZsoZC8goZCHjXmTDSI+yen
@@ -4085,7 +4085,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:14 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:48 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/52c452d7763a4295950527948232a3e5/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -4100,7 +4100,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9f339daaf2b442ea94a1334e891fdbd8
+      - '08232f81c46946d0b1944a39c6b1c79a'
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4113,9 +4113,9 @@ http_interactions:
       Content-Length:
       - '1611'
       X-Compute-Request-Id:
-      - req-839c3904-b6d4-42b0-bcf0-10e45568e813
+      - req-82a304d0-e528-45c4-9141-8ecc0d87f3bf
       Date:
-      - Thu, 25 Oct 2018 18:23:14 GMT
+      - Thu, 01 Nov 2018 18:31:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKQyhM0ECmYmB8mI4vfeTEaY90skgHYgA/5apgT+cHhKzZX59Go+LGfb98dOCYEjnV3XKdO5dy7MrSdI5QSvGJmJIQPsH4WZNpRNuEhHzcHS1fEPe9zMceRlLafkTeUKhUGMIi1gOmBRdyZtz6fJw37AK6ioM4+16IhXjNVLV09jHn2PsUjh2RsGX5TzA3eHivptzINBD8eMBkyQwS2uejY42FlIg9qBpa8KEMgyo4KLvd/99kw9wLg1D9Y5+3OxA/J6hLfjSBv7Vd7Xvwd4ZmDlkU5+yH88b2ZOte8MyfAnlVA4v8bMdSsAf1e5NvUuZsoZC8goZCHjXmTDSI+yen
@@ -4125,7 +4125,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:14 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:48 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-keypairs?limit=1000
@@ -4140,7 +4140,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d5e08decea854f9d9045e427794321a4
+      - 91c772b42a324045a203d6215c73a103
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4153,9 +4153,9 @@ http_interactions:
       Content-Length:
       - '1611'
       X-Compute-Request-Id:
-      - req-42010771-ba82-4da9-aead-962678453e55
+      - req-abb514e0-87c7-4de7-a6c4-2bc2ec566b55
       Date:
-      - Thu, 25 Oct 2018 18:23:14 GMT
+      - Thu, 01 Nov 2018 18:31:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKQyhM0ECmYmB8mI4vfeTEaY90skgHYgA/5apgT+cHhKzZX59Go+LGfb98dOCYEjnV3XKdO5dy7MrSdI5QSvGJmJIQPsH4WZNpRNuEhHzcHS1fEPe9zMceRlLafkTeUKhUGMIi1gOmBRdyZtz6fJw37AK6ioM4+16IhXjNVLV09jHn2PsUjh2RsGX5TzA3eHivptzINBD8eMBkyQwS2uejY42FlIg9qBpa8KEMgyo4KLvd/99kw9wLg1D9Y5+3OxA/J6hLfjSBv7Vd7Xvwd4ZmDlkU5+yH88b2ZOte8MyfAnlVA4v8bMdSsAf1e5NvUuZsoZC8goZCHjXmTDSI+yen
@@ -4165,7 +4165,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:14 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:48 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -4180,7 +4180,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d5e08decea854f9d9045e427794321a4
+      - 91c772b42a324045a203d6215c73a103
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4193,9 +4193,9 @@ http_interactions:
       Content-Length:
       - '1611'
       X-Compute-Request-Id:
-      - req-3fa69ad7-a86c-471e-b4df-5893877fa0cb
+      - req-37d5bdcd-1b14-4dc9-94bf-6faa1c9ba86b
       Date:
-      - Thu, 25 Oct 2018 18:23:14 GMT
+      - Thu, 01 Nov 2018 18:31:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKQyhM0ECmYmB8mI4vfeTEaY90skgHYgA/5apgT+cHhKzZX59Go+LGfb98dOCYEjnV3XKdO5dy7MrSdI5QSvGJmJIQPsH4WZNpRNuEhHzcHS1fEPe9zMceRlLafkTeUKhUGMIi1gOmBRdyZtz6fJw37AK6ioM4+16IhXjNVLV09jHn2PsUjh2RsGX5TzA3eHivptzINBD8eMBkyQwS2uejY42FlIg9qBpa8KEMgyo4KLvd/99kw9wLg1D9Y5+3OxA/J6hLfjSBv7Vd7Xvwd4ZmDlkU5+yH88b2ZOte8MyfAnlVA4v8bMdSsAf1e5NvUuZsoZC8goZCHjXmTDSI+yen
@@ -4205,7 +4205,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:14 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:48 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/d09cbe26295d47ff848ea73c74264e23/os-keypairs?limit=1000
@@ -4220,7 +4220,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 822b32934d0b41cc9dc4b9cb86cdc202
+      - 6c722a2ac5f945f0a5f61fbf11ca3618
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4233,9 +4233,9 @@ http_interactions:
       Content-Length:
       - '1611'
       X-Compute-Request-Id:
-      - req-6182766e-fcb3-41a9-82f4-13a14c04eec7
+      - req-1d0a39dd-8b63-40ec-b22f-72892d78c754
       Date:
-      - Thu, 25 Oct 2018 18:23:14 GMT
+      - Thu, 01 Nov 2018 18:31:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKQyhM0ECmYmB8mI4vfeTEaY90skgHYgA/5apgT+cHhKzZX59Go+LGfb98dOCYEjnV3XKdO5dy7MrSdI5QSvGJmJIQPsH4WZNpRNuEhHzcHS1fEPe9zMceRlLafkTeUKhUGMIi1gOmBRdyZtz6fJw37AK6ioM4+16IhXjNVLV09jHn2PsUjh2RsGX5TzA3eHivptzINBD8eMBkyQwS2uejY42FlIg9qBpa8KEMgyo4KLvd/99kw9wLg1D9Y5+3OxA/J6hLfjSBv7Vd7Xvwd4ZmDlkU5+yH88b2ZOte8MyfAnlVA4v8bMdSsAf1e5NvUuZsoZC8goZCHjXmTDSI+yen
@@ -4245,7 +4245,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:14 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:48 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/d09cbe26295d47ff848ea73c74264e23/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -4260,7 +4260,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 822b32934d0b41cc9dc4b9cb86cdc202
+      - 6c722a2ac5f945f0a5f61fbf11ca3618
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4273,9 +4273,9 @@ http_interactions:
       Content-Length:
       - '1611'
       X-Compute-Request-Id:
-      - req-92350d1a-a4bc-49d5-a115-de7f5c8649d1
+      - req-64f34394-876a-46ce-93ef-ef5dbd50e171
       Date:
-      - Thu, 25 Oct 2018 18:23:14 GMT
+      - Thu, 01 Nov 2018 18:31:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKQyhM0ECmYmB8mI4vfeTEaY90skgHYgA/5apgT+cHhKzZX59Go+LGfb98dOCYEjnV3XKdO5dy7MrSdI5QSvGJmJIQPsH4WZNpRNuEhHzcHS1fEPe9zMceRlLafkTeUKhUGMIi1gOmBRdyZtz6fJw37AK6ioM4+16IhXjNVLV09jHn2PsUjh2RsGX5TzA3eHivptzINBD8eMBkyQwS2uejY42FlIg9qBpa8KEMgyo4KLvd/99kw9wLg1D9Y5+3OxA/J6hLfjSBv7Vd7Xvwd4ZmDlkU5+yH88b2ZOte8MyfAnlVA4v8bMdSsAf1e5NvUuZsoZC8goZCHjXmTDSI+yen
@@ -4285,7 +4285,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:14 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:48 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/os-keypairs?limit=1000
@@ -4300,7 +4300,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 180af607b5ef47c8940e3c3e35de425c
+      - 5ad6db8acf29438ebc1b24e0de3f5974
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4313,9 +4313,9 @@ http_interactions:
       Content-Length:
       - '1611'
       X-Compute-Request-Id:
-      - req-4b2085dd-e0d1-4eb3-a3e5-415299f1898c
+      - req-af22f473-bc25-4b5c-b8e8-7ef68583a5c3
       Date:
-      - Thu, 25 Oct 2018 18:23:14 GMT
+      - Thu, 01 Nov 2018 18:31:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKQyhM0ECmYmB8mI4vfeTEaY90skgHYgA/5apgT+cHhKzZX59Go+LGfb98dOCYEjnV3XKdO5dy7MrSdI5QSvGJmJIQPsH4WZNpRNuEhHzcHS1fEPe9zMceRlLafkTeUKhUGMIi1gOmBRdyZtz6fJw37AK6ioM4+16IhXjNVLV09jHn2PsUjh2RsGX5TzA3eHivptzINBD8eMBkyQwS2uejY42FlIg9qBpa8KEMgyo4KLvd/99kw9wLg1D9Y5+3OxA/J6hLfjSBv7Vd7Xvwd4ZmDlkU5+yH88b2ZOte8MyfAnlVA4v8bMdSsAf1e5NvUuZsoZC8goZCHjXmTDSI+yen
@@ -4325,7 +4325,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:14 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:48 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -4340,7 +4340,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 180af607b5ef47c8940e3c3e35de425c
+      - 5ad6db8acf29438ebc1b24e0de3f5974
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4353,9 +4353,9 @@ http_interactions:
       Content-Length:
       - '1611'
       X-Compute-Request-Id:
-      - req-a7019d90-2f5d-4dbf-9b32-6c39f4689715
+      - req-b4533029-d52f-47cb-b2ad-0f4800b2a123
       Date:
-      - Thu, 25 Oct 2018 18:23:14 GMT
+      - Thu, 01 Nov 2018 18:31:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKQyhM0ECmYmB8mI4vfeTEaY90skgHYgA/5apgT+cHhKzZX59Go+LGfb98dOCYEjnV3XKdO5dy7MrSdI5QSvGJmJIQPsH4WZNpRNuEhHzcHS1fEPe9zMceRlLafkTeUKhUGMIi1gOmBRdyZtz6fJw37AK6ioM4+16IhXjNVLV09jHn2PsUjh2RsGX5TzA3eHivptzINBD8eMBkyQwS2uejY42FlIg9qBpa8KEMgyo4KLvd/99kw9wLg1D9Y5+3OxA/J6hLfjSBv7Vd7Xvwd4ZmDlkU5+yH88b2ZOte8MyfAnlVA4v8bMdSsAf1e5NvUuZsoZC8goZCHjXmTDSI+yen
@@ -4365,7 +4365,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:14 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:48 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -4383,15 +4383,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:23:14 GMT
+      - Thu, 01 Nov 2018 18:31:48 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - '0789bdef445543c09723fd0e23a315d6'
+      - 1cda659b20214033a7737e1ca3cd58ff
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-a21f21ae-6c51-48ac-89f7-6f592f54436a
+      - req-8eacb587-904a-4dfc-9146-a20bf65d1e9b
       Content-Length:
       - '7311'
       Connection:
@@ -4403,7 +4403,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-10-25T19:23:15.050201Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-11-01T19:31:48.916440Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -4482,10 +4482,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["mBtOEUnPSJK8K7NXPIjpzw"],
-        "issued_at": "2018-10-25T18:23:15.050225Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["hZ45S1jGQxqHsr5VCqGZXA"],
+        "issued_at": "2018-11-01T18:31:48.916461Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:15 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:48 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -4503,15 +4503,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:23:15 GMT
+      - Thu, 01 Nov 2018 18:31:49 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - e642a4ee8a3f4358a962f1b5ab58b263
+      - 0d8e1a1ecf9c4b3e95920fbd2d6106cb
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-c64a0b6b-a59a-47ce-b919-3dac2df6ea14
+      - req-4f70eeec-40d9-4935-8b28-4bdbea3d62be
       Content-Length:
       - '7278'
       Connection:
@@ -4523,7 +4523,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:23:15.248318Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:31:49.127273Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -4602,10 +4602,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["6YCFMsGuRDOD2l7P59bQ0g"],
-        "issued_at": "2018-10-25T18:23:15.248341Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["x9utAtdQQViiAnZql7xlAg"],
+        "issued_at": "2018-11-01T18:31:49.127293Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:15 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:49 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/0098405163cd4c9dbb42c2cb43eb6fd3/stacks?limit=1000&show_nested=true
@@ -4620,7 +4620,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e642a4ee8a3f4358a962f1b5ab58b263
+      - 0d8e1a1ecf9c4b3e95920fbd2d6106cb
   response:
     status:
       code: 200
@@ -4631,14 +4631,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-40eb0b9a-a1e1-4290-8001-81d1a3a1404b
+      - req-c5254707-65c9-4a37-82eb-279e8edd48fd
       Date:
-      - Thu, 25 Oct 2018 18:23:15 GMT
+      - Thu, 01 Nov 2018 18:31:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:15 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:49 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -4656,15 +4656,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:23:15 GMT
+      - Thu, 01 Nov 2018 18:31:49 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - d41ff711da6543ed88b017dd3195c356
+      - 8fcdae86127f4360bb8f63489263b6e9
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-8572b440-4668-42cf-9b08-eab4d62f95ea
+      - req-5508a209-60f2-4aeb-9322-7967f29f1941
       Content-Length:
       - '7278'
       Connection:
@@ -4676,7 +4676,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:23:15.578020Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:31:49.490347Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -4755,10 +4755,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["tPW-SMfESquok_kCKjV8pw"],
-        "issued_at": "2018-10-25T18:23:15.578041Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["RWKFtUm9QCObzmqOKoxd4Q"],
+        "issued_at": "2018-11-01T18:31:49.490366Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:15 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:49 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/28db8f69ba9e4305b7fad82da4c86e74/stacks?limit=1000&show_nested=true
@@ -4773,7 +4773,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d41ff711da6543ed88b017dd3195c356
+      - 8fcdae86127f4360bb8f63489263b6e9
   response:
     status:
       code: 200
@@ -4784,14 +4784,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-0e902fd2-f57e-47d4-b53c-80936f06a297
+      - req-929936c7-ccb4-49e1-afb4-f9ed3ad5df09
       Date:
-      - Thu, 25 Oct 2018 18:23:15 GMT
+      - Thu, 01 Nov 2018 18:31:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:15 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:49 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -4809,15 +4809,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:23:15 GMT
+      - Thu, 01 Nov 2018 18:31:49 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - faa88d26ea1647bcb811cd5fda7a0f13
+      - b67cc1756adf41258287f44845d8d337
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-ff432820-040c-49da-a150-5b3fea94a575
+      - req-933b06a2-7b88-43dc-ab88-7e88acbc0cda
       Content-Length:
       - '7264'
       Connection:
@@ -4829,7 +4829,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:23:15.901135Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:31:49.821788Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -4908,10 +4908,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["eTiYDuHxSQ2KPlW0GacP5Q"],
-        "issued_at": "2018-10-25T18:23:15.901156Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["-vm94KUMR-OKgeLQd6gsBg"],
+        "issued_at": "2018-11-01T18:31:49.821809Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:15 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:49 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks?limit=1000&show_nested=true
@@ -4926,7 +4926,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - faa88d26ea1647bcb811cd5fda7a0f13
+      - b67cc1756adf41258287f44845d8d337
   response:
     status:
       code: 200
@@ -4937,9 +4937,9 @@ http_interactions:
       Content-Length:
       - '2559'
       X-Openstack-Request-Id:
-      - req-87b2cbe1-7c72-4877-8e74-380399c3d1f6
+      - req-fbbe0ff6-388e-4e05-8143-2a8e00e35728
       Date:
-      - Thu, 25 Oct 2018 18:23:16 GMT
+      - Thu, 01 Nov 2018 18:31:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": [{"description": "Heat WordPress template to support F20,
@@ -4973,7 +4973,7 @@ http_interactions:
         "rel": "self"}], "updated_time": null, "stack_owner": null, "stack_status":
         "CREATE_COMPLETE", "id": "7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:16 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:50 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks?limit=1000&marker=7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0&show_nested=true
@@ -4988,7 +4988,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - faa88d26ea1647bcb811cd5fda7a0f13
+      - b67cc1756adf41258287f44845d8d337
   response:
     status:
       code: 200
@@ -4999,14 +4999,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-5e648cf9-df01-4f31-ad45-8c8fb67ff60e
+      - req-51b94f17-6c76-44ab-b0be-8fc10dcac143
       Date:
-      - Thu, 25 Oct 2018 18:23:16 GMT
+      - Thu, 01 Nov 2018 18:31:50 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:16 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:50 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -5024,15 +5024,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:23:16 GMT
+      - Thu, 01 Nov 2018 18:31:50 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - '01580a6b380d4d4296a594666fe62d4a'
+      - 4d56ecf25ab94ca0b61eae1c631e57ae
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-f9172b86-4349-4870-95c5-6b1349a8b61c
+      - req-aa331b0f-7770-4972-b1c2-d78c1eefe3d4
       Content-Length:
       - '7278'
       Connection:
@@ -5044,7 +5044,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:23:16.352769Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:31:50.297683Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -5123,10 +5123,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["pZDTgcPSSvK1u2SK7j_2HA"],
-        "issued_at": "2018-10-25T18:23:16.352789Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["JKGQX9P5SqePRb87fGuskg"],
+        "issued_at": "2018-11-01T18:31:50.297703Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:16 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:50 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/52c452d7763a4295950527948232a3e5/stacks?limit=1000&show_nested=true
@@ -5141,7 +5141,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '01580a6b380d4d4296a594666fe62d4a'
+      - 4d56ecf25ab94ca0b61eae1c631e57ae
   response:
     status:
       code: 200
@@ -5152,14 +5152,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-a0efff89-f8e3-44cf-996f-332d3ba4001d
+      - req-cfbf7266-af45-4c73-9cc5-1bcf347d665f
       Date:
-      - Thu, 25 Oct 2018 18:23:16 GMT
+      - Thu, 01 Nov 2018 18:31:50 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:16 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:50 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/88ae57d444fd485ab2dfddd5a2615d52/stacks?limit=1000&show_nested=true
@@ -5174,7 +5174,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '0789bdef445543c09723fd0e23a315d6'
+      - 1cda659b20214033a7737e1ca3cd58ff
   response:
     status:
       code: 200
@@ -5185,14 +5185,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-0f15d2ea-cf71-4dfb-b45b-fd48a56a0de7
+      - req-53629b3a-2a0d-44eb-96e9-9f04ce9ce173
       Date:
-      - Thu, 25 Oct 2018 18:23:16 GMT
+      - Thu, 01 Nov 2018 18:31:50 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:16 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:50 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -5210,15 +5210,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:23:16 GMT
+      - Thu, 01 Nov 2018 18:31:50 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 7c1e42367d0841f9b20f5d74e107ff2c
+      - 758c087274f34f97b463c26cd0cf3082
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-a237b272-9244-4131-9b71-416f894a5a9f
+      - req-56d1cfa9-fff6-4b03-a314-ea3676af90ab
       Content-Length:
       - '7265'
       Connection:
@@ -5230,7 +5230,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:23:16.813271Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:31:50.778035Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -5309,10 +5309,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["K8q1uPOCTPK2seULGgLl_g"],
-        "issued_at": "2018-10-25T18:23:16.813291Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["4rOw7B2FQDKK7tvoKzsiYg"],
+        "issued_at": "2018-11-01T18:31:50.778067Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:16 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:50 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/d09cbe26295d47ff848ea73c74264e23/stacks?limit=1000&show_nested=true
@@ -5327,7 +5327,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7c1e42367d0841f9b20f5d74e107ff2c
+      - 758c087274f34f97b463c26cd0cf3082
   response:
     status:
       code: 200
@@ -5338,14 +5338,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-820f8114-1c06-49ad-be63-a70b00f821ea
+      - req-e64c52d1-91d9-4790-b5cb-3e3e3e406c24
       Date:
-      - Thu, 25 Oct 2018 18:23:16 GMT
+      - Thu, 01 Nov 2018 18:31:50 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:16 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:50 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -5363,15 +5363,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:23:17 GMT
+      - Thu, 01 Nov 2018 18:31:51 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 11c10ab07bf140ffa66105c5267a1aa8
+      - 4d9e6ea47efc41ce9733ec186eda3bf6
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-32d5ed23-193c-4d01-8661-64cf47d09574
+      - req-9b7a8a43-1fa9-4e5b-8fb1-d688000332d5
       Content-Length:
       - '7278'
       Connection:
@@ -5383,7 +5383,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:23:17.151617Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:31:51.151681Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -5462,10 +5462,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["DJCsaPEUSxCyDqSndbdmDg"],
-        "issued_at": "2018-10-25T18:23:17.151639Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["M7-W5LuVRNaO07UB-4ergg"],
+        "issued_at": "2018-11-01T18:31:51.151702Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:17 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:51 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/ef2a3405d1ef4dfd9a3616993ef46a4d/stacks?limit=1000&show_nested=true
@@ -5480,7 +5480,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 11c10ab07bf140ffa66105c5267a1aa8
+      - 4d9e6ea47efc41ce9733ec186eda3bf6
   response:
     status:
       code: 200
@@ -5491,14 +5491,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-081f5a47-5c0b-4b36-aaf9-8642e06f51c3
+      - req-d67326e1-2ead-41e9-9590-9c0710e55e33
       Date:
-      - Thu, 25 Oct 2018 18:23:17 GMT
+      - Thu, 01 Nov 2018 18:31:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:17 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:51 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack3/00c5dc04-2c94-48d2-8031-db08934e9a44
@@ -5513,7 +5513,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - faa88d26ea1647bcb811cd5fda7a0f13
+      - b67cc1756adf41258287f44845d8d337
   response:
     status:
       code: 200
@@ -5524,9 +5524,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-658b52ce-07de-445a-8b76-002b62c1f1df
+      - req-fce45636-6d9d-418e-80d0-7f14599fa885
       Date:
-      - Thu, 25 Oct 2018 18:23:17 GMT
+      - Thu, 01 Nov 2018 18:31:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -5553,7 +5553,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:17 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:51 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack2/d6eba2a2-7b0d-4213-afbb-69c8f6dddd8d
@@ -5568,7 +5568,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - faa88d26ea1647bcb811cd5fda7a0f13
+      - b67cc1756adf41258287f44845d8d337
   response:
     status:
       code: 200
@@ -5579,9 +5579,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-ad146f56-16f0-4dcf-8abe-06ab089e7b64
+      - req-90b15b64-0c7a-4416-8896-8c3a7e9e5077
       Date:
-      - Thu, 25 Oct 2018 18:23:17 GMT
+      - Thu, 01 Nov 2018 18:31:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -5608,7 +5608,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:17 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:51 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack1/7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0
@@ -5623,7 +5623,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - faa88d26ea1647bcb811cd5fda7a0f13
+      - b67cc1756adf41258287f44845d8d337
   response:
     status:
       code: 200
@@ -5634,9 +5634,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-071c8844-eff4-433b-8ab1-8f59ba01c40b
+      - req-9e77f740-8fb1-4718-a294-53147e9f9529
       Date:
-      - Thu, 25 Oct 2018 18:23:18 GMT
+      - Thu, 01 Nov 2018 18:31:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -5663,7 +5663,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:18 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:52 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack3/00c5dc04-2c94-48d2-8031-db08934e9a44/template
@@ -5678,7 +5678,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - faa88d26ea1647bcb811cd5fda7a0f13
+      - b67cc1756adf41258287f44845d8d337
   response:
     status:
       code: 200
@@ -5689,9 +5689,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-5a984e65-f995-4dfd-9404-c3a3256719f6
+      - req-657bea6c-76fe-424b-b815-ccf440a9374a
       Date:
-      - Thu, 25 Oct 2018 18:23:18 GMT
+      - Thu, 01 Nov 2018 18:31:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -5747,7 +5747,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:18 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:52 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack3/00c5dc04-2c94-48d2-8031-db08934e9a44/resources
@@ -5762,7 +5762,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - faa88d26ea1647bcb811cd5fda7a0f13
+      - b67cc1756adf41258287f44845d8d337
   response:
     status:
       code: 200
@@ -5773,9 +5773,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-a0255f2a-70ad-4553-ac0b-d0249a254427
+      - req-55bed774-21f9-43ce-af51-2f88f55b727f
       Date:
-      - Thu, 25 Oct 2018 18:23:18 GMT
+      - Thu, 01 Nov 2018 18:31:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -5787,7 +5787,7 @@ http_interactions:
         changed", "physical_resource_id": "40989f26-9c38-4f72-b739-afccb44397cf",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:18 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:52 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3/servers/detail?limit=1000
@@ -5802,7 +5802,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f130f696cdfa428089d3a195c4b33719
+      - a56d2a9d7a0a4153aa5df041f2480d4a
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5815,14 +5815,14 @@ http_interactions:
       Content-Length:
       - '15'
       X-Compute-Request-Id:
-      - req-5c49aa75-1178-43a5-8591-4093d1cf232f
+      - req-ef27381f-47b1-4cf4-9d8b-848382080573
       Date:
-      - Thu, 25 Oct 2018 18:23:18 GMT
+      - Thu, 01 Nov 2018 18:31:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:18 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:52 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/28db8f69ba9e4305b7fad82da4c86e74/servers/detail?limit=1000
@@ -5837,7 +5837,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e9afc6b25c6a43feb9c5d51bbd84241a
+      - f9137d18297a4fd98d146990230151e2
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5850,14 +5850,14 @@ http_interactions:
       Content-Length:
       - '15'
       X-Compute-Request-Id:
-      - req-aba06592-ee6b-468c-a68d-d9c077601cdd
+      - req-c228a58b-148e-4270-870d-fa8d6a5f8b84
       Date:
-      - Thu, 25 Oct 2018 18:23:18 GMT
+      - Thu, 01 Nov 2018 18:31:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:18 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:52 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/servers/detail?limit=1000
@@ -5872,7 +5872,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f3704f32307549d9ae9d8754d49694c9
+      - 89d8021eb8c540c2b147ddb1c40e7a7b
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5885,9 +5885,9 @@ http_interactions:
       Content-Length:
       - '3981'
       X-Compute-Request-Id:
-      - req-150d77a7-11a4-46b8-b4fc-645f927b7ec7
+      - req-3d30db22-aab8-47bf-bbd1-9b8ebbeeb80c
       Date:
-      - Thu, 25 Oct 2018 18:23:18 GMT
+      - Thu, 01 Nov 2018 18:31:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/servers/detail?limit=1000&marker=43f23d3a-fe8d-4bbb-9d23-fe1c437c7813",
@@ -5933,7 +5933,7 @@ http_interactions:
         [], "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:18 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:53 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/servers/detail?limit=1000&marker=43f23d3a-fe8d-4bbb-9d23-fe1c437c7813
@@ -5948,7 +5948,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f3704f32307549d9ae9d8754d49694c9
+      - 89d8021eb8c540c2b147ddb1c40e7a7b
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5961,9 +5961,9 @@ http_interactions:
       Content-Length:
       - '4045'
       X-Compute-Request-Id:
-      - req-ed844646-fb0e-46f4-a27f-bf6a789c4453
+      - req-573d0d2a-101c-4d4b-8428-5a9a2b4b781c
       Date:
-      - Thu, 25 Oct 2018 18:23:19 GMT
+      - Thu, 01 Nov 2018 18:31:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/servers/detail?limit=1000&marker=5d121f19-3e04-4743-8ed7-c5dfaa6ef71f",
@@ -6009,7 +6009,7 @@ http_interactions:
         [], "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 3, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:19 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:53 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/servers/detail?limit=1000&marker=5d121f19-3e04-4743-8ed7-c5dfaa6ef71f
@@ -6024,7 +6024,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f3704f32307549d9ae9d8754d49694c9
+      - 89d8021eb8c540c2b147ddb1c40e7a7b
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6037,9 +6037,9 @@ http_interactions:
       Content-Length:
       - '4127'
       X-Compute-Request-Id:
-      - req-ba299b09-d9f7-493f-8f50-ccab73681480
+      - req-8bd07de6-771f-431b-a6cc-8a7cb5f9b76a
       Date:
-      - Thu, 25 Oct 2018 18:23:19 GMT
+      - Thu, 01 Nov 2018 18:31:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/servers/detail?limit=1000&marker=7edb7855-d974-4e45-8ad2-88491541ab91",
@@ -6087,7 +6087,7 @@ http_interactions:
         "", "progress": 0, "OS-EXT-STS:power_state": 1, "config_drive": "", "metadata":
         {}}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:19 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:53 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/servers/detail?limit=1000&marker=7edb7855-d974-4e45-8ad2-88491541ab91
@@ -6102,7 +6102,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f3704f32307549d9ae9d8754d49694c9
+      - 89d8021eb8c540c2b147ddb1c40e7a7b
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6115,9 +6115,9 @@ http_interactions:
       Content-Length:
       - '3796'
       X-Compute-Request-Id:
-      - req-c1c55381-cc30-4695-9660-8283e1b0cf46
+      - req-89644ea7-df48-487b-94f6-c42eb1fed9fa
       Date:
-      - Thu, 25 Oct 2018 18:23:19 GMT
+      - Thu, 01 Nov 2018 18:31:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/servers/detail?limit=1000&marker=ad4f7eb0-9122-41a6-a0f7-55c1d4ca5e02",
@@ -6159,7 +6159,7 @@ http_interactions:
         "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:19 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:54 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/servers/detail?limit=1000&marker=ad4f7eb0-9122-41a6-a0f7-55c1d4ca5e02
@@ -6174,7 +6174,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f3704f32307549d9ae9d8754d49694c9
+      - 89d8021eb8c540c2b147ddb1c40e7a7b
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6187,9 +6187,9 @@ http_interactions:
       Content-Length:
       - '1816'
       X-Compute-Request-Id:
-      - req-278206c3-ef81-42a0-927d-1a518f0b37b7
+      - req-01e80c55-706d-4c8a-955f-529ee658f8ae
       Date:
-      - Thu, 25 Oct 2018 18:23:19 GMT
+      - Thu, 01 Nov 2018 18:31:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": [{"status": "SHUTOFF", "updated": "2017-05-22T16:01:49Z",
@@ -6212,7 +6212,7 @@ http_interactions:
         "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:19 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:54 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/52c452d7763a4295950527948232a3e5/servers/detail?limit=1000
@@ -6227,7 +6227,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9f339daaf2b442ea94a1334e891fdbd8
+      - '08232f81c46946d0b1944a39c6b1c79a'
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6240,14 +6240,14 @@ http_interactions:
       Content-Length:
       - '15'
       X-Compute-Request-Id:
-      - req-bfc01903-ca4b-4223-b0e1-17b11915e095
+      - req-dec3b123-4c6f-4cf7-864f-c0e4d65adaca
       Date:
-      - Thu, 25 Oct 2018 18:23:19 GMT
+      - Thu, 01 Nov 2018 18:31:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:20 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:54 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?limit=1000
@@ -6262,7 +6262,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d5e08decea854f9d9045e427794321a4
+      - 91c772b42a324045a203d6215c73a103
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6275,14 +6275,14 @@ http_interactions:
       Content-Length:
       - '15'
       X-Compute-Request-Id:
-      - req-4d74956f-e31b-416e-89c1-e55b620f1170
+      - req-13b8a15b-04ac-44f2-a5c0-22d39b4827db
       Date:
-      - Thu, 25 Oct 2018 18:23:20 GMT
+      - Thu, 01 Nov 2018 18:31:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:20 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:54 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/d09cbe26295d47ff848ea73c74264e23/servers/detail?limit=1000
@@ -6297,7 +6297,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 822b32934d0b41cc9dc4b9cb86cdc202
+      - 6c722a2ac5f945f0a5f61fbf11ca3618
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6310,14 +6310,14 @@ http_interactions:
       Content-Length:
       - '15'
       X-Compute-Request-Id:
-      - req-8b742950-ec5c-4484-968d-c7129c2df08f
+      - req-4eccbbb8-ba04-4c72-8896-4b469198fa0c
       Date:
-      - Thu, 25 Oct 2018 18:23:20 GMT
+      - Thu, 01 Nov 2018 18:31:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:20 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:54 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/servers/detail?limit=1000
@@ -6332,7 +6332,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 180af607b5ef47c8940e3c3e35de425c
+      - 5ad6db8acf29438ebc1b24e0de3f5974
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6345,14 +6345,14 @@ http_interactions:
       Content-Length:
       - '15'
       X-Compute-Request-Id:
-      - req-1330e64e-bace-41a8-9885-22d0e1d59449
+      - req-cd85dc84-740d-4712-9ca1-90194802c147
       Date:
-      - Thu, 25 Oct 2018 18:23:20 GMT
+      - Thu, 01 Nov 2018 18:31:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:20 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:54 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack2/d6eba2a2-7b0d-4213-afbb-69c8f6dddd8d/template
@@ -6367,7 +6367,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - faa88d26ea1647bcb811cd5fda7a0f13
+      - b67cc1756adf41258287f44845d8d337
   response:
     status:
       code: 200
@@ -6378,9 +6378,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-33ce865e-5236-43d5-b26d-4afcee794f09
+      - req-d00c9c5d-9d7d-4617-9ca1-7c8b09f3c716
       Date:
-      - Thu, 25 Oct 2018 18:23:20 GMT
+      - Thu, 01 Nov 2018 18:31:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -6436,7 +6436,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:20 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:54 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack2/d6eba2a2-7b0d-4213-afbb-69c8f6dddd8d/resources
@@ -6451,7 +6451,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - faa88d26ea1647bcb811cd5fda7a0f13
+      - b67cc1756adf41258287f44845d8d337
   response:
     status:
       code: 200
@@ -6462,9 +6462,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-ff914aea-8af0-4482-8fe8-10d85f2d6e24
+      - req-1112af23-1ba8-4515-afcf-d2feaa7ca84d
       Date:
-      - Thu, 25 Oct 2018 18:23:20 GMT
+      - Thu, 01 Nov 2018 18:31:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -6476,7 +6476,7 @@ http_interactions:
         changed", "physical_resource_id": "ad4f7eb0-9122-41a6-a0f7-55c1d4ca5e02",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:20 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:55 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack1/7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0/template
@@ -6491,7 +6491,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - faa88d26ea1647bcb811cd5fda7a0f13
+      - b67cc1756adf41258287f44845d8d337
   response:
     status:
       code: 200
@@ -6502,9 +6502,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-263fda41-5313-4f21-972c-30908edf0a28
+      - req-a2b38c53-4aa9-4330-b9b7-937c944968d3
       Date:
-      - Thu, 25 Oct 2018 18:23:20 GMT
+      - Thu, 01 Nov 2018 18:31:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -6560,7 +6560,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:20 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:55 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack1/7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0/resources
@@ -6575,7 +6575,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - faa88d26ea1647bcb811cd5fda7a0f13
+      - b67cc1756adf41258287f44845d8d337
   response:
     status:
       code: 200
@@ -6586,9 +6586,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-bfd4dbdf-f26d-4824-a4e6-8c8b4c75471f
+      - req-e21be138-f111-438f-8080-3583e1fc20ba
       Date:
-      - Thu, 25 Oct 2018 18:23:20 GMT
+      - Thu, 01 Nov 2018 18:31:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -6600,7 +6600,7 @@ http_interactions:
         changed", "physical_resource_id": "8022b967-813a-4e3b-8ff4-7c036957a8a0",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:20 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:55 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3//os-quota-sets/0098405163cd4c9dbb42c2cb43eb6fd3
@@ -6615,7 +6615,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f130f696cdfa428089d3a195c4b33719
+      - a56d2a9d7a0a4153aa5df041f2480d4a
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6628,9 +6628,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-c6030d6d-be6d-4e68-a4a4-3af30ee6e89f
+      - req-f3768e73-5a66-4896-af0d-8635ff8d5ae8
       Date:
-      - Thu, 25 Oct 2018 18:23:20 GMT
+      - Thu, 01 Nov 2018 18:31:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -6639,7 +6639,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:20 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:55 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/28db8f69ba9e4305b7fad82da4c86e74//os-quota-sets/28db8f69ba9e4305b7fad82da4c86e74
@@ -6654,7 +6654,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e9afc6b25c6a43feb9c5d51bbd84241a
+      - f9137d18297a4fd98d146990230151e2
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6667,9 +6667,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-3978441e-afd7-4dad-b0fb-548a488e8f0e
+      - req-9ef9864f-929f-47a3-a29d-ef3a6d0a7499
       Date:
-      - Thu, 25 Oct 2018 18:23:21 GMT
+      - Thu, 01 Nov 2018 18:31:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -6678,7 +6678,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:21 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:55 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91//os-quota-sets/4637c33fee924ebea81f8d209e452c91
@@ -6693,7 +6693,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f3704f32307549d9ae9d8754d49694c9
+      - 89d8021eb8c540c2b147ddb1c40e7a7b
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6706,9 +6706,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-514a7e82-7f5e-4cf3-b693-46a2f51bb310
+      - req-761d778a-f2fe-4273-95a8-b312759750a9
       Date:
-      - Thu, 25 Oct 2018 18:23:21 GMT
+      - Thu, 01 Nov 2018 18:31:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -6717,7 +6717,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:21 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:55 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/52c452d7763a4295950527948232a3e5//os-quota-sets/52c452d7763a4295950527948232a3e5
@@ -6732,7 +6732,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9f339daaf2b442ea94a1334e891fdbd8
+      - '08232f81c46946d0b1944a39c6b1c79a'
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6745,9 +6745,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-056c77a4-ef8e-4dec-9c3c-bb1c9e73b1bd
+      - req-d532fcbf-4dc8-4b47-8324-8248fed814a5
       Date:
-      - Thu, 25 Oct 2018 18:23:21 GMT
+      - Thu, 01 Nov 2018 18:31:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -6756,7 +6756,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:21 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:55 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52//os-quota-sets/88ae57d444fd485ab2dfddd5a2615d52
@@ -6771,7 +6771,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d5e08decea854f9d9045e427794321a4
+      - 91c772b42a324045a203d6215c73a103
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6784,9 +6784,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-c08fb11c-e86e-4931-b0ab-72c8e8b2d836
+      - req-0fc9a4df-699c-4187-ab0c-572a65cec547
       Date:
-      - Thu, 25 Oct 2018 18:23:21 GMT
+      - Thu, 01 Nov 2018 18:31:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -6795,7 +6795,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:21 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:55 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/d09cbe26295d47ff848ea73c74264e23//os-quota-sets/d09cbe26295d47ff848ea73c74264e23
@@ -6810,7 +6810,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 822b32934d0b41cc9dc4b9cb86cdc202
+      - 6c722a2ac5f945f0a5f61fbf11ca3618
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6823,9 +6823,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-bce71348-a64f-4719-9c7c-6e449969bcb3
+      - req-3067d3ab-9742-4792-bc70-2418d8df83f2
       Date:
-      - Thu, 25 Oct 2018 18:23:21 GMT
+      - Thu, 01 Nov 2018 18:31:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -6834,7 +6834,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:21 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:55 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/ef2a3405d1ef4dfd9a3616993ef46a4d//os-quota-sets/ef2a3405d1ef4dfd9a3616993ef46a4d
@@ -6849,7 +6849,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 180af607b5ef47c8940e3c3e35de425c
+      - 5ad6db8acf29438ebc1b24e0de3f5974
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6862,9 +6862,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-139479c5-b3c3-4967-94f2-7d84d5de9df8
+      - req-9eabc084-29d6-4e31-bf58-0f22254bfb81
       Date:
-      - Thu, 25 Oct 2018 18:23:21 GMT
+      - Thu, 01 Nov 2018 18:31:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -6873,7 +6873,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:21 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:55 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -6891,15 +6891,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:23:21 GMT
+      - Thu, 01 Nov 2018 18:31:56 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - af0c0dc7d33e455795f54919f18c62e8
+      - 2457cdd9f0b94a04863bab30bc9b0168
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-2b87c194-4d29-432e-8abd-0139b5570c96
+      - req-21ea1710-2efd-4ff2-810a-80959979d3cf
       Content-Length:
       - '7278'
       Connection:
@@ -6911,7 +6911,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:23:21.707503Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:31:56.163122Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -6990,10 +6990,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["_x5hyvPwT_qO3lO6hPddMg"],
-        "issued_at": "2018-10-25T18:23:21.707526Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["qKTfvJ8CTrGqCql4wRcGJQ"],
+        "issued_at": "2018-11-01T18:31:56.163145Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:21 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:56 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3//os-quota-sets/0098405163cd4c9dbb42c2cb43eb6fd3
@@ -7008,22 +7008,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - af0c0dc7d33e455795f54919f18c62e8
+      - 2457cdd9f0b94a04863bab30bc9b0168
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-bd7329a1-c55b-48c1-866f-756d7979b9e6
+      - req-936cbaf4-fbff-4696-91ac-512817f2e060
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-bd7329a1-c55b-48c1-866f-756d7979b9e6
+      - req-936cbaf4-fbff-4696-91ac-512817f2e060
       Date:
-      - Thu, 25 Oct 2018 18:23:21 GMT
+      - Thu, 01 Nov 2018 18:31:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -7033,7 +7033,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "0098405163cd4c9dbb42c2cb43eb6fd3"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:22 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:56 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -7051,15 +7051,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:23:22 GMT
+      - Thu, 01 Nov 2018 18:31:56 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 40df23f85caf4012800eb3fcfc9892f8
+      - 1afe8617646f47ec864febb3c4e06997
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-88790f2e-6c05-4468-9a3c-c3ec65100e46
+      - req-e0e0e8fc-17d1-4cd9-aabd-51293b0a5429
       Content-Length:
       - '7278'
       Connection:
@@ -7071,7 +7071,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:23:22.172805Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:31:56.673904Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -7150,10 +7150,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["C9qHiyGzSc2lx4U3_1XnQQ"],
-        "issued_at": "2018-10-25T18:23:22.172838Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["o8irFvyRRJymRMt2AIkbJg"],
+        "issued_at": "2018-11-01T18:31:56.673926Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:22 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:56 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74//os-quota-sets/28db8f69ba9e4305b7fad82da4c86e74
@@ -7168,22 +7168,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 40df23f85caf4012800eb3fcfc9892f8
+      - 1afe8617646f47ec864febb3c4e06997
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-642a86ca-a343-491f-ad8a-96728ca5d7d9
+      - req-03f12f5d-8449-429f-a056-30ed1d0903ee
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-642a86ca-a343-491f-ad8a-96728ca5d7d9
+      - req-03f12f5d-8449-429f-a056-30ed1d0903ee
       Date:
-      - Thu, 25 Oct 2018 18:23:22 GMT
+      - Thu, 01 Nov 2018 18:31:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -7193,7 +7193,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "28db8f69ba9e4305b7fad82da4c86e74"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:22 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:56 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -7211,15 +7211,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:23:22 GMT
+      - Thu, 01 Nov 2018 18:31:57 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - af141bbba50d4c7682fc8e0ef20fa8b0
+      - f4c53918d7c5459cb87e08cc38e3f107
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-9232466a-53e5-49bd-bd7c-73be0aaeda1b
+      - req-a3b3d646-f7e2-4b19-9744-1fe2fee0d206
       Content-Length:
       - '7264'
       Connection:
@@ -7231,7 +7231,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:23:22.617586Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:31:57.136831Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -7310,10 +7310,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["UTrxYQ2iQIWiL6qIbTPt-w"],
-        "issued_at": "2018-10-25T18:23:22.617608Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["xIEjZY1nS-iBioBzVFtISA"],
+        "issued_at": "2018-11-01T18:31:57.136852Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:22 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:57 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91//os-quota-sets/4637c33fee924ebea81f8d209e452c91
@@ -7328,22 +7328,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - af141bbba50d4c7682fc8e0ef20fa8b0
+      - f4c53918d7c5459cb87e08cc38e3f107
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-fe84678f-6479-4400-9a0d-917ebf4c0ad2
+      - req-d05d23d2-0db5-47e2-a1a0-f0ef8510185a
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-fe84678f-6479-4400-9a0d-917ebf4c0ad2
+      - req-d05d23d2-0db5-47e2-a1a0-f0ef8510185a
       Date:
-      - Thu, 25 Oct 2018 18:23:22 GMT
+      - Thu, 01 Nov 2018 18:31:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -7353,7 +7353,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "4637c33fee924ebea81f8d209e452c91"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:22 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:57 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -7371,15 +7371,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:23:22 GMT
+      - Thu, 01 Nov 2018 18:31:57 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 4c95374afc0046328c9725d0f7aa1ee9
+      - 1543a40f347d49dc90d3a9631029e246
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-aadb940b-cd8b-4bb7-9bbd-01750cc9fc47
+      - req-b0fe3b3b-b444-4d31-933e-538361901c87
       Content-Length:
       - '7278'
       Connection:
@@ -7391,7 +7391,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:23:23.076905Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:31:57.626121Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -7470,10 +7470,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["ZlYENFj7S029PEFlcFXCKQ"],
-        "issued_at": "2018-10-25T18:23:23.076926Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["n68lWNMaSzauuMIpCOF3Nw"],
+        "issued_at": "2018-11-01T18:31:57.626143Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:23 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:57 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5//os-quota-sets/52c452d7763a4295950527948232a3e5
@@ -7488,22 +7488,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4c95374afc0046328c9725d0f7aa1ee9
+      - 1543a40f347d49dc90d3a9631029e246
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-7a52f46e-8dcd-43fa-a782-562b06608d69
+      - req-8956cd65-1cf3-4562-ba00-a36c3a0cd519
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-7a52f46e-8dcd-43fa-a782-562b06608d69
+      - req-8956cd65-1cf3-4562-ba00-a36c3a0cd519
       Date:
-      - Thu, 25 Oct 2018 18:23:23 GMT
+      - Thu, 01 Nov 2018 18:31:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -7513,7 +7513,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "52c452d7763a4295950527948232a3e5"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:23 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:57 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52//os-quota-sets/88ae57d444fd485ab2dfddd5a2615d52
@@ -7528,22 +7528,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 33a0d96815174b8aa583a7ca218f6c04
+      - dbe191db653e4c6581367157a0c9475f
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-3964489c-0bff-4572-8af9-98b4dd085536
+      - req-de0c1db8-4246-4745-8b3c-a59df0a4e4fa
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-3964489c-0bff-4572-8af9-98b4dd085536
+      - req-de0c1db8-4246-4745-8b3c-a59df0a4e4fa
       Date:
-      - Thu, 25 Oct 2018 18:23:23 GMT
+      - Thu, 01 Nov 2018 18:31:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -7553,7 +7553,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "88ae57d444fd485ab2dfddd5a2615d52"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:23 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:58 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -7571,15 +7571,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:23:23 GMT
+      - Thu, 01 Nov 2018 18:31:58 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - b76000d73bb449eeab41eed995219e04
+      - 97e71d3fc7524545b7ac54df97dd021b
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-6974d5e2-8635-465b-9244-a4b91993e3c3
+      - req-4da3f6e6-d113-448c-bf4e-71d2c784f906
       Content-Length:
       - '7265'
       Connection:
@@ -7591,7 +7591,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:23:23.842968Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:31:58.375727Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -7670,10 +7670,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["DTa2IPo3R8OlxeUOPlbFAg"],
-        "issued_at": "2018-10-25T18:23:23.842996Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["QQIs-ximSkmeugXqNEYJNw"],
+        "issued_at": "2018-11-01T18:31:58.375746Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:23 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:58 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23//os-quota-sets/d09cbe26295d47ff848ea73c74264e23
@@ -7688,22 +7688,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b76000d73bb449eeab41eed995219e04
+      - 97e71d3fc7524545b7ac54df97dd021b
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-6c9174d0-25f2-43e8-8dd3-7cfa6a857c72
+      - req-f23fc3e8-0238-43f4-8d9d-85b7e0c5d453
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-6c9174d0-25f2-43e8-8dd3-7cfa6a857c72
+      - req-f23fc3e8-0238-43f4-8d9d-85b7e0c5d453
       Date:
-      - Thu, 25 Oct 2018 18:23:24 GMT
+      - Thu, 01 Nov 2018 18:31:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -7713,7 +7713,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "d09cbe26295d47ff848ea73c74264e23"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:24 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:58 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -7731,15 +7731,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:23:24 GMT
+      - Thu, 01 Nov 2018 18:31:58 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - ddc3d137ab67417fad7b53b1298dd5f0
+      - 81f84e686e5e411da83f58ca489ff9b9
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-3bce1804-b5e8-4448-8e43-58cdefa96cee
+      - req-9f52be92-46cd-4a16-b364-8c5e0652bfe7
       Content-Length:
       - '7278'
       Connection:
@@ -7751,7 +7751,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:23:24.314775Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:31:58.849609Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -7830,10 +7830,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["9_DTs891TDOZNp_X9xu2XA"],
-        "issued_at": "2018-10-25T18:23:24.314795Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["_H3hbZnwRJWbuiK1jYd-OQ"],
+        "issued_at": "2018-11-01T18:31:58.849628Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:24 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:58 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d//os-quota-sets/ef2a3405d1ef4dfd9a3616993ef46a4d
@@ -7848,22 +7848,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ddc3d137ab67417fad7b53b1298dd5f0
+      - 81f84e686e5e411da83f58ca489ff9b9
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-947e6061-acf3-48e0-a6e1-50105604cd98
+      - req-a3f5a2ee-556c-45f8-ad04-d715791ad6aa
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-947e6061-acf3-48e0-a6e1-50105604cd98
+      - req-a3f5a2ee-556c-45f8-ad04-d715791ad6aa
       Date:
-      - Thu, 25 Oct 2018 18:23:24 GMT
+      - Thu, 01 Nov 2018 18:31:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -7873,7 +7873,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:24 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:59 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -7891,15 +7891,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:23:24 GMT
+      - Thu, 01 Nov 2018 18:31:59 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 2c1afe73a4784a67afdc6faf2c93d065
+      - de94e88187f04360ab0bb7b6df85966d
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-8fa246d5-9a3e-420c-971e-371c6ccc0bda
+      - req-21cb04e9-0850-4f8a-a7a1-f8a6d3125f2d
       Content-Length:
       - '7311'
       Connection:
@@ -7911,7 +7911,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-10-25T19:23:25.063753Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-11-01T19:31:59.327743Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -7990,10 +7990,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["xHUhFpmwSZOtOaNqDt5I_A"],
-        "issued_at": "2018-10-25T18:23:25.063785Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["w_C2GbKGStqdAfWqj150Qg"],
+        "issued_at": "2018-11-01T18:31:59.327761Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:25 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:59 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -8011,15 +8011,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:23:25 GMT
+      - Thu, 01 Nov 2018 18:31:59 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - cfb208185354488a91573eab8e40133a
+      - b497d4eed47a411ea351864437ad6ef9
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-d8588edf-5c12-4d8e-9126-d250b4c76a59
+      - req-72e3c967-4bdd-4bbf-bb26-6cd0c4b4a2fe
       Content-Length:
       - '7278'
       Connection:
@@ -8031,7 +8031,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:23:25.273952Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:31:59.548388Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -8110,10 +8110,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["KmFRYUEjQ9-OPRCqAHy9zw"],
-        "issued_at": "2018-10-25T18:23:25.273972Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["SxgFQ3jUTFuwcJhXTxMT8A"],
+        "issued_at": "2018-11-01T18:31:59.548408Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:25 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:59 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/0098405163cd4c9dbb42c2cb43eb6fd3
@@ -8128,7 +8128,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cfb208185354488a91573eab8e40133a
+      - b497d4eed47a411ea351864437ad6ef9
   response:
     status:
       code: 200
@@ -8139,16 +8139,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-f9551114-9f2f-4560-ad15-b771fdea7ed0
+      - req-d5f1e9cb-6ac4-4bad-a0ee-6cbe1e0d4d18
       Date:
-      - Thu, 25 Oct 2018 18:23:25 GMT
+      - Thu, 01 Nov 2018 18:31:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:25 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:59 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -8166,15 +8166,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:23:25 GMT
+      - Thu, 01 Nov 2018 18:31:59 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - ed72b8b815bc43fd8a4df9c46bbf17c8
+      - 5cbe2e9faa5348c786d0e6079f577e8d
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-11ebd1a4-ab2d-48d2-98aa-ca5458bb3b2e
+      - req-1c6a8efa-bc33-4e5c-86ec-470e4d99482b
       Content-Length:
       - '7278'
       Connection:
@@ -8186,7 +8186,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:23:25.580784Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:31:59.873920Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -8265,10 +8265,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["DO-q4X2yRJ2eGBnKDJlD_Q"],
-        "issued_at": "2018-10-25T18:23:25.580805Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Q3TxtIeNTCmePXcP8gnjTg"],
+        "issued_at": "2018-11-01T18:31:59.873941Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:25 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:59 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/28db8f69ba9e4305b7fad82da4c86e74
@@ -8283,7 +8283,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ed72b8b815bc43fd8a4df9c46bbf17c8
+      - 5cbe2e9faa5348c786d0e6079f577e8d
   response:
     status:
       code: 200
@@ -8294,16 +8294,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-c19deb53-48b9-41e3-bea6-f15bed39a537
+      - req-1213b1d3-7c2e-4093-9d1b-25ad98501509
       Date:
-      - Thu, 25 Oct 2018 18:23:25 GMT
+      - Thu, 01 Nov 2018 18:32:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:25 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:00 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -8321,15 +8321,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:23:25 GMT
+      - Thu, 01 Nov 2018 18:32:00 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 669a659aab354ab89912bf090e2dbfa1
+      - 3b3ee92e04b84f96abc42141ed9253e0
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-db7bb487-a399-47de-9603-7794dd54e7df
+      - req-896f7783-6c8d-4586-9860-39502edf5fc0
       Content-Length:
       - '7264'
       Connection:
@@ -8341,7 +8341,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:23:25.912560Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:32:00.242807Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -8420,10 +8420,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["EGpdyBHxSl6N9mlAqPdc4w"],
-        "issued_at": "2018-10-25T18:23:25.912585Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["GEss8M-LR8yTBUbCT4BLoA"],
+        "issued_at": "2018-11-01T18:32:00.242835Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:25 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:00 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/4637c33fee924ebea81f8d209e452c91
@@ -8438,7 +8438,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 669a659aab354ab89912bf090e2dbfa1
+      - 3b3ee92e04b84f96abc42141ed9253e0
   response:
     status:
       code: 200
@@ -8449,16 +8449,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-378d3687-b20b-4b0c-8717-7b125f9dbf4e
+      - req-363d7143-c6c7-4047-922f-ff28d4485d86
       Date:
-      - Thu, 25 Oct 2018 18:23:26 GMT
+      - Thu, 01 Nov 2018 18:32:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 20, "network": 20, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:26 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:00 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -8476,15 +8476,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:23:26 GMT
+      - Thu, 01 Nov 2018 18:32:00 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 3d068caf8da240a2a7784206e098fac9
+      - 3d6d89c6ad5548e2a1da4eb700af4290
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-01a08f26-d03b-4b96-a780-9773bf832cb6
+      - req-34945b6d-6d2f-4503-bfca-b6f1734477bc
       Content-Length:
       - '7278'
       Connection:
@@ -8496,7 +8496,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:23:26.223395Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:32:00.563522Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -8575,10 +8575,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["2c80vBEpSOq3Iznv0bTw_w"],
-        "issued_at": "2018-10-25T18:23:26.223416Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["L7YlMSNRTTSRFlOcEhnIVg"],
+        "issued_at": "2018-11-01T18:32:00.563543Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:26 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:00 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/52c452d7763a4295950527948232a3e5
@@ -8593,7 +8593,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3d068caf8da240a2a7784206e098fac9
+      - 3d6d89c6ad5548e2a1da4eb700af4290
   response:
     status:
       code: 200
@@ -8604,16 +8604,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-5f5ceaa6-869c-444c-a01d-9cffb4e55818
+      - req-2ad3994b-a185-4a81-be12-ec08fe622532
       Date:
-      - Thu, 25 Oct 2018 18:23:26 GMT
+      - Thu, 01 Nov 2018 18:32:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:26 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:00 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/88ae57d444fd485ab2dfddd5a2615d52
@@ -8628,7 +8628,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2c1afe73a4784a67afdc6faf2c93d065
+      - de94e88187f04360ab0bb7b6df85966d
   response:
     status:
       code: 200
@@ -8639,16 +8639,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-3326ed4b-006e-461e-b47b-85d030e2a3c1
+      - req-2d62c8d3-d759-4167-9dfb-92e580d12768
       Date:
-      - Thu, 25 Oct 2018 18:23:26 GMT
+      - Thu, 01 Nov 2018 18:32:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:26 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:00 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -8666,15 +8666,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:23:26 GMT
+      - Thu, 01 Nov 2018 18:32:00 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - a253380776d44024ab5310257058cabe
+      - c9a445b863074a6683fff5c88c219810
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-c7837f50-6351-4b7f-b32c-937d33d5e5e7
+      - req-d2a2e6ca-d303-4b7f-8fbf-cace2fdb7fdf
       Content-Length:
       - '7265'
       Connection:
@@ -8686,7 +8686,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:23:26.630467Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:32:00.993329Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -8765,10 +8765,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["KpVR8--YTsi8WnaaP2rSNQ"],
-        "issued_at": "2018-10-25T18:23:26.630488Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["k85fd9cNTMWuomB8-QEXBw"],
+        "issued_at": "2018-11-01T18:32:00.993350Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:26 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:01 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/d09cbe26295d47ff848ea73c74264e23
@@ -8783,7 +8783,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a253380776d44024ab5310257058cabe
+      - c9a445b863074a6683fff5c88c219810
   response:
     status:
       code: 200
@@ -8794,16 +8794,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-2ae12fed-31fa-4838-868b-9772a7ad29e5
+      - req-79f9d6db-fc64-46f8-829b-50677d42acbb
       Date:
-      - Thu, 25 Oct 2018 18:23:26 GMT
+      - Thu, 01 Nov 2018 18:32:01 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:26 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:01 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -8821,15 +8821,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:23:26 GMT
+      - Thu, 01 Nov 2018 18:32:01 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - fab986bc9b66491c9053ca37a6af92c5
+      - 23e2de355f1c49ad86ab4a4be3f66b70
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-66bc261e-de69-4584-8a83-6ad6f872b518
+      - req-9283c8c6-d0e6-4895-95c2-18b5321b0120
       Content-Length:
       - '7278'
       Connection:
@@ -8841,7 +8841,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:23:26.938235Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:32:01.312667Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -8920,10 +8920,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["kSLVBR9NRVC1psITGUub7g"],
-        "issued_at": "2018-10-25T18:23:26.938257Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["AgN3FrmgS2ug7_2GfuPwNQ"],
+        "issued_at": "2018-11-01T18:32:01.312687Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:26 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:01 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/ef2a3405d1ef4dfd9a3616993ef46a4d
@@ -8938,7 +8938,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fab986bc9b66491c9053ca37a6af92c5
+      - 23e2de355f1c49ad86ab4a4be3f66b70
   response:
     status:
       code: 200
@@ -8949,16 +8949,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-f7a298b8-babb-4544-ba36-33d897b933d9
+      - req-3f4864c5-79c6-4ea7-a631-10ba96eea9c3
       Date:
-      - Thu, 25 Oct 2018 18:23:27 GMT
+      - Thu, 01 Nov 2018 18:32:01 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:27 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:01 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/os-floating-ips
@@ -8973,7 +8973,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f3704f32307549d9ae9d8754d49694c9
+      - 89d8021eb8c540c2b147ddb1c40e7a7b
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -8986,9 +8986,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-550c7d2e-03c3-42f4-8ce0-1729c577fd5c
+      - req-646240b5-0885-4ff7-9f9d-8b58759a98a7
       Date:
-      - Thu, 25 Oct 2018 18:23:27 GMT
+      - Thu, 01 Nov 2018 18:32:01 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": "5d121f19-3e04-4743-8ed7-c5dfaa6ef71f",
@@ -9011,7 +9011,7 @@ http_interactions:
         "pool": "EmsRefreshSpec-NetworkPublic"}, {"instance_id": null, "ip": "172.16.17.14",
         "fixed_ip": null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60", "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:27 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:01 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/os-floating-ips
@@ -9026,7 +9026,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f3704f32307549d9ae9d8754d49694c9
+      - 89d8021eb8c540c2b147ddb1c40e7a7b
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -9039,9 +9039,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-ce1b3ebf-1e74-4848-95ba-ecce3c29eadd
+      - req-cf1e8856-038e-4fe4-9779-c3cbf6908c6f
       Date:
-      - Thu, 25 Oct 2018 18:23:27 GMT
+      - Thu, 01 Nov 2018 18:32:01 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": "5d121f19-3e04-4743-8ed7-c5dfaa6ef71f",
@@ -9064,7 +9064,7 @@ http_interactions:
         "pool": "EmsRefreshSpec-NetworkPublic"}, {"instance_id": null, "ip": "172.16.17.14",
         "fixed_ip": null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60", "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:27 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:01 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/os-floating-ips
@@ -9079,7 +9079,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f3704f32307549d9ae9d8754d49694c9
+      - 89d8021eb8c540c2b147ddb1c40e7a7b
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -9092,9 +9092,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-2ecec3b6-fbe6-446a-bb2c-a9ffbbe0212b
+      - req-cf043fb6-d236-4e44-8d9c-d456f3525793
       Date:
-      - Thu, 25 Oct 2018 18:23:27 GMT
+      - Thu, 01 Nov 2018 18:32:02 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": "5d121f19-3e04-4743-8ed7-c5dfaa6ef71f",
@@ -9117,7 +9117,7 @@ http_interactions:
         "pool": "EmsRefreshSpec-NetworkPublic"}, {"instance_id": null, "ip": "172.16.17.14",
         "fixed_ip": null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60", "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:27 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:02 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/os-floating-ips
@@ -9132,7 +9132,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f3704f32307549d9ae9d8754d49694c9
+      - 89d8021eb8c540c2b147ddb1c40e7a7b
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -9145,9 +9145,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-0e9424e7-0a2c-4b39-8d2e-24509b59f361
+      - req-36cc4720-d688-44b0-b0ad-331b56b94457
       Date:
-      - Thu, 25 Oct 2018 18:23:27 GMT
+      - Thu, 01 Nov 2018 18:32:02 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": "5d121f19-3e04-4743-8ed7-c5dfaa6ef71f",
@@ -9170,7 +9170,7 @@ http_interactions:
         "pool": "EmsRefreshSpec-NetworkPublic"}, {"instance_id": null, "ip": "172.16.17.14",
         "fixed_ip": null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60", "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:27 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:02 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/os-floating-ips
@@ -9185,7 +9185,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f3704f32307549d9ae9d8754d49694c9
+      - 89d8021eb8c540c2b147ddb1c40e7a7b
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -9198,9 +9198,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-ae9377a1-5916-4460-b5b6-62c4d99b88ae
+      - req-25a22bef-c65d-437c-92fa-84a6aef5097b
       Date:
-      - Thu, 25 Oct 2018 18:23:28 GMT
+      - Thu, 01 Nov 2018 18:32:02 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": "5d121f19-3e04-4743-8ed7-c5dfaa6ef71f",
@@ -9223,7 +9223,7 @@ http_interactions:
         "pool": "EmsRefreshSpec-NetworkPublic"}, {"instance_id": null, "ip": "172.16.17.14",
         "fixed_ip": null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60", "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:28 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:02 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/servers/98b5cc33-7fb8-42b3-86f0-b35883e902aa/os-volume_attachments
@@ -9238,7 +9238,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f3704f32307549d9ae9d8754d49694c9
+      - 89d8021eb8c540c2b147ddb1c40e7a7b
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -9251,15 +9251,15 @@ http_interactions:
       Content-Length:
       - '197'
       X-Compute-Request-Id:
-      - req-7ac75672-6e1c-4860-9eed-f9d2908bfe0e
+      - req-bb273651-c4cf-47ae-a57a-b421ef9de577
       Date:
-      - Thu, 25 Oct 2018 18:23:28 GMT
+      - Thu, 01 Nov 2018 18:32:02 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumeAttachments": [{"device": "/dev/vda", "serverId": "98b5cc33-7fb8-42b3-86f0-b35883e902aa",
         "id": "032b36d1-3dfc-4ff8-af30-5fa74ff47a39", "volumeId": "032b36d1-3dfc-4ff8-af30-5fa74ff47a39"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:28 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:02 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/os-floating-ips
@@ -9274,7 +9274,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f3704f32307549d9ae9d8754d49694c9
+      - 89d8021eb8c540c2b147ddb1c40e7a7b
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -9287,9 +9287,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-e658e389-5b5f-4f21-8683-72bea529568c
+      - req-db27361c-869c-4a4a-96f1-a604df627d6a
       Date:
-      - Thu, 25 Oct 2018 18:23:28 GMT
+      - Thu, 01 Nov 2018 18:32:02 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": "5d121f19-3e04-4743-8ed7-c5dfaa6ef71f",
@@ -9312,7 +9312,7 @@ http_interactions:
         "pool": "EmsRefreshSpec-NetworkPublic"}, {"instance_id": null, "ip": "172.16.17.14",
         "fixed_ip": null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60", "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:28 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:02 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/servers/7edb7855-d974-4e45-8ad2-88491541ab91/os-volume_attachments
@@ -9327,7 +9327,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f3704f32307549d9ae9d8754d49694c9
+      - 89d8021eb8c540c2b147ddb1c40e7a7b
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -9340,15 +9340,15 @@ http_interactions:
       Content-Length:
       - '197'
       X-Compute-Request-Id:
-      - req-f38908cf-27b4-48ac-aa0c-fae6dc45d03e
+      - req-a8c072cf-7f27-40bd-9bf1-d14c490a2348
       Date:
-      - Thu, 25 Oct 2018 18:23:28 GMT
+      - Thu, 01 Nov 2018 18:32:02 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumeAttachments": [{"device": "/dev/vdd", "serverId": "7edb7855-d974-4e45-8ad2-88491541ab91",
         "id": "8791e24f-874d-4f1e-99ec-75fdb9d48ca5", "volumeId": "8791e24f-874d-4f1e-99ec-75fdb9d48ca5"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:28 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:03 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/os-floating-ips
@@ -9363,7 +9363,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f3704f32307549d9ae9d8754d49694c9
+      - 89d8021eb8c540c2b147ddb1c40e7a7b
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -9376,9 +9376,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-08780e1b-35c3-466b-95e8-ba6e8705f440
+      - req-883d6b89-2aea-4c19-874d-b3bfca3e9a9d
       Date:
-      - Thu, 25 Oct 2018 18:23:28 GMT
+      - Thu, 01 Nov 2018 18:32:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": "5d121f19-3e04-4743-8ed7-c5dfaa6ef71f",
@@ -9401,7 +9401,7 @@ http_interactions:
         "pool": "EmsRefreshSpec-NetworkPublic"}, {"instance_id": null, "ip": "172.16.17.14",
         "fixed_ip": null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60", "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:28 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:03 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/os-floating-ips
@@ -9416,7 +9416,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f3704f32307549d9ae9d8754d49694c9
+      - 89d8021eb8c540c2b147ddb1c40e7a7b
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -9429,9 +9429,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-21216fcb-62ba-4ce6-9ed7-63d93dfb08c4
+      - req-0ef27ad9-58e0-43ef-920c-41292661fc85
       Date:
-      - Thu, 25 Oct 2018 18:23:28 GMT
+      - Thu, 01 Nov 2018 18:32:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": "5d121f19-3e04-4743-8ed7-c5dfaa6ef71f",
@@ -9454,7 +9454,7 @@ http_interactions:
         "pool": "EmsRefreshSpec-NetworkPublic"}, {"instance_id": null, "ip": "172.16.17.14",
         "fixed_ip": null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60", "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:28 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:03 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/os-floating-ips
@@ -9469,7 +9469,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f3704f32307549d9ae9d8754d49694c9
+      - 89d8021eb8c540c2b147ddb1c40e7a7b
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -9482,9 +9482,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-fbc79449-fdc8-4ef2-8749-393aba1a6889
+      - req-c88e56f6-60bb-4965-99c7-03a2db29be68
       Date:
-      - Thu, 25 Oct 2018 18:23:29 GMT
+      - Thu, 01 Nov 2018 18:32:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": "5d121f19-3e04-4743-8ed7-c5dfaa6ef71f",
@@ -9507,7 +9507,7 @@ http_interactions:
         "pool": "EmsRefreshSpec-NetworkPublic"}, {"instance_id": null, "ip": "172.16.17.14",
         "fixed_ip": null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60", "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:29 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:03 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -9525,15 +9525,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:23:29 GMT
+      - Thu, 01 Nov 2018 18:32:03 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 91f2addda8dd4eeb953a3b605764778e
+      - f482842595af4ba09f6482c31fcf899d
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-43a3f2c8-436a-4852-99dc-52340a2384dc
+      - req-82e03520-51a9-4e25-944d-2bd743ae2acc
       Content-Length:
       - '7311'
       Connection:
@@ -9545,7 +9545,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-10-25T19:23:29.279631Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-11-01T19:32:04.029295Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -9624,10 +9624,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["heIUFfV2TgeSY2QTa-EFIg"],
-        "issued_at": "2018-10-25T18:23:29.279652Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["XbdeAlOjQT-WzeIIeoxaSw"],
+        "issued_at": "2018-11-01T18:32:04.029316Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:29 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:04 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -9645,15 +9645,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:23:29 GMT
+      - Thu, 01 Nov 2018 18:32:04 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 84d6245eeb704851bff7d935de1851b4
+      - f49fc979638e44e58b5502d00cd84463
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-285a77a1-7610-491b-857b-15ecf0522310
+      - req-76939165-74c0-4354-8afb-e7514329238b
       Content-Length:
       - '7311'
       Connection:
@@ -9665,7 +9665,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-10-25T19:23:29.484587Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-11-01T19:32:04.236283Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -9744,10 +9744,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["DBNzH03iTXKnt-4mJaba7Q"],
-        "issued_at": "2018-10-25T18:23:29.484607Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["0wvriBKmT6eNEuiYDdffsg"],
+        "issued_at": "2018-11-01T18:32:04.236304Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:29 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:04 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-aggregates
@@ -9762,7 +9762,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d5e08decea854f9d9045e427794321a4
+      - 91c772b42a324045a203d6215c73a103
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -9775,14 +9775,14 @@ http_interactions:
       Content-Length:
       - '18'
       X-Compute-Request-Id:
-      - req-3b7affa7-cf83-4950-a1cb-586392863b02
+      - req-c68051c4-d6a8-475f-8b27-a4ce27407554
       Date:
-      - Thu, 25 Oct 2018 18:23:29 GMT
+      - Thu, 01 Nov 2018 18:32:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"aggregates": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:29 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:04 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/volumes/detail?limit=1000&status=available
@@ -9797,27 +9797,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - af0c0dc7d33e455795f54919f18c62e8
+      - 2457cdd9f0b94a04863bab30bc9b0168
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-96855370-94f8-4bd2-a9b2-823166434939
+      - req-f324f7a8-035a-4b4d-96ac-5b213207f24a
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-96855370-94f8-4bd2-a9b2-823166434939
+      - req-f324f7a8-035a-4b4d-96ac-5b213207f24a
       Date:
-      - Thu, 25 Oct 2018 18:23:29 GMT
+      - Thu, 01 Nov 2018 18:32:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:29 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:04 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/volumes/detail?limit=1000&status=available
@@ -9832,27 +9832,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 40df23f85caf4012800eb3fcfc9892f8
+      - 1afe8617646f47ec864febb3c4e06997
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-bd103677-2c57-40be-9da3-6da5e36420f5
+      - req-cde16475-15e9-4f86-84e7-6052cb1327fb
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-bd103677-2c57-40be-9da3-6da5e36420f5
+      - req-cde16475-15e9-4f86-84e7-6052cb1327fb
       Date:
-      - Thu, 25 Oct 2018 18:23:29 GMT
+      - Thu, 01 Nov 2018 18:32:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:29 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:04 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&status=available
@@ -9867,22 +9867,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - af141bbba50d4c7682fc8e0ef20fa8b0
+      - f4c53918d7c5459cb87e08cc38e3f107
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-6e4159bd-ba34-46f9-a293-e09d2e013f99
+      - req-ef16ffb0-3fde-4822-a134-f3adb7153f79
       Content-Type:
       - application/json
       Content-Length:
       - '2723'
       X-Openstack-Request-Id:
-      - req-6e4159bd-ba34-46f9-a293-e09d2e013f99
+      - req-ef16ffb0-3fde-4822-a134-f3adb7153f79
       Date:
-      - Thu, 25 Oct 2018 18:23:30 GMT
+      - Thu, 01 Nov 2018 18:32:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&status=available&marker=f46458aa-309d-4f47-b996-a39db065030a",
@@ -9915,7 +9915,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-4", "bootable": "true", "created_at":
         "2016-08-19T08:37:45.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:30 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:04 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=f46458aa-309d-4f47-b996-a39db065030a&status=available
@@ -9930,22 +9930,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - af141bbba50d4c7682fc8e0ef20fa8b0
+      - f4c53918d7c5459cb87e08cc38e3f107
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-87d4a405-7955-4662-a330-f42b2c9ccf77
+      - req-98e025f6-635f-47fc-9561-3496d4a0ce29
       Content-Type:
       - application/json
       Content-Length:
       - '1180'
       X-Openstack-Request-Id:
-      - req-87d4a405-7955-4662-a330-f42b2c9ccf77
+      - req-98e025f6-635f-47fc-9561-3496d4a0ce29
       Date:
-      - Thu, 25 Oct 2018 18:23:30 GMT
+      - Thu, 01 Nov 2018 18:32:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": [{"migration_status": null, "attachments": [], "links":
@@ -9962,7 +9962,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-FromSnapshot", "bootable": "false", "created_at":
         "2016-08-19T08:37:13.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:30 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:04 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/volumes/detail?limit=1000&status=available
@@ -9977,27 +9977,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4c95374afc0046328c9725d0f7aa1ee9
+      - 1543a40f347d49dc90d3a9631029e246
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-8824a436-80fc-47df-b64d-84889f62a17b
+      - req-e84521b9-1150-435c-98ed-93ee6bda98f7
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-8824a436-80fc-47df-b64d-84889f62a17b
+      - req-e84521b9-1150-435c-98ed-93ee6bda98f7
       Date:
-      - Thu, 25 Oct 2018 18:23:30 GMT
+      - Thu, 01 Nov 2018 18:32:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:30 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:05 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/volumes/detail?limit=1000&status=available
@@ -10012,27 +10012,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 33a0d96815174b8aa583a7ca218f6c04
+      - dbe191db653e4c6581367157a0c9475f
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-dbeadca5-ef16-4bf1-a0c4-8231be42fa5f
+      - req-24da6431-0fbb-4079-8c63-11b65756ed4c
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-dbeadca5-ef16-4bf1-a0c4-8231be42fa5f
+      - req-24da6431-0fbb-4079-8c63-11b65756ed4c
       Date:
-      - Thu, 25 Oct 2018 18:23:30 GMT
+      - Thu, 01 Nov 2018 18:32:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:30 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:05 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/volumes/detail?limit=1000&status=available
@@ -10047,27 +10047,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b76000d73bb449eeab41eed995219e04
+      - 97e71d3fc7524545b7ac54df97dd021b
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-5aa36745-557a-4155-948c-53d6b6a6c181
+      - req-804f33da-e5bf-4b53-b8ff-293c2e1d38c0
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-5aa36745-557a-4155-948c-53d6b6a6c181
+      - req-804f33da-e5bf-4b53-b8ff-293c2e1d38c0
       Date:
-      - Thu, 25 Oct 2018 18:23:30 GMT
+      - Thu, 01 Nov 2018 18:32:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:30 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:05 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/volumes/detail?limit=1000&status=available
@@ -10082,27 +10082,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ddc3d137ab67417fad7b53b1298dd5f0
+      - 81f84e686e5e411da83f58ca489ff9b9
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-92f9459a-56cd-408f-a7ed-911216a78495
+      - req-0b300a40-1c1f-401c-812b-64487c5be563
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-92f9459a-56cd-408f-a7ed-911216a78495
+      - req-0b300a40-1c1f-401c-812b-64487c5be563
       Date:
-      - Thu, 25 Oct 2018 18:23:30 GMT
+      - Thu, 01 Nov 2018 18:32:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:30 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:05 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/snapshots/detail
@@ -10117,27 +10117,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - af0c0dc7d33e455795f54919f18c62e8
+      - 2457cdd9f0b94a04863bab30bc9b0168
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-a06ef15a-5f1f-45b1-ad0b-de06cd858e5a
+      - req-8e2c652e-16ae-4c19-9191-6ac1906744bf
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-a06ef15a-5f1f-45b1-ad0b-de06cd858e5a
+      - req-8e2c652e-16ae-4c19-9191-6ac1906744bf
       Date:
-      - Thu, 25 Oct 2018 18:23:30 GMT
+      - Thu, 01 Nov 2018 18:32:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:30 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:05 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/snapshots/detail?limit=1000&status=available
@@ -10152,27 +10152,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - af0c0dc7d33e455795f54919f18c62e8
+      - 2457cdd9f0b94a04863bab30bc9b0168
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-c2a1abae-ab29-4742-8b76-3659e9ac35b5
+      - req-6ac5a533-965b-41b6-8f9f-6036c2a019fb
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-c2a1abae-ab29-4742-8b76-3659e9ac35b5
+      - req-6ac5a533-965b-41b6-8f9f-6036c2a019fb
       Date:
-      - Thu, 25 Oct 2018 18:23:30 GMT
+      - Thu, 01 Nov 2018 18:32:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:30 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:05 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/snapshots/detail
@@ -10187,27 +10187,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 40df23f85caf4012800eb3fcfc9892f8
+      - 1afe8617646f47ec864febb3c4e06997
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-2b6fb03c-a5df-44fe-92ce-1765f154c598
+      - req-01c9f1e7-b274-409a-8a7d-9719281ca902
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-2b6fb03c-a5df-44fe-92ce-1765f154c598
+      - req-01c9f1e7-b274-409a-8a7d-9719281ca902
       Date:
-      - Thu, 25 Oct 2018 18:23:31 GMT
+      - Thu, 01 Nov 2018 18:32:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:31 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:05 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/snapshots/detail?limit=1000&status=available
@@ -10222,27 +10222,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 40df23f85caf4012800eb3fcfc9892f8
+      - 1afe8617646f47ec864febb3c4e06997
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-770d7907-42af-4c6c-8bdd-2ba2555f8c12
+      - req-d1967b08-4e71-4cc2-90d7-d4f1f034d2d5
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-770d7907-42af-4c6c-8bdd-2ba2555f8c12
+      - req-d1967b08-4e71-4cc2-90d7-d4f1f034d2d5
       Date:
-      - Thu, 25 Oct 2018 18:23:31 GMT
+      - Thu, 01 Nov 2018 18:32:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:31 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:05 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/snapshots/detail
@@ -10257,22 +10257,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - af141bbba50d4c7682fc8e0ef20fa8b0
+      - f4c53918d7c5459cb87e08cc38e3f107
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-7af9f0f5-050d-4f58-bcee-0ae635a983af
+      - req-f130857c-a23f-4d9c-b52c-da8ff1475365
       Content-Type:
       - application/json
       Content-Length:
       - '1053'
       X-Openstack-Request-Id:
-      - req-7af9f0f5-050d-4f58-bcee-0ae635a983af
+      - req-f130857c-a23f-4d9c-b52c-da8ff1475365
       Date:
-      - Thu, 25 Oct 2018 18:23:31 GMT
+      - Thu, 01 Nov 2018 18:32:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/snapshots/detail?marker=c44d3eb3-31fe-46ed-bfae-707920be171d",
@@ -10287,7 +10287,7 @@ http_interactions:
         "created_at": "2016-08-19T08:37:24.000000", "size": 1, "id": "c44d3eb3-31fe-46ed-bfae-707920be171d",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:31 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:06 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/snapshots/detail?limit=1000&status=available
@@ -10302,22 +10302,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - af141bbba50d4c7682fc8e0ef20fa8b0
+      - f4c53918d7c5459cb87e08cc38e3f107
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-da667e53-4fd0-4436-9d5f-5a59ef38c164
+      - req-a83ebedc-72e8-429c-9241-5b2914fd0105
       Content-Type:
       - application/json
       Content-Length:
       - '1081'
       X-Openstack-Request-Id:
-      - req-da667e53-4fd0-4436-9d5f-5a59ef38c164
+      - req-a83ebedc-72e8-429c-9241-5b2914fd0105
       Date:
-      - Thu, 25 Oct 2018 18:23:31 GMT
+      - Thu, 01 Nov 2018 18:32:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/snapshots/detail?limit=1000&status=available&marker=c44d3eb3-31fe-46ed-bfae-707920be171d",
@@ -10332,7 +10332,7 @@ http_interactions:
         "created_at": "2016-08-19T08:37:24.000000", "size": 1, "id": "c44d3eb3-31fe-46ed-bfae-707920be171d",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:31 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:06 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/snapshots/detail
@@ -10347,27 +10347,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4c95374afc0046328c9725d0f7aa1ee9
+      - 1543a40f347d49dc90d3a9631029e246
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-d38b5b8c-0424-40b5-b221-c2cb965d9681
+      - req-c666dcae-2675-45be-85ff-c1797a0eb3ee
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-d38b5b8c-0424-40b5-b221-c2cb965d9681
+      - req-c666dcae-2675-45be-85ff-c1797a0eb3ee
       Date:
-      - Thu, 25 Oct 2018 18:23:31 GMT
+      - Thu, 01 Nov 2018 18:32:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:31 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:06 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/snapshots/detail?limit=1000&status=available
@@ -10382,27 +10382,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4c95374afc0046328c9725d0f7aa1ee9
+      - 1543a40f347d49dc90d3a9631029e246
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-bde6f186-a431-4ff5-abf5-b9e03a856eea
+      - req-701df082-4cdf-4269-aa4d-2b27d65bb7f8
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-bde6f186-a431-4ff5-abf5-b9e03a856eea
+      - req-701df082-4cdf-4269-aa4d-2b27d65bb7f8
       Date:
-      - Thu, 25 Oct 2018 18:23:31 GMT
+      - Thu, 01 Nov 2018 18:32:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:31 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:06 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/snapshots/detail
@@ -10417,27 +10417,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 33a0d96815174b8aa583a7ca218f6c04
+      - dbe191db653e4c6581367157a0c9475f
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-5ae8c6ba-1f7a-4b55-acd0-6b4a6f1fcdeb
+      - req-af959ad7-8ba3-4407-9daf-952c3b7d29fe
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-5ae8c6ba-1f7a-4b55-acd0-6b4a6f1fcdeb
+      - req-af959ad7-8ba3-4407-9daf-952c3b7d29fe
       Date:
-      - Thu, 25 Oct 2018 18:23:31 GMT
+      - Thu, 01 Nov 2018 18:32:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:31 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:06 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/snapshots/detail?limit=1000&status=available
@@ -10452,27 +10452,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 33a0d96815174b8aa583a7ca218f6c04
+      - dbe191db653e4c6581367157a0c9475f
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-56b10ec0-9ca7-4598-829e-835c3bb7e28f
+      - req-1a7a574c-31e1-4c7c-b96f-f5473cd0abc9
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-56b10ec0-9ca7-4598-829e-835c3bb7e28f
+      - req-1a7a574c-31e1-4c7c-b96f-f5473cd0abc9
       Date:
-      - Thu, 25 Oct 2018 18:23:31 GMT
+      - Thu, 01 Nov 2018 18:32:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:31 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:06 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/snapshots/detail
@@ -10487,27 +10487,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b76000d73bb449eeab41eed995219e04
+      - 97e71d3fc7524545b7ac54df97dd021b
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-8f9118d6-8032-4f88-af7e-b993f49ac30b
+      - req-62c4efc9-6c06-439c-853e-06095f9a9510
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-8f9118d6-8032-4f88-af7e-b993f49ac30b
+      - req-62c4efc9-6c06-439c-853e-06095f9a9510
       Date:
-      - Thu, 25 Oct 2018 18:23:31 GMT
+      - Thu, 01 Nov 2018 18:32:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:31 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:06 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/snapshots/detail?limit=1000&status=available
@@ -10522,27 +10522,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b76000d73bb449eeab41eed995219e04
+      - 97e71d3fc7524545b7ac54df97dd021b
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-7704632e-4d12-4f5b-89a1-d1255845caef
+      - req-2134e1e6-45f1-42e4-9b4b-f7016f0732d2
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-7704632e-4d12-4f5b-89a1-d1255845caef
+      - req-2134e1e6-45f1-42e4-9b4b-f7016f0732d2
       Date:
-      - Thu, 25 Oct 2018 18:23:31 GMT
+      - Thu, 01 Nov 2018 18:32:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:31 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:06 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/snapshots/detail
@@ -10557,27 +10557,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ddc3d137ab67417fad7b53b1298dd5f0
+      - 81f84e686e5e411da83f58ca489ff9b9
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-652accdb-65f0-4970-9dcd-10916aa18cb4
+      - req-a672c76c-5431-4f27-9af0-81c3fcd58eb0
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-652accdb-65f0-4970-9dcd-10916aa18cb4
+      - req-a672c76c-5431-4f27-9af0-81c3fcd58eb0
       Date:
-      - Thu, 25 Oct 2018 18:23:32 GMT
+      - Thu, 01 Nov 2018 18:32:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:32 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:06 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/snapshots/detail?limit=1000&status=available
@@ -10592,27 +10592,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ddc3d137ab67417fad7b53b1298dd5f0
+      - 81f84e686e5e411da83f58ca489ff9b9
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-f29ee310-754d-49b0-a9c3-556457ae0e51
+      - req-2fbc0925-598f-4c05-816c-0b23e2f0c0c6
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-f29ee310-754d-49b0-a9c3-556457ae0e51
+      - req-2fbc0925-598f-4c05-816c-0b23e2f0c0c6
       Date:
-      - Thu, 25 Oct 2018 18:23:32 GMT
+      - Thu, 01 Nov 2018 18:32:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:32 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:06 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/volumes/detail?limit=1000
@@ -10627,27 +10627,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - af0c0dc7d33e455795f54919f18c62e8
+      - 2457cdd9f0b94a04863bab30bc9b0168
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-f01c38ea-ddc9-4cb6-99a1-8661e46b000e
+      - req-ef603b7b-746c-492a-b663-b0ad664e5bc3
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-f01c38ea-ddc9-4cb6-99a1-8661e46b000e
+      - req-ef603b7b-746c-492a-b663-b0ad664e5bc3
       Date:
-      - Thu, 25 Oct 2018 18:23:32 GMT
+      - Thu, 01 Nov 2018 18:32:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:32 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:07 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/volumes/detail?limit=1000
@@ -10662,27 +10662,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 40df23f85caf4012800eb3fcfc9892f8
+      - 1afe8617646f47ec864febb3c4e06997
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-a4b5d01d-a944-4828-a902-5f5749498c77
+      - req-f3912a68-e0c6-4744-aae3-c75a6f2d7e05
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-a4b5d01d-a944-4828-a902-5f5749498c77
+      - req-f3912a68-e0c6-4744-aae3-c75a6f2d7e05
       Date:
-      - Thu, 25 Oct 2018 18:23:32 GMT
+      - Thu, 01 Nov 2018 18:32:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:32 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:07 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000
@@ -10697,22 +10697,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - af141bbba50d4c7682fc8e0ef20fa8b0
+      - f4c53918d7c5459cb87e08cc38e3f107
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-6b02bc8b-bccd-4fd7-b617-9a533129993f
+      - req-d02749ce-8c33-4d77-b258-82ffd68fba4b
       Content-Type:
       - application/json
       Content-Length:
       - '2706'
       X-Openstack-Request-Id:
-      - req-6b02bc8b-bccd-4fd7-b617-9a533129993f
+      - req-d02749ce-8c33-4d77-b258-82ffd68fba4b
       Date:
-      - Thu, 25 Oct 2018 18:23:32 GMT
+      - Thu, 01 Nov 2018 18:32:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=f46458aa-309d-4f47-b996-a39db065030a",
@@ -10745,7 +10745,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-4", "bootable": "true", "created_at":
         "2016-08-19T08:37:45.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:32 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:07 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=f46458aa-309d-4f47-b996-a39db065030a
@@ -10760,22 +10760,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - af141bbba50d4c7682fc8e0ef20fa8b0
+      - f4c53918d7c5459cb87e08cc38e3f107
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-c2897109-e9bc-4e3a-9dc7-6849b9724fbb
+      - req-509f3395-6536-4fdd-97ca-237004c0609e
       Content-Type:
       - application/json
       Content-Length:
       - '3284'
       X-Openstack-Request-Id:
-      - req-c2897109-e9bc-4e3a-9dc7-6849b9724fbb
+      - req-509f3395-6536-4fdd-97ca-237004c0609e
       Date:
-      - Thu, 25 Oct 2018 18:23:32 GMT
+      - Thu, 01 Nov 2018 18:32:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=476a0c89-4322-42aa-b7ce-3ac21be55af7",
@@ -10816,7 +10816,7 @@ http_interactions:
         "name": "EmsRefreshSpec-Volume-2", "bootable": "false", "created_at": "2016-08-19T08:37:33.000000",
         "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:32 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:07 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=476a0c89-4322-42aa-b7ce-3ac21be55af7
@@ -10831,22 +10831,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - af141bbba50d4c7682fc8e0ef20fa8b0
+      - f4c53918d7c5459cb87e08cc38e3f107
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-c06519c0-18ac-4fe5-8028-20d2942eaf7b
+      - req-f3ffa24b-c374-485f-899b-b4f9be27bf70
       Content-Type:
       - application/json
       Content-Length:
       - '2753'
       X-Openstack-Request-Id:
-      - req-c06519c0-18ac-4fe5-8028-20d2942eaf7b
+      - req-f3ffa24b-c374-485f-899b-b4f9be27bf70
       Date:
-      - Thu, 25 Oct 2018 18:23:32 GMT
+      - Thu, 01 Nov 2018 18:32:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=8791e24f-874d-4f1e-99ec-75fdb9d48ca5",
@@ -10880,7 +10880,7 @@ http_interactions:
         "bootable": "false", "created_at": "2016-08-19T08:37:05.000000", "volume_type":
         "iscsi"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:32 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:07 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=8791e24f-874d-4f1e-99ec-75fdb9d48ca5
@@ -10895,27 +10895,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - af141bbba50d4c7682fc8e0ef20fa8b0
+      - f4c53918d7c5459cb87e08cc38e3f107
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-1fbc69ab-15bc-4183-924b-eda1a0dd1300
+      - req-b210f51f-6887-4a5f-8a4c-5261cf07f72b
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-1fbc69ab-15bc-4183-924b-eda1a0dd1300
+      - req-b210f51f-6887-4a5f-8a4c-5261cf07f72b
       Date:
-      - Thu, 25 Oct 2018 18:23:32 GMT
+      - Thu, 01 Nov 2018 18:32:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:33 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:07 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/volumes/detail?limit=1000
@@ -10930,27 +10930,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4c95374afc0046328c9725d0f7aa1ee9
+      - 1543a40f347d49dc90d3a9631029e246
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-51354c60-fe64-48e2-8b64-9b3948a7937c
+      - req-435bfaea-631f-4916-86d9-5e6ba64306a9
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-51354c60-fe64-48e2-8b64-9b3948a7937c
+      - req-435bfaea-631f-4916-86d9-5e6ba64306a9
       Date:
-      - Thu, 25 Oct 2018 18:23:33 GMT
+      - Thu, 01 Nov 2018 18:32:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:33 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:08 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/volumes/detail?limit=1000
@@ -10965,27 +10965,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 33a0d96815174b8aa583a7ca218f6c04
+      - dbe191db653e4c6581367157a0c9475f
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-14b89e13-55fe-4d33-9673-2a0474234acf
+      - req-78d379f2-ecdc-45c0-b8ae-0756dfe34a05
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-14b89e13-55fe-4d33-9673-2a0474234acf
+      - req-78d379f2-ecdc-45c0-b8ae-0756dfe34a05
       Date:
-      - Thu, 25 Oct 2018 18:23:33 GMT
+      - Thu, 01 Nov 2018 18:32:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:33 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:08 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/volumes/detail?limit=1000
@@ -11000,27 +11000,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b76000d73bb449eeab41eed995219e04
+      - 97e71d3fc7524545b7ac54df97dd021b
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-b16eb563-c94b-4e9b-b43d-afcbb2332d87
+      - req-c2ada5a2-6cc8-4f07-b5c2-ab747e53d72e
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-b16eb563-c94b-4e9b-b43d-afcbb2332d87
+      - req-c2ada5a2-6cc8-4f07-b5c2-ab747e53d72e
       Date:
-      - Thu, 25 Oct 2018 18:23:33 GMT
+      - Thu, 01 Nov 2018 18:32:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:33 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:08 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/volumes/detail?limit=1000
@@ -11035,27 +11035,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ddc3d137ab67417fad7b53b1298dd5f0
+      - 81f84e686e5e411da83f58ca489ff9b9
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-8095280a-0a8e-497e-b062-9ccf4a6361e5
+      - req-1d12f83c-64f7-4aaf-bb3e-dd3145a2abb0
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-8095280a-0a8e-497e-b062-9ccf4a6361e5
+      - req-1d12f83c-64f7-4aaf-bb3e-dd3145a2abb0
       Date:
-      - Thu, 25 Oct 2018 18:23:33 GMT
+      - Thu, 01 Nov 2018 18:32:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:33 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:08 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -11073,15 +11073,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:23:34 GMT
+      - Thu, 01 Nov 2018 18:32:09 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - c189d6d9bc994a9fbf8c3f5802a82f6c
+      - 101adcdbfd0249a5a59ca267da0cb732
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-be644ebb-081b-49de-8104-98b2bb83b894
+      - req-af3ff732-b164-403d-bb37-4aeec9fb771a
       Content-Length:
       - '7311'
       Connection:
@@ -11093,7 +11093,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-10-25T19:23:34.848016Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-11-01T19:32:09.870056Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -11172,10 +11172,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["NLa_yjJ3SZaxwpJtSxU1rg"],
-        "issued_at": "2018-10-25T18:23:34.848037Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["wJzGZ7o-Th-W81fgP_kGiA"],
+        "issued_at": "2018-11-01T18:32:09.870078Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:34 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:09 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -11193,15 +11193,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:23:34 GMT
+      - Thu, 01 Nov 2018 18:32:10 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - e5c2c8c12d3741cf8758152a15318f97
+      - e4031829ca794b898e1211cfc89e4ea0
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-14b761b6-73ea-4062-8faf-cbef002ab10b
+      - req-dc8f6429-f361-47bb-95f4-d1a69db43216
       Content-Length:
       - '7311'
       Connection:
@@ -11213,7 +11213,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-10-25T19:23:35.050604Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-11-01T19:32:10.083647Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -11292,10 +11292,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["qiPhQpT2TL-2VT_8_uk0xw"],
-        "issued_at": "2018-10-25T18:23:35.050626Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["QsTuf4yST-mciv0gHeZtaw"],
+        "issued_at": "2018-11-01T18:32:10.083668Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:35 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:10 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/networks
@@ -11310,7 +11310,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e5c2c8c12d3741cf8758152a15318f97
+      - e4031829ca794b898e1211cfc89e4ea0
   response:
     status:
       code: 200
@@ -11321,58 +11321,18 @@ http_interactions:
       Content-Length:
       - '5330'
       X-Openstack-Request-Id:
-      - req-15a51ff9-590b-4560-ae87-268a9997bc4e
+      - req-8c1f4c32-87c0-4633-a75d-0e8873751125
       Date:
-      - Thu, 25 Oct 2018 18:23:35 GMT
+      - Thu, 01 Nov 2018 18:32:10 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"networks": [{"status": "ACTIVE", "subnets": ["9801267c-cd57-437a-a852-b46640cb4332",
-        "978d38ec-4845-45ce-b3e3-89e7c9d9109b"], "name": "EmsRefreshSpec-IsolatedNetworkPrivate_2",
-        "provider:physical_network": null, "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
-        "vxlan", "id": "483c08c7-96b0-4e08-9db7-96d5650974ac", "provider:segmentation_id":
-        36}, {"status": "ACTIVE", "subnets": ["76d851f4-9cd9-49ca-93ac-bcc7b3c8153a"],
-        "name": "EmsRefreshSpec-NetworkPublic_20", "provider:physical_network": "public_net_2",
-        "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
-        0, "router:external": true, "shared": false, "provider:network_type": "flat",
-        "id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "provider:segmentation_id":
-        null}, {"status": "ACTIVE", "subnets": ["f477c0cd-eba7-4f8d-a2cc-b05ece115c43"],
-        "name": "EmsRefreshSpec-NetworkPublic", "provider:physical_network": "public_net_0",
-        "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
-        0, "router:external": true, "shared": false, "provider:network_type": "flat",
-        "id": "c66145df-4d9d-4898-9e35-12a102b66346", "provider:segmentation_id":
-        null}, {"status": "ACTIVE", "subnets": ["e96c89d2-810a-4cdb-a19b-93072db5dd20"],
-        "name": "EmsRefreshSpec-NetworkPrivate_3", "provider:physical_network": null,
-        "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
-        0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
-        "id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571", "provider:segmentation_id":
-        99}, {"status": "ACTIVE", "subnets": ["e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d"],
-        "name": "EmsRefreshSpec-NetworkPrivate_20", "provider:physical_network": null,
-        "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
-        0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
-        "id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "provider:segmentation_id":
-        31}, {"status": "ACTIVE", "subnets": ["c2ab9441-dd1c-4acc-a3a6-753f1a582291",
-        "3be7c490-3820-43ad-8bc4-00d0367b8d21"], "name": "EmsRefreshSpec-NetworkPrivate_30",
-        "provider:physical_network": null, "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
-        "vxlan", "id": "91eed80f-14a3-41a1-8acb-558dd451ecec", "provider:segmentation_id":
-        59}, {"status": "ACTIVE", "subnets": ["53450d1a-8ecc-43aa-a641-95db25b6be2e"],
-        "name": "EmsRefreshSpec-NetworkPublic_40", "provider:physical_network": "public_net_4",
-        "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
-        0, "router:external": true, "shared": false, "provider:network_type": "flat",
-        "id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "provider:segmentation_id":
-        null}, {"status": "ACTIVE", "subnets": ["75e7a9c8-eeaf-4cd0-80da-05165f897e69"],
-        "name": "EmsRefreshSpec-NetworkPublic_10", "provider:physical_network": "public_net_1",
-        "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
-        0, "router:external": true, "shared": false, "provider:network_type": "flat",
-        "id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "provider:segmentation_id":
-        null}, {"status": "ACTIVE", "subnets": ["c53efdb0-e706-4c94-b0e5-a9a2eb84b459"],
+      string: '{"networks": [{"status": "ACTIVE", "subnets": ["c53efdb0-e706-4c94-b0e5-a9a2eb84b459"],
         "name": "EmsRefreshSpec-IsolatedNetworkPrivate_1", "provider:physical_network":
         null, "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
         "vxlan", "id": "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "provider:segmentation_id":
-        13}, {"status": "ACTIVE", "subnets": ["a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
-        "9bb84a96-3a02-45be-9b16-b0db19c167db"], "name": "EmsRefreshSpec-NetworkPublic_50",
+        13}, {"status": "ACTIVE", "subnets": ["9bb84a96-3a02-45be-9b16-b0db19c167db",
+        "a6dc66a9-aac3-4fad-97a6-896dd23fbb10"], "name": "EmsRefreshSpec-NetworkPublic_50",
         "provider:physical_network": "public_net_5", "admin_state_up": true, "tenant_id":
         "4637c33fee924ebea81f8d209e452c91", "mtu": 0, "router:external": true, "shared":
         false, "provider:network_type": "flat", "id": "f4823e3f-2c96-44e8-9366-915319145d8a",
@@ -11386,6 +11346,46 @@ http_interactions:
         "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
         0, "router:external": true, "shared": false, "provider:network_type": "flat",
         "id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e", "provider:segmentation_id":
+        null}, {"status": "ACTIVE", "subnets": ["f477c0cd-eba7-4f8d-a2cc-b05ece115c43"],
+        "name": "EmsRefreshSpec-NetworkPublic", "provider:physical_network": "public_net_0",
+        "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
+        0, "router:external": true, "shared": false, "provider:network_type": "flat",
+        "id": "c66145df-4d9d-4898-9e35-12a102b66346", "provider:segmentation_id":
+        null}, {"status": "ACTIVE", "subnets": ["9801267c-cd57-437a-a852-b46640cb4332",
+        "978d38ec-4845-45ce-b3e3-89e7c9d9109b"], "name": "EmsRefreshSpec-IsolatedNetworkPrivate_2",
+        "provider:physical_network": null, "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
+        "vxlan", "id": "483c08c7-96b0-4e08-9db7-96d5650974ac", "provider:segmentation_id":
+        36}, {"status": "ACTIVE", "subnets": ["76d851f4-9cd9-49ca-93ac-bcc7b3c8153a"],
+        "name": "EmsRefreshSpec-NetworkPublic_20", "provider:physical_network": "public_net_2",
+        "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
+        0, "router:external": true, "shared": false, "provider:network_type": "flat",
+        "id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "provider:segmentation_id":
+        null}, {"status": "ACTIVE", "subnets": ["e96c89d2-810a-4cdb-a19b-93072db5dd20"],
+        "name": "EmsRefreshSpec-NetworkPrivate_3", "provider:physical_network": null,
+        "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
+        0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
+        "id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571", "provider:segmentation_id":
+        99}, {"status": "ACTIVE", "subnets": ["e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d"],
+        "name": "EmsRefreshSpec-NetworkPrivate_20", "provider:physical_network": null,
+        "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
+        0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
+        "id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "provider:segmentation_id":
+        31}, {"status": "ACTIVE", "subnets": ["53450d1a-8ecc-43aa-a641-95db25b6be2e"],
+        "name": "EmsRefreshSpec-NetworkPublic_40", "provider:physical_network": "public_net_4",
+        "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
+        0, "router:external": true, "shared": false, "provider:network_type": "flat",
+        "id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "provider:segmentation_id":
+        null}, {"status": "ACTIVE", "subnets": ["c2ab9441-dd1c-4acc-a3a6-753f1a582291",
+        "3be7c490-3820-43ad-8bc4-00d0367b8d21"], "name": "EmsRefreshSpec-NetworkPrivate_30",
+        "provider:physical_network": null, "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
+        "vxlan", "id": "91eed80f-14a3-41a1-8acb-558dd451ecec", "provider:segmentation_id":
+        59}, {"status": "ACTIVE", "subnets": ["75e7a9c8-eeaf-4cd0-80da-05165f897e69"],
+        "name": "EmsRefreshSpec-NetworkPublic_10", "provider:physical_network": "public_net_1",
+        "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
+        0, "router:external": true, "shared": false, "provider:network_type": "flat",
+        "id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "provider:segmentation_id":
         null}, {"status": "ACTIVE", "subnets": ["f4c17602-9618-4604-b3c9-9e4801d094d3",
         "24c83610-eab6-4f68-99dd-ab22a638b4a0"], "name": "EmsRefreshSpec-NetworkPrivate",
         "provider:physical_network": null, "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91",
@@ -11393,7 +11393,7 @@ http_interactions:
         "vxlan", "id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "provider:segmentation_id":
         11}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:35 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:10 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -11411,15 +11411,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:23:35 GMT
+      - Thu, 01 Nov 2018 18:32:10 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 8e16167250ec47f2b108cd70bc9cc787
+      - 76818b51dec5460bb2314acf4049a6a0
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-44f41342-1f5a-47e6-894f-b20515bc5b3b
+      - req-6ee80a1b-70e2-4393-8ef2-c19a5c021fa9
       Content-Length:
       - '7311'
       Connection:
@@ -11431,7 +11431,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-10-25T19:23:35.391533Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-11-01T19:32:10.482237Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -11510,10 +11510,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["XVcT-gBNS8O8tMt0lA882Q"],
-        "issued_at": "2018-10-25T18:23:35.391554Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["QMDW0RO3R5S4-zPRoE-RxQ"],
+        "issued_at": "2018-11-01T18:32:10.482260Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:35 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:10 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -11531,15 +11531,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:23:35 GMT
+      - Thu, 01 Nov 2018 18:32:10 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 7194695b7af6423aaea002585dd94416
+      - 852c780f9f304799a8dd1ff30b4e8076
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-1fefbdd4-5ba1-4c2b-bf5b-e90018f4e028
+      - req-ec2d2009-e320-4cca-9bd1-e9d4db1b4cb6
       Content-Length:
       - '297'
       Connection:
@@ -11548,12 +11548,12 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"token": {"methods": ["password"], "expires_at": "2018-10-25T19:23:35.558630Z",
+      string: '{"token": {"methods": ["password"], "expires_at": "2018-11-01T19:32:10.656935Z",
         "extras": {}, "user": {"domain": {"id": "default", "name": "Default"}, "id":
-        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["NluokNZ3SsWsUjraHNumVQ"],
-        "issued_at": "2018-10-25T18:23:35.558649Z"}}'
+        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Cj09DUC2SQy3dd44yoWgCw"],
+        "issued_at": "2018-11-01T18:32:10.656953Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:35 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:10 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects?domain_id=default
@@ -11568,20 +11568,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7194695b7af6423aaea002585dd94416
+      - 852c780f9f304799a8dd1ff30b4e8076
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:23:35 GMT
+      - Thu, 01 Nov 2018 18:32:10 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-920e200e-c906-46b7-97c4-fa45eea6c506
+      - req-5fbf21d6-7064-4b7f-b1fb-a291f1e31141
       Content-Length:
       - '2475'
       Connection:
@@ -11614,7 +11614,7 @@ http_interactions:
         "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
         "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:35 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:10 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -11632,15 +11632,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:23:35 GMT
+      - Thu, 01 Nov 2018 18:32:10 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 878b79a3862e48baa94b6172632086f1
+      - 234729ff811c499a882729bf0de75223
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-a2b0a0a8-a26c-4f2d-bd23-de6b63cd94e9
+      - req-8bc38e39-1ee8-45c2-a6b7-f9a184700225
       Content-Length:
       - '7278'
       Connection:
@@ -11652,7 +11652,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:23:35.898621Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:32:10.997425Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -11731,10 +11731,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["N1TZciWISdOVP47fEPNJUA"],
-        "issued_at": "2018-10-25T18:23:35.898643Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["qpXpzYgRSKGhKHeuIClWAA"],
+        "issued_at": "2018-11-01T18:32:10.997445Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:35 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:11 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -11752,15 +11752,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:23:36 GMT
+      - Thu, 01 Nov 2018 18:32:11 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 7e6af8e7383b4dfab4c46156d8621990
+      - 331e59716f1745ae885ea8031ed22378
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-c94fbdc7-934e-4cf2-981a-ec1448a37091
+      - req-fdcd5165-e367-40dd-b642-23b348d1e00d
       Content-Length:
       - '7278'
       Connection:
@@ -11772,7 +11772,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:23:36.094239Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:32:11.208802Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -11851,10 +11851,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["vY3VMbu3Tz2Q0pSBhK0xFw"],
-        "issued_at": "2018-10-25T18:23:36.094260Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["z4FdbzcNRsWLhvJjC14chg"],
+        "issued_at": "2018-11-01T18:32:11.208824Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:36 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:11 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -11872,15 +11872,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:23:36 GMT
+      - Thu, 01 Nov 2018 18:32:11 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 6cca12e1cfc54261a53c64dfb342b99b
+      - d8bc7ffa703443e2bc7a78763f0951ae
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-c076a32e-a834-495b-89d0-f4ab506d3002
+      - req-2413d6b7-2f43-49a3-84a9-f69d0c66e557
       Content-Length:
       - '7264'
       Connection:
@@ -11892,7 +11892,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:23:36.293567Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:32:11.414190Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -11971,10 +11971,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["jOiYGwrJRtGYzzpk4HWtqg"],
-        "issued_at": "2018-10-25T18:23:36.293585Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["K0rQQmauSaeJXUo1apbyJw"],
+        "issued_at": "2018-11-01T18:32:11.414210Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:36 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:11 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -11992,15 +11992,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:23:36 GMT
+      - Thu, 01 Nov 2018 18:32:11 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 95645d8247de4f099bb7b908e5348b70
+      - f806c1bfe9ad482b9b3e04a0f12b7c0b
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-d7f2075d-2515-4639-b7c6-7c65aeaabba3
+      - req-771f8680-7f3c-4088-a52a-52dbaa32fb0f
       Content-Length:
       - '7278'
       Connection:
@@ -12012,7 +12012,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:23:36.492584Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:32:11.623451Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -12091,10 +12091,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["9NkcUo1NRfSaBaotjW84LA"],
-        "issued_at": "2018-10-25T18:23:36.492603Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["eCvNKFbOR7GkRaZA8mt_dA"],
+        "issued_at": "2018-11-01T18:32:11.623473Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:36 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:11 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -12112,15 +12112,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:23:36 GMT
+      - Thu, 01 Nov 2018 18:32:11 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - cd9da9be9c944719a803c695a8e5c02c
+      - e76970875a4743bf83b9e924d0132948
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-f0ac65b1-925f-44e9-83ed-0af401e68bfc
+      - req-0114cf67-3415-43d4-8a82-4b00acf3cb49
       Content-Length:
       - '7265'
       Connection:
@@ -12132,7 +12132,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:23:36.694022Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:32:11.845353Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -12211,10 +12211,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["UG73LZVqTqe0RRvr9IDQbw"],
-        "issued_at": "2018-10-25T18:23:36.694043Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["nNoyFWtYRrG4lRyoftLllQ"],
+        "issued_at": "2018-11-01T18:32:11.845373Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:36 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:11 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -12232,15 +12232,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:23:36 GMT
+      - Thu, 01 Nov 2018 18:32:11 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - ef5c8e7541da431cbb4c0d470b5a516e
+      - c559e13c8e3a48a3957905fb01dab8e0
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-17f1d26f-1c99-4acd-aec4-a1589e783454
+      - req-c1ecf5d4-3391-428c-b341-fcc18e39df52
       Content-Length:
       - '7278'
       Connection:
@@ -12252,7 +12252,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:23:36.893740Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:32:12.051560Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -12331,10 +12331,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["FfzdmXoPQYmrYvYu6gMcnQ"],
-        "issued_at": "2018-10-25T18:23:36.893773Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["IhFNxQdlQRm-4nBNwqFK1g"],
+        "issued_at": "2018-11-01T18:32:12.051581Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:36 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:12 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -12352,15 +12352,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:23:37 GMT
+      - Thu, 01 Nov 2018 18:32:12 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - f58da1f4da954aa2af5b0cd84d7f21ab
+      - 81aa1fe25bba4a56a8069cf561cb2ea7
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-4c67453b-0a87-4083-81d4-6ca8acd7e3eb
+      - req-b1b6c134-f17d-4d50-9cda-71e886767c18
       Content-Length:
       - '7278'
       Connection:
@@ -12372,7 +12372,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:23:37.100170Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:32:12.262184Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -12451,10 +12451,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["ZGEnfti0Q2uZuTPRlZlZOQ"],
-        "issued_at": "2018-10-25T18:23:37.100192Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["vbDud-4iSQivIabLy0dK5Q"],
+        "issued_at": "2018-11-01T18:32:12.262204Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:37 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:12 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/0098405163cd4c9dbb42c2cb43eb6fd3/stacks?limit=1000&show_nested=true
@@ -12469,7 +12469,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f58da1f4da954aa2af5b0cd84d7f21ab
+      - 81aa1fe25bba4a56a8069cf561cb2ea7
   response:
     status:
       code: 200
@@ -12480,14 +12480,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-d58fd1af-6b1c-40d1-9755-55017ff2ef6a
+      - req-463e1992-001a-4131-8170-2e98f88fb2de
       Date:
-      - Thu, 25 Oct 2018 18:23:37 GMT
+      - Thu, 01 Nov 2018 18:32:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:37 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:12 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -12505,15 +12505,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:23:37 GMT
+      - Thu, 01 Nov 2018 18:32:12 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 57e81df591f7407389aa03b21ed51da1
+      - ac5887455c32482ead65fe94197fa0b0
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-db00f0f5-1a1d-4912-8bba-1e2f9cb15091
+      - req-70f5b59c-961a-4394-9898-b53f00df6725
       Content-Length:
       - '7278'
       Connection:
@@ -12525,7 +12525,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:23:37.424152Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:32:12.605728Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -12604,10 +12604,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["w3jyCsOfTsqTgmExo0cHrQ"],
-        "issued_at": "2018-10-25T18:23:37.424173Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["1WnoC_ijRdGSZFBQYafbvQ"],
+        "issued_at": "2018-11-01T18:32:12.605749Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:37 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:12 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/28db8f69ba9e4305b7fad82da4c86e74/stacks?limit=1000&show_nested=true
@@ -12622,7 +12622,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 57e81df591f7407389aa03b21ed51da1
+      - ac5887455c32482ead65fe94197fa0b0
   response:
     status:
       code: 200
@@ -12633,14 +12633,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-5a510e37-30dd-47cf-9e4f-46758d84d786
+      - req-0737b75e-b0ed-41dc-b076-8ab10f7d2b46
       Date:
-      - Thu, 25 Oct 2018 18:23:37 GMT
+      - Thu, 01 Nov 2018 18:32:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:37 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:12 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -12658,15 +12658,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:23:37 GMT
+      - Thu, 01 Nov 2018 18:32:12 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - d31c9ee5542d4b02801b15d4137e1b8b
+      - aca4d18482e64eafafb275ee61900b2d
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-7624af31-4beb-44e0-8510-b94e4782fe61
+      - req-bc1de861-7598-4df0-95f9-b747b15312db
       Content-Length:
       - '7264'
       Connection:
@@ -12678,7 +12678,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:23:37.748666Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:32:12.975855Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -12757,10 +12757,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["FsH2IhsXQmmybBRGzpCxww"],
-        "issued_at": "2018-10-25T18:23:37.748687Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["U45_3MSzRVmo0IpPjZbKTw"],
+        "issued_at": "2018-11-01T18:32:12.975876Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:37 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:13 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks?limit=1000&show_nested=true
@@ -12775,7 +12775,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d31c9ee5542d4b02801b15d4137e1b8b
+      - aca4d18482e64eafafb275ee61900b2d
   response:
     status:
       code: 200
@@ -12786,9 +12786,9 @@ http_interactions:
       Content-Length:
       - '2559'
       X-Openstack-Request-Id:
-      - req-940df5df-6996-4503-95ea-defb12448bd3
+      - req-ae07ca50-c023-4d98-a6f5-8b987d662024
       Date:
-      - Thu, 25 Oct 2018 18:23:37 GMT
+      - Thu, 01 Nov 2018 18:32:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": [{"description": "Heat WordPress template to support F20,
@@ -12822,7 +12822,7 @@ http_interactions:
         "rel": "self"}], "updated_time": null, "stack_owner": null, "stack_status":
         "CREATE_COMPLETE", "id": "7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:37 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:13 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks?limit=1000&marker=7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0&show_nested=true
@@ -12837,7 +12837,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d31c9ee5542d4b02801b15d4137e1b8b
+      - aca4d18482e64eafafb275ee61900b2d
   response:
     status:
       code: 200
@@ -12848,14 +12848,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-0972e4ac-7d18-4566-8add-b2be13442e4e
+      - req-03cfaee5-ad72-4034-9707-7e4f0de9c059
       Date:
-      - Thu, 25 Oct 2018 18:23:38 GMT
+      - Thu, 01 Nov 2018 18:32:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:38 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:13 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -12873,15 +12873,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:23:38 GMT
+      - Thu, 01 Nov 2018 18:32:13 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 65f9ac6e647d4ba3aa14c0ffadf748a6
+      - ddec2fcc9b8842f2963f4f25b0824259
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-95ed8bf0-9bd8-4f94-b880-582556beae6d
+      - req-dddf02d0-ef54-430e-a57f-bcad8d68e302
       Content-Length:
       - '7278'
       Connection:
@@ -12893,7 +12893,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:23:38.202619Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:32:13.458986Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -12972,10 +12972,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["35RQG6F3T2mTSKGiNgL6uw"],
-        "issued_at": "2018-10-25T18:23:38.202640Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["uMzVNHqQSlS9eYRGK2mrpg"],
+        "issued_at": "2018-11-01T18:32:13.459008Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:38 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:13 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/52c452d7763a4295950527948232a3e5/stacks?limit=1000&show_nested=true
@@ -12990,7 +12990,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 65f9ac6e647d4ba3aa14c0ffadf748a6
+      - ddec2fcc9b8842f2963f4f25b0824259
   response:
     status:
       code: 200
@@ -13001,14 +13001,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-7b86a8d7-2ff3-412b-835b-5509f3d5407d
+      - req-888f21bd-a0cc-4fae-8c95-9806bd2bd4e1
       Date:
-      - Thu, 25 Oct 2018 18:23:38 GMT
+      - Thu, 01 Nov 2018 18:32:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:38 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:13 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/88ae57d444fd485ab2dfddd5a2615d52/stacks?limit=1000&show_nested=true
@@ -13023,7 +13023,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8e16167250ec47f2b108cd70bc9cc787
+      - 76818b51dec5460bb2314acf4049a6a0
   response:
     status:
       code: 200
@@ -13034,14 +13034,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-521618aa-bffb-4993-8508-66ff4dd9cd47
+      - req-aec56c3d-c02a-4f01-9f0e-1ca51ba5f14b
       Date:
-      - Thu, 25 Oct 2018 18:23:38 GMT
+      - Thu, 01 Nov 2018 18:32:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:38 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:13 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -13059,15 +13059,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:23:38 GMT
+      - Thu, 01 Nov 2018 18:32:13 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 190692da52be495a94895799d7fa5a49
+      - 63ccf71affe943d3b9ec623d4f57a0f4
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-9b74cdf9-0c60-4a5f-a085-762ec969a4a9
+      - req-4e31ccd5-75ec-4e72-b597-36b1e509fb6f
       Content-Length:
       - '7265'
       Connection:
@@ -13079,7 +13079,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:23:38.646223Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:32:13.930214Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -13158,10 +13158,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["_MQMWeM5QHe0J3AUudVUPg"],
-        "issued_at": "2018-10-25T18:23:38.646244Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["rFYVqEieTjCmDkjmtpR4Uw"],
+        "issued_at": "2018-11-01T18:32:13.930236Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:38 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:13 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/d09cbe26295d47ff848ea73c74264e23/stacks?limit=1000&show_nested=true
@@ -13176,7 +13176,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 190692da52be495a94895799d7fa5a49
+      - 63ccf71affe943d3b9ec623d4f57a0f4
   response:
     status:
       code: 200
@@ -13187,14 +13187,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-87de3328-9d9e-4bb2-9ce4-7023ed10d806
+      - req-69b71650-1cca-47fb-b37b-0865bc64252b
       Date:
-      - Thu, 25 Oct 2018 18:23:38 GMT
+      - Thu, 01 Nov 2018 18:32:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:38 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:14 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -13212,15 +13212,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:23:38 GMT
+      - Thu, 01 Nov 2018 18:32:14 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 77f9f0a7fd4e4a17b137b85509c433f0
+      - c8fe84820a6946d1b971c06a6800d324
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-5bf7f788-d2bb-4ce8-b2a3-4b8619371d24
+      - req-63ed4301-e5c0-46e2-aa63-06266f5e5518
       Content-Length:
       - '7278'
       Connection:
@@ -13232,7 +13232,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:23:38.981439Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:32:14.272133Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -13311,10 +13311,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["_e9KvGYCRZyn3DuRYmjwQQ"],
-        "issued_at": "2018-10-25T18:23:38.981462Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["_hgH0YjPRhGF83HkDiGT7w"],
+        "issued_at": "2018-11-01T18:32:14.272153Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:39 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:14 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/ef2a3405d1ef4dfd9a3616993ef46a4d/stacks?limit=1000&show_nested=true
@@ -13329,7 +13329,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 77f9f0a7fd4e4a17b137b85509c433f0
+      - c8fe84820a6946d1b971c06a6800d324
   response:
     status:
       code: 200
@@ -13340,14 +13340,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-7edf233d-050a-4dbc-9627-ccbb6d929c75
+      - req-cbab0e45-946b-4438-a3de-71181446fdc4
       Date:
-      - Thu, 25 Oct 2018 18:23:39 GMT
+      - Thu, 01 Nov 2018 18:32:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:39 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:14 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack3/00c5dc04-2c94-48d2-8031-db08934e9a44
@@ -13362,7 +13362,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d31c9ee5542d4b02801b15d4137e1b8b
+      - aca4d18482e64eafafb275ee61900b2d
   response:
     status:
       code: 200
@@ -13373,9 +13373,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-846b2135-de54-491d-a0ab-d637b6d83cbd
+      - req-ede6851f-fe44-4d25-8fea-8d204372c299
       Date:
-      - Thu, 25 Oct 2018 18:23:39 GMT
+      - Thu, 01 Nov 2018 18:32:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -13402,7 +13402,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:39 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:14 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack2/d6eba2a2-7b0d-4213-afbb-69c8f6dddd8d
@@ -13417,7 +13417,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d31c9ee5542d4b02801b15d4137e1b8b
+      - aca4d18482e64eafafb275ee61900b2d
   response:
     status:
       code: 200
@@ -13428,9 +13428,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-ff18fa29-1564-4fa5-830a-8c537659d3f2
+      - req-b272d14f-02d1-47a5-a3d7-6b68a6788ead
       Date:
-      - Thu, 25 Oct 2018 18:23:39 GMT
+      - Thu, 01 Nov 2018 18:32:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -13457,7 +13457,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:39 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:15 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack1/7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0
@@ -13472,7 +13472,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d31c9ee5542d4b02801b15d4137e1b8b
+      - aca4d18482e64eafafb275ee61900b2d
   response:
     status:
       code: 200
@@ -13483,9 +13483,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-2bfc3b8a-48ea-487f-8f9b-e58f3249a627
+      - req-a915b6eb-4407-4f62-b349-3a7d935e402b
       Date:
-      - Thu, 25 Oct 2018 18:23:40 GMT
+      - Thu, 01 Nov 2018 18:32:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -13512,7 +13512,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:40 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:15 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack3/00c5dc04-2c94-48d2-8031-db08934e9a44/resources
@@ -13527,7 +13527,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d31c9ee5542d4b02801b15d4137e1b8b
+      - aca4d18482e64eafafb275ee61900b2d
   response:
     status:
       code: 200
@@ -13538,9 +13538,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-80130b8d-2968-4ddc-bc30-949b71982e0a
+      - req-62dc365c-ff31-47df-a863-48135a19b220
       Date:
-      - Thu, 25 Oct 2018 18:23:40 GMT
+      - Thu, 01 Nov 2018 18:32:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -13552,7 +13552,7 @@ http_interactions:
         changed", "physical_resource_id": "40989f26-9c38-4f72-b739-afccb44397cf",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:40 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:15 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack2/d6eba2a2-7b0d-4213-afbb-69c8f6dddd8d/resources
@@ -13567,7 +13567,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d31c9ee5542d4b02801b15d4137e1b8b
+      - aca4d18482e64eafafb275ee61900b2d
   response:
     status:
       code: 200
@@ -13578,9 +13578,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-4f27770a-d28b-442f-958b-900efaf34e96
+      - req-a04e3edc-163f-4327-acff-88210f151e33
       Date:
-      - Thu, 25 Oct 2018 18:23:40 GMT
+      - Thu, 01 Nov 2018 18:32:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -13592,7 +13592,7 @@ http_interactions:
         changed", "physical_resource_id": "ad4f7eb0-9122-41a6-a0f7-55c1d4ca5e02",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:40 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:15 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack1/7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0/resources
@@ -13607,7 +13607,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d31c9ee5542d4b02801b15d4137e1b8b
+      - aca4d18482e64eafafb275ee61900b2d
   response:
     status:
       code: 200
@@ -13618,9 +13618,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-19d5924d-5b83-42a8-b0b0-1cae50dd559a
+      - req-1d972d9c-6b04-4cc3-be23-96cc9bbc5365
       Date:
-      - Thu, 25 Oct 2018 18:23:40 GMT
+      - Thu, 01 Nov 2018 18:32:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -13632,7 +13632,7 @@ http_interactions:
         changed", "physical_resource_id": "8022b967-813a-4e3b-8ff4-7c036957a8a0",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:40 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:15 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -13650,15 +13650,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:23:40 GMT
+      - Thu, 01 Nov 2018 18:32:15 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 6e695167a49543658712ae5942bf5d3b
+      - 06f689fe899a47fc8eb53b9d2cf52ac7
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-3cf93e11-4b5d-42fd-b834-16ae33f30288
+      - req-1585aa88-6174-4cc6-9fe5-3c62c8846654
       Content-Length:
       - '7278'
       Connection:
@@ -13670,7 +13670,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:23:40.588062Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:32:15.900989Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -13749,10 +13749,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["2gdwBpTZRv6NHWWgKjeziw"],
-        "issued_at": "2018-10-25T18:23:40.588085Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["gsFbmOVjTXG61HRJXxDlvQ"],
+        "issued_at": "2018-11-01T18:32:15.901010Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:40 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:15 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000
@@ -13767,7 +13767,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6e695167a49543658712ae5942bf5d3b
+      - 06f689fe899a47fc8eb53b9d2cf52ac7
   response:
     status:
       code: 200
@@ -13778,29 +13778,12 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-b5a444f4-19a0-4617-b7e6-1428f0bfc2c6
+      - req-ef6a3747-cd4a-4eef-888f-06af047d90ea
       Date:
-      - Thu, 25 Oct 2018 18:23:40 GMT
+      - Thu, 01 Nov 2018 18:32:16 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp":
-        true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
-        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
-        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
         "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
@@ -13871,23 +13854,40 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
         "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "f4c17602-9618-4604-b3c9-9e4801d094d3",
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
+        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
         true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        null, "allocation_pools": [{"start": "192.168.0.8", "end": "192.168.0.8"},
+        {"start": "192.168.0.3", "end": "192.168.0.5"}], "host_routes": [], "ip_version":
         4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
-        "subnetpool_id": null}]}'
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:40 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:16 GMT
 - request:
     method: get
-    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=24c83610-eab6-4f68-99dd-ab22a638b4a0
+    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=f4c17602-9618-4604-b3c9-9e4801d094d3
     body:
       encoding: US-ASCII
       string: ''
@@ -13899,7 +13899,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6e695167a49543658712ae5942bf5d3b
+      - 06f689fe899a47fc8eb53b9d2cf52ac7
   response:
     status:
       code: 200
@@ -13910,74 +13910,28 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-163d1e18-0d10-4515-9d14-34bd0afff97a
+      - req-16fd8a3f-8799-4fc1-80a4-b07c95ec4e66
       Date:
-      - Thu, 25 Oct 2018 18:23:40 GMT
+      - Thu, 01 Nov 2018 18:32:16 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
-        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "9801267c-cd57-437a-a852-b46640cb4332",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
-        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.20.0/24", "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21",
-        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.51.2",
-        "end": "192.168.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.51.0/24", "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
-        true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
-        "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
         "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
         "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
         [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
         "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp": false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49",
+        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e",
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.18.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2",
-        "end": "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
+        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
         false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
@@ -13991,6 +13945,12 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
         [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
         "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.8",
+        "end": "192.168.3.10"}, {"start": "192.168.3.2", "end": "192.168.3.6"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
         "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
@@ -14002,20 +13962,61 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
         "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
+        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
+        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.8", "end": "192.168.0.8"},
+        {"start": "192.168.0.3", "end": "192.168.0.5"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
         null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}]}'
+        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:40 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:16 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -14033,15 +14034,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:23:41 GMT
+      - Thu, 01 Nov 2018 18:32:16 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 2bb685c4c23f4431b4a48d9148bc83d8
+      - 1ec5fca68ec44827953ebeed4666c9ef
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-8bb9eda9-7eee-48eb-a49b-83d6597ef73c
+      - req-f2f0fcb0-7650-4cec-bbd7-39925b253415
       Content-Length:
       - '7278'
       Connection:
@@ -14053,7 +14054,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:23:41.126334Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:32:16.479161Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -14132,10 +14133,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["jA7ok5EnSb-wxmdE-Hs56Q"],
-        "issued_at": "2018-10-25T18:23:41.126355Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["VDHvpcKkTduUzMF3ebCogQ"],
+        "issued_at": "2018-11-01T18:32:16.479186Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:41 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:16 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000
@@ -14150,7 +14151,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2bb685c4c23f4431b4a48d9148bc83d8
+      - 1ec5fca68ec44827953ebeed4666c9ef
   response:
     status:
       code: 200
@@ -14161,9 +14162,141 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-92e686d7-8dd2-4a01-b136-7d5205ee6e6b
+      - req-a7aef3f2-3245-4108-b2ce-847058fa84f3
       Date:
-      - Thu, 25 Oct 2018 18:23:41 GMT
+      - Thu, 01 Nov 2018 18:32:16 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
+        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.8",
+        "end": "192.168.3.10"}, {"start": "192.168.3.2", "end": "192.168.3.6"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
+        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
+        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.8", "end": "192.168.0.8"},
+        {"start": "192.168.0.3", "end": "192.168.0.5"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 01 Nov 2018 18:32:16 GMT
+- request:
+    method: get
+    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=f4c17602-9618-4604-b3c9-9e4801d094d3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 1ec5fca68ec44827953ebeed4666c9ef
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-89d4dcc3-a29a-4ca3-b307-2aec16a4fe96
+      Date:
+      - Thu, 01 Nov 2018 18:32:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
@@ -14267,7 +14400,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:41 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:16 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=24c83610-eab6-4f68-99dd-ab22a638b4a0
@@ -14282,7 +14415,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2bb685c4c23f4431b4a48d9148bc83d8
+      - 1ec5fca68ec44827953ebeed4666c9ef
   response:
     status:
       code: 200
@@ -14293,29 +14426,12 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-63f559aa-5754-4a87-9415-14396f7137e6
+      - req-34321664-6354-499d-93c7-495a240f10cf
       Date:
-      - Thu, 25 Oct 2018 18:23:41 GMT
+      - Thu, 01 Nov 2018 18:32:16 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp":
-        true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
-        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
-        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
         "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
@@ -14386,20 +14502,169 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
         "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "f4c17602-9618-4604-b3c9-9e4801d094d3",
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
+        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
         true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        null, "allocation_pools": [{"start": "192.168.0.8", "end": "192.168.0.8"},
+        {"start": "192.168.0.3", "end": "192.168.0.5"}], "host_routes": [], "ip_version":
         4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
-        "subnetpool_id": null}]}'
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:41 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:17 GMT
+- request:
+    method: get
+    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=f4c17602-9618-4604-b3c9-9e4801d094d3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 1ec5fca68ec44827953ebeed4666c9ef
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-6bdfa53b-941f-41bf-b985-0b43e835d494
+      Date:
+      - Thu, 01 Nov 2018 18:32:17 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
+        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.8",
+        "end": "192.168.3.10"}, {"start": "192.168.3.2", "end": "192.168.3.6"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
+        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
+        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.8", "end": "192.168.0.8"},
+        {"start": "192.168.0.3", "end": "192.168.0.5"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 01 Nov 2018 18:32:17 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -14417,15 +14682,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:23:41 GMT
+      - Thu, 01 Nov 2018 18:32:17 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 33810e4d05be4b359550aa74f52aea0f
+      - 26912eb40f1b466cbc86e846a195e182
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-c5402aba-d973-459e-a5ca-51ee094946a5
+      - req-5a55a53c-8002-46b2-9720-6ce9e3e6540e
       Content-Length:
       - '7264'
       Connection:
@@ -14437,7 +14702,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:23:41.659751Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:32:17.347388Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -14516,10 +14781,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["4cEQ0h-WRZeqvLZnG6wsPA"],
-        "issued_at": "2018-10-25T18:23:41.659783Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["q4SSSwzZTJSjeC3YOpkChw"],
+        "issued_at": "2018-11-01T18:32:17.347407Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:41 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:17 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000
@@ -14534,7 +14799,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 33810e4d05be4b359550aa74f52aea0f
+      - 26912eb40f1b466cbc86e846a195e182
   response:
     status:
       code: 200
@@ -14545,29 +14810,12 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-d3df6035-7246-48e1-b82e-54e53a38704a
+      - req-889f1335-1612-4bf8-aef7-443dd0b0b0a9
       Date:
-      - Thu, 25 Oct 2018 18:23:41 GMT
+      - Thu, 01 Nov 2018 18:32:17 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp":
-        true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
-        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
-        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
         "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
@@ -14638,23 +14886,40 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
         "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "f4c17602-9618-4604-b3c9-9e4801d094d3",
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
+        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
         true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        null, "allocation_pools": [{"start": "192.168.0.8", "end": "192.168.0.8"},
+        {"start": "192.168.0.3", "end": "192.168.0.5"}], "host_routes": [], "ip_version":
         4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
-        "subnetpool_id": null}]}'
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:41 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:17 GMT
 - request:
     method: get
-    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=24c83610-eab6-4f68-99dd-ab22a638b4a0
+    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=f4c17602-9618-4604-b3c9-9e4801d094d3
     body:
       encoding: US-ASCII
       string: ''
@@ -14666,7 +14931,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 33810e4d05be4b359550aa74f52aea0f
+      - 26912eb40f1b466cbc86e846a195e182
   response:
     status:
       code: 200
@@ -14677,63 +14942,64 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-fce97bf5-9938-4b91-a277-b8030b1092ab
+      - req-6199198a-84d6-4d5a-9148-0fa5dfe82953
       Date:
-      - Thu, 25 Oct 2018 18:23:41 GMT
+      - Thu, 01 Nov 2018 18:32:17 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
-        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "9801267c-cd57-437a-a852-b46640cb4332",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.2", "end": "192.168.3.6"}, {"start":
+        "192.168.3.8", "end": "192.168.3.10"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
+        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
         "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
         "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0",
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
-        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.20.0/24", "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21",
-        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.51.2",
-        "end": "192.168.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.51.0/24", "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
-        true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
-        "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
+        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
         "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
@@ -14741,10 +15007,16 @@ http_interactions:
         "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
         [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
         "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp": false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49",
+        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e",
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.18.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2",
-        "end": "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
+        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
         false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
@@ -14763,12 +15035,6 @@ http_interactions:
         "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
         "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
@@ -14782,7 +15048,271 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:42 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:17 GMT
+- request:
+    method: get
+    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=24c83610-eab6-4f68-99dd-ab22a638b4a0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 26912eb40f1b466cbc86e846a195e182
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-deba6b6e-c47b-4003-b844-7b1b720f55e3
+      Date:
+      - Thu, 01 Nov 2018 18:32:17 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
+        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.8",
+        "end": "192.168.3.10"}, {"start": "192.168.3.2", "end": "192.168.3.6"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
+        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
+        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.8", "end": "192.168.0.8"},
+        {"start": "192.168.0.3", "end": "192.168.0.5"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 01 Nov 2018 18:32:17 GMT
+- request:
+    method: get
+    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=f4c17602-9618-4604-b3c9-9e4801d094d3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 26912eb40f1b466cbc86e846a195e182
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-1173b3ca-dfa7-4c2b-b22b-c13301cb66fd
+      Date:
+      - Thu, 01 Nov 2018 18:32:17 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
+        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.8",
+        "end": "192.168.3.10"}, {"start": "192.168.3.2", "end": "192.168.3.6"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
+        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
+        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.8", "end": "192.168.0.8"},
+        {"start": "192.168.0.3", "end": "192.168.0.5"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 01 Nov 2018 18:32:18 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -14800,15 +15330,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:23:42 GMT
+      - Thu, 01 Nov 2018 18:32:18 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 488ad1530437494fb329fd84ad52067e
+      - af27476c4b9b4566a8db7c8e9510acad
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-9ab00f5b-162a-49e0-83d0-ebebdad6698b
+      - req-d5a442b7-08ad-4356-8a21-9793f6695edb
       Content-Length:
       - '7278'
       Connection:
@@ -14820,7 +15350,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:23:42.204583Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:32:18.202424Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -14899,10 +15429,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["OEq8qSlWSPqA4qq66008vQ"],
-        "issued_at": "2018-10-25T18:23:42.204605Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["fP_mYoPZQaCnEoBrnZo__w"],
+        "issued_at": "2018-11-01T18:32:18.202450Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:42 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:18 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000
@@ -14917,7 +15447,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 488ad1530437494fb329fd84ad52067e
+      - af27476c4b9b4566a8db7c8e9510acad
   response:
     status:
       code: 200
@@ -14928,74 +15458,28 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-807d1a39-5594-4258-8031-84a2f45b0f33
+      - req-a79d8203-f572-4a26-9529-cc60798c76e9
       Date:
-      - Thu, 25 Oct 2018 18:23:42 GMT
+      - Thu, 01 Nov 2018 18:32:18 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
-        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "9801267c-cd57-437a-a852-b46640cb4332",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
-        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.20.0/24", "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21",
-        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.51.2",
-        "end": "192.168.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.51.0/24", "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
-        true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
-        "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
         "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
         "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
         [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
         "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp": false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49",
+        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e",
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.18.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2",
-        "end": "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
+        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
         false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
@@ -15009,6 +15493,12 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
         [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
         "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.8",
+        "end": "192.168.3.10"}, {"start": "192.168.3.2", "end": "192.168.3.6"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
         "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
@@ -15020,23 +15510,64 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
         "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
+        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
+        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.8", "end": "192.168.0.8"},
+        {"start": "192.168.0.3", "end": "192.168.0.5"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
         null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}]}'
+        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:42 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:18 GMT
 - request:
     method: get
-    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=24c83610-eab6-4f68-99dd-ab22a638b4a0
+    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=f4c17602-9618-4604-b3c9-9e4801d094d3
     body:
       encoding: US-ASCII
       string: ''
@@ -15048,7 +15579,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 488ad1530437494fb329fd84ad52067e
+      - af27476c4b9b4566a8db7c8e9510acad
   response:
     status:
       code: 200
@@ -15059,9 +15590,9 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-a4ba6847-862d-4193-9bb8-90aba2c0b68a
+      - req-2f9f986d-86c6-42d7-9378-291e5d7558e0
       Date:
-      - Thu, 25 Oct 2018 18:23:42 GMT
+      - Thu, 01 Nov 2018 18:32:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
@@ -15165,138 +15696,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:42 GMT
-- request:
-    method: get
-    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - e5c2c8c12d3741cf8758152a15318f97
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-87aeef68-336c-4141-8529-f3c29a4af0b3
-      Date:
-      - Thu, 25 Oct 2018 18:23:42 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
-        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "9801267c-cd57-437a-a852-b46640cb4332",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
-        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.20.0/24", "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21",
-        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.51.2",
-        "end": "192.168.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.51.0/24", "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
-        true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
-        "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp": false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.18.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2",
-        "end": "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:42 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:18 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=24c83610-eab6-4f68-99dd-ab22a638b4a0
@@ -15311,7 +15711,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e5c2c8c12d3741cf8758152a15318f97
+      - af27476c4b9b4566a8db7c8e9510acad
   response:
     status:
       code: 200
@@ -15322,23 +15722,430 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-d14b611f-acab-47ec-ac8c-f98fccd71794
+      - req-a45850d3-7975-470c-b353-f7ad64897486
       Date:
-      - Thu, 25 Oct 2018 18:23:42 GMT
+      - Thu, 01 Nov 2018 18:32:18 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
+        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.8",
+        "end": "192.168.3.10"}, {"start": "192.168.3.2", "end": "192.168.3.6"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
         false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
         "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
         "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.2", "end": "192.168.3.6"}, {"start":
-        "192.168.3.8", "end": "192.168.3.10"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
+        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
+        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.8", "end": "192.168.0.8"},
+        {"start": "192.168.0.3", "end": "192.168.0.5"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 01 Nov 2018 18:32:18 GMT
+- request:
+    method: get
+    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=f4c17602-9618-4604-b3c9-9e4801d094d3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - af27476c4b9b4566a8db7c8e9510acad
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-e16dccc4-99d6-494e-a795-8f5dd815def6
+      Date:
+      - Thu, 01 Nov 2018 18:32:18 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
+        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.8",
+        "end": "192.168.3.10"}, {"start": "192.168.3.2", "end": "192.168.3.6"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
+        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
+        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.8", "end": "192.168.0.8"},
+        {"start": "192.168.0.3", "end": "192.168.0.5"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 01 Nov 2018 18:32:18 GMT
+- request:
+    method: get
+    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - e4031829ca794b898e1211cfc89e4ea0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-82ff1ffa-2105-4c6a-a2dd-72b0f77bf142
+      Date:
+      - Thu, 01 Nov 2018 18:32:18 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
+        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.8",
+        "end": "192.168.3.10"}, {"start": "192.168.3.2", "end": "192.168.3.6"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
+        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
+        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.8", "end": "192.168.0.8"},
+        {"start": "192.168.0.3", "end": "192.168.0.5"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 01 Nov 2018 18:32:19 GMT
+- request:
+    method: get
+    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=f4c17602-9618-4604-b3c9-9e4801d094d3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - e4031829ca794b898e1211cfc89e4ea0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-79a76773-3e8c-402e-881f-cece9b076b72
+      Date:
+      - Thu, 01 Nov 2018 18:32:19 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.8",
+        "end": "192.168.3.10"}, {"start": "192.168.3.2", "end": "192.168.3.6"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
         "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
@@ -15404,17 +16211,6 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
         "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
@@ -15428,7 +16224,271 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:42 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:19 GMT
+- request:
+    method: get
+    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=24c83610-eab6-4f68-99dd-ab22a638b4a0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - e4031829ca794b898e1211cfc89e4ea0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-08b6993a-09a3-4b3c-9e71-bb498325f5a4
+      Date:
+      - Thu, 01 Nov 2018 18:32:19 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
+        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
+        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.8",
+        "end": "192.168.3.10"}, {"start": "192.168.3.2", "end": "192.168.3.6"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
+        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.8", "end": "192.168.0.8"},
+        {"start": "192.168.0.3", "end": "192.168.0.5"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 01 Nov 2018 18:32:19 GMT
+- request:
+    method: get
+    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=f4c17602-9618-4604-b3c9-9e4801d094d3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - e4031829ca794b898e1211cfc89e4ea0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-51f0cb8a-542c-4494-b416-e54656e0f249
+      Date:
+      - Thu, 01 Nov 2018 18:32:19 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
+        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.8",
+        "end": "192.168.3.10"}, {"start": "192.168.3.2", "end": "192.168.3.6"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
+        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
+        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.8", "end": "192.168.0.8"},
+        {"start": "192.168.0.3", "end": "192.168.0.5"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 01 Nov 2018 18:32:19 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -15446,15 +16506,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:23:42 GMT
+      - Thu, 01 Nov 2018 18:32:19 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 3e3a7e9b834e47a3b8db9c4414bf8cac
+      - 0ad930d725df4f8ea482767d2723409a
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-f5587fc3-c56a-4c0e-84f9-ff4f098783b3
+      - req-3bd6f93c-5f57-42b2-abff-2ec6aa6a69aa
       Content-Length:
       - '7265'
       Connection:
@@ -15466,7 +16526,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:23:43.060249Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:32:19.721761Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -15545,10 +16605,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["qpVl8eUEQUugc9xkijensA"],
-        "issued_at": "2018-10-25T18:23:43.060278Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["lvgYJ37lSCicykNNLOsOQg"],
+        "issued_at": "2018-11-01T18:32:19.721796Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:43 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:19 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000
@@ -15563,7 +16623,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3e3a7e9b834e47a3b8db9c4414bf8cac
+      - 0ad930d725df4f8ea482767d2723409a
   response:
     status:
       code: 200
@@ -15574,74 +16634,28 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-06570cc8-9698-4b92-ab15-71c29e5c7a1d
+      - req-0c2c065c-f173-498d-ae0d-909c8083d65e
       Date:
-      - Thu, 25 Oct 2018 18:23:43 GMT
+      - Thu, 01 Nov 2018 18:32:19 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
-        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "9801267c-cd57-437a-a852-b46640cb4332",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
-        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.20.0/24", "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21",
-        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.51.2",
-        "end": "192.168.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.51.0/24", "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
-        true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
-        "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
         "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
         "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
         [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
         "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp": false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49",
+        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e",
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.18.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2",
-        "end": "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
+        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
         false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
@@ -15655,6 +16669,12 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
         [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
         "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.8",
+        "end": "192.168.3.10"}, {"start": "192.168.3.2", "end": "192.168.3.6"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
         "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
@@ -15666,274 +16686,64 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
         "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:43 GMT
-- request:
-    method: get
-    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=24c83610-eab6-4f68-99dd-ab22a638b4a0
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 3e3a7e9b834e47a3b8db9c4414bf8cac
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-8c8d9f99-7a30-451b-994e-92ed3b463650
-      Date:
-      - Thu, 25 Oct 2018 18:23:43 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
-        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "9801267c-cd57-437a-a852-b46640cb4332",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
+        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
         "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
         "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0",
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
-        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.20.0/24", "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21",
-        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.51.2",
-        "end": "192.168.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.51.0/24", "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
-        true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
-        "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
+        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp": false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.18.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2",
-        "end": "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.8", "end": "192.168.0.8"},
+        {"start": "192.168.0.3", "end": "192.168.0.5"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
         null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}]}'
+        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:43 GMT
-- request:
-    method: post
-    uri: http://11.22.33.44:5000/v3/auth/tokens
-    body:
-      encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-2","domain":{"id":"default"}}}}}'
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 201
-      message: Created
-    headers:
-      Date:
-      - Thu, 25 Oct 2018 18:23:43 GMT
-      Server:
-      - Apache/2.4.6 (Red Hat Enterprise Linux)
-      X-Subject-Token:
-      - 40668f3b334b4e65857fc7fdb74d2771
-      Vary:
-      - X-Auth-Token
-      X-Openstack-Request-Id:
-      - req-c41f7314-9b6b-495b-8be7-dfbc564e9fe1
-      Content-Length:
-      - '7278'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: ASCII-8BIT
-      string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
-        "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
-        "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:23:43.605176Z", "project": {"domain": {"id":
-        "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
-        "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
-        "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
-        "public", "id": "34cb7f8ea1f0450ab0ec046c9eeb9176"}, {"region_id": "RegionOne",
-        "url": "http://10.8.99.206:35357/v3", "region": "RegionOne", "interface":
-        "admin", "id": "a879cd474f4f45f0acd813ecd67db5b5"}, {"region_id": "RegionOne",
-        "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "internal",
-        "id": "c42f0b5755644f0dab41c5baee5a4203"}], "type": "identity", "id": "378e5c74fa504811b10c62d26765f7fb",
-        "name": "keystone"}, {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:9292",
-        "region": "RegionOne", "interface": "internal", "id": "240e0fa371c94693a694869ed9dd3190"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:9292", "region": "RegionOne",
-        "interface": "public", "id": "9d8368b60ca34133be09d57bc831e499"}, {"region_id":
-        "RegionOne", "url": "http://10.8.99.206:9292", "region": "RegionOne", "interface":
-        "admin", "id": "f8cddd96970c4c15b6d3058753ac64c0"}], "type": "image", "id":
-        "3fc24923e2b34eff8078c8274bfd5ba4", "name": "glance"}, {"endpoints": [{"region_id":
-        "RegionOne", "url": "http://10.8.99.206:8777", "region": "RegionOne", "interface":
-        "public", "id": "0f0f40e5a2f145e2844eee69a7586257"}, {"region_id": "RegionOne",
-        "url": "http://10.8.99.206:8777", "region": "RegionOne", "interface": "admin",
-        "id": "72927918447d45269cfbafed21ea84e0"}, {"region_id": "RegionOne", "url":
-        "http://10.8.99.206:8777", "region": "RegionOne", "interface": "internal",
-        "id": "f0397fadc13245d9b678e1fd2ea4a95f"}], "type": "metering", "id": "43d262cde2b14730ab0a61e201b234ef",
-        "name": "ceilometer"}, {"endpoints": [{"region_id": "RegionOne", "url": "http://127.0.0.1:8774/v3",
-        "region": "RegionOne", "interface": "internal", "id": "054d6e2484744480b091a8ea0e6e5477"},
-        {"region_id": "RegionOne", "url": "http://127.0.0.1:8774/v3", "region": "RegionOne",
-        "interface": "admin", "id": "769ff19e965d45a39824d5a055e461ca"}, {"region_id":
-        "RegionOne", "url": "http://127.0.0.1:8774/v3", "region": "RegionOne", "interface":
-        "public", "id": "831ee4d526e7486e89e337febc5d7c58"}], "type": "computev3",
-        "id": "47f8d97599724a198240fc1c87c05abb", "name": "novav3"}, {"endpoints":
-        [{"region_id": "RegionOne", "url": "http://10.8.99.206:8773/services/Cloud",
-        "region": "RegionOne", "interface": "internal", "id": "2c9c27be8c144aca869c79bb064b03a6"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8773/services/Cloud",
-        "region": "RegionOne", "interface": "public", "id": "e97612a8a6114aaa9bedf36b3987826f"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8773/services/Admin",
-        "region": "RegionOne", "interface": "admin", "id": "fdf49d42181440e6807920689cc8c8df"}],
-        "type": "ec2", "id": "5a5f143e5561472ebc13b70863c91118", "name": "nova_ec2"},
-        {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v1/ef2a3405d1ef4dfd9a3616993ef46a4d",
-        "region": "RegionOne", "interface": "internal", "id": "0126f635192042669a4a4e7151ea4add"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v1/ef2a3405d1ef4dfd9a3616993ef46a4d",
-        "region": "RegionOne", "interface": "public", "id": "3b7ed33e12ca475d8d8e6d6be8774760"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v1/ef2a3405d1ef4dfd9a3616993ef46a4d",
-        "region": "RegionOne", "interface": "admin", "id": "db336e82925142a89e4a9c193066c0fb"}],
-        "type": "volume", "id": "6853145a3cd44ee5b3d23336a01357ce", "name": "cinder"},
-        {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:8774/v2/ef2a3405d1ef4dfd9a3616993ef46a4d",
-        "region": "RegionOne", "interface": "admin", "id": "2743bb5edbff4fe3a99465295e7686f4"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8774/v2/ef2a3405d1ef4dfd9a3616993ef46a4d",
-        "region": "RegionOne", "interface": "internal", "id": "b269df32dc89471ab84ab10385d314c2"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8774/v2/ef2a3405d1ef4dfd9a3616993ef46a4d",
-        "region": "RegionOne", "interface": "public", "id": "d9f5ae421fcf41bb8753261822583aef"}],
-        "type": "compute", "id": "8dff9e9f63224a7fb98f9b0638f2f4d4", "name": "nova"},
-        {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d",
-        "region": "RegionOne", "interface": "public", "id": "1412d9b3e8d64503b8e5e60e07cf338f"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d",
-        "region": "RegionOne", "interface": "internal", "id": "64fae0d703de4d16909d9abd740ac37e"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d",
-        "region": "RegionOne", "interface": "admin", "id": "d6e70de7d8de4f1cabf141a969d1bcbd"}],
-        "type": "volumev2", "id": "98fbad4787294144b026a89efdb550d6", "name": "cinderv2"},
-        {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:9696",
-        "region": "RegionOne", "interface": "admin", "id": "ac6ad70d28764d2688f1a45592c80f79"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:9696", "region": "RegionOne",
-        "interface": "public", "id": "e4381e1a44a04306b08d4c1d42c6b79c"}, {"region_id":
-        "RegionOne", "url": "http://10.8.99.206:9696", "region": "RegionOne", "interface":
-        "internal", "id": "f1af202638604065b335662a7c48ff11"}], "type": "network",
-        "id": "c44c166b9e3b46e38d646d4080ec1f03", "name": "neutron"}, {"endpoints":
-        [{"region_id": "RegionOne", "url": "http://10.8.99.206:8080", "region": "RegionOne",
-        "interface": "admin", "id": "76a21c541726433ba1d34d74c4410584"}, {"region_id":
-        "RegionOne", "url": "http://10.8.99.206:8080/v1/AUTH_ef2a3405d1ef4dfd9a3616993ef46a4d",
-        "region": "RegionOne", "interface": "internal", "id": "9b22f81013f249c3a25eb2971b76a1c4"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8080/v1/AUTH_ef2a3405d1ef4dfd9a3616993ef46a4d",
-        "region": "RegionOne", "interface": "public", "id": "c691466ada4a4fedab7cb52c8d78f5f7"}],
-        "type": "object-store", "id": "c77afa5055604ebf902b31a54ca514fa", "name":
-        "swift"}, {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:8004/v1/ef2a3405d1ef4dfd9a3616993ef46a4d",
-        "region": "RegionOne", "interface": "admin", "id": "2d908c9ff95d45a393a5d54718935b9f"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8004/v1/ef2a3405d1ef4dfd9a3616993ef46a4d",
-        "region": "RegionOne", "interface": "internal", "id": "4d1abf0ee917466795b0be07e4508232"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8004/v1/ef2a3405d1ef4dfd9a3616993ef46a4d",
-        "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
-        "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
-        "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["_CgkLie2ThCjS9kvN01Q5Q"],
-        "issued_at": "2018-10-25T18:23:43.605198Z"}}'
-    http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:43 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:19 GMT
 - request:
     method: get
-    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000
+    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=f4c17602-9618-4604-b3c9-9e4801d094d3
     body:
       encoding: US-ASCII
       string: ''
@@ -15945,7 +16755,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 40668f3b334b4e65857fc7fdb74d2771
+      - 0ad930d725df4f8ea482767d2723409a
   response:
     status:
       code: 200
@@ -15956,9 +16766,9 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-f0097441-0280-49b3-a928-90ac3f40ef6e
+      - req-edde261d-8885-40ec-9254-12627781686e
       Date:
-      - Thu, 25 Oct 2018 18:23:43 GMT
+      - Thu, 01 Nov 2018 18:32:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
@@ -16062,7 +16872,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:43 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:20 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=24c83610-eab6-4f68-99dd-ab22a638b4a0
@@ -16077,7 +16887,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 40668f3b334b4e65857fc7fdb74d2771
+      - 0ad930d725df4f8ea482767d2723409a
   response:
     status:
       code: 200
@@ -16088,29 +16898,12 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-ee9f5eab-716f-4839-b089-401bafe0af17
+      - req-86ebc376-1d3b-4b0b-a1e8-041057b7e4d1
       Date:
-      - Thu, 25 Oct 2018 18:23:43 GMT
+      - Thu, 01 Nov 2018 18:32:20 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp":
-        true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
-        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
-        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
         "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
@@ -16181,20 +16974,553 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
         "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "f4c17602-9618-4604-b3c9-9e4801d094d3",
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
+        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
         true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        null, "allocation_pools": [{"start": "192.168.0.8", "end": "192.168.0.8"},
+        {"start": "192.168.0.3", "end": "192.168.0.5"}], "host_routes": [], "ip_version":
         4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
-        "subnetpool_id": null}]}'
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:43 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:20 GMT
+- request:
+    method: get
+    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=f4c17602-9618-4604-b3c9-9e4801d094d3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 0ad930d725df4f8ea482767d2723409a
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-6097b0e9-1b16-4b98-8d0e-510c845f43ff
+      Date:
+      - Thu, 01 Nov 2018 18:32:20 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
+        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.8",
+        "end": "192.168.3.10"}, {"start": "192.168.3.2", "end": "192.168.3.6"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
+        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
+        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.8", "end": "192.168.0.8"},
+        {"start": "192.168.0.3", "end": "192.168.0.5"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 01 Nov 2018 18:32:20 GMT
+- request:
+    method: post
+    uri: http://11.22.33.44:5000/v3/auth/tokens
+    body:
+      encoding: UTF-8
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-2","domain":{"id":"default"}}}}}'
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Thu, 01 Nov 2018 18:32:20 GMT
+      Server:
+      - Apache/2.4.6 (Red Hat Enterprise Linux)
+      X-Subject-Token:
+      - a1a08d45df5e479ebcac1fcdc42840dc
+      Vary:
+      - X-Auth-Token
+      X-Openstack-Request-Id:
+      - req-794d6441-4c8f-4c87-b9be-6885678da130
+      Content-Length:
+      - '7278'
+      Connection:
+      - close
+      Content-Type:
+      - application/json
+    body:
+      encoding: ASCII-8BIT
+      string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
+        "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
+        "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
+        "expires_at": "2018-11-01T19:32:20.714326Z", "project": {"domain": {"id":
+        "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
+        "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
+        "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
+        "public", "id": "34cb7f8ea1f0450ab0ec046c9eeb9176"}, {"region_id": "RegionOne",
+        "url": "http://10.8.99.206:35357/v3", "region": "RegionOne", "interface":
+        "admin", "id": "a879cd474f4f45f0acd813ecd67db5b5"}, {"region_id": "RegionOne",
+        "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "internal",
+        "id": "c42f0b5755644f0dab41c5baee5a4203"}], "type": "identity", "id": "378e5c74fa504811b10c62d26765f7fb",
+        "name": "keystone"}, {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:9292",
+        "region": "RegionOne", "interface": "internal", "id": "240e0fa371c94693a694869ed9dd3190"},
+        {"region_id": "RegionOne", "url": "http://10.8.99.206:9292", "region": "RegionOne",
+        "interface": "public", "id": "9d8368b60ca34133be09d57bc831e499"}, {"region_id":
+        "RegionOne", "url": "http://10.8.99.206:9292", "region": "RegionOne", "interface":
+        "admin", "id": "f8cddd96970c4c15b6d3058753ac64c0"}], "type": "image", "id":
+        "3fc24923e2b34eff8078c8274bfd5ba4", "name": "glance"}, {"endpoints": [{"region_id":
+        "RegionOne", "url": "http://10.8.99.206:8777", "region": "RegionOne", "interface":
+        "public", "id": "0f0f40e5a2f145e2844eee69a7586257"}, {"region_id": "RegionOne",
+        "url": "http://10.8.99.206:8777", "region": "RegionOne", "interface": "admin",
+        "id": "72927918447d45269cfbafed21ea84e0"}, {"region_id": "RegionOne", "url":
+        "http://10.8.99.206:8777", "region": "RegionOne", "interface": "internal",
+        "id": "f0397fadc13245d9b678e1fd2ea4a95f"}], "type": "metering", "id": "43d262cde2b14730ab0a61e201b234ef",
+        "name": "ceilometer"}, {"endpoints": [{"region_id": "RegionOne", "url": "http://127.0.0.1:8774/v3",
+        "region": "RegionOne", "interface": "internal", "id": "054d6e2484744480b091a8ea0e6e5477"},
+        {"region_id": "RegionOne", "url": "http://127.0.0.1:8774/v3", "region": "RegionOne",
+        "interface": "admin", "id": "769ff19e965d45a39824d5a055e461ca"}, {"region_id":
+        "RegionOne", "url": "http://127.0.0.1:8774/v3", "region": "RegionOne", "interface":
+        "public", "id": "831ee4d526e7486e89e337febc5d7c58"}], "type": "computev3",
+        "id": "47f8d97599724a198240fc1c87c05abb", "name": "novav3"}, {"endpoints":
+        [{"region_id": "RegionOne", "url": "http://10.8.99.206:8773/services/Cloud",
+        "region": "RegionOne", "interface": "internal", "id": "2c9c27be8c144aca869c79bb064b03a6"},
+        {"region_id": "RegionOne", "url": "http://10.8.99.206:8773/services/Cloud",
+        "region": "RegionOne", "interface": "public", "id": "e97612a8a6114aaa9bedf36b3987826f"},
+        {"region_id": "RegionOne", "url": "http://10.8.99.206:8773/services/Admin",
+        "region": "RegionOne", "interface": "admin", "id": "fdf49d42181440e6807920689cc8c8df"}],
+        "type": "ec2", "id": "5a5f143e5561472ebc13b70863c91118", "name": "nova_ec2"},
+        {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v1/ef2a3405d1ef4dfd9a3616993ef46a4d",
+        "region": "RegionOne", "interface": "internal", "id": "0126f635192042669a4a4e7151ea4add"},
+        {"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v1/ef2a3405d1ef4dfd9a3616993ef46a4d",
+        "region": "RegionOne", "interface": "public", "id": "3b7ed33e12ca475d8d8e6d6be8774760"},
+        {"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v1/ef2a3405d1ef4dfd9a3616993ef46a4d",
+        "region": "RegionOne", "interface": "admin", "id": "db336e82925142a89e4a9c193066c0fb"}],
+        "type": "volume", "id": "6853145a3cd44ee5b3d23336a01357ce", "name": "cinder"},
+        {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:8774/v2/ef2a3405d1ef4dfd9a3616993ef46a4d",
+        "region": "RegionOne", "interface": "admin", "id": "2743bb5edbff4fe3a99465295e7686f4"},
+        {"region_id": "RegionOne", "url": "http://10.8.99.206:8774/v2/ef2a3405d1ef4dfd9a3616993ef46a4d",
+        "region": "RegionOne", "interface": "internal", "id": "b269df32dc89471ab84ab10385d314c2"},
+        {"region_id": "RegionOne", "url": "http://10.8.99.206:8774/v2/ef2a3405d1ef4dfd9a3616993ef46a4d",
+        "region": "RegionOne", "interface": "public", "id": "d9f5ae421fcf41bb8753261822583aef"}],
+        "type": "compute", "id": "8dff9e9f63224a7fb98f9b0638f2f4d4", "name": "nova"},
+        {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d",
+        "region": "RegionOne", "interface": "public", "id": "1412d9b3e8d64503b8e5e60e07cf338f"},
+        {"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d",
+        "region": "RegionOne", "interface": "internal", "id": "64fae0d703de4d16909d9abd740ac37e"},
+        {"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d",
+        "region": "RegionOne", "interface": "admin", "id": "d6e70de7d8de4f1cabf141a969d1bcbd"}],
+        "type": "volumev2", "id": "98fbad4787294144b026a89efdb550d6", "name": "cinderv2"},
+        {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:9696",
+        "region": "RegionOne", "interface": "admin", "id": "ac6ad70d28764d2688f1a45592c80f79"},
+        {"region_id": "RegionOne", "url": "http://10.8.99.206:9696", "region": "RegionOne",
+        "interface": "public", "id": "e4381e1a44a04306b08d4c1d42c6b79c"}, {"region_id":
+        "RegionOne", "url": "http://10.8.99.206:9696", "region": "RegionOne", "interface":
+        "internal", "id": "f1af202638604065b335662a7c48ff11"}], "type": "network",
+        "id": "c44c166b9e3b46e38d646d4080ec1f03", "name": "neutron"}, {"endpoints":
+        [{"region_id": "RegionOne", "url": "http://10.8.99.206:8080", "region": "RegionOne",
+        "interface": "admin", "id": "76a21c541726433ba1d34d74c4410584"}, {"region_id":
+        "RegionOne", "url": "http://10.8.99.206:8080/v1/AUTH_ef2a3405d1ef4dfd9a3616993ef46a4d",
+        "region": "RegionOne", "interface": "internal", "id": "9b22f81013f249c3a25eb2971b76a1c4"},
+        {"region_id": "RegionOne", "url": "http://10.8.99.206:8080/v1/AUTH_ef2a3405d1ef4dfd9a3616993ef46a4d",
+        "region": "RegionOne", "interface": "public", "id": "c691466ada4a4fedab7cb52c8d78f5f7"}],
+        "type": "object-store", "id": "c77afa5055604ebf902b31a54ca514fa", "name":
+        "swift"}, {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:8004/v1/ef2a3405d1ef4dfd9a3616993ef46a4d",
+        "region": "RegionOne", "interface": "admin", "id": "2d908c9ff95d45a393a5d54718935b9f"},
+        {"region_id": "RegionOne", "url": "http://10.8.99.206:8004/v1/ef2a3405d1ef4dfd9a3616993ef46a4d",
+        "region": "RegionOne", "interface": "internal", "id": "4d1abf0ee917466795b0be07e4508232"},
+        {"region_id": "RegionOne", "url": "http://10.8.99.206:8004/v1/ef2a3405d1ef4dfd9a3616993ef46a4d",
+        "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
+        "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
+        "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["vXelHc8iS4mLFjGKreXe3A"],
+        "issued_at": "2018-11-01T18:32:20.714345Z"}}'
+    http_version: 
+  recorded_at: Thu, 01 Nov 2018 18:32:20 GMT
+- request:
+    method: get
+    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - a1a08d45df5e479ebcac1fcdc42840dc
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-68428975-82e3-41a6-9097-8c625513508c
+      Date:
+      - Thu, 01 Nov 2018 18:32:20 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
+        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.8",
+        "end": "192.168.3.10"}, {"start": "192.168.3.2", "end": "192.168.3.6"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
+        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
+        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.8", "end": "192.168.0.8"},
+        {"start": "192.168.0.3", "end": "192.168.0.5"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 01 Nov 2018 18:32:20 GMT
+- request:
+    method: get
+    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=f4c17602-9618-4604-b3c9-9e4801d094d3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - a1a08d45df5e479ebcac1fcdc42840dc
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-4202049a-d7df-4cf5-b1b4-567d4e6bc38b
+      Date:
+      - Thu, 01 Nov 2018 18:32:21 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
+        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.8",
+        "end": "192.168.3.10"}, {"start": "192.168.3.2", "end": "192.168.3.6"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
+        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
+        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.8", "end": "192.168.0.8"},
+        {"start": "192.168.0.3", "end": "192.168.0.5"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 01 Nov 2018 18:32:21 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/floatingips?limit=1000
@@ -16209,7 +17535,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6e695167a49543658712ae5942bf5d3b
+      - 06f689fe899a47fc8eb53b9d2cf52ac7
   response:
     status:
       code: 200
@@ -16220,9 +17546,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-925e2f9d-e371-40b5-8c45-327bc881ee3a
+      - req-23031e18-8846-4527-8fb7-2e0d026f379c
       Date:
-      - Thu, 25 Oct 2018 18:23:44 GMT
+      - Thu, 01 Nov 2018 18:32:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
@@ -16264,7 +17590,7 @@ http_interactions:
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:44 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:21 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/floatingips?limit=1000&marker=e5a4a7fd-b2c7-4a38-b725-a666d4f90f60
@@ -16279,7 +17605,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6e695167a49543658712ae5942bf5d3b
+      - 06f689fe899a47fc8eb53b9d2cf52ac7
   response:
     status:
       code: 200
@@ -16290,9 +17616,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-2a073e37-e1f7-45fd-b8ed-a843dbc2ae0e
+      - req-92c6c514-9837-4967-88d5-d305e70642b5
       Date:
-      - Thu, 25 Oct 2018 18:23:44 GMT
+      - Thu, 01 Nov 2018 18:32:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
@@ -16334,7 +17660,7 @@ http_interactions:
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:44 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:21 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/floatingips?limit=1000
@@ -16349,7 +17675,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2bb685c4c23f4431b4a48d9148bc83d8
+      - 1ec5fca68ec44827953ebeed4666c9ef
   response:
     status:
       code: 200
@@ -16360,9 +17686,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-27563458-dfb6-4944-a892-55cfaba07d83
+      - req-1ea1ddb3-f1d2-4b31-9ccf-09fe2f585c9a
       Date:
-      - Thu, 25 Oct 2018 18:23:44 GMT
+      - Thu, 01 Nov 2018 18:32:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
@@ -16404,7 +17730,7 @@ http_interactions:
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:44 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:21 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/floatingips?limit=1000&marker=e5a4a7fd-b2c7-4a38-b725-a666d4f90f60
@@ -16419,7 +17745,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2bb685c4c23f4431b4a48d9148bc83d8
+      - 1ec5fca68ec44827953ebeed4666c9ef
   response:
     status:
       code: 200
@@ -16430,9 +17756,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-8efd8a8c-72e0-4670-a47c-ee94166d4c0d
+      - req-660f9a08-f703-4cd4-af43-7c71504bcedc
       Date:
-      - Thu, 25 Oct 2018 18:23:44 GMT
+      - Thu, 01 Nov 2018 18:32:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
@@ -16474,7 +17800,7 @@ http_interactions:
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:44 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:21 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/floatingips?limit=1000
@@ -16489,7 +17815,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 33810e4d05be4b359550aa74f52aea0f
+      - 26912eb40f1b466cbc86e846a195e182
   response:
     status:
       code: 200
@@ -16500,9 +17826,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-a9e069d8-f5b9-4eaa-9e44-b13a0dc88ca7
+      - req-8965532f-1fa5-439a-9057-534b79795020
       Date:
-      - Thu, 25 Oct 2018 18:23:44 GMT
+      - Thu, 01 Nov 2018 18:32:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
@@ -16544,7 +17870,7 @@ http_interactions:
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:44 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:21 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/floatingips?limit=1000&marker=e5a4a7fd-b2c7-4a38-b725-a666d4f90f60
@@ -16559,7 +17885,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 33810e4d05be4b359550aa74f52aea0f
+      - 26912eb40f1b466cbc86e846a195e182
   response:
     status:
       code: 200
@@ -16570,9 +17896,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-4bae1713-1f95-47e4-9d9a-da2891bd1de9
+      - req-28696683-372b-4b53-b920-5022a22b5865
       Date:
-      - Thu, 25 Oct 2018 18:23:44 GMT
+      - Thu, 01 Nov 2018 18:32:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
@@ -16614,7 +17940,7 @@ http_interactions:
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:44 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:21 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/floatingips?limit=1000
@@ -16629,7 +17955,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 488ad1530437494fb329fd84ad52067e
+      - af27476c4b9b4566a8db7c8e9510acad
   response:
     status:
       code: 200
@@ -16640,9 +17966,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-063dd348-72ff-4d80-8e45-7838921b8188
+      - req-5daa70f7-f099-437b-8050-961cc85df8e4
       Date:
-      - Thu, 25 Oct 2018 18:23:44 GMT
+      - Thu, 01 Nov 2018 18:32:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
@@ -16684,7 +18010,7 @@ http_interactions:
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:44 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:21 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/floatingips?limit=1000&marker=e5a4a7fd-b2c7-4a38-b725-a666d4f90f60
@@ -16699,7 +18025,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 488ad1530437494fb329fd84ad52067e
+      - af27476c4b9b4566a8db7c8e9510acad
   response:
     status:
       code: 200
@@ -16710,9 +18036,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-76338af0-ac12-446e-8385-60bd7aeb10b3
+      - req-2d605776-ee4e-4b50-8fc8-0f3735263717
       Date:
-      - Thu, 25 Oct 2018 18:23:44 GMT
+      - Thu, 01 Nov 2018 18:32:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
@@ -16754,7 +18080,7 @@ http_interactions:
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:44 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:21 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/floatingips?limit=1000
@@ -16769,7 +18095,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e5c2c8c12d3741cf8758152a15318f97
+      - e4031829ca794b898e1211cfc89e4ea0
   response:
     status:
       code: 200
@@ -16780,9 +18106,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-1f8e6d1e-95a1-49fa-87e8-d3a47bc4e665
+      - req-d8f0f6d1-8b2b-41bb-abc2-6c2a654aeb46
       Date:
-      - Thu, 25 Oct 2018 18:23:44 GMT
+      - Thu, 01 Nov 2018 18:32:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
@@ -16824,7 +18150,7 @@ http_interactions:
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:44 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:22 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/floatingips?limit=1000&marker=e5a4a7fd-b2c7-4a38-b725-a666d4f90f60
@@ -16839,7 +18165,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e5c2c8c12d3741cf8758152a15318f97
+      - e4031829ca794b898e1211cfc89e4ea0
   response:
     status:
       code: 200
@@ -16850,9 +18176,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-29973715-cf36-4788-9530-30fa652d3ef4
+      - req-644d95cc-1aa9-4b1b-94db-4d89e9950276
       Date:
-      - Thu, 25 Oct 2018 18:23:44 GMT
+      - Thu, 01 Nov 2018 18:32:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
@@ -16894,7 +18220,7 @@ http_interactions:
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:45 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:22 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/floatingips?limit=1000
@@ -16909,7 +18235,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3e3a7e9b834e47a3b8db9c4414bf8cac
+      - 0ad930d725df4f8ea482767d2723409a
   response:
     status:
       code: 200
@@ -16920,9 +18246,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-177df783-a0c1-417d-97f6-0ca7dcef7c3a
+      - req-8e6d793c-9a8c-4ba8-a100-c7f7939e68a9
       Date:
-      - Thu, 25 Oct 2018 18:23:45 GMT
+      - Thu, 01 Nov 2018 18:32:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
@@ -16964,7 +18290,7 @@ http_interactions:
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:45 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:22 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/floatingips?limit=1000&marker=e5a4a7fd-b2c7-4a38-b725-a666d4f90f60
@@ -16979,7 +18305,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3e3a7e9b834e47a3b8db9c4414bf8cac
+      - 0ad930d725df4f8ea482767d2723409a
   response:
     status:
       code: 200
@@ -16990,9 +18316,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-07ebc7fd-ef25-4c7b-a1fc-5d937117a2eb
+      - req-bb72b50f-8fe4-4e49-b765-7d93143a7798
       Date:
-      - Thu, 25 Oct 2018 18:23:45 GMT
+      - Thu, 01 Nov 2018 18:32:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
@@ -17034,7 +18360,7 @@ http_interactions:
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:45 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:22 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/floatingips?limit=1000
@@ -17049,7 +18375,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 40668f3b334b4e65857fc7fdb74d2771
+      - a1a08d45df5e479ebcac1fcdc42840dc
   response:
     status:
       code: 200
@@ -17060,9 +18386,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-9a56dc0c-a868-42ec-9ee7-14e821d9d802
+      - req-5f8ab917-73ae-48c8-b48e-7f781e7f96c9
       Date:
-      - Thu, 25 Oct 2018 18:23:45 GMT
+      - Thu, 01 Nov 2018 18:32:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
@@ -17104,7 +18430,7 @@ http_interactions:
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:45 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:22 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/floatingips?limit=1000&marker=e5a4a7fd-b2c7-4a38-b725-a666d4f90f60
@@ -17119,7 +18445,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 40668f3b334b4e65857fc7fdb74d2771
+      - a1a08d45df5e479ebcac1fcdc42840dc
   response:
     status:
       code: 200
@@ -17130,9 +18456,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-b6cb3fdb-143a-416b-adb2-8e80cc1731d1
+      - req-11f8d95e-b6fe-4b0a-8d1a-2bd0b03af086
       Date:
-      - Thu, 25 Oct 2018 18:23:45 GMT
+      - Thu, 01 Nov 2018 18:32:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
@@ -17174,7 +18500,7 @@ http_interactions:
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:45 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:22 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/ports?limit=1000
@@ -17189,7 +18515,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6e695167a49543658712ae5942bf5d3b
+      - 06f689fe899a47fc8eb53b9d2cf52ac7
   response:
     status:
       code: 200
@@ -17200,9 +18526,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-ded8b19f-170b-4f81-b927-85deaa630af5
+      - req-4d8c531b-af03-4a51-ac60-6e14bfcb0fdc
       Date:
-      - Thu, 25 Oct 2018 18:23:45 GMT
+      - Thu, 01 Nov 2018 18:32:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -17605,7 +18931,7 @@ http_interactions:
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:45 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:22 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/ports?limit=1000&marker=fb9152f8-5f19-4171-9b8e-f1e594c24d64
@@ -17620,7 +18946,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6e695167a49543658712ae5942bf5d3b
+      - 06f689fe899a47fc8eb53b9d2cf52ac7
   response:
     status:
       code: 200
@@ -17631,9 +18957,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-2ee69273-3d0f-40cd-afeb-bd54b3dc9d32
+      - req-fe564e17-8764-48f0-8d80-5c7f32874cfc
       Date:
-      - Thu, 25 Oct 2018 18:23:45 GMT
+      - Thu, 01 Nov 2018 18:32:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -18036,7 +19362,7 @@ http_interactions:
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:45 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:22 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/ports?limit=1000
@@ -18051,7 +19377,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2bb685c4c23f4431b4a48d9148bc83d8
+      - 1ec5fca68ec44827953ebeed4666c9ef
   response:
     status:
       code: 200
@@ -18062,9 +19388,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-c6758c61-fab5-44ee-aee0-651d1095252a
+      - req-428ffedd-54dd-4e33-83ff-3cfc66f05bea
       Date:
-      - Thu, 25 Oct 2018 18:23:45 GMT
+      - Thu, 01 Nov 2018 18:32:23 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -18467,7 +19793,7 @@ http_interactions:
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:45 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:23 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/ports?limit=1000&marker=fb9152f8-5f19-4171-9b8e-f1e594c24d64
@@ -18482,7 +19808,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2bb685c4c23f4431b4a48d9148bc83d8
+      - 1ec5fca68ec44827953ebeed4666c9ef
   response:
     status:
       code: 200
@@ -18493,9 +19819,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-d8d43297-f21b-469c-99db-fe63dd00a743
+      - req-9a72f64c-5dd3-4186-9caf-e23bfad5e9c9
       Date:
-      - Thu, 25 Oct 2018 18:23:46 GMT
+      - Thu, 01 Nov 2018 18:32:23 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -18898,7 +20224,7 @@ http_interactions:
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:46 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:23 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/ports?limit=1000
@@ -18913,7 +20239,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 33810e4d05be4b359550aa74f52aea0f
+      - 26912eb40f1b466cbc86e846a195e182
   response:
     status:
       code: 200
@@ -18924,9 +20250,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-147cfb73-4aad-429f-9c2f-aacaef0a1c80
+      - req-212e227b-44aa-4838-b28a-44517e969742
       Date:
-      - Thu, 25 Oct 2018 18:23:46 GMT
+      - Thu, 01 Nov 2018 18:32:23 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -19329,7 +20655,7 @@ http_interactions:
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:46 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:23 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/ports?limit=1000&marker=fb9152f8-5f19-4171-9b8e-f1e594c24d64
@@ -19344,7 +20670,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 33810e4d05be4b359550aa74f52aea0f
+      - 26912eb40f1b466cbc86e846a195e182
   response:
     status:
       code: 200
@@ -19355,9 +20681,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-5936e646-c02b-4294-a44f-365148c3e1e2
+      - req-6f16c372-e050-4338-a1a3-b788f059d31d
       Date:
-      - Thu, 25 Oct 2018 18:23:46 GMT
+      - Thu, 01 Nov 2018 18:32:23 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -19760,7 +21086,7 @@ http_interactions:
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:46 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:23 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/ports?limit=1000
@@ -19775,7 +21101,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 488ad1530437494fb329fd84ad52067e
+      - af27476c4b9b4566a8db7c8e9510acad
   response:
     status:
       code: 200
@@ -19786,9 +21112,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-77e52c37-f2ae-45d8-af1a-7ff8804051af
+      - req-4a81de20-251e-4e71-a379-cbc23c51f799
       Date:
-      - Thu, 25 Oct 2018 18:23:46 GMT
+      - Thu, 01 Nov 2018 18:32:23 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -20191,7 +21517,7 @@ http_interactions:
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:46 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:23 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/ports?limit=1000&marker=fb9152f8-5f19-4171-9b8e-f1e594c24d64
@@ -20206,7 +21532,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 488ad1530437494fb329fd84ad52067e
+      - af27476c4b9b4566a8db7c8e9510acad
   response:
     status:
       code: 200
@@ -20217,9 +21543,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-577171be-f34c-413e-a5c3-856785cac0bd
+      - req-a0874d77-6127-46d5-93ec-7e7766520151
       Date:
-      - Thu, 25 Oct 2018 18:23:46 GMT
+      - Thu, 01 Nov 2018 18:32:24 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -20622,7 +21948,7 @@ http_interactions:
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:46 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:24 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/ports?limit=1000
@@ -20637,7 +21963,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e5c2c8c12d3741cf8758152a15318f97
+      - e4031829ca794b898e1211cfc89e4ea0
   response:
     status:
       code: 200
@@ -20648,9 +21974,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-80d22c18-6e1e-4944-ad04-94b838f64019
+      - req-a08062af-7bc9-4262-b741-eef593d57a13
       Date:
-      - Thu, 25 Oct 2018 18:23:47 GMT
+      - Thu, 01 Nov 2018 18:32:24 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -21053,7 +22379,7 @@ http_interactions:
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:47 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:24 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/ports?limit=1000&marker=fb9152f8-5f19-4171-9b8e-f1e594c24d64
@@ -21068,7 +22394,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e5c2c8c12d3741cf8758152a15318f97
+      - e4031829ca794b898e1211cfc89e4ea0
   response:
     status:
       code: 200
@@ -21079,9 +22405,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-5e0345a5-3b6b-4ef5-ad42-32128cd64ead
+      - req-03e33e0b-d9e8-475c-9a42-47ce60e6ee07
       Date:
-      - Thu, 25 Oct 2018 18:23:47 GMT
+      - Thu, 01 Nov 2018 18:32:24 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -21484,7 +22810,7 @@ http_interactions:
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:47 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:24 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/ports?limit=1000
@@ -21499,7 +22825,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3e3a7e9b834e47a3b8db9c4414bf8cac
+      - 0ad930d725df4f8ea482767d2723409a
   response:
     status:
       code: 200
@@ -21510,9 +22836,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-08a8093e-71ab-4c5e-9a20-3db63b854da1
+      - req-a3dbe8d7-a54e-4fdb-bbf5-3b8db26fb4a6
       Date:
-      - Thu, 25 Oct 2018 18:23:47 GMT
+      - Thu, 01 Nov 2018 18:32:24 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -21915,7 +23241,7 @@ http_interactions:
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:47 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:24 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/ports?limit=1000&marker=fb9152f8-5f19-4171-9b8e-f1e594c24d64
@@ -21930,7 +23256,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3e3a7e9b834e47a3b8db9c4414bf8cac
+      - 0ad930d725df4f8ea482767d2723409a
   response:
     status:
       code: 200
@@ -21941,9 +23267,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-6d3ef0b7-9c4b-4bcc-83a0-ede251063bae
+      - req-b921ca5d-28d6-4fa3-b9f1-0a7d85911ca0
       Date:
-      - Thu, 25 Oct 2018 18:23:47 GMT
+      - Thu, 01 Nov 2018 18:32:24 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -22346,7 +23672,7 @@ http_interactions:
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:47 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:24 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/ports?limit=1000
@@ -22361,7 +23687,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 40668f3b334b4e65857fc7fdb74d2771
+      - a1a08d45df5e479ebcac1fcdc42840dc
   response:
     status:
       code: 200
@@ -22372,9 +23698,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-dfbb0c47-0e72-4582-89c3-d8fc40f930b8
+      - req-6ba6207b-454f-4b65-88cc-dfd89f0ce030
       Date:
-      - Thu, 25 Oct 2018 18:23:47 GMT
+      - Thu, 01 Nov 2018 18:32:25 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -22777,7 +24103,7 @@ http_interactions:
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:47 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:25 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/ports?limit=1000&marker=fb9152f8-5f19-4171-9b8e-f1e594c24d64
@@ -22792,7 +24118,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 40668f3b334b4e65857fc7fdb74d2771
+      - a1a08d45df5e479ebcac1fcdc42840dc
   response:
     status:
       code: 200
@@ -22803,9 +24129,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-f62d7017-f86c-4289-916b-b6279ed78f8b
+      - req-f3507d78-3ffa-4223-bf16-400cea1ecfce
       Date:
-      - Thu, 25 Oct 2018 18:23:47 GMT
+      - Thu, 01 Nov 2018 18:32:25 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -23208,7 +24534,7 @@ http_interactions:
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:48 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:25 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/routers?limit=1000
@@ -23223,7 +24549,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6e695167a49543658712ae5942bf5d3b
+      - 06f689fe899a47fc8eb53b9d2cf52ac7
   response:
     status:
       code: 200
@@ -23234,9 +24560,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-bc4793ec-9247-464d-a046-3a3ef809e716
+      - req-ad55d44a-2ec2-4325-8be6-33fe1126fdee
       Date:
-      - Thu, 25 Oct 2018 18:23:48 GMT
+      - Thu, 01 Nov 2018 18:32:25 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -23268,7 +24594,7 @@ http_interactions:
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:48 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:25 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/routers?limit=1000&marker=e49f1a18-9fd8-4130-9e9f-f13b5190f9fd
@@ -23283,7 +24609,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6e695167a49543658712ae5942bf5d3b
+      - 06f689fe899a47fc8eb53b9d2cf52ac7
   response:
     status:
       code: 200
@@ -23294,9 +24620,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-e6dda8c7-a149-4dc0-bb2e-756b1db51311
+      - req-ed9a3e50-568a-4589-8f56-9657eba0f714
       Date:
-      - Thu, 25 Oct 2018 18:23:48 GMT
+      - Thu, 01 Nov 2018 18:32:25 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -23328,7 +24654,7 @@ http_interactions:
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:48 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:25 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/routers?limit=1000
@@ -23343,7 +24669,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2bb685c4c23f4431b4a48d9148bc83d8
+      - 1ec5fca68ec44827953ebeed4666c9ef
   response:
     status:
       code: 200
@@ -23354,9 +24680,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-9b10cb17-100b-4cef-95f4-a6624be6581f
+      - req-9c83a489-6db1-4ccc-a99d-6ccbf5b72899
       Date:
-      - Thu, 25 Oct 2018 18:23:48 GMT
+      - Thu, 01 Nov 2018 18:32:25 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -23388,7 +24714,7 @@ http_interactions:
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:48 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:25 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/routers?limit=1000&marker=e49f1a18-9fd8-4130-9e9f-f13b5190f9fd
@@ -23403,7 +24729,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2bb685c4c23f4431b4a48d9148bc83d8
+      - 1ec5fca68ec44827953ebeed4666c9ef
   response:
     status:
       code: 200
@@ -23414,9 +24740,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-77a743a1-774e-4532-8522-a7f2357d94b2
+      - req-ea6397a7-3656-4535-ab86-1473a16ec30c
       Date:
-      - Thu, 25 Oct 2018 18:23:48 GMT
+      - Thu, 01 Nov 2018 18:32:25 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -23448,7 +24774,7 @@ http_interactions:
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:48 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:25 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/routers?limit=1000
@@ -23463,7 +24789,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 33810e4d05be4b359550aa74f52aea0f
+      - 26912eb40f1b466cbc86e846a195e182
   response:
     status:
       code: 200
@@ -23474,9 +24800,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-5efd7e32-10e6-41c8-928b-78c10aafea58
+      - req-5e17d613-0a27-4f1e-8f94-348e1cedcc4e
       Date:
-      - Thu, 25 Oct 2018 18:23:48 GMT
+      - Thu, 01 Nov 2018 18:32:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -23508,7 +24834,7 @@ http_interactions:
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:48 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:26 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/routers?limit=1000&marker=e49f1a18-9fd8-4130-9e9f-f13b5190f9fd
@@ -23523,7 +24849,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 33810e4d05be4b359550aa74f52aea0f
+      - 26912eb40f1b466cbc86e846a195e182
   response:
     status:
       code: 200
@@ -23534,9 +24860,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-7e9386a8-cb0a-4a51-b8f0-79d795128d12
+      - req-dac71171-007b-4b2a-8e49-1af7632b9164
       Date:
-      - Thu, 25 Oct 2018 18:23:48 GMT
+      - Thu, 01 Nov 2018 18:32:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -23568,7 +24894,7 @@ http_interactions:
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:48 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:26 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/routers?limit=1000
@@ -23583,7 +24909,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 488ad1530437494fb329fd84ad52067e
+      - af27476c4b9b4566a8db7c8e9510acad
   response:
     status:
       code: 200
@@ -23594,9 +24920,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-4ff91ed5-8770-4577-8336-5b2d6e9acdd0
+      - req-efb2693d-2808-46a8-942a-e88f2b94d188
       Date:
-      - Thu, 25 Oct 2018 18:23:48 GMT
+      - Thu, 01 Nov 2018 18:32:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -23628,7 +24954,7 @@ http_interactions:
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:48 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:26 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/routers?limit=1000&marker=e49f1a18-9fd8-4130-9e9f-f13b5190f9fd
@@ -23643,7 +24969,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 488ad1530437494fb329fd84ad52067e
+      - af27476c4b9b4566a8db7c8e9510acad
   response:
     status:
       code: 200
@@ -23654,9 +24980,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-9f81efc1-c613-42a3-b809-81b3cd77d9f6
+      - req-a9b8c93c-314f-4c42-a8b1-f307bf81427b
       Date:
-      - Thu, 25 Oct 2018 18:23:48 GMT
+      - Thu, 01 Nov 2018 18:32:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -23688,7 +25014,7 @@ http_interactions:
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:48 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:26 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/routers?limit=1000
@@ -23703,7 +25029,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e5c2c8c12d3741cf8758152a15318f97
+      - e4031829ca794b898e1211cfc89e4ea0
   response:
     status:
       code: 200
@@ -23714,9 +25040,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-e8a69cf0-528b-4277-8fe3-bdd33fa0605d
+      - req-4f642957-dcb2-42f4-9019-c00e8261979a
       Date:
-      - Thu, 25 Oct 2018 18:23:49 GMT
+      - Thu, 01 Nov 2018 18:32:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -23748,7 +25074,7 @@ http_interactions:
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:49 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:26 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/routers?limit=1000&marker=e49f1a18-9fd8-4130-9e9f-f13b5190f9fd
@@ -23763,7 +25089,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e5c2c8c12d3741cf8758152a15318f97
+      - e4031829ca794b898e1211cfc89e4ea0
   response:
     status:
       code: 200
@@ -23774,9 +25100,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-3775ddb1-9ee6-42b3-8a65-5c30d27ac76a
+      - req-bb0e734c-f46d-4fa1-af50-8e25a53dc4e4
       Date:
-      - Thu, 25 Oct 2018 18:23:49 GMT
+      - Thu, 01 Nov 2018 18:32:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -23808,7 +25134,7 @@ http_interactions:
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:49 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:26 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/routers?limit=1000
@@ -23823,7 +25149,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3e3a7e9b834e47a3b8db9c4414bf8cac
+      - 0ad930d725df4f8ea482767d2723409a
   response:
     status:
       code: 200
@@ -23834,9 +25160,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-efead6d4-d575-4d23-9d6f-68f2dad8fdb3
+      - req-1948f71e-81c2-4464-bb54-e9ab11a569f7
       Date:
-      - Thu, 25 Oct 2018 18:23:49 GMT
+      - Thu, 01 Nov 2018 18:32:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -23868,7 +25194,7 @@ http_interactions:
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:49 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:26 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/routers?limit=1000&marker=e49f1a18-9fd8-4130-9e9f-f13b5190f9fd
@@ -23883,7 +25209,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3e3a7e9b834e47a3b8db9c4414bf8cac
+      - 0ad930d725df4f8ea482767d2723409a
   response:
     status:
       code: 200
@@ -23894,9 +25220,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-aea1c78f-0e93-45aa-b18b-a64d141ac7fc
+      - req-2fb0d9b4-f4bb-4be7-a31b-e0bb0b11dbb9
       Date:
-      - Thu, 25 Oct 2018 18:23:49 GMT
+      - Thu, 01 Nov 2018 18:32:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -23928,7 +25254,7 @@ http_interactions:
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:49 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:26 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/routers?limit=1000
@@ -23943,7 +25269,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 40668f3b334b4e65857fc7fdb74d2771
+      - a1a08d45df5e479ebcac1fcdc42840dc
   response:
     status:
       code: 200
@@ -23954,9 +25280,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-bab9cbbe-d4b2-4663-88dc-60b7c2f2cf76
+      - req-bc6910b2-3c34-4c2b-af65-fd86a726ec56
       Date:
-      - Thu, 25 Oct 2018 18:23:49 GMT
+      - Thu, 01 Nov 2018 18:32:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -23988,7 +25314,7 @@ http_interactions:
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:49 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:26 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/routers?limit=1000&marker=e49f1a18-9fd8-4130-9e9f-f13b5190f9fd
@@ -24003,7 +25329,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 40668f3b334b4e65857fc7fdb74d2771
+      - a1a08d45df5e479ebcac1fcdc42840dc
   response:
     status:
       code: 200
@@ -24014,9 +25340,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-b70ea594-2017-4303-a741-1a2bc0c77e1c
+      - req-bb5468c2-ceb6-4a7f-92a3-7f3ea528420d
       Date:
-      - Thu, 25 Oct 2018 18:23:49 GMT
+      - Thu, 01 Nov 2018 18:32:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -24048,7 +25374,7 @@ http_interactions:
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:49 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:27 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000
@@ -24063,7 +25389,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6e695167a49543658712ae5942bf5d3b
+      - 06f689fe899a47fc8eb53b9d2cf52ac7
   response:
     status:
       code: 200
@@ -24074,9 +25400,9 @@ http_interactions:
       Content-Length:
       - '2717'
       X-Openstack-Request-Id:
-      - req-b33ca35e-1cde-49d8-9398-d4196236b089
+      - req-0528151c-28fe-4375-8261-99f8e75abf18
       Date:
-      - Thu, 25 Oct 2018 18:23:49 GMT
+      - Thu, 01 Nov 2018 18:32:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=2e57d382-aeb2-4107-85cd-9dbde325f8f7",
@@ -24111,7 +25437,7 @@ http_interactions:
         null, "port_range_min": null, "id": "7e354503-9d45-4cc4-a742-4ff9501ba396",
         "security_group_id": "2e57d382-aeb2-4107-85cd-9dbde325f8f7"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:49 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:27 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=2e57d382-aeb2-4107-85cd-9dbde325f8f7
@@ -24126,7 +25452,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6e695167a49543658712ae5942bf5d3b
+      - 06f689fe899a47fc8eb53b9d2cf52ac7
   response:
     status:
       code: 200
@@ -24137,9 +25463,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-b9f7ffee-10ae-48c7-9668-34e20e2b7179
+      - req-cece5cad-0c2a-48ce-935f-10c591b36a8e
       Date:
-      - Thu, 25 Oct 2018 18:23:49 GMT
+      - Thu, 01 Nov 2018 18:32:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=42bcab35-fe98-49f3-ba0e-705a2737b81d",
@@ -24182,7 +25508,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "f87c3733-0682-46d9-8df1-05f1207541d1",
         "security_group_id": "42bcab35-fe98-49f3-ba0e-705a2737b81d"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:49 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:27 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=42bcab35-fe98-49f3-ba0e-705a2737b81d
@@ -24197,7 +25523,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6e695167a49543658712ae5942bf5d3b
+      - 06f689fe899a47fc8eb53b9d2cf52ac7
   response:
     status:
       code: 200
@@ -24208,9 +25534,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-1a0177b5-b51f-437b-8513-3be092cf9d4e
+      - req-3acd0f68-a9f0-4dc3-a24e-ad8b85d8ec2e
       Date:
-      - Thu, 25 Oct 2018 18:23:49 GMT
+      - Thu, 01 Nov 2018 18:32:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=7250f04f-facd-4731-b072-f346b1cc7a80",
@@ -24253,7 +25579,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "d0ee1562-3ff7-4ad5-b29f-8dd350ed221f",
         "security_group_id": "7250f04f-facd-4731-b072-f346b1cc7a80"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:49 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:27 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=7250f04f-facd-4731-b072-f346b1cc7a80
@@ -24268,7 +25594,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6e695167a49543658712ae5942bf5d3b
+      - 06f689fe899a47fc8eb53b9d2cf52ac7
   response:
     status:
       code: 200
@@ -24279,9 +25605,9 @@ http_interactions:
       Content-Length:
       - '8737'
       X-Openstack-Request-Id:
-      - req-b409c06e-4327-44a7-ab02-fc8c1fdbcfe0
+      - req-973cbd21-1b0c-46f3-b0ba-ff664b3778be
       Date:
-      - Thu, 25 Oct 2018 18:23:49 GMT
+      - Thu, 01 Nov 2018 18:32:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d",
@@ -24388,7 +25714,7 @@ http_interactions:
         "port_range_max": 65535, "port_range_min": 1, "id": "e483857b-5eb5-4cb0-94d6-b431a2f0cb10",
         "security_group_id": "8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:50 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:28 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d
@@ -24403,7 +25729,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6e695167a49543658712ae5942bf5d3b
+      - 06f689fe899a47fc8eb53b9d2cf52ac7
   response:
     status:
       code: 200
@@ -24414,9 +25740,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-2c4f58b0-7844-4f82-85f3-b6177f0f61ae
+      - req-67b8e605-5aa6-40aa-947f-f27f63b60965
       Date:
-      - Thu, 25 Oct 2018 18:23:50 GMT
+      - Thu, 01 Nov 2018 18:32:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=bab65d2f-4717-47eb-bfb2-95100b254563",
@@ -24458,7 +25784,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "e1aa03c0-0758-42ca-b030-a3d62800e578",
         "security_group_id": "bab65d2f-4717-47eb-bfb2-95100b254563"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:50 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:28 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=bab65d2f-4717-47eb-bfb2-95100b254563
@@ -24473,7 +25799,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6e695167a49543658712ae5942bf5d3b
+      - 06f689fe899a47fc8eb53b9d2cf52ac7
   response:
     status:
       code: 200
@@ -24484,15 +25810,15 @@ http_interactions:
       Content-Length:
       - '156'
       X-Openstack-Request-Id:
-      - req-509795e1-de59-4b29-bc18-409630cf754d
+      - req-8ddfde91-6f4d-4007-8e4f-00856af06061
       Date:
-      - Thu, 25 Oct 2018 18:23:50 GMT
+      - Thu, 01 Nov 2018 18:32:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&page_reverse=True",
         "rel": "previous"}], "security_groups": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:50 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:28 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000
@@ -24507,7 +25833,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2bb685c4c23f4431b4a48d9148bc83d8
+      - 1ec5fca68ec44827953ebeed4666c9ef
   response:
     status:
       code: 200
@@ -24518,9 +25844,9 @@ http_interactions:
       Content-Length:
       - '2717'
       X-Openstack-Request-Id:
-      - req-3e537365-3a59-48c0-b394-d14c46c15302
+      - req-79ae007c-d20a-4121-a027-a567489a6f94
       Date:
-      - Thu, 25 Oct 2018 18:23:50 GMT
+      - Thu, 01 Nov 2018 18:32:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=2e57d382-aeb2-4107-85cd-9dbde325f8f7",
@@ -24555,7 +25881,7 @@ http_interactions:
         null, "port_range_min": null, "id": "7e354503-9d45-4cc4-a742-4ff9501ba396",
         "security_group_id": "2e57d382-aeb2-4107-85cd-9dbde325f8f7"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:50 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:28 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=2e57d382-aeb2-4107-85cd-9dbde325f8f7
@@ -24570,7 +25896,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2bb685c4c23f4431b4a48d9148bc83d8
+      - 1ec5fca68ec44827953ebeed4666c9ef
   response:
     status:
       code: 200
@@ -24581,9 +25907,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-f591606b-83c5-4adc-a22b-7bed5b4fd2ad
+      - req-302a2ed9-91b5-40d2-a206-3759e5ced8d1
       Date:
-      - Thu, 25 Oct 2018 18:23:50 GMT
+      - Thu, 01 Nov 2018 18:32:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=42bcab35-fe98-49f3-ba0e-705a2737b81d",
@@ -24626,7 +25952,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "f87c3733-0682-46d9-8df1-05f1207541d1",
         "security_group_id": "42bcab35-fe98-49f3-ba0e-705a2737b81d"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:50 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:29 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=42bcab35-fe98-49f3-ba0e-705a2737b81d
@@ -24641,7 +25967,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2bb685c4c23f4431b4a48d9148bc83d8
+      - 1ec5fca68ec44827953ebeed4666c9ef
   response:
     status:
       code: 200
@@ -24652,9 +25978,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-ed4b3606-ff63-4989-82cd-1d780ca47b30
+      - req-1d31b2d9-ca75-43ef-86d4-ac136c9bf293
       Date:
-      - Thu, 25 Oct 2018 18:23:50 GMT
+      - Thu, 01 Nov 2018 18:32:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=7250f04f-facd-4731-b072-f346b1cc7a80",
@@ -24697,7 +26023,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "d0ee1562-3ff7-4ad5-b29f-8dd350ed221f",
         "security_group_id": "7250f04f-facd-4731-b072-f346b1cc7a80"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:50 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:29 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=7250f04f-facd-4731-b072-f346b1cc7a80
@@ -24712,7 +26038,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2bb685c4c23f4431b4a48d9148bc83d8
+      - 1ec5fca68ec44827953ebeed4666c9ef
   response:
     status:
       code: 200
@@ -24723,9 +26049,9 @@ http_interactions:
       Content-Length:
       - '8737'
       X-Openstack-Request-Id:
-      - req-5a7b5a90-de94-49a9-898b-77f847cccd02
+      - req-5e7a424e-386e-4b4d-80ec-0294a71d9fad
       Date:
-      - Thu, 25 Oct 2018 18:23:50 GMT
+      - Thu, 01 Nov 2018 18:32:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d",
@@ -24832,7 +26158,7 @@ http_interactions:
         "port_range_max": 65535, "port_range_min": 1, "id": "e483857b-5eb5-4cb0-94d6-b431a2f0cb10",
         "security_group_id": "8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:50 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:29 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d
@@ -24847,7 +26173,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2bb685c4c23f4431b4a48d9148bc83d8
+      - 1ec5fca68ec44827953ebeed4666c9ef
   response:
     status:
       code: 200
@@ -24858,9 +26184,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-e52fbcef-912b-4c4a-80fe-2d01b418d50d
+      - req-40ca1884-1e1b-4971-ae25-75487da7c5b4
       Date:
-      - Thu, 25 Oct 2018 18:23:50 GMT
+      - Thu, 01 Nov 2018 18:32:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=bab65d2f-4717-47eb-bfb2-95100b254563",
@@ -24902,7 +26228,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "e1aa03c0-0758-42ca-b030-a3d62800e578",
         "security_group_id": "bab65d2f-4717-47eb-bfb2-95100b254563"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:50 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:29 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=bab65d2f-4717-47eb-bfb2-95100b254563
@@ -24917,7 +26243,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2bb685c4c23f4431b4a48d9148bc83d8
+      - 1ec5fca68ec44827953ebeed4666c9ef
   response:
     status:
       code: 200
@@ -24928,15 +26254,15 @@ http_interactions:
       Content-Length:
       - '156'
       X-Openstack-Request-Id:
-      - req-45e0264e-f7d4-4f6c-96e1-71b9ce830f03
+      - req-e1774a2a-706b-4beb-b719-6d9953d86576
       Date:
-      - Thu, 25 Oct 2018 18:23:50 GMT
+      - Thu, 01 Nov 2018 18:32:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&page_reverse=True",
         "rel": "previous"}], "security_groups": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:50 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:29 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000
@@ -24951,7 +26277,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 33810e4d05be4b359550aa74f52aea0f
+      - 26912eb40f1b466cbc86e846a195e182
   response:
     status:
       code: 200
@@ -24962,9 +26288,9 @@ http_interactions:
       Content-Length:
       - '2717'
       X-Openstack-Request-Id:
-      - req-0f4bca40-a615-47fe-a205-18e476c84a77
+      - req-893a24fb-ffd4-475a-bfb8-d4d9cb31cb0b
       Date:
-      - Thu, 25 Oct 2018 18:23:51 GMT
+      - Thu, 01 Nov 2018 18:32:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=2e57d382-aeb2-4107-85cd-9dbde325f8f7",
@@ -24999,7 +26325,7 @@ http_interactions:
         null, "port_range_min": null, "id": "7e354503-9d45-4cc4-a742-4ff9501ba396",
         "security_group_id": "2e57d382-aeb2-4107-85cd-9dbde325f8f7"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:51 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:29 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=2e57d382-aeb2-4107-85cd-9dbde325f8f7
@@ -25014,7 +26340,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 33810e4d05be4b359550aa74f52aea0f
+      - 26912eb40f1b466cbc86e846a195e182
   response:
     status:
       code: 200
@@ -25025,9 +26351,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-c7e83a88-8995-4625-b87e-b149b7d8ebea
+      - req-bec2f116-b630-4a3e-a35a-5693dda555e1
       Date:
-      - Thu, 25 Oct 2018 18:23:51 GMT
+      - Thu, 01 Nov 2018 18:32:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=42bcab35-fe98-49f3-ba0e-705a2737b81d",
@@ -25070,7 +26396,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "f87c3733-0682-46d9-8df1-05f1207541d1",
         "security_group_id": "42bcab35-fe98-49f3-ba0e-705a2737b81d"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:51 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:29 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=42bcab35-fe98-49f3-ba0e-705a2737b81d
@@ -25085,7 +26411,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 33810e4d05be4b359550aa74f52aea0f
+      - 26912eb40f1b466cbc86e846a195e182
   response:
     status:
       code: 200
@@ -25096,9 +26422,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-62dec04a-fbe2-4167-9757-16365896f324
+      - req-cd4c826a-dec7-4139-922d-3b23c28cb8c0
       Date:
-      - Thu, 25 Oct 2018 18:23:51 GMT
+      - Thu, 01 Nov 2018 18:32:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=7250f04f-facd-4731-b072-f346b1cc7a80",
@@ -25141,7 +26467,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "d0ee1562-3ff7-4ad5-b29f-8dd350ed221f",
         "security_group_id": "7250f04f-facd-4731-b072-f346b1cc7a80"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:51 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:29 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=7250f04f-facd-4731-b072-f346b1cc7a80
@@ -25156,7 +26482,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 33810e4d05be4b359550aa74f52aea0f
+      - 26912eb40f1b466cbc86e846a195e182
   response:
     status:
       code: 200
@@ -25167,9 +26493,9 @@ http_interactions:
       Content-Length:
       - '8737'
       X-Openstack-Request-Id:
-      - req-7d7dd0e6-d08e-4eb7-9c38-a8c3a9a7b87d
+      - req-455f289c-aa8c-4fe8-b88f-737f22fafe17
       Date:
-      - Thu, 25 Oct 2018 18:23:51 GMT
+      - Thu, 01 Nov 2018 18:32:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d",
@@ -25276,7 +26602,7 @@ http_interactions:
         "port_range_max": 65535, "port_range_min": 1, "id": "e483857b-5eb5-4cb0-94d6-b431a2f0cb10",
         "security_group_id": "8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:51 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:30 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d
@@ -25291,7 +26617,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 33810e4d05be4b359550aa74f52aea0f
+      - 26912eb40f1b466cbc86e846a195e182
   response:
     status:
       code: 200
@@ -25302,9 +26628,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-204a39b6-1fe1-492c-b137-8fd11ab51b7d
+      - req-53498ded-58d4-4912-bc5e-46bc17dd7961
       Date:
-      - Thu, 25 Oct 2018 18:23:51 GMT
+      - Thu, 01 Nov 2018 18:32:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=bab65d2f-4717-47eb-bfb2-95100b254563",
@@ -25346,7 +26672,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "e1aa03c0-0758-42ca-b030-a3d62800e578",
         "security_group_id": "bab65d2f-4717-47eb-bfb2-95100b254563"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:51 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:30 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=bab65d2f-4717-47eb-bfb2-95100b254563
@@ -25361,7 +26687,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 33810e4d05be4b359550aa74f52aea0f
+      - 26912eb40f1b466cbc86e846a195e182
   response:
     status:
       code: 200
@@ -25372,15 +26698,15 @@ http_interactions:
       Content-Length:
       - '156'
       X-Openstack-Request-Id:
-      - req-9db744c7-2b4b-421e-aeb2-c1c6f1b92537
+      - req-65408b8e-2700-4e8b-a3ea-dbf26daa7ccb
       Date:
-      - Thu, 25 Oct 2018 18:23:51 GMT
+      - Thu, 01 Nov 2018 18:32:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&page_reverse=True",
         "rel": "previous"}], "security_groups": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:51 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:30 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000
@@ -25395,7 +26721,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 488ad1530437494fb329fd84ad52067e
+      - af27476c4b9b4566a8db7c8e9510acad
   response:
     status:
       code: 200
@@ -25406,9 +26732,9 @@ http_interactions:
       Content-Length:
       - '2717'
       X-Openstack-Request-Id:
-      - req-3ac45dd6-107d-4730-ac7b-5bd8ad3993bb
+      - req-3c17e60d-a77c-4e4b-9de1-cacd716a5750
       Date:
-      - Thu, 25 Oct 2018 18:23:51 GMT
+      - Thu, 01 Nov 2018 18:32:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=2e57d382-aeb2-4107-85cd-9dbde325f8f7",
@@ -25443,7 +26769,7 @@ http_interactions:
         null, "port_range_min": null, "id": "7e354503-9d45-4cc4-a742-4ff9501ba396",
         "security_group_id": "2e57d382-aeb2-4107-85cd-9dbde325f8f7"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:51 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:30 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=2e57d382-aeb2-4107-85cd-9dbde325f8f7
@@ -25458,7 +26784,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 488ad1530437494fb329fd84ad52067e
+      - af27476c4b9b4566a8db7c8e9510acad
   response:
     status:
       code: 200
@@ -25469,9 +26795,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-c2fceb1a-9215-4aee-964b-dfa4160f5c83
+      - req-3dd450a6-a85b-4ffa-80ec-bba8ea872d2f
       Date:
-      - Thu, 25 Oct 2018 18:23:51 GMT
+      - Thu, 01 Nov 2018 18:32:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=42bcab35-fe98-49f3-ba0e-705a2737b81d",
@@ -25514,7 +26840,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "f87c3733-0682-46d9-8df1-05f1207541d1",
         "security_group_id": "42bcab35-fe98-49f3-ba0e-705a2737b81d"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:51 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:30 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=42bcab35-fe98-49f3-ba0e-705a2737b81d
@@ -25529,7 +26855,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 488ad1530437494fb329fd84ad52067e
+      - af27476c4b9b4566a8db7c8e9510acad
   response:
     status:
       code: 200
@@ -25540,9 +26866,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-c5c5137b-e9c1-401f-a985-82c05bae0708
+      - req-f49158fe-4119-4b5f-a044-888a3f1f95c1
       Date:
-      - Thu, 25 Oct 2018 18:23:52 GMT
+      - Thu, 01 Nov 2018 18:32:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=7250f04f-facd-4731-b072-f346b1cc7a80",
@@ -25585,7 +26911,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "d0ee1562-3ff7-4ad5-b29f-8dd350ed221f",
         "security_group_id": "7250f04f-facd-4731-b072-f346b1cc7a80"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:52 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:30 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=7250f04f-facd-4731-b072-f346b1cc7a80
@@ -25600,7 +26926,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 488ad1530437494fb329fd84ad52067e
+      - af27476c4b9b4566a8db7c8e9510acad
   response:
     status:
       code: 200
@@ -25611,9 +26937,9 @@ http_interactions:
       Content-Length:
       - '8737'
       X-Openstack-Request-Id:
-      - req-5b58ca38-9bf8-4a6b-9772-5610c16f00cd
+      - req-5ffdff6d-fcc3-4676-a20a-fcbbbc7e47c4
       Date:
-      - Thu, 25 Oct 2018 18:23:52 GMT
+      - Thu, 01 Nov 2018 18:32:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d",
@@ -25720,7 +27046,7 @@ http_interactions:
         "port_range_max": 65535, "port_range_min": 1, "id": "e483857b-5eb5-4cb0-94d6-b431a2f0cb10",
         "security_group_id": "8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:52 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:30 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d
@@ -25735,7 +27061,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 488ad1530437494fb329fd84ad52067e
+      - af27476c4b9b4566a8db7c8e9510acad
   response:
     status:
       code: 200
@@ -25746,9 +27072,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-a6e4d55d-cc22-4bec-b29d-ef8260768d44
+      - req-7522cf0a-55e7-4f4d-933d-b1c061d3dfe8
       Date:
-      - Thu, 25 Oct 2018 18:23:52 GMT
+      - Thu, 01 Nov 2018 18:32:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=bab65d2f-4717-47eb-bfb2-95100b254563",
@@ -25790,7 +27116,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "e1aa03c0-0758-42ca-b030-a3d62800e578",
         "security_group_id": "bab65d2f-4717-47eb-bfb2-95100b254563"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:52 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:31 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=bab65d2f-4717-47eb-bfb2-95100b254563
@@ -25805,7 +27131,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 488ad1530437494fb329fd84ad52067e
+      - af27476c4b9b4566a8db7c8e9510acad
   response:
     status:
       code: 200
@@ -25816,15 +27142,15 @@ http_interactions:
       Content-Length:
       - '156'
       X-Openstack-Request-Id:
-      - req-691d0f51-9900-41b6-a1c1-aebafa753536
+      - req-5114d718-d37c-4b1f-bd55-aa2d7b0227c2
       Date:
-      - Thu, 25 Oct 2018 18:23:52 GMT
+      - Thu, 01 Nov 2018 18:32:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&page_reverse=True",
         "rel": "previous"}], "security_groups": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:52 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:31 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000
@@ -25839,7 +27165,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e5c2c8c12d3741cf8758152a15318f97
+      - e4031829ca794b898e1211cfc89e4ea0
   response:
     status:
       code: 200
@@ -25850,9 +27176,9 @@ http_interactions:
       Content-Length:
       - '2717'
       X-Openstack-Request-Id:
-      - req-64149c51-5137-4a3f-a867-18e0dbfd8e12
+      - req-39c98c1c-182b-4805-94b8-cd7003746700
       Date:
-      - Thu, 25 Oct 2018 18:23:52 GMT
+      - Thu, 01 Nov 2018 18:32:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=2e57d382-aeb2-4107-85cd-9dbde325f8f7",
@@ -25887,7 +27213,7 @@ http_interactions:
         null, "port_range_min": null, "id": "7e354503-9d45-4cc4-a742-4ff9501ba396",
         "security_group_id": "2e57d382-aeb2-4107-85cd-9dbde325f8f7"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:52 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:31 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=2e57d382-aeb2-4107-85cd-9dbde325f8f7
@@ -25902,7 +27228,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e5c2c8c12d3741cf8758152a15318f97
+      - e4031829ca794b898e1211cfc89e4ea0
   response:
     status:
       code: 200
@@ -25913,9 +27239,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-96ba721e-4483-41e8-a93f-dfe0ef31d264
+      - req-b484311b-48ec-404a-bead-a1690afb00a3
       Date:
-      - Thu, 25 Oct 2018 18:23:52 GMT
+      - Thu, 01 Nov 2018 18:32:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=42bcab35-fe98-49f3-ba0e-705a2737b81d",
@@ -25958,7 +27284,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "f87c3733-0682-46d9-8df1-05f1207541d1",
         "security_group_id": "42bcab35-fe98-49f3-ba0e-705a2737b81d"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:52 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:31 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=42bcab35-fe98-49f3-ba0e-705a2737b81d
@@ -25973,7 +27299,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e5c2c8c12d3741cf8758152a15318f97
+      - e4031829ca794b898e1211cfc89e4ea0
   response:
     status:
       code: 200
@@ -25984,9 +27310,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-90ef9ee3-40e8-4f6a-8816-6f484465792a
+      - req-00f95129-263e-43bb-bae5-60c22a84324d
       Date:
-      - Thu, 25 Oct 2018 18:23:52 GMT
+      - Thu, 01 Nov 2018 18:32:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=7250f04f-facd-4731-b072-f346b1cc7a80",
@@ -26029,7 +27355,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "d0ee1562-3ff7-4ad5-b29f-8dd350ed221f",
         "security_group_id": "7250f04f-facd-4731-b072-f346b1cc7a80"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:52 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:31 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=7250f04f-facd-4731-b072-f346b1cc7a80
@@ -26044,7 +27370,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e5c2c8c12d3741cf8758152a15318f97
+      - e4031829ca794b898e1211cfc89e4ea0
   response:
     status:
       code: 200
@@ -26055,9 +27381,9 @@ http_interactions:
       Content-Length:
       - '8737'
       X-Openstack-Request-Id:
-      - req-8948824b-2618-4f21-93a3-ab47b3f84024
+      - req-1716ec52-34cb-4d78-929c-4ef866478c5c
       Date:
-      - Thu, 25 Oct 2018 18:23:52 GMT
+      - Thu, 01 Nov 2018 18:32:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d",
@@ -26164,7 +27490,7 @@ http_interactions:
         "port_range_max": 65535, "port_range_min": 1, "id": "e483857b-5eb5-4cb0-94d6-b431a2f0cb10",
         "security_group_id": "8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:53 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:31 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d
@@ -26179,7 +27505,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e5c2c8c12d3741cf8758152a15318f97
+      - e4031829ca794b898e1211cfc89e4ea0
   response:
     status:
       code: 200
@@ -26190,9 +27516,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-a3552132-a70c-41ee-9e78-991c871780df
+      - req-a8eb2263-e6ec-467d-9363-2be17b094b46
       Date:
-      - Thu, 25 Oct 2018 18:23:53 GMT
+      - Thu, 01 Nov 2018 18:32:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=bab65d2f-4717-47eb-bfb2-95100b254563",
@@ -26234,7 +27560,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "e1aa03c0-0758-42ca-b030-a3d62800e578",
         "security_group_id": "bab65d2f-4717-47eb-bfb2-95100b254563"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:53 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:31 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=bab65d2f-4717-47eb-bfb2-95100b254563
@@ -26249,7 +27575,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e5c2c8c12d3741cf8758152a15318f97
+      - e4031829ca794b898e1211cfc89e4ea0
   response:
     status:
       code: 200
@@ -26260,15 +27586,15 @@ http_interactions:
       Content-Length:
       - '156'
       X-Openstack-Request-Id:
-      - req-f6b00b5f-4c5c-4f6d-8806-ac995f5ee225
+      - req-9ee341a5-2416-4372-a243-4b6f2646c14c
       Date:
-      - Thu, 25 Oct 2018 18:23:53 GMT
+      - Thu, 01 Nov 2018 18:32:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&page_reverse=True",
         "rel": "previous"}], "security_groups": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:53 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:31 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000
@@ -26283,7 +27609,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3e3a7e9b834e47a3b8db9c4414bf8cac
+      - 0ad930d725df4f8ea482767d2723409a
   response:
     status:
       code: 200
@@ -26294,9 +27620,9 @@ http_interactions:
       Content-Length:
       - '2717'
       X-Openstack-Request-Id:
-      - req-ca8dc3dc-f06e-4a56-a386-e3599632b3f7
+      - req-e975efbd-625b-4c45-8757-0289d7c18400
       Date:
-      - Thu, 25 Oct 2018 18:23:53 GMT
+      - Thu, 01 Nov 2018 18:32:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=2e57d382-aeb2-4107-85cd-9dbde325f8f7",
@@ -26331,7 +27657,7 @@ http_interactions:
         null, "port_range_min": null, "id": "7e354503-9d45-4cc4-a742-4ff9501ba396",
         "security_group_id": "2e57d382-aeb2-4107-85cd-9dbde325f8f7"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:53 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:31 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=2e57d382-aeb2-4107-85cd-9dbde325f8f7
@@ -26346,7 +27672,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3e3a7e9b834e47a3b8db9c4414bf8cac
+      - 0ad930d725df4f8ea482767d2723409a
   response:
     status:
       code: 200
@@ -26357,9 +27683,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-bb24ae04-2677-4b00-957a-4836be4d5feb
+      - req-e926831c-030a-480c-b658-317c445be050
       Date:
-      - Thu, 25 Oct 2018 18:23:53 GMT
+      - Thu, 01 Nov 2018 18:32:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=42bcab35-fe98-49f3-ba0e-705a2737b81d",
@@ -26402,7 +27728,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "f87c3733-0682-46d9-8df1-05f1207541d1",
         "security_group_id": "42bcab35-fe98-49f3-ba0e-705a2737b81d"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:53 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:32 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=42bcab35-fe98-49f3-ba0e-705a2737b81d
@@ -26417,7 +27743,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3e3a7e9b834e47a3b8db9c4414bf8cac
+      - 0ad930d725df4f8ea482767d2723409a
   response:
     status:
       code: 200
@@ -26428,9 +27754,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-30ff5bfb-6bb1-4f72-bfc3-6c61d1167980
+      - req-41ed6536-2775-4fef-a7ca-f42813a89056
       Date:
-      - Thu, 25 Oct 2018 18:23:53 GMT
+      - Thu, 01 Nov 2018 18:32:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=7250f04f-facd-4731-b072-f346b1cc7a80",
@@ -26473,7 +27799,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "d0ee1562-3ff7-4ad5-b29f-8dd350ed221f",
         "security_group_id": "7250f04f-facd-4731-b072-f346b1cc7a80"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:53 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:32 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=7250f04f-facd-4731-b072-f346b1cc7a80
@@ -26488,7 +27814,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3e3a7e9b834e47a3b8db9c4414bf8cac
+      - 0ad930d725df4f8ea482767d2723409a
   response:
     status:
       code: 200
@@ -26499,9 +27825,9 @@ http_interactions:
       Content-Length:
       - '8737'
       X-Openstack-Request-Id:
-      - req-41019c7c-46b1-48ff-957c-46789ad94185
+      - req-32a37220-b7d9-4e32-9097-ab290ef059b1
       Date:
-      - Thu, 25 Oct 2018 18:23:53 GMT
+      - Thu, 01 Nov 2018 18:32:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d",
@@ -26608,7 +27934,7 @@ http_interactions:
         "port_range_max": 65535, "port_range_min": 1, "id": "e483857b-5eb5-4cb0-94d6-b431a2f0cb10",
         "security_group_id": "8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:53 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:32 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d
@@ -26623,7 +27949,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3e3a7e9b834e47a3b8db9c4414bf8cac
+      - 0ad930d725df4f8ea482767d2723409a
   response:
     status:
       code: 200
@@ -26634,9 +27960,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-fd5f6a09-01f2-47a5-a874-6d1a1305ccdb
+      - req-4e2d530d-e25a-4395-8f7f-c2154100ed42
       Date:
-      - Thu, 25 Oct 2018 18:23:53 GMT
+      - Thu, 01 Nov 2018 18:32:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=bab65d2f-4717-47eb-bfb2-95100b254563",
@@ -26678,7 +28004,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "e1aa03c0-0758-42ca-b030-a3d62800e578",
         "security_group_id": "bab65d2f-4717-47eb-bfb2-95100b254563"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:53 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:32 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=bab65d2f-4717-47eb-bfb2-95100b254563
@@ -26693,7 +28019,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3e3a7e9b834e47a3b8db9c4414bf8cac
+      - 0ad930d725df4f8ea482767d2723409a
   response:
     status:
       code: 200
@@ -26704,15 +28030,15 @@ http_interactions:
       Content-Length:
       - '156'
       X-Openstack-Request-Id:
-      - req-2d40d42a-3e96-4924-9eb2-89d22344a412
+      - req-db08af93-9f5b-4a14-b82c-fbd5e3c9272e
       Date:
-      - Thu, 25 Oct 2018 18:23:53 GMT
+      - Thu, 01 Nov 2018 18:32:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&page_reverse=True",
         "rel": "previous"}], "security_groups": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:53 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:32 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000
@@ -26727,7 +28053,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 40668f3b334b4e65857fc7fdb74d2771
+      - a1a08d45df5e479ebcac1fcdc42840dc
   response:
     status:
       code: 200
@@ -26738,9 +28064,9 @@ http_interactions:
       Content-Length:
       - '2717'
       X-Openstack-Request-Id:
-      - req-ccd9658f-ecc1-416e-b3c0-1ae0803035b5
+      - req-76055972-e844-46eb-a3cb-fd71192b4f85
       Date:
-      - Thu, 25 Oct 2018 18:23:54 GMT
+      - Thu, 01 Nov 2018 18:32:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=2e57d382-aeb2-4107-85cd-9dbde325f8f7",
@@ -26775,7 +28101,7 @@ http_interactions:
         null, "port_range_min": null, "id": "7e354503-9d45-4cc4-a742-4ff9501ba396",
         "security_group_id": "2e57d382-aeb2-4107-85cd-9dbde325f8f7"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:54 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:32 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=2e57d382-aeb2-4107-85cd-9dbde325f8f7
@@ -26790,7 +28116,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 40668f3b334b4e65857fc7fdb74d2771
+      - a1a08d45df5e479ebcac1fcdc42840dc
   response:
     status:
       code: 200
@@ -26801,9 +28127,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-bfa89d09-d17c-4314-8716-6323d7f8e0a9
+      - req-86fa4fcb-631d-4c93-9ed0-94698d687f67
       Date:
-      - Thu, 25 Oct 2018 18:23:54 GMT
+      - Thu, 01 Nov 2018 18:32:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=42bcab35-fe98-49f3-ba0e-705a2737b81d",
@@ -26846,7 +28172,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "f87c3733-0682-46d9-8df1-05f1207541d1",
         "security_group_id": "42bcab35-fe98-49f3-ba0e-705a2737b81d"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:54 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:32 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=42bcab35-fe98-49f3-ba0e-705a2737b81d
@@ -26861,7 +28187,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 40668f3b334b4e65857fc7fdb74d2771
+      - a1a08d45df5e479ebcac1fcdc42840dc
   response:
     status:
       code: 200
@@ -26872,9 +28198,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-5e452dbc-f4de-4047-9ba9-c87e5472e854
+      - req-378e8a59-49fe-459f-9474-8155eb215e4f
       Date:
-      - Thu, 25 Oct 2018 18:23:54 GMT
+      - Thu, 01 Nov 2018 18:32:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=7250f04f-facd-4731-b072-f346b1cc7a80",
@@ -26917,7 +28243,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "d0ee1562-3ff7-4ad5-b29f-8dd350ed221f",
         "security_group_id": "7250f04f-facd-4731-b072-f346b1cc7a80"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:54 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:32 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=7250f04f-facd-4731-b072-f346b1cc7a80
@@ -26932,7 +28258,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 40668f3b334b4e65857fc7fdb74d2771
+      - a1a08d45df5e479ebcac1fcdc42840dc
   response:
     status:
       code: 200
@@ -26943,9 +28269,9 @@ http_interactions:
       Content-Length:
       - '8737'
       X-Openstack-Request-Id:
-      - req-dac97a77-04e3-4722-94ef-0395f2cebf28
+      - req-ea3385ea-01da-4ab9-b633-0d5099791768
       Date:
-      - Thu, 25 Oct 2018 18:23:54 GMT
+      - Thu, 01 Nov 2018 18:32:34 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d",
@@ -27052,7 +28378,7 @@ http_interactions:
         "port_range_max": 65535, "port_range_min": 1, "id": "e483857b-5eb5-4cb0-94d6-b431a2f0cb10",
         "security_group_id": "8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:54 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:34 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d
@@ -27067,7 +28393,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 40668f3b334b4e65857fc7fdb74d2771
+      - a1a08d45df5e479ebcac1fcdc42840dc
   response:
     status:
       code: 200
@@ -27078,9 +28404,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-b3201c7e-11c3-4dfe-995e-5063faa6c25b
+      - req-cfea5f7d-5863-4a32-a360-3904b45d6f71
       Date:
-      - Thu, 25 Oct 2018 18:23:54 GMT
+      - Thu, 01 Nov 2018 18:32:34 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=bab65d2f-4717-47eb-bfb2-95100b254563",
@@ -27122,7 +28448,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "e1aa03c0-0758-42ca-b030-a3d62800e578",
         "security_group_id": "bab65d2f-4717-47eb-bfb2-95100b254563"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:54 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:34 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=bab65d2f-4717-47eb-bfb2-95100b254563
@@ -27137,7 +28463,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 40668f3b334b4e65857fc7fdb74d2771
+      - a1a08d45df5e479ebcac1fcdc42840dc
   response:
     status:
       code: 200
@@ -27148,15 +28474,15 @@ http_interactions:
       Content-Length:
       - '156'
       X-Openstack-Request-Id:
-      - req-4a47f275-2383-418c-bdea-cdb7a98bd66d
+      - req-261f1d56-6826-42f7-b34a-838239c08c2b
       Date:
-      - Thu, 25 Oct 2018 18:23:54 GMT
+      - Thu, 01 Nov 2018 18:32:34 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&page_reverse=True",
         "rel": "previous"}], "security_groups": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:54 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:34 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -27174,15 +28500,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:24:00 GMT
+      - Thu, 01 Nov 2018 18:32:34 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 3157745a867848e281e869e05d266dba
+      - 2783c794cd314d12bc158caa7d0b9eeb
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-5e95c455-e933-4a42-9098-de42d8749ca7
+      - req-981c4cbf-3789-43bb-a3ab-a7c922c9c1ca
       Content-Length:
       - '7311'
       Connection:
@@ -27194,7 +28520,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-10-25T19:24:00.322800Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-11-01T19:32:34.943746Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -27273,10 +28599,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["sdkeG2wNRoGepAK3H8c-dw"],
-        "issued_at": "2018-10-25T18:24:00.322821Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["oOT4cMsgTEiRHngORecbTQ"],
+        "issued_at": "2018-11-01T18:32:34.943782Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:00 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:34 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -27294,15 +28620,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:24:00 GMT
+      - Thu, 01 Nov 2018 18:32:35 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 4923ea4471e64411818e216ba29d6561
+      - c020ee7e1e5d404cad1e6cd45a9defa8
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-28c8e661-f9d7-4be3-b747-caed11f0ce58
+      - req-e7900451-dbca-4a95-ba95-cf07229a3cdc
       Content-Length:
       - '7311'
       Connection:
@@ -27314,7 +28640,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-10-25T19:24:00.523188Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-11-01T19:32:35.154415Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -27393,10 +28719,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Q5xW9D59SWGXKY86TmQmoA"],
-        "issued_at": "2018-10-25T18:24:00.523211Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["LJ7mSLnRRT6UysO9DaTEgA"],
+        "issued_at": "2018-11-01T18:32:35.154435Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:00 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:35 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -27414,15 +28740,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:24:00 GMT
+      - Thu, 01 Nov 2018 18:32:35 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 757941b4cc0a453c9c7cb9a7a4d69b86
+      - aa412a172e0c4dbb90865e95af5913e6
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-e4650153-58cd-4bc8-9128-61c6aa380830
+      - req-6f6f80d9-a425-4de5-8de7-385162fb4d0e
       Content-Length:
       - '297'
       Connection:
@@ -27431,12 +28757,12 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"token": {"methods": ["password"], "expires_at": "2018-10-25T19:24:00.689813Z",
+      string: '{"token": {"methods": ["password"], "expires_at": "2018-11-01T19:32:35.332902Z",
         "extras": {}, "user": {"domain": {"id": "default", "name": "Default"}, "id":
-        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["PRqZLNkqSASdLUupay9qSQ"],
-        "issued_at": "2018-10-25T18:24:00.689834Z"}}'
+        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["NAJoGu3GQI-wJAAyDMGGZA"],
+        "issued_at": "2018-11-01T18:32:35.332922Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:00 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:35 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects?domain_id=default
@@ -27451,20 +28777,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 757941b4cc0a453c9c7cb9a7a4d69b86
+      - aa412a172e0c4dbb90865e95af5913e6
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:24:00 GMT
+      - Thu, 01 Nov 2018 18:32:35 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-94f69a1f-f1b8-4174-b4df-9e5ca8b3673e
+      - req-62d738d6-49c0-417d-8184-1c17c2f89c3a
       Content-Length:
       - '2475'
       Connection:
@@ -27497,7 +28823,7 @@ http_interactions:
         "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
         "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:00 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:35 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -27515,15 +28841,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:24:00 GMT
+      - Thu, 01 Nov 2018 18:32:35 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - ad77da44a58942b79652d8652460ac3c
+      - d19b204d34bd44d1af8476743ea6671b
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-bde57675-d58d-4e4f-90d8-cb578b82d02f
+      - req-1c528325-68cf-4170-a952-b7d55db8497f
       Content-Length:
       - '7278'
       Connection:
@@ -27535,7 +28861,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:24:01.053790Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:32:35.677286Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -27614,10 +28940,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["EveH55csQoawM1Db65MWwA"],
-        "issued_at": "2018-10-25T18:24:01.053813Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["bG_hNQ0dQy2H0mp65T9aiQ"],
+        "issued_at": "2018-11-01T18:32:35.677307Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:01 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:35 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -27635,15 +28961,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:24:01 GMT
+      - Thu, 01 Nov 2018 18:32:35 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - b5d92530c4584c73bbcecbd4592f5b8b
+      - a724675f89784f35853aa64cbfe7890f
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-b782f9af-df14-446a-a1c1-7d2e8b89359f
+      - req-7d0e099d-c8ef-4996-ae1b-31c21badd004
       Content-Length:
       - '7278'
       Connection:
@@ -27655,7 +28981,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:24:01.252697Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:32:35.884877Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -27734,10 +29060,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["_K9lKYdZQfKBctBxs0f5Tg"],
-        "issued_at": "2018-10-25T18:24:01.252719Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["fpLhVa3bQiSorHJL8Ua0Uw"],
+        "issued_at": "2018-11-01T18:32:35.884897Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:01 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:35 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -27755,15 +29081,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:24:01 GMT
+      - Thu, 01 Nov 2018 18:32:36 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 428c2207dffe423bb85245cd450a3ec5
+      - c418bb78eae448d6bc518c4d5136d056
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-0d1f76a6-2b33-4a07-b172-c6b6ba4c322d
+      - req-33b4bf4e-9bfc-40d7-96fa-43c9cdb73db2
       Content-Length:
       - '7264'
       Connection:
@@ -27775,7 +29101,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:24:01.453454Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:32:36.097597Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -27854,10 +29180,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["5M4OW9IHSj63c4sGFi9_og"],
-        "issued_at": "2018-10-25T18:24:01.453475Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["jMIgEbrjSkSs_n_xXP08Gg"],
+        "issued_at": "2018-11-01T18:32:36.097617Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:01 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:36 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -27875,15 +29201,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:24:01 GMT
+      - Thu, 01 Nov 2018 18:32:36 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 9c2f70da6fa54b1c83ec26930bfbe0ab
+      - 18684ba0fa404e108feb9bd8bff0d919
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-fc884d82-6112-44c5-a45a-a78753dac5d6
+      - req-12fe79b2-cba4-481d-9d0b-c177a6731547
       Content-Length:
       - '7278'
       Connection:
@@ -27895,7 +29221,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:24:01.648973Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:32:36.307163Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -27974,10 +29300,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["iOrxVA3DS-CJzWJ_Tg7CmQ"],
-        "issued_at": "2018-10-25T18:24:01.648995Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["btHtxNZnSt29aUJeRRZIWA"],
+        "issued_at": "2018-11-01T18:32:36.307183Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:01 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:36 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -27995,15 +29321,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:24:01 GMT
+      - Thu, 01 Nov 2018 18:32:36 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - b394499ccb9b4ab68dcb15825bb37336
+      - 2f93d09dc80b41549b4dd0068d96025b
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-d7f7b9b9-1e34-4cbe-b6c1-0ce35624233f
+      - req-707d31aa-b78e-4cc1-b0c2-bbd8af2a369d
       Content-Length:
       - '7265'
       Connection:
@@ -28015,7 +29341,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:24:01.841948Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:32:36.538433Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -28094,10 +29420,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["caYpKcsaQl6sBd5HdWBd2Q"],
-        "issued_at": "2018-10-25T18:24:01.841970Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["kwAJa7UhSZazNeP6FA-ORQ"],
+        "issued_at": "2018-11-01T18:32:36.538454Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:01 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:36 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -28115,15 +29441,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:24:01 GMT
+      - Thu, 01 Nov 2018 18:32:36 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - c7c877ed31a44274b3c99210cf7438fe
+      - 95d204f9a5c74656802c2b4806d13285
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-feaddb11-4115-470b-8903-3db7f14d83dd
+      - req-bfd7340c-e62b-443d-b942-2877230a8213
       Content-Length:
       - '7278'
       Connection:
@@ -28135,7 +29461,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:24:02.053029Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:32:36.750917Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -28214,10 +29540,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["-HLK30ApQ2OBulSRO_gpHA"],
-        "issued_at": "2018-10-25T18:24:02.053056Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["sdqaJSjHRLeEgE4ykFYMVw"],
+        "issued_at": "2018-11-01T18:32:36.750937Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:02 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:36 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -28235,15 +29561,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:24:02 GMT
+      - Thu, 01 Nov 2018 18:32:36 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - d74fed218e93457291e2dcf7ac87e56a
+      - 0f9256c999ce4d2bac9b25ff9b6b3362
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-4b2d3f34-9372-4c13-a504-6fb034d17698
+      - req-634c9cdb-f361-4a3c-8fdc-f5b0f20c6517
       Content-Length:
       - '7278'
       Connection:
@@ -28255,7 +29581,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:24:02.252210Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:32:36.973442Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -28334,10 +29660,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["ZKzSq2O7S-m0zX9HSJ_U3g"],
-        "issued_at": "2018-10-25T18:24:02.252232Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["1rDkpZQwT-6p7OFYyJmBgA"],
+        "issued_at": "2018-11-01T18:32:36.973464Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:02 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:37 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/volumes/detail?limit=1000
@@ -28352,27 +29678,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d74fed218e93457291e2dcf7ac87e56a
+      - 0f9256c999ce4d2bac9b25ff9b6b3362
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-68a4c5a5-a70a-4a16-8e46-5a2c7067dfc9
+      - req-031e8df3-9b00-4a99-bdeb-f4be8b24ae9a
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-68a4c5a5-a70a-4a16-8e46-5a2c7067dfc9
+      - req-031e8df3-9b00-4a99-bdeb-f4be8b24ae9a
       Date:
-      - Thu, 25 Oct 2018 18:24:02 GMT
+      - Thu, 01 Nov 2018 18:32:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:02 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:37 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -28390,15 +29716,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:24:02 GMT
+      - Thu, 01 Nov 2018 18:32:37 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - bd59c3a31a604a50b25e8b400b7dc1cd
+      - 10e55ca1a6384cd9bd95042dcbff0320
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-c7b460e5-6696-4123-9884-c1b02fec5ee7
+      - req-bc1fbeb9-43ab-4174-8f04-295eaa8d89a0
       Content-Length:
       - '7278'
       Connection:
@@ -28410,7 +29736,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:24:02.597486Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:32:37.328763Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -28489,10 +29815,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["w7gEJnbfRkmGnWC8jc7L1Q"],
-        "issued_at": "2018-10-25T18:24:02.597507Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["RlVy8-qEQwWwgV8fVzpBDQ"],
+        "issued_at": "2018-11-01T18:32:37.328783Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:02 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:37 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/volumes/detail?limit=1000
@@ -28507,27 +29833,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bd59c3a31a604a50b25e8b400b7dc1cd
+      - 10e55ca1a6384cd9bd95042dcbff0320
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-08d7bffc-7d84-4837-99cc-64bcfaaa3f1a
+      - req-49fc5e1d-277d-4474-9cec-cd75c4b43804
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-08d7bffc-7d84-4837-99cc-64bcfaaa3f1a
+      - req-49fc5e1d-277d-4474-9cec-cd75c4b43804
       Date:
-      - Thu, 25 Oct 2018 18:24:02 GMT
+      - Thu, 01 Nov 2018 18:32:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:02 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:37 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -28545,15 +29871,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:24:02 GMT
+      - Thu, 01 Nov 2018 18:32:37 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - d737307f6aaa4aa4926bc081aaddbe70
+      - f13a5bb7ab0347c79275113ac8bd60e3
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-29ab32bd-c92b-48a1-8792-df93850269b8
+      - req-a7f57d67-e0a9-4ea4-9546-cb85dfe70355
       Content-Length:
       - '7264'
       Connection:
@@ -28565,7 +29891,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:24:02.942587Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:32:37.682416Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -28644,10 +29970,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["9nkEEdbDSZq4eLON0FFk_Q"],
-        "issued_at": "2018-10-25T18:24:02.942610Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["F3hDkxCNR-eRFjftf-Eojg"],
+        "issued_at": "2018-11-01T18:32:37.682436Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:02 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:37 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000
@@ -28662,22 +29988,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d737307f6aaa4aa4926bc081aaddbe70
+      - f13a5bb7ab0347c79275113ac8bd60e3
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-60f8cc8c-7b05-4427-b0b8-31d519b26f46
+      - req-54dbcee6-de83-4136-a2c5-a57986bb5f70
       Content-Type:
       - application/json
       Content-Length:
       - '2706'
       X-Openstack-Request-Id:
-      - req-60f8cc8c-7b05-4427-b0b8-31d519b26f46
+      - req-54dbcee6-de83-4136-a2c5-a57986bb5f70
       Date:
-      - Thu, 25 Oct 2018 18:24:03 GMT
+      - Thu, 01 Nov 2018 18:32:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=f46458aa-309d-4f47-b996-a39db065030a",
@@ -28710,7 +30036,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-4", "bootable": "true", "created_at":
         "2016-08-19T08:37:45.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:03 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:37 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=f46458aa-309d-4f47-b996-a39db065030a
@@ -28725,22 +30051,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d737307f6aaa4aa4926bc081aaddbe70
+      - f13a5bb7ab0347c79275113ac8bd60e3
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-aee182ee-7974-4d7c-b2eb-adfe1f7463cc
+      - req-9e66b5a8-af0e-4557-a94f-55f63614dff5
       Content-Type:
       - application/json
       Content-Length:
       - '3284'
       X-Openstack-Request-Id:
-      - req-aee182ee-7974-4d7c-b2eb-adfe1f7463cc
+      - req-9e66b5a8-af0e-4557-a94f-55f63614dff5
       Date:
-      - Thu, 25 Oct 2018 18:24:03 GMT
+      - Thu, 01 Nov 2018 18:32:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=476a0c89-4322-42aa-b7ce-3ac21be55af7",
@@ -28781,7 +30107,7 @@ http_interactions:
         "name": "EmsRefreshSpec-Volume-2", "bootable": "false", "created_at": "2016-08-19T08:37:33.000000",
         "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:03 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:38 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=476a0c89-4322-42aa-b7ce-3ac21be55af7
@@ -28796,22 +30122,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d737307f6aaa4aa4926bc081aaddbe70
+      - f13a5bb7ab0347c79275113ac8bd60e3
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-fdebeec6-b9f6-4a45-9a8b-38c5f03fe2e9
+      - req-6f3a4721-19e5-4dce-b099-1d0cf9e15c75
       Content-Type:
       - application/json
       Content-Length:
       - '2753'
       X-Openstack-Request-Id:
-      - req-fdebeec6-b9f6-4a45-9a8b-38c5f03fe2e9
+      - req-6f3a4721-19e5-4dce-b099-1d0cf9e15c75
       Date:
-      - Thu, 25 Oct 2018 18:24:03 GMT
+      - Thu, 01 Nov 2018 18:32:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=8791e24f-874d-4f1e-99ec-75fdb9d48ca5",
@@ -28845,7 +30171,7 @@ http_interactions:
         "bootable": "false", "created_at": "2016-08-19T08:37:05.000000", "volume_type":
         "iscsi"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:03 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:38 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=8791e24f-874d-4f1e-99ec-75fdb9d48ca5
@@ -28860,27 +30186,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d737307f6aaa4aa4926bc081aaddbe70
+      - f13a5bb7ab0347c79275113ac8bd60e3
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-e04c82c9-4ce1-449c-bc38-29cafa713429
+      - req-3fb90e28-13dc-4a8a-8e12-1636c59dc5f5
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-e04c82c9-4ce1-449c-bc38-29cafa713429
+      - req-3fb90e28-13dc-4a8a-8e12-1636c59dc5f5
       Date:
-      - Thu, 25 Oct 2018 18:24:03 GMT
+      - Thu, 01 Nov 2018 18:32:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:03 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:38 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -28898,15 +30224,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:24:03 GMT
+      - Thu, 01 Nov 2018 18:32:38 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 3ab1c9677a544f4589fa009361756c73
+      - aca6bf2651f04683ab09a7d43546b39d
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-6d866991-ccb5-420b-8738-84a760a4820c
+      - req-7ccd14e7-f066-4c57-b9d7-00cb1190e35d
       Content-Length:
       - '7278'
       Connection:
@@ -28918,7 +30244,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:24:03.774859Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:32:38.565427Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -28997,10 +30323,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["0N9k0RO2Rbms3oVVM5bzZQ"],
-        "issued_at": "2018-10-25T18:24:03.774879Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["4d2zIT-lSd-ndr6hW920dA"],
+        "issued_at": "2018-11-01T18:32:38.565446Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:03 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:38 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/volumes/detail?limit=1000
@@ -29015,27 +30341,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3ab1c9677a544f4589fa009361756c73
+      - aca6bf2651f04683ab09a7d43546b39d
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-3077d975-f141-4dbd-8f49-79598f6ad358
+      - req-c977e67e-c084-4e3b-97d5-88d6b464da02
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-3077d975-f141-4dbd-8f49-79598f6ad358
+      - req-c977e67e-c084-4e3b-97d5-88d6b464da02
       Date:
-      - Thu, 25 Oct 2018 18:24:03 GMT
+      - Thu, 01 Nov 2018 18:32:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:03 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:38 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/volumes/detail?limit=1000
@@ -29050,27 +30376,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4923ea4471e64411818e216ba29d6561
+      - c020ee7e1e5d404cad1e6cd45a9defa8
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-894050a4-8438-4a8d-b49f-50d2a3a33898
+      - req-f2a9cb54-7784-4570-859a-494004a3cac3
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-894050a4-8438-4a8d-b49f-50d2a3a33898
+      - req-f2a9cb54-7784-4570-859a-494004a3cac3
       Date:
-      - Thu, 25 Oct 2018 18:24:04 GMT
+      - Thu, 01 Nov 2018 18:32:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:04 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:38 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -29088,15 +30414,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:24:04 GMT
+      - Thu, 01 Nov 2018 18:32:39 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - dfc4919a0467404182d5ac200ac72b49
+      - 0176ab8d48ab40d5ac738a52f91f24ba
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-d49f21c9-84bf-41db-8e59-5561216c8f69
+      - req-e0d23d1c-8f3c-403a-a3cf-7923d6b068ee
       Content-Length:
       - '7265'
       Connection:
@@ -29108,7 +30434,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:24:04.269202Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:32:39.106596Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -29187,10 +30513,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["gRkej8i9SFq7s9ktWIIAkQ"],
-        "issued_at": "2018-10-25T18:24:04.269223Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["GMHtdR_NQ4qjCRhOeLw41A"],
+        "issued_at": "2018-11-01T18:32:39.106616Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:04 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:39 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/volumes/detail?limit=1000
@@ -29205,27 +30531,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - dfc4919a0467404182d5ac200ac72b49
+      - 0176ab8d48ab40d5ac738a52f91f24ba
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-7d9f8db5-de23-4346-a787-a1d45135a18c
+      - req-51ffdd3a-d863-4917-b8a0-cfefbea4317e
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-7d9f8db5-de23-4346-a787-a1d45135a18c
+      - req-51ffdd3a-d863-4917-b8a0-cfefbea4317e
       Date:
-      - Thu, 25 Oct 2018 18:24:04 GMT
+      - Thu, 01 Nov 2018 18:32:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:04 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:39 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -29243,15 +30569,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:24:04 GMT
+      - Thu, 01 Nov 2018 18:32:39 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - edf3ad6c8254485cb136ac2f7b143438
+      - 3566e2eb4bb140e2bf838efcdaff9c87
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-d7953d11-af73-459f-9ad0-5b900670e694
+      - req-4d2dfc95-28e2-4ef3-a7fe-1f2b89f79ebe
       Content-Length:
       - '7278'
       Connection:
@@ -29263,7 +30589,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:24:04.613923Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:32:39.465471Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -29342,10 +30668,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["iQjFn0hyRESAapCXTRw5ig"],
-        "issued_at": "2018-10-25T18:24:04.613955Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["csToV3RVSJW94t2k7AmqDw"],
+        "issued_at": "2018-11-01T18:32:39.465492Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:04 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:39 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/volumes/detail?limit=1000
@@ -29360,27 +30686,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - edf3ad6c8254485cb136ac2f7b143438
+      - 3566e2eb4bb140e2bf838efcdaff9c87
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-9556bcf4-1386-4b59-8529-171dbb69d709
+      - req-82f6614e-2571-4f9d-95e1-c1fa9b85c1e2
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-9556bcf4-1386-4b59-8529-171dbb69d709
+      - req-82f6614e-2571-4f9d-95e1-c1fa9b85c1e2
       Date:
-      - Thu, 25 Oct 2018 18:24:04 GMT
+      - Thu, 01 Nov 2018 18:32:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:04 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:39 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/snapshots/detail
@@ -29395,27 +30721,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d74fed218e93457291e2dcf7ac87e56a
+      - 0f9256c999ce4d2bac9b25ff9b6b3362
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-ceb4db6f-4137-4e6e-b9e2-1460b03fbbb1
+      - req-ccd04694-1750-49a0-8d8c-ec49a7529ed0
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-ceb4db6f-4137-4e6e-b9e2-1460b03fbbb1
+      - req-ccd04694-1750-49a0-8d8c-ec49a7529ed0
       Date:
-      - Thu, 25 Oct 2018 18:24:04 GMT
+      - Thu, 01 Nov 2018 18:32:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:04 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:39 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/snapshots/detail?limit=1000
@@ -29430,27 +30756,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d74fed218e93457291e2dcf7ac87e56a
+      - 0f9256c999ce4d2bac9b25ff9b6b3362
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-3cf6c5da-9fe5-46b2-ba82-b8b4eff9892f
+      - req-00d29657-3948-46cb-be50-86acda791121
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-3cf6c5da-9fe5-46b2-ba82-b8b4eff9892f
+      - req-00d29657-3948-46cb-be50-86acda791121
       Date:
-      - Thu, 25 Oct 2018 18:24:05 GMT
+      - Thu, 01 Nov 2018 18:32:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:05 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:39 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/snapshots/detail
@@ -29465,27 +30791,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bd59c3a31a604a50b25e8b400b7dc1cd
+      - 10e55ca1a6384cd9bd95042dcbff0320
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-82325759-8851-4718-b5e3-eee42d5c9bdb
+      - req-27164d5b-d113-4756-b065-dba13c66e515
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-82325759-8851-4718-b5e3-eee42d5c9bdb
+      - req-27164d5b-d113-4756-b065-dba13c66e515
       Date:
-      - Thu, 25 Oct 2018 18:24:05 GMT
+      - Thu, 01 Nov 2018 18:32:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:05 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:39 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/snapshots/detail?limit=1000
@@ -29500,27 +30826,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bd59c3a31a604a50b25e8b400b7dc1cd
+      - 10e55ca1a6384cd9bd95042dcbff0320
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-9793862b-ebcb-4449-83b1-f62b8335dabf
+      - req-d6287f51-15e8-4d44-8e9f-008f72dc17c5
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-9793862b-ebcb-4449-83b1-f62b8335dabf
+      - req-d6287f51-15e8-4d44-8e9f-008f72dc17c5
       Date:
-      - Thu, 25 Oct 2018 18:24:05 GMT
+      - Thu, 01 Nov 2018 18:32:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:05 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:40 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/snapshots/detail
@@ -29535,22 +30861,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d737307f6aaa4aa4926bc081aaddbe70
+      - f13a5bb7ab0347c79275113ac8bd60e3
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-b65b89d9-132d-46f1-9aa2-28e68581116c
+      - req-cb8f4e6f-607e-4651-a168-64a366cdfe06
       Content-Type:
       - application/json
       Content-Length:
       - '1053'
       X-Openstack-Request-Id:
-      - req-b65b89d9-132d-46f1-9aa2-28e68581116c
+      - req-cb8f4e6f-607e-4651-a168-64a366cdfe06
       Date:
-      - Thu, 25 Oct 2018 18:24:05 GMT
+      - Thu, 01 Nov 2018 18:32:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/snapshots/detail?marker=c44d3eb3-31fe-46ed-bfae-707920be171d",
@@ -29565,7 +30891,7 @@ http_interactions:
         "created_at": "2016-08-19T08:37:24.000000", "size": 1, "id": "c44d3eb3-31fe-46ed-bfae-707920be171d",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:05 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:40 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/snapshots/detail?limit=1000
@@ -29580,22 +30906,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d737307f6aaa4aa4926bc081aaddbe70
+      - f13a5bb7ab0347c79275113ac8bd60e3
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-ee523951-e715-4c3c-8ff3-5e8655f38b03
+      - req-2652ed63-26e0-4d56-9f14-1d508892df28
       Content-Type:
       - application/json
       Content-Length:
       - '1064'
       X-Openstack-Request-Id:
-      - req-ee523951-e715-4c3c-8ff3-5e8655f38b03
+      - req-2652ed63-26e0-4d56-9f14-1d508892df28
       Date:
-      - Thu, 25 Oct 2018 18:24:05 GMT
+      - Thu, 01 Nov 2018 18:32:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/snapshots/detail?limit=1000&marker=c44d3eb3-31fe-46ed-bfae-707920be171d",
@@ -29610,7 +30936,7 @@ http_interactions:
         "created_at": "2016-08-19T08:37:24.000000", "size": 1, "id": "c44d3eb3-31fe-46ed-bfae-707920be171d",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:05 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:40 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/snapshots/detail
@@ -29625,27 +30951,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3ab1c9677a544f4589fa009361756c73
+      - aca6bf2651f04683ab09a7d43546b39d
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-be897d55-a652-468d-94bc-72641c034a88
+      - req-688b75d8-73a3-4420-af78-5107e74aecb2
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-be897d55-a652-468d-94bc-72641c034a88
+      - req-688b75d8-73a3-4420-af78-5107e74aecb2
       Date:
-      - Thu, 25 Oct 2018 18:24:05 GMT
+      - Thu, 01 Nov 2018 18:32:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:05 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:40 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/snapshots/detail?limit=1000
@@ -29660,27 +30986,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3ab1c9677a544f4589fa009361756c73
+      - aca6bf2651f04683ab09a7d43546b39d
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-4290f174-eada-4be6-8ad4-108529b958a6
+      - req-d49e73d5-bd0b-415c-bc0d-c16d222d81b8
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-4290f174-eada-4be6-8ad4-108529b958a6
+      - req-d49e73d5-bd0b-415c-bc0d-c16d222d81b8
       Date:
-      - Thu, 25 Oct 2018 18:24:05 GMT
+      - Thu, 01 Nov 2018 18:32:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:05 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:40 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/snapshots/detail
@@ -29695,27 +31021,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4923ea4471e64411818e216ba29d6561
+      - c020ee7e1e5d404cad1e6cd45a9defa8
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-a123e533-f535-4000-a510-d7ace01608f0
+      - req-df4aab4d-c273-42c2-b94e-40bc3dd34788
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-a123e533-f535-4000-a510-d7ace01608f0
+      - req-df4aab4d-c273-42c2-b94e-40bc3dd34788
       Date:
-      - Thu, 25 Oct 2018 18:24:05 GMT
+      - Thu, 01 Nov 2018 18:32:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:05 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:40 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/snapshots/detail?limit=1000
@@ -29730,27 +31056,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4923ea4471e64411818e216ba29d6561
+      - c020ee7e1e5d404cad1e6cd45a9defa8
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-1515fced-9039-42d7-b17e-670043ed50ee
+      - req-892719a7-0d7a-408f-aa27-930dd85be38e
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-1515fced-9039-42d7-b17e-670043ed50ee
+      - req-892719a7-0d7a-408f-aa27-930dd85be38e
       Date:
-      - Thu, 25 Oct 2018 18:24:05 GMT
+      - Thu, 01 Nov 2018 18:32:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:05 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:40 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/snapshots/detail
@@ -29765,27 +31091,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - dfc4919a0467404182d5ac200ac72b49
+      - 0176ab8d48ab40d5ac738a52f91f24ba
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-bd2e8351-5a55-4026-a540-5d12586f275d
+      - req-dc102812-7e1b-4729-a021-e1c46ef6c5f6
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-bd2e8351-5a55-4026-a540-5d12586f275d
+      - req-dc102812-7e1b-4729-a021-e1c46ef6c5f6
       Date:
-      - Thu, 25 Oct 2018 18:24:05 GMT
+      - Thu, 01 Nov 2018 18:32:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:06 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:40 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/snapshots/detail?limit=1000
@@ -29800,27 +31126,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - dfc4919a0467404182d5ac200ac72b49
+      - 0176ab8d48ab40d5ac738a52f91f24ba
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-e1ce46a0-60ac-45e3-ac87-d99f1b0c728e
+      - req-f9cd124f-4234-4b6c-b063-1cd82f375a4e
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-e1ce46a0-60ac-45e3-ac87-d99f1b0c728e
+      - req-f9cd124f-4234-4b6c-b063-1cd82f375a4e
       Date:
-      - Thu, 25 Oct 2018 18:24:06 GMT
+      - Thu, 01 Nov 2018 18:32:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:06 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:40 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/snapshots/detail
@@ -29835,27 +31161,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - edf3ad6c8254485cb136ac2f7b143438
+      - 3566e2eb4bb140e2bf838efcdaff9c87
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-c4143081-9063-49bf-8afb-315a63d504c0
+      - req-2b4ff9b5-04ff-4447-acda-4c9050444c9b
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-c4143081-9063-49bf-8afb-315a63d504c0
+      - req-2b4ff9b5-04ff-4447-acda-4c9050444c9b
       Date:
-      - Thu, 25 Oct 2018 18:24:06 GMT
+      - Thu, 01 Nov 2018 18:32:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:06 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:41 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/snapshots/detail?limit=1000
@@ -29870,27 +31196,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - edf3ad6c8254485cb136ac2f7b143438
+      - 3566e2eb4bb140e2bf838efcdaff9c87
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-8868a914-0879-4645-b571-186591da40de
+      - req-f30c3307-a24e-4413-8445-e2c097e8eab7
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-8868a914-0879-4645-b571-186591da40de
+      - req-f30c3307-a24e-4413-8445-e2c097e8eab7
       Date:
-      - Thu, 25 Oct 2018 18:24:06 GMT
+      - Thu, 01 Nov 2018 18:32:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:06 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:41 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/backups/detail
@@ -29905,27 +31231,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d74fed218e93457291e2dcf7ac87e56a
+      - 0f9256c999ce4d2bac9b25ff9b6b3362
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-b16e6fa4-15cc-4f3e-b86d-8e68ffa7adb2
+      - req-325ac7ef-e0a4-46b9-9d8e-a22e4157e3fa
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-b16e6fa4-15cc-4f3e-b86d-8e68ffa7adb2
+      - req-325ac7ef-e0a4-46b9-9d8e-a22e4157e3fa
       Date:
-      - Thu, 25 Oct 2018 18:24:06 GMT
+      - Thu, 01 Nov 2018 18:32:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:06 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:41 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/backups/detail?limit=1000
@@ -29940,27 +31266,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d74fed218e93457291e2dcf7ac87e56a
+      - 0f9256c999ce4d2bac9b25ff9b6b3362
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-739610b8-23e6-4f6a-9aff-b3244c6a017a
+      - req-27b0f8e1-528b-4b37-8743-25ee2a588636
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-739610b8-23e6-4f6a-9aff-b3244c6a017a
+      - req-27b0f8e1-528b-4b37-8743-25ee2a588636
       Date:
-      - Thu, 25 Oct 2018 18:24:06 GMT
+      - Thu, 01 Nov 2018 18:32:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:06 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:41 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/backups/detail
@@ -29975,27 +31301,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bd59c3a31a604a50b25e8b400b7dc1cd
+      - 10e55ca1a6384cd9bd95042dcbff0320
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-8e1a1d35-67c1-452a-a47e-82785edb3315
+      - req-176aac36-35c8-40e6-b93b-91de3ec48db8
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-8e1a1d35-67c1-452a-a47e-82785edb3315
+      - req-176aac36-35c8-40e6-b93b-91de3ec48db8
       Date:
-      - Thu, 25 Oct 2018 18:24:06 GMT
+      - Thu, 01 Nov 2018 18:32:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:06 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:41 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/backups/detail?limit=1000
@@ -30010,27 +31336,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bd59c3a31a604a50b25e8b400b7dc1cd
+      - 10e55ca1a6384cd9bd95042dcbff0320
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-6cf264f7-ab63-4efa-ae2a-18f0a2ba064a
+      - req-91cbb706-7b65-4bdb-a9ca-397773690a43
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-6cf264f7-ab63-4efa-ae2a-18f0a2ba064a
+      - req-91cbb706-7b65-4bdb-a9ca-397773690a43
       Date:
-      - Thu, 25 Oct 2018 18:24:06 GMT
+      - Thu, 01 Nov 2018 18:32:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:06 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:41 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/backups/detail
@@ -30045,27 +31371,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d737307f6aaa4aa4926bc081aaddbe70
+      - f13a5bb7ab0347c79275113ac8bd60e3
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-99c5901b-60cd-469b-ab5b-d13f19c6df0f
+      - req-0d77ad66-3ca5-4a2e-b6ac-48af3c1b2161
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-99c5901b-60cd-469b-ab5b-d13f19c6df0f
+      - req-0d77ad66-3ca5-4a2e-b6ac-48af3c1b2161
       Date:
-      - Thu, 25 Oct 2018 18:24:06 GMT
+      - Thu, 01 Nov 2018 18:32:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:06 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:41 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/backups/detail?limit=1000
@@ -30080,27 +31406,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d737307f6aaa4aa4926bc081aaddbe70
+      - f13a5bb7ab0347c79275113ac8bd60e3
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-2d141e49-2136-44fa-b151-98a35a731578
+      - req-fbb423d4-b595-4379-b378-09cdd0fb7209
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-2d141e49-2136-44fa-b151-98a35a731578
+      - req-fbb423d4-b595-4379-b378-09cdd0fb7209
       Date:
-      - Thu, 25 Oct 2018 18:24:06 GMT
+      - Thu, 01 Nov 2018 18:32:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:06 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:42 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/backups/detail
@@ -30115,27 +31441,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3ab1c9677a544f4589fa009361756c73
+      - aca6bf2651f04683ab09a7d43546b39d
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-05caa3aa-2c9b-4f16-b2fc-167c4eefd184
+      - req-60cdf8e4-0b8a-4d02-8548-ae2134d122ca
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-05caa3aa-2c9b-4f16-b2fc-167c4eefd184
+      - req-60cdf8e4-0b8a-4d02-8548-ae2134d122ca
       Date:
-      - Thu, 25 Oct 2018 18:24:06 GMT
+      - Thu, 01 Nov 2018 18:32:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:06 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:42 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/backups/detail?limit=1000
@@ -30150,27 +31476,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3ab1c9677a544f4589fa009361756c73
+      - aca6bf2651f04683ab09a7d43546b39d
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-22854cc5-53c7-4694-b75d-c0accf77c722
+      - req-e883a956-df2b-4c82-9b3c-ecd6acbab900
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-22854cc5-53c7-4694-b75d-c0accf77c722
+      - req-e883a956-df2b-4c82-9b3c-ecd6acbab900
       Date:
-      - Thu, 25 Oct 2018 18:24:07 GMT
+      - Thu, 01 Nov 2018 18:32:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:07 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:42 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/backups/detail
@@ -30185,27 +31511,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4923ea4471e64411818e216ba29d6561
+      - c020ee7e1e5d404cad1e6cd45a9defa8
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-451fb883-2f06-44f0-aee5-5d69ea88f4d5
+      - req-9f8e5e59-8c99-402b-b986-d293c33080ae
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-451fb883-2f06-44f0-aee5-5d69ea88f4d5
+      - req-9f8e5e59-8c99-402b-b986-d293c33080ae
       Date:
-      - Thu, 25 Oct 2018 18:24:07 GMT
+      - Thu, 01 Nov 2018 18:32:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:07 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:42 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/backups/detail?limit=1000
@@ -30220,27 +31546,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4923ea4471e64411818e216ba29d6561
+      - c020ee7e1e5d404cad1e6cd45a9defa8
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-d1630f0c-85c2-4094-a406-2f65c9740186
+      - req-db7c3987-6cca-488e-b291-3993cfedf77f
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-d1630f0c-85c2-4094-a406-2f65c9740186
+      - req-db7c3987-6cca-488e-b291-3993cfedf77f
       Date:
-      - Thu, 25 Oct 2018 18:24:07 GMT
+      - Thu, 01 Nov 2018 18:32:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:07 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:42 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/backups/detail
@@ -30255,27 +31581,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - dfc4919a0467404182d5ac200ac72b49
+      - 0176ab8d48ab40d5ac738a52f91f24ba
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-68842ca5-9faf-45fb-b649-3980d39dbd69
+      - req-c8059525-c779-4938-94ba-21f9dd830214
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-68842ca5-9faf-45fb-b649-3980d39dbd69
+      - req-c8059525-c779-4938-94ba-21f9dd830214
       Date:
-      - Thu, 25 Oct 2018 18:24:07 GMT
+      - Thu, 01 Nov 2018 18:32:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:07 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:42 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/backups/detail?limit=1000
@@ -30290,27 +31616,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - dfc4919a0467404182d5ac200ac72b49
+      - 0176ab8d48ab40d5ac738a52f91f24ba
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-5cab6efa-26ad-4d6c-a3e4-6109c68944e4
+      - req-50bb8e23-4124-4a2a-b68c-06ffd92d87d0
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-5cab6efa-26ad-4d6c-a3e4-6109c68944e4
+      - req-50bb8e23-4124-4a2a-b68c-06ffd92d87d0
       Date:
-      - Thu, 25 Oct 2018 18:24:07 GMT
+      - Thu, 01 Nov 2018 18:32:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:07 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:42 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/backups/detail
@@ -30325,27 +31651,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - edf3ad6c8254485cb136ac2f7b143438
+      - 3566e2eb4bb140e2bf838efcdaff9c87
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-7978a3ce-7752-4b04-ae42-c6a35eca2293
+      - req-97ce1ebc-cb38-4844-a6ce-3668b13682aa
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-7978a3ce-7752-4b04-ae42-c6a35eca2293
+      - req-97ce1ebc-cb38-4844-a6ce-3668b13682aa
       Date:
-      - Thu, 25 Oct 2018 18:24:07 GMT
+      - Thu, 01 Nov 2018 18:32:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:07 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:42 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/backups/detail?limit=1000
@@ -30360,27 +31686,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - edf3ad6c8254485cb136ac2f7b143438
+      - 3566e2eb4bb140e2bf838efcdaff9c87
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-888d76ba-c9f4-44bd-9268-b854e3393277
+      - req-13d98109-ecb8-4334-8e37-7e11950144c8
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-888d76ba-c9f4-44bd-9268-b854e3393277
+      - req-13d98109-ecb8-4334-8e37-7e11950144c8
       Date:
-      - Thu, 25 Oct 2018 18:24:07 GMT
+      - Thu, 01 Nov 2018 18:32:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:07 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:42 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/types?limit=1000
@@ -30395,22 +31721,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d74fed218e93457291e2dcf7ac87e56a
+      - 0f9256c999ce4d2bac9b25ff9b6b3362
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-a405fc63-cd94-481a-8bc4-36b9392364bd
+      - req-70a35d2c-1cd7-48c8-8454-54858ab78384
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-a405fc63-cd94-481a-8bc4-36b9392364bd
+      - req-70a35d2c-1cd7-48c8-8454-54858ab78384
       Date:
-      - Thu, 25 Oct 2018 18:24:07 GMT
+      - Thu, 01 Nov 2018 18:32:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -30422,7 +31748,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:07 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:42 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/types?limit=1000&marker=b953db40-aeea-4a55-9bd9-c08dcafd6f7e
@@ -30437,22 +31763,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d74fed218e93457291e2dcf7ac87e56a
+      - 0f9256c999ce4d2bac9b25ff9b6b3362
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-875d3003-63c6-498c-a9fc-d530db02ae5c
+      - req-85af95e5-12ed-4945-9490-4270e1b4d691
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-875d3003-63c6-498c-a9fc-d530db02ae5c
+      - req-85af95e5-12ed-4945-9490-4270e1b4d691
       Date:
-      - Thu, 25 Oct 2018 18:24:07 GMT
+      - Thu, 01 Nov 2018 18:32:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -30464,7 +31790,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:07 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:43 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/types?limit=1000
@@ -30479,22 +31805,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bd59c3a31a604a50b25e8b400b7dc1cd
+      - 10e55ca1a6384cd9bd95042dcbff0320
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-a1857c42-c1d4-4fc2-aa39-4df2a91a2f0e
+      - req-17d73241-f900-431b-a540-2771c5875b13
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-a1857c42-c1d4-4fc2-aa39-4df2a91a2f0e
+      - req-17d73241-f900-431b-a540-2771c5875b13
       Date:
-      - Thu, 25 Oct 2018 18:24:07 GMT
+      - Thu, 01 Nov 2018 18:32:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -30506,7 +31832,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:07 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:43 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/types?limit=1000&marker=b953db40-aeea-4a55-9bd9-c08dcafd6f7e
@@ -30521,22 +31847,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bd59c3a31a604a50b25e8b400b7dc1cd
+      - 10e55ca1a6384cd9bd95042dcbff0320
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-b3c7999d-509f-42c4-8fb2-c8c25c9fda2b
+      - req-499d590b-b5c7-4479-9750-b646417e7891
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-b3c7999d-509f-42c4-8fb2-c8c25c9fda2b
+      - req-499d590b-b5c7-4479-9750-b646417e7891
       Date:
-      - Thu, 25 Oct 2018 18:24:07 GMT
+      - Thu, 01 Nov 2018 18:32:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -30548,7 +31874,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:07 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:43 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/types?limit=1000
@@ -30563,22 +31889,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d737307f6aaa4aa4926bc081aaddbe70
+      - f13a5bb7ab0347c79275113ac8bd60e3
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-4a628a3a-5f59-4716-ba0f-f613f3c0099b
+      - req-9bf10f3c-ecc0-4f72-ae1a-9e4938ae559c
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-4a628a3a-5f59-4716-ba0f-f613f3c0099b
+      - req-9bf10f3c-ecc0-4f72-ae1a-9e4938ae559c
       Date:
-      - Thu, 25 Oct 2018 18:24:08 GMT
+      - Thu, 01 Nov 2018 18:32:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -30590,7 +31916,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:08 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:43 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/types?limit=1000&marker=b953db40-aeea-4a55-9bd9-c08dcafd6f7e
@@ -30605,22 +31931,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d737307f6aaa4aa4926bc081aaddbe70
+      - f13a5bb7ab0347c79275113ac8bd60e3
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-6794fe3a-5790-4bac-b3af-c431f55a0f66
+      - req-3df18f2a-9814-42e4-a05f-cf7b7d541e5c
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-6794fe3a-5790-4bac-b3af-c431f55a0f66
+      - req-3df18f2a-9814-42e4-a05f-cf7b7d541e5c
       Date:
-      - Thu, 25 Oct 2018 18:24:08 GMT
+      - Thu, 01 Nov 2018 18:32:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -30632,7 +31958,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:08 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:43 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/types?limit=1000
@@ -30647,22 +31973,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3ab1c9677a544f4589fa009361756c73
+      - aca6bf2651f04683ab09a7d43546b39d
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-5b5821f1-883e-42e6-83fa-868fd54e2aca
+      - req-09df0154-d7ee-4260-bf44-dc4c569cbc15
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-5b5821f1-883e-42e6-83fa-868fd54e2aca
+      - req-09df0154-d7ee-4260-bf44-dc4c569cbc15
       Date:
-      - Thu, 25 Oct 2018 18:24:08 GMT
+      - Thu, 01 Nov 2018 18:32:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -30674,7 +32000,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:08 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:43 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/types?limit=1000&marker=b953db40-aeea-4a55-9bd9-c08dcafd6f7e
@@ -30689,22 +32015,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3ab1c9677a544f4589fa009361756c73
+      - aca6bf2651f04683ab09a7d43546b39d
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-43f84a60-80a7-46a9-a826-9999e1fadb6c
+      - req-ee2b1df4-1de8-4015-bbca-d840ebc0a43b
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-43f84a60-80a7-46a9-a826-9999e1fadb6c
+      - req-ee2b1df4-1de8-4015-bbca-d840ebc0a43b
       Date:
-      - Thu, 25 Oct 2018 18:24:08 GMT
+      - Thu, 01 Nov 2018 18:32:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -30716,7 +32042,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:08 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:43 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/types?limit=1000
@@ -30731,22 +32057,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4923ea4471e64411818e216ba29d6561
+      - c020ee7e1e5d404cad1e6cd45a9defa8
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-414d8334-7c9d-48e4-9e3a-7f8243220f80
+      - req-a6f03303-c200-4668-a001-993f883ff492
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-414d8334-7c9d-48e4-9e3a-7f8243220f80
+      - req-a6f03303-c200-4668-a001-993f883ff492
       Date:
-      - Thu, 25 Oct 2018 18:24:08 GMT
+      - Thu, 01 Nov 2018 18:32:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -30758,7 +32084,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:08 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:43 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/types?limit=1000&marker=b953db40-aeea-4a55-9bd9-c08dcafd6f7e
@@ -30773,22 +32099,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4923ea4471e64411818e216ba29d6561
+      - c020ee7e1e5d404cad1e6cd45a9defa8
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-4a70950e-2ee5-4831-8176-36f16ecf6f1b
+      - req-5b52a51c-a0cc-4f0b-ae54-2241d3371d26
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-4a70950e-2ee5-4831-8176-36f16ecf6f1b
+      - req-5b52a51c-a0cc-4f0b-ae54-2241d3371d26
       Date:
-      - Thu, 25 Oct 2018 18:24:08 GMT
+      - Thu, 01 Nov 2018 18:32:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -30800,7 +32126,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:08 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:43 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/types?limit=1000
@@ -30815,22 +32141,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - dfc4919a0467404182d5ac200ac72b49
+      - 0176ab8d48ab40d5ac738a52f91f24ba
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-3ca563ce-d501-452c-9d22-bc6bdc27b480
+      - req-b3260468-a5d6-46d1-8fc8-c7ca13a73f45
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-3ca563ce-d501-452c-9d22-bc6bdc27b480
+      - req-b3260468-a5d6-46d1-8fc8-c7ca13a73f45
       Date:
-      - Thu, 25 Oct 2018 18:24:08 GMT
+      - Thu, 01 Nov 2018 18:32:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -30842,7 +32168,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:08 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:43 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/types?limit=1000&marker=b953db40-aeea-4a55-9bd9-c08dcafd6f7e
@@ -30857,22 +32183,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - dfc4919a0467404182d5ac200ac72b49
+      - 0176ab8d48ab40d5ac738a52f91f24ba
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-5272087d-9361-47b1-99e7-3f8c328a2def
+      - req-bc97b9e2-52e2-4246-96e4-9b8ffac5e3b8
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-5272087d-9361-47b1-99e7-3f8c328a2def
+      - req-bc97b9e2-52e2-4246-96e4-9b8ffac5e3b8
       Date:
-      - Thu, 25 Oct 2018 18:24:08 GMT
+      - Thu, 01 Nov 2018 18:32:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -30884,7 +32210,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:08 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:44 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/types?limit=1000
@@ -30899,22 +32225,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - edf3ad6c8254485cb136ac2f7b143438
+      - 3566e2eb4bb140e2bf838efcdaff9c87
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-cb2a5c9b-d748-444a-8c28-15e6cb80784e
+      - req-7493d428-c29e-4417-9f52-006a5fb4cae3
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-cb2a5c9b-d748-444a-8c28-15e6cb80784e
+      - req-7493d428-c29e-4417-9f52-006a5fb4cae3
       Date:
-      - Thu, 25 Oct 2018 18:24:08 GMT
+      - Thu, 01 Nov 2018 18:32:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -30926,7 +32252,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:08 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:44 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/types?limit=1000&marker=b953db40-aeea-4a55-9bd9-c08dcafd6f7e
@@ -30941,22 +32267,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - edf3ad6c8254485cb136ac2f7b143438
+      - 3566e2eb4bb140e2bf838efcdaff9c87
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-8a74c90b-e71a-44f1-8297-d44b202e42cb
+      - req-69e0b1b8-041d-4ee0-b9f7-06bd709e418a
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-8a74c90b-e71a-44f1-8297-d44b202e42cb
+      - req-69e0b1b8-041d-4ee0-b9f7-06bd709e418a
       Date:
-      - Thu, 25 Oct 2018 18:24:08 GMT
+      - Thu, 01 Nov 2018 18:32:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -30968,7 +32294,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:08 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:44 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -30986,15 +32312,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:24:09 GMT
+      - Thu, 01 Nov 2018 18:32:44 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 6c4010d958ac4f718165a177d6e589d3
+      - 957d74a323204518834b37caf4e3c482
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-52629336-a82a-44a1-863a-b74b5cef52aa
+      - req-3e54a29f-908e-495d-9adb-ec1a61800533
       Content-Length:
       - '7311'
       Connection:
@@ -31006,7 +32332,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-10-25T19:24:09.185590Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-11-01T19:32:44.547470Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -31085,10 +32411,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["3zimhwGkSCSnY9dl1_dnww"],
-        "issued_at": "2018-10-25T18:24:09.185616Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["6yZtUerCTLalgv2GYiBKHA"],
+        "issued_at": "2018-11-01T18:32:44.547490Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:09 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:44 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -31106,15 +32432,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:24:09 GMT
+      - Thu, 01 Nov 2018 18:32:44 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 48f8e77486d14079af9d597bbde854bd
+      - 013446be3a264b088458b5f255edce4a
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-5c1344be-c13f-42a6-b276-6e57e43b4655
+      - req-c29611a3-e6d7-4073-ac0a-c568219d6b1e
       Content-Length:
       - '7311'
       Connection:
@@ -31126,7 +32452,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-10-25T19:24:09.397640Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-11-01T19:32:44.765644Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -31205,10 +32531,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["LUeoAEbjTGubaZ9PF0EvBw"],
-        "issued_at": "2018-10-25T18:24:09.397661Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["ztwKsDFkQia1Vq4WrmszMA"],
+        "issued_at": "2018-11-01T18:32:44.765664Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:09 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:44 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -31226,15 +32552,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:24:09 GMT
+      - Thu, 01 Nov 2018 18:32:44 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - b1d7b08d804040d1929028fa8e96ec4a
+      - 9aa3a50f7da1498f91190156ca6d2bd6
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-8d6e1823-a971-463b-8917-d045d0f839c0
+      - req-f78eed0a-fe00-43fd-85de-e094fa996af3
       Content-Length:
       - '297'
       Connection:
@@ -31243,12 +32569,12 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"token": {"methods": ["password"], "expires_at": "2018-10-25T19:24:09.563722Z",
+      string: '{"token": {"methods": ["password"], "expires_at": "2018-11-01T19:32:44.939178Z",
         "extras": {}, "user": {"domain": {"id": "default", "name": "Default"}, "id":
-        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["REtnHYMESRKFB_W3Ll-D7A"],
-        "issued_at": "2018-10-25T18:24:09.563745Z"}}'
+        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["JymNi-jeTIGEMfSLLFqfWA"],
+        "issued_at": "2018-11-01T18:32:44.939198Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:09 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:44 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects?domain_id=default
@@ -31263,20 +32589,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b1d7b08d804040d1929028fa8e96ec4a
+      - 9aa3a50f7da1498f91190156ca6d2bd6
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:24:09 GMT
+      - Thu, 01 Nov 2018 18:32:45 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-cb3353ed-3502-40fd-b552-33e7328bc5ba
+      - req-644e084c-5738-4a7e-b880-f69ed5c15939
       Content-Length:
       - '2475'
       Connection:
@@ -31309,7 +32635,7 @@ http_interactions:
         "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
         "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:09 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:45 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -31327,15 +32653,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:24:09 GMT
+      - Thu, 01 Nov 2018 18:32:45 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - cc5a663163de4453a50b4b4fb2f3ea0c
+      - 45ed6ec06649479891a9e42cef6aaf48
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-49bed36d-b593-43b7-9ea1-7f867628cbf1
+      - req-e2e2db9e-801d-45c0-97d8-9a83a96b7e07
       Content-Length:
       - '7278'
       Connection:
@@ -31347,7 +32673,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:24:09.893038Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:32:45.303886Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -31426,10 +32752,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["AUZ5Ls01TBGKFPdbKmNXlg"],
-        "issued_at": "2018-10-25T18:24:09.893062Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["IGU_rNOTRvGIT1jrUms8Rw"],
+        "issued_at": "2018-11-01T18:32:45.303905Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:09 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:45 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -31447,15 +32773,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:24:10 GMT
+      - Thu, 01 Nov 2018 18:32:45 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 670a33aff13d43cfb1aa16d921671585
+      - e8798180fc7e4f7f9696f5add3571068
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-9956caa6-2e10-44c7-9bc6-46efb8e1343e
+      - req-f5764d0c-756e-4eb5-917d-74fdd46c932b
       Content-Length:
       - '7278'
       Connection:
@@ -31467,7 +32793,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:24:10.106557Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:32:45.510797Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -31546,10 +32872,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["uOK1KqAaSwa6-cFh1SAXjg"],
-        "issued_at": "2018-10-25T18:24:10.106587Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["ipN4_VFFTaqAQATZ3__TUA"],
+        "issued_at": "2018-11-01T18:32:45.510818Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:10 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:45 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -31567,15 +32893,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:24:10 GMT
+      - Thu, 01 Nov 2018 18:32:45 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 616fe4a46c4d4f13ba980c4566773d74
+      - cc68ee5c4ee54db688126ca612186f45
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-ee38e22d-a4bb-43fb-90b7-ccc86121d0dc
+      - req-f80ca5ff-61b5-4a0b-8395-ba30f1b07359
       Content-Length:
       - '7264'
       Connection:
@@ -31587,7 +32913,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:24:10.305318Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:32:45.714191Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -31666,10 +32992,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["3uA7LQsuTIywgdFmwovZ-w"],
-        "issued_at": "2018-10-25T18:24:10.305338Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["44XRqm48SMaCqtabGCUb4w"],
+        "issued_at": "2018-11-01T18:32:45.714209Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:10 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:45 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -31687,15 +33013,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:24:10 GMT
+      - Thu, 01 Nov 2018 18:32:45 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 9653aad73be84907b94d9e9f8a41347f
+      - cbff0a7a3c7845438cec72b205c2548f
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-8555fd1e-ffd9-4b90-a0ea-afe11942ce00
+      - req-21810a0e-5250-4485-86d0-6de36f4a66b3
       Content-Length:
       - '7278'
       Connection:
@@ -31707,7 +33033,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:24:10.506389Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:32:45.917844Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -31786,10 +33112,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["SPmNg8qbTDyAMS8OlHdPRQ"],
-        "issued_at": "2018-10-25T18:24:10.506410Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["n2Mf0JwLQeKkhfTyqPlcIA"],
+        "issued_at": "2018-11-01T18:32:45.917862Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:10 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:45 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -31807,15 +33133,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:24:10 GMT
+      - Thu, 01 Nov 2018 18:32:46 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - e3f0e950b947432ab18072a9f4eb642b
+      - b720b531740340b0860ef001b2455e44
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-30eaa599-2277-4f3a-a161-c5a6c0150f3b
+      - req-36baef50-92a9-4d1a-8151-cf3aee1a932d
       Content-Length:
       - '7265'
       Connection:
@@ -31827,7 +33153,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:24:10.702459Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:32:46.134202Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -31906,10 +33232,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["tlSXByITSd-etMXfJlY25A"],
-        "issued_at": "2018-10-25T18:24:10.702479Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["m5m3tTGhS3S3szPVqheGQg"],
+        "issued_at": "2018-11-01T18:32:46.134222Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:10 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:46 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -31927,15 +33253,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:24:10 GMT
+      - Thu, 01 Nov 2018 18:32:46 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 332412fda58742479c88bfdbacad82df
+      - 0575a86484994802aa9692f80c71ca97
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-2e3b5c58-1354-490e-889c-8e2ab114cb3d
+      - req-f73e0109-170b-450c-9b12-6f7486991fab
       Content-Length:
       - '7278'
       Connection:
@@ -31947,7 +33273,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:24:10.909646Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:32:46.345258Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -32026,10 +33352,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["nx8DdoueQje_3NBYlgc5UQ"],
-        "issued_at": "2018-10-25T18:24:10.909668Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["OcCULJLCQpGn8fsJoSa5-g"],
+        "issued_at": "2018-11-01T18:32:46.345280Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:10 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:46 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -32047,15 +33373,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:24:11 GMT
+      - Thu, 01 Nov 2018 18:32:46 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 6eb0c50eaa194f768f8123d8d2dea1a5
+      - 32d12123c9264f2cbd5abc632bd1aafd
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-d322da7b-3b91-47c7-8561-1b737a6540cb
+      - req-758ce8a6-814f-46c4-a395-7dd5fa4b1896
       Content-Length:
       - '7278'
       Connection:
@@ -32067,7 +33393,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:24:11.119905Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:32:46.574438Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -32146,10 +33472,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["UsA7TIIFQqaukIeuaJuSFQ"],
-        "issued_at": "2018-10-25T18:24:11.119926Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["1AbuLfEuQAu5_TsESPXI3g"],
+        "issued_at": "2018-11-01T18:32:46.574460Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:11 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:46 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_0098405163cd4c9dbb42c2cb43eb6fd3/?format=json&limit=1000
@@ -32164,7 +33490,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6eb0c50eaa194f768f8123d8d2dea1a5
+      - 32d12123c9264f2cbd5abc632bd1aafd
   response:
     status:
       code: 200
@@ -32177,22 +33503,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1540491851.25065'
+      - '1541097166.72623'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1540491851.25065'
+      - '1541097166.72623'
       X-Trans-Id:
-      - tx987578296c47405bb87a9-005bd20a4b
+      - tx5607b68264e541d0bbaed-005bdb46ce
       Date:
-      - Thu, 25 Oct 2018 18:24:11 GMT
+      - Thu, 01 Nov 2018 18:32:46 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:11 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:46 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -32210,15 +33536,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:24:11 GMT
+      - Thu, 01 Nov 2018 18:32:46 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 998fc8dc0eb842eca0afd05cd5e28847
+      - 0ee1dd1094ff45f39a1dfd1e6eb94b65
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-a5faad60-da11-431c-8e92-b9dec320fb4e
+      - req-f8401112-d760-4219-a9cd-6651b2aff65d
       Content-Length:
       - '7278'
       Connection:
@@ -32230,7 +33556,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:24:11.443170Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:32:46.918307Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -32309,10 +33635,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["CzTYrtTNTpqqPN8PmMP55Q"],
-        "issued_at": "2018-10-25T18:24:11.443191Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["1VFbfqJuQHekUbqmFh-1vg"],
+        "issued_at": "2018-11-01T18:32:46.918327Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:11 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:46 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_28db8f69ba9e4305b7fad82da4c86e74/?format=json&limit=1000
@@ -32327,7 +33653,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 998fc8dc0eb842eca0afd05cd5e28847
+      - 0ee1dd1094ff45f39a1dfd1e6eb94b65
   response:
     status:
       code: 200
@@ -32340,22 +33666,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1540491851.57664'
+      - '1541097167.05743'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1540491851.57664'
+      - '1541097167.05743'
       X-Trans-Id:
-      - txdbf178ea841a4b539bbe1-005bd20a4b
+      - tx14ae768cff4545848a719-005bdb46cf
       Date:
-      - Thu, 25 Oct 2018 18:24:11 GMT
+      - Thu, 01 Nov 2018 18:32:47 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:11 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:47 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -32373,15 +33699,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:24:11 GMT
+      - Thu, 01 Nov 2018 18:32:47 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 9ccd4d47522041608afa017e1a0895f0
+      - 25ab2a8537c44a158825465d98396242
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-fe892ff6-75de-41dd-9e26-e0f1ea8b75b4
+      - req-1125d30f-996e-4f4d-afc6-05e343733525
       Content-Length:
       - '7264'
       Connection:
@@ -32393,7 +33719,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:24:11.778850Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:32:47.624571Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -32472,10 +33798,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["1evk1eJGSDCfTFY84bbklA"],
-        "issued_at": "2018-10-25T18:24:11.778871Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["ouulP7FQRPOEUzyYfZokfA"],
+        "issued_at": "2018-11-01T18:32:47.624591Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:11 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:47 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_4637c33fee924ebea81f8d209e452c91/?format=json&limit=1000
@@ -32490,7 +33816,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9ccd4d47522041608afa017e1a0895f0
+      - 25ab2a8537c44a158825465d98396242
   response:
     status:
       code: 200
@@ -32519,15 +33845,15 @@ http_interactions:
       X-Account-Project-Domain-Id:
       - default
       X-Trans-Id:
-      - tx7d9e38cb13d642569b32e-005bd20a4b
+      - txf7263af0a7e344d3ba884-005bdb46cf
       Date:
-      - Thu, 25 Oct 2018 18:24:11 GMT
+      - Thu, 01 Nov 2018 18:32:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '[{"count": 3, "bytes": 33, "name": "dir_1"}, {"count": 0, "bytes":
         0, "name": "dir_2"}, {"count": 0, "bytes": 0, "name": "dir_3"}]'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:11 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:47 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_4637c33fee924ebea81f8d209e452c91/?format=json&limit=1000&marker=dir_3
@@ -32542,7 +33868,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9ccd4d47522041608afa017e1a0895f0
+      - 25ab2a8537c44a158825465d98396242
   response:
     status:
       code: 200
@@ -32571,14 +33897,14 @@ http_interactions:
       X-Account-Project-Domain-Id:
       - default
       X-Trans-Id:
-      - tx867e75ed99524010b90a0-005bd20a4b
+      - txb9ca01fc5278416fadc9d-005bdb46cf
       Date:
-      - Thu, 25 Oct 2018 18:24:11 GMT
+      - Thu, 01 Nov 2018 18:32:47 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:12 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:47 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -32596,15 +33922,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:24:12 GMT
+      - Thu, 01 Nov 2018 18:32:47 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 731a02f8c1834d1f99110618f8268e7e
+      - f52f2af7eec94ca58105148857a7ce0f
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-8c2f7241-421c-44ea-acff-b27100836cbd
+      - req-7152f8b3-72af-4972-8dad-c59e90d48314
       Content-Length:
       - '7278'
       Connection:
@@ -32616,7 +33942,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:24:12.194972Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:32:48.063774Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -32695,10 +34021,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["XYz124NhSnqJW-q3_IivdQ"],
-        "issued_at": "2018-10-25T18:24:12.194993Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["1kldMIAZQEmQUzrIe-CbvQ"],
+        "issued_at": "2018-11-01T18:32:48.063797Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:12 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:48 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_52c452d7763a4295950527948232a3e5/?format=json&limit=1000
@@ -32713,7 +34039,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 731a02f8c1834d1f99110618f8268e7e
+      - f52f2af7eec94ca58105148857a7ce0f
   response:
     status:
       code: 200
@@ -32726,22 +34052,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1540491852.32435'
+      - '1541097168.19854'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1540491852.32435'
+      - '1541097168.19854'
       X-Trans-Id:
-      - tx7ec7c95074ba498395d3b-005bd20a4c
+      - txa21d1ad4aec946d2ae6b0-005bdb46d0
       Date:
-      - Thu, 25 Oct 2018 18:24:12 GMT
+      - Thu, 01 Nov 2018 18:32:48 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:12 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:48 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_88ae57d444fd485ab2dfddd5a2615d52/?format=json&limit=1000
@@ -32756,7 +34082,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 48f8e77486d14079af9d597bbde854bd
+      - 013446be3a264b088458b5f255edce4a
   response:
     status:
       code: 200
@@ -32769,22 +34095,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1540491852.44465'
+      - '1541097168.31528'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1540491852.44465'
+      - '1541097168.31528'
       X-Trans-Id:
-      - tx7ece0df71def4a0d8db01-005bd20a4c
+      - tx117c4771b6a843e38005d-005bdb46d0
       Date:
-      - Thu, 25 Oct 2018 18:24:12 GMT
+      - Thu, 01 Nov 2018 18:32:48 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:12 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:48 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -32802,15 +34128,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:24:12 GMT
+      - Thu, 01 Nov 2018 18:32:48 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 4113fafe11c44016801d1ec78fd05b30
+      - 07b3faab145546c78400d8fd4f1040c2
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-ef97b384-67a2-4d88-864e-8149025e98b8
+      - req-ed512521-b062-4d18-977f-fcdf044d29a8
       Content-Length:
       - '7265'
       Connection:
@@ -32822,7 +34148,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:24:12.638781Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:32:48.530047Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -32901,10 +34227,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["KmSrq_NPTIGWrWAzu6iszw"],
-        "issued_at": "2018-10-25T18:24:12.638803Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["lnM6FtbETQO6LfcNIQEkiw"],
+        "issued_at": "2018-11-01T18:32:48.530070Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:12 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:48 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_d09cbe26295d47ff848ea73c74264e23/?format=json&limit=1000
@@ -32919,7 +34245,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4113fafe11c44016801d1ec78fd05b30
+      - 07b3faab145546c78400d8fd4f1040c2
   response:
     status:
       code: 200
@@ -32932,22 +34258,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1540491852.76760'
+      - '1541097168.67112'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1540491852.76760'
+      - '1541097168.67112'
       X-Trans-Id:
-      - txd585523dbfe949b98100f-005bd20a4c
+      - tx385cb13eb96e42c49dd24-005bdb46d0
       Date:
-      - Thu, 25 Oct 2018 18:24:12 GMT
+      - Thu, 01 Nov 2018 18:32:48 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:12 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:48 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -32965,15 +34291,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:24:12 GMT
+      - Thu, 01 Nov 2018 18:32:48 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 06c77d14b0ad43fda0443ea14e2ffa00
+      - fa663803abcc4831a835fc617522a2ce
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-1200c333-c7f2-4274-8787-9b4039fb6939
+      - req-599806ad-2a3e-4766-95b9-48f2ac06639a
       Content-Length:
       - '7278'
       Connection:
@@ -32985,7 +34311,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:24:12.987502Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:32:48.873860Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -33064,10 +34390,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["_A2_HjPxSm-JIWMfGIR98Q"],
-        "issued_at": "2018-10-25T18:24:12.987528Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["HzBtrwYdR_OGZHhxNZtYvQ"],
+        "issued_at": "2018-11-01T18:32:48.873881Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:13 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:48 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_ef2a3405d1ef4dfd9a3616993ef46a4d/?format=json&limit=1000
@@ -33082,7 +34408,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 06c77d14b0ad43fda0443ea14e2ffa00
+      - fa663803abcc4831a835fc617522a2ce
   response:
     status:
       code: 200
@@ -33095,22 +34421,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1540491853.13466'
+      - '1541097169.00639'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1540491853.13466'
+      - '1541097169.00639'
       X-Trans-Id:
-      - tx094210218be641b3ab80f-005bd20a4d
+      - tx2ddab79ba9a141359bff3-005bdb46d0
       Date:
-      - Thu, 25 Oct 2018 18:24:13 GMT
+      - Thu, 01 Nov 2018 18:32:49 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:13 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:49 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_4637c33fee924ebea81f8d209e452c91/dir_1?format=json
@@ -33125,7 +34451,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9ccd4d47522041608afa017e1a0895f0
+      - 25ab2a8537c44a158825465d98396242
   response:
     status:
       code: 200
@@ -33146,9 +34472,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - txc9b907d88fcc48ccb3d5d-005bd20a4d
+      - tx0ab53220acea4e4f95f5c-005bdb46d1
       Date:
-      - Thu, 25 Oct 2018 18:24:13 GMT
+      - Thu, 01 Nov 2018 18:32:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '[{"hash": "61257bf228e2f6802a196c9a460d19a8", "last_modified": "2016-08-19T08:37:59.564460",
@@ -33158,7 +34484,7 @@ http_interactions:
         {"hash": "1727a9b61bddf85bbe7a5710c9f45691", "last_modified": "2016-08-19T08:38:00.995870",
         "bytes": 11, "name": "file_3", "content_type": "application/octet-stream"}]'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:13 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:49 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_4637c33fee924ebea81f8d209e452c91/dir_2?format=json
@@ -33173,7 +34499,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9ccd4d47522041608afa017e1a0895f0
+      - 25ab2a8537c44a158825465d98396242
   response:
     status:
       code: 200
@@ -33194,14 +34520,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - tx4655e714563547a8b481a-005bd20a4d
+      - tx50d43798dd0a4a5a892cc-005bdb46d1
       Date:
-      - Thu, 25 Oct 2018 18:24:13 GMT
+      - Thu, 01 Nov 2018 18:32:49 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:13 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:49 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_4637c33fee924ebea81f8d209e452c91/dir_3?format=json
@@ -33216,7 +34542,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9ccd4d47522041608afa017e1a0895f0
+      - 25ab2a8537c44a158825465d98396242
   response:
     status:
       code: 200
@@ -33237,12 +34563,12 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - tx84c5f0901506429fb38c1-005bd20a4d
+      - tx18372e9435c14b14b092e-005bdb46d1
       Date:
-      - Thu, 25 Oct 2018 18:24:13 GMT
+      - Thu, 01 Nov 2018 18:32:49 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:13 GMT
+  recorded_at: Thu, 01 Nov 2018 18:32:49 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_keystone_v3_fast_refresh.yml
+++ b/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_keystone_v3_fast_refresh.yml
@@ -17,15 +17,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:24:19 GMT
+      - Thu, 01 Nov 2018 18:33:02 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 85dc3e037ff1478f99a91d0eec9026bd
+      - 3aa1e9306dfa4d11b62305024423fee7
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-aabef904-f8d3-4e3f-b182-bbb5149b22a4
+      - req-c73f4c23-1c44-49c1-8d58-4c1d9892dfed
       Content-Length:
       - '7311'
       Connection:
@@ -37,7 +37,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-10-25T19:24:19.290231Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-11-01T19:33:02.629433Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -116,10 +116,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["OasnnWq-S7mMWbp4UKaybw"],
-        "issued_at": "2018-10-25T18:24:19.290251Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["oosTtoZQQY-z5qP0dmqwlA"],
+        "issued_at": "2018-11-01T18:33:02.629463Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:19 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:02 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -134,7 +134,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 85dc3e037ff1478f99a91d0eec9026bd
+      - 3aa1e9306dfa4d11b62305024423fee7
   response:
     status:
       code: 200
@@ -145,7 +145,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Thu, 25 Oct 2018 18:24:19 GMT
+      - Thu, 01 Nov 2018 18:33:02 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -154,7 +154,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:19 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:02 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-availability-zone
@@ -169,7 +169,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 85dc3e037ff1478f99a91d0eec9026bd
+      - 3aa1e9306dfa4d11b62305024423fee7
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -182,15 +182,15 @@ http_interactions:
       Content-Length:
       - '97'
       X-Compute-Request-Id:
-      - req-dbfe3f2d-6f2f-4080-add4-00cf9c1496c9
+      - req-e1fe7b20-dbae-46c9-8318-8ba3b5ea944e
       Date:
-      - Thu, 25 Oct 2018 18:24:19 GMT
+      - Thu, 01 Nov 2018 18:33:02 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"availabilityZoneInfo": [{"zoneState": {"available": true}, "hosts":
         null, "zoneName": "nova"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:19 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:02 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -208,15 +208,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:24:19 GMT
+      - Thu, 01 Nov 2018 18:33:03 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - e717ded0b812448380d7dd4ddb0bd929
+      - f7ab4eb9dd0f43c2a676ffe90e43fdf3
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-a02bbb19-9d44-434e-9456-b40fe5c59fd2
+      - req-1cf2d040-03f0-491f-b928-5deb4fe61230
       Content-Length:
       - '7311'
       Connection:
@@ -228,7 +228,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-10-25T19:24:19.706814Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-11-01T19:33:03.077489Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -307,10 +307,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["vNPMSIi_RiWxdkUtU-g7XQ"],
-        "issued_at": "2018-10-25T18:24:19.706838Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["CIvaWe94RnuwiwEveDSMwg"],
+        "issued_at": "2018-11-01T18:33:03.077511Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:19 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:03 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/os-availability-zone.json
@@ -325,28 +325,28 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e717ded0b812448380d7dd4ddb0bd929
+      - f7ab4eb9dd0f43c2a676ffe90e43fdf3
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-20219a07-b943-4612-a4ee-14a8f3ea0db7
+      - req-50adff21-e190-44cd-b1a5-e0c5f0975f9a
       Content-Type:
       - application/json
       Content-Length:
       - '82'
       X-Openstack-Request-Id:
-      - req-20219a07-b943-4612-a4ee-14a8f3ea0db7
+      - req-50adff21-e190-44cd-b1a5-e0c5f0975f9a
       Date:
-      - Thu, 25 Oct 2018 18:24:19 GMT
+      - Thu, 01 Nov 2018 18:33:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"availabilityZoneInfo": [{"zoneState": {"available": true}, "zoneName":
         "nova"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:19 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:03 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-services?all_tenants=True&limit=1000
@@ -361,7 +361,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 85dc3e037ff1478f99a91d0eec9026bd
+      - 3aa1e9306dfa4d11b62305024423fee7
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -374,26 +374,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-90dc134d-859c-484e-8646-d519e217207f
+      - req-a307c69e-ce45-4137-b823-06f672fead6a
       Date:
-      - Thu, 25 Oct 2018 18:24:19 GMT
+      - Thu, 01 Nov 2018 18:33:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-10-25T18:24:14.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-11-01T18:33:03.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-10-25T18:24:10.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-11-01T18:32:55.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-10-25T18:24:13.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-11-01T18:33:01.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 5, "updated_at":
-        "2018-10-25T18:24:15.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-11-01T18:33:03.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-10-25T18:24:16.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-11-01T18:32:54.000000"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:19 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:03 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-services?all_tenants=True&limit=1000&marker=6
@@ -408,7 +408,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 85dc3e037ff1478f99a91d0eec9026bd
+      - 3aa1e9306dfa4d11b62305024423fee7
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -421,26 +421,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-d10a1996-85e1-4ac0-94fb-1696bb3dd788
+      - req-4f1181c3-d406-4044-b87f-fefd6522361a
       Date:
-      - Thu, 25 Oct 2018 18:24:20 GMT
+      - Thu, 01 Nov 2018 18:33:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-10-25T18:24:14.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-11-01T18:33:03.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-10-25T18:24:10.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-11-01T18:32:55.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-10-25T18:24:13.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-11-01T18:33:01.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 5, "updated_at":
-        "2018-10-25T18:24:15.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-11-01T18:33:03.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-10-25T18:24:16.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-11-01T18:32:54.000000"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:20 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:03 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000
@@ -455,7 +455,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 85dc3e037ff1478f99a91d0eec9026bd
+      - 3aa1e9306dfa4d11b62305024423fee7
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -468,9 +468,9 @@ http_interactions:
       Content-Length:
       - '1010'
       X-Compute-Request-Id:
-      - req-56f2867e-bd66-4d6b-8136-3d2b5ef63e54
+      - req-09950c5d-9a26-40d4-ae2b-e1b0ac4a28ea
       Date:
-      - Thu, 25 Oct 2018 18:24:20 GMT
+      - Thu, 01 Nov 2018 18:33:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.tiny", "links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/1",
@@ -484,7 +484,7 @@ http_interactions:
         0, "disk": 20, "id": "2"}], "flavors_links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=2",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:20 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:03 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=2
@@ -499,7 +499,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 85dc3e037ff1478f99a91d0eec9026bd
+      - 3aa1e9306dfa4d11b62305024423fee7
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -512,9 +512,9 @@ http_interactions:
       Content-Length:
       - '1014'
       X-Compute-Request-Id:
-      - req-90d7d60f-6cd3-4d61-b676-4228ff019756
+      - req-5b4532d2-438c-4e77-aff2-358d7ee48d63
       Date:
-      - Thu, 25 Oct 2018 18:24:20 GMT
+      - Thu, 01 Nov 2018 18:33:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.medium", "links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/3",
@@ -528,7 +528,7 @@ http_interactions:
         0, "disk": 80, "id": "4"}], "flavors_links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=4",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:20 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:03 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=4
@@ -543,7 +543,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 85dc3e037ff1478f99a91d0eec9026bd
+      - 3aa1e9306dfa4d11b62305024423fee7
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -556,9 +556,9 @@ http_interactions:
       Content-Length:
       - '1026'
       X-Compute-Request-Id:
-      - req-bee01574-e4c5-4c07-a7b8-3fc55b277250
+      - req-99b66715-3c4a-42d4-afdf-9093e6428872
       Date:
-      - Thu, 25 Oct 2018 18:24:20 GMT
+      - Thu, 01 Nov 2018 18:33:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.xlarge", "links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/5",
@@ -573,7 +573,7 @@ http_interactions:
         1, "disk": 1, "id": "6"}], "flavors_links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=6",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:20 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:03 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=6
@@ -588,7 +588,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 85dc3e037ff1478f99a91d0eec9026bd
+      - 3aa1e9306dfa4d11b62305024423fee7
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -601,9 +601,9 @@ http_interactions:
       Content-Length:
       - '448'
       X-Compute-Request-Id:
-      - req-b3297c08-db98-4664-bfc4-be1d1942f1bf
+      - req-cfaeca03-39ea-466e-b554-705ae25f1cc8
       Date:
-      - Thu, 25 Oct 2018 18:24:20 GMT
+      - Thu, 01 Nov 2018 18:33:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.ems_refresh_spec_private", "links": [{"href":
@@ -613,7 +613,7 @@ http_interactions:
         8, "swap": "", "os-flavor-access:is_public": false, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         0, "disk": 160, "id": "7"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:20 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:03 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -631,15 +631,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:24:20 GMT
+      - Thu, 01 Nov 2018 18:33:04 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - d81018949b0942039349a0db44daa1fe
+      - 01f4f97474184083b7a6fc2dac50ef09
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-b4f8ee43-2ae9-4659-9fb5-6345e88ed861
+      - req-593cc9ec-4226-4a04-9fea-8ecb71fde004
       Content-Length:
       - '7311'
       Connection:
@@ -651,7 +651,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-10-25T19:24:20.657498Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-11-01T19:33:04.105359Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -730,10 +730,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["QXbVx-slR6a0G7Swyj3P_g"],
-        "issued_at": "2018-10-25T18:24:20.657519Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["OSeDf-C0Qf6jVxVvd3uy3A"],
+        "issued_at": "2018-11-01T18:33:04.105381Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:20 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:04 GMT
 - request:
     method: get
     uri: http://10.8.99.206:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects?domain_id=default
@@ -748,20 +748,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d81018949b0942039349a0db44daa1fe
+      - 01f4f97474184083b7a6fc2dac50ef09
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:24:20 GMT
+      - Thu, 01 Nov 2018 18:33:04 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-3fd60159-529c-47c0-91cc-98b88b538805
+      - req-2e98b91e-09f4-4255-ac5f-a27eb36afaed
       Content-Length:
       - '2179'
       Connection:
@@ -794,7 +794,7 @@ http_interactions:
         "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
         "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:20 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:04 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/7/os-flavor-access
@@ -809,7 +809,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 85dc3e037ff1478f99a91d0eec9026bd
+      - 3aa1e9306dfa4d11b62305024423fee7
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -822,15 +822,15 @@ http_interactions:
       Content-Length:
       - '88'
       X-Compute-Request-Id:
-      - req-61c58568-0e6f-4621-9311-98e931195125
+      - req-25016906-397a-4494-8f7f-0c92be36229c
       Date:
-      - Thu, 25 Oct 2018 18:24:20 GMT
+      - Thu, 01 Nov 2018 18:33:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavor_access": [{"tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "flavor_id": "7"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:20 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:04 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -848,15 +848,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:24:21 GMT
+      - Thu, 01 Nov 2018 18:33:04 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 5e1aff5ec0484f4e9e5736516ec7cd28
+      - d37137d32ece4be4bd88604b833c7603
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-90f5dde4-5401-4b3a-b293-4c2af56f5c06
+      - req-e9222f35-c34f-4811-bc1e-3e758d28d723
       Content-Length:
       - '7311'
       Connection:
@@ -868,7 +868,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-10-25T19:24:21.084902Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-11-01T19:33:04.546902Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -947,10 +947,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["R5dAsMepT8eMSltOHKAYVA"],
-        "issued_at": "2018-10-25T18:24:21.084923Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["ThebYPXSTGCFkEBQU1TNtA"],
+        "issued_at": "2018-11-01T18:33:04.546924Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:21 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:04 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images
@@ -965,7 +965,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5e1aff5ec0484f4e9e5736516ec7cd28
+      - d37137d32ece4be4bd88604b833c7603
   response:
     status:
       code: 200
@@ -976,9 +976,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-31ca643b-51f5-42b5-97c6-16560b3ea0aa
+      - req-17222b33-0ac6-496a-a60e-b9b305df0e78
       Date:
-      - Thu, 25 Oct 2018 18:24:21 GMT
+      - Thu, 01 Nov 2018 18:33:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -1020,7 +1020,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images"}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:21 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:04 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images?marker=b672acdb-654b-41d7-963c-44a0349bd285
@@ -1035,7 +1035,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5e1aff5ec0484f4e9e5736516ec7cd28
+      - d37137d32ece4be4bd88604b833c7603
   response:
     status:
       code: 200
@@ -1046,14 +1046,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-ed956f86-ce66-4e30-aa1e-5fb9a3e8ab32
+      - req-c9e5e543-bb28-4961-987d-5f04190f929f
       Date:
-      - Thu, 25 Oct 2018 18:24:21 GMT
+      - Thu, 01 Nov 2018 18:33:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images"}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:21 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:04 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-keypairs?all_tenants=True&limit=1000
@@ -1068,7 +1068,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 85dc3e037ff1478f99a91d0eec9026bd
+      - 3aa1e9306dfa4d11b62305024423fee7
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1081,9 +1081,9 @@ http_interactions:
       Content-Length:
       - '1611'
       X-Compute-Request-Id:
-      - req-2be1ce34-fc67-45c1-bcac-444a5a1d16eb
+      - req-229269ea-f5b5-4d07-b3c7-88d657256425
       Date:
-      - Thu, 25 Oct 2018 18:24:21 GMT
+      - Thu, 01 Nov 2018 18:33:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKQyhM0ECmYmB8mI4vfeTEaY90skgHYgA/5apgT+cHhKzZX59Go+LGfb98dOCYEjnV3XKdO5dy7MrSdI5QSvGJmJIQPsH4WZNpRNuEhHzcHS1fEPe9zMceRlLafkTeUKhUGMIi1gOmBRdyZtz6fJw37AK6ioM4+16IhXjNVLV09jHn2PsUjh2RsGX5TzA3eHivptzINBD8eMBkyQwS2uejY42FlIg9qBpa8KEMgyo4KLvd/99kw9wLg1D9Y5+3OxA/J6hLfjSBv7Vd7Xvwd4ZmDlkU5+yH88b2ZOte8MyfAnlVA4v8bMdSsAf1e5NvUuZsoZC8goZCHjXmTDSI+yen
@@ -1093,7 +1093,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:21 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:04 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-keypairs?all_tenants=True&limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -1108,7 +1108,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 85dc3e037ff1478f99a91d0eec9026bd
+      - 3aa1e9306dfa4d11b62305024423fee7
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1121,9 +1121,9 @@ http_interactions:
       Content-Length:
       - '1611'
       X-Compute-Request-Id:
-      - req-6a2b2e53-622f-4c5b-88c1-22bcc1aa1205
+      - req-f4d6dea0-8de4-4401-b5e1-4867b17c04a9
       Date:
-      - Thu, 25 Oct 2018 18:24:21 GMT
+      - Thu, 01 Nov 2018 18:33:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKQyhM0ECmYmB8mI4vfeTEaY90skgHYgA/5apgT+cHhKzZX59Go+LGfb98dOCYEjnV3XKdO5dy7MrSdI5QSvGJmJIQPsH4WZNpRNuEhHzcHS1fEPe9zMceRlLafkTeUKhUGMIi1gOmBRdyZtz6fJw37AK6ioM4+16IhXjNVLV09jHn2PsUjh2RsGX5TzA3eHivptzINBD8eMBkyQwS2uejY42FlIg9qBpa8KEMgyo4KLvd/99kw9wLg1D9Y5+3OxA/J6hLfjSBv7Vd7Xvwd4ZmDlkU5+yH88b2ZOte8MyfAnlVA4v8bMdSsAf1e5NvUuZsoZC8goZCHjXmTDSI+yen
@@ -1133,7 +1133,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:21 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:05 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -1151,15 +1151,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:24:21 GMT
+      - Thu, 01 Nov 2018 18:33:05 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 8f631613b3b74216a0536221a2db51aa
+      - ead9dc8827574fd58616d822d86eccaf
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-75eef0b5-1937-42bf-a316-a7b8a2acb10b
+      - req-dd80f76c-12bd-4ed1-b790-c78777cb8310
       Content-Length:
       - '7311'
       Connection:
@@ -1171,7 +1171,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-10-25T19:24:21.718674Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-11-01T19:33:05.236137Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -1250,10 +1250,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["8ad2KO4FQTKDaoH-yHRrmw"],
-        "issued_at": "2018-10-25T18:24:21.718699Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["i1hE9x7oTOWGYqKRJTp9LQ"],
+        "issued_at": "2018-11-01T18:33:05.236157Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:21 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:05 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -1271,15 +1271,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:24:21 GMT
+      - Thu, 01 Nov 2018 18:33:05 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 15001c0d532545d1826bad7c6a240519
+      - 91f7aeedc99d4a4aa68cf151f5828345
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-0883d6c4-6985-458c-aba1-141425372226
+      - req-6d3cc850-f684-47c0-82ef-47eca41c0947
       Content-Length:
       - '297'
       Connection:
@@ -1288,12 +1288,12 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"token": {"methods": ["password"], "expires_at": "2018-10-25T19:24:21.887839Z",
+      string: '{"token": {"methods": ["password"], "expires_at": "2018-11-01T19:33:05.412960Z",
         "extras": {}, "user": {"domain": {"id": "default", "name": "Default"}, "id":
-        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["KnX_OJJaSDOlxyybicvquA"],
-        "issued_at": "2018-10-25T18:24:21.887859Z"}}'
+        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["YRYum-6LRDyLQF0C4g5uqQ"],
+        "issued_at": "2018-11-01T18:33:05.412992Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:21 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:05 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects?domain_id=default
@@ -1308,20 +1308,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 15001c0d532545d1826bad7c6a240519
+      - 91f7aeedc99d4a4aa68cf151f5828345
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:24:22 GMT
+      - Thu, 01 Nov 2018 18:33:05 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-839b344a-b383-418a-b7fd-24270e34e523
+      - req-59d6d134-08f8-478a-af14-2f9a3d6bec60
       Content-Length:
       - '2475'
       Connection:
@@ -1354,7 +1354,7 @@ http_interactions:
         "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
         "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:22 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:05 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -1372,15 +1372,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:24:22 GMT
+      - Thu, 01 Nov 2018 18:33:05 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 215d7b47250645168667d3794b615a62
+      - 72035a780da641f394196a98405b5b28
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-b89b6166-a27a-49b3-a035-2b7eeee2ff1b
+      - req-c80c1214-60a8-4505-bb8c-20f6f48c16cf
       Content-Length:
       - '7278'
       Connection:
@@ -1392,7 +1392,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:24:22.215578Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:33:05.751334Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -1471,10 +1471,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["_gLaWxMiTlS85teOJ6ToSw"],
-        "issued_at": "2018-10-25T18:24:22.215598Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["npp-vEsVSAyCXeLZvhnH6A"],
+        "issued_at": "2018-11-01T18:33:05.751354Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:22 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:05 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -1489,7 +1489,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 215d7b47250645168667d3794b615a62
+      - 72035a780da641f394196a98405b5b28
   response:
     status:
       code: 200
@@ -1500,7 +1500,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Thu, 25 Oct 2018 18:24:22 GMT
+      - Thu, 01 Nov 2018 18:33:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -1509,7 +1509,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:22 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:05 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -1527,15 +1527,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:24:22 GMT
+      - Thu, 01 Nov 2018 18:33:05 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - ecf802efb0e841fa8ee3e7b01874f6d6
+      - 196abaf2f5df4332884fc06dcbdfb02d
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-c73dc7b8-08ba-4c3c-80c5-f79f4e3802cd
+      - req-a5cee7fe-efbd-49b7-a9ea-f2be28d18fe2
       Content-Length:
       - '7278'
       Connection:
@@ -1547,7 +1547,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:24:22.497516Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:33:06.053166Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -1626,10 +1626,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["bsKr6oaqSyer7sW7QSthIw"],
-        "issued_at": "2018-10-25T18:24:22.497536Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["J-SEr8qFSoOQQ_Y8tJEq8A"],
+        "issued_at": "2018-11-01T18:33:06.053187Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:22 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:06 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -1644,7 +1644,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ecf802efb0e841fa8ee3e7b01874f6d6
+      - 196abaf2f5df4332884fc06dcbdfb02d
   response:
     status:
       code: 200
@@ -1655,7 +1655,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Thu, 25 Oct 2018 18:24:22 GMT
+      - Thu, 01 Nov 2018 18:33:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -1664,7 +1664,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:22 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:06 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -1682,15 +1682,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:24:22 GMT
+      - Thu, 01 Nov 2018 18:33:06 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - f22ffeeaf87641cab8f4c158f10a5090
+      - 4d912fe0e1a84da3b4a43681b04cc0c8
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-6f017271-bcc4-490d-ab99-c5098f62bcf5
+      - req-c4ece705-b828-4eee-ad44-04e26d86a7c3
       Content-Length:
       - '7264'
       Connection:
@@ -1702,7 +1702,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:24:22.775539Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:33:06.338130Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -1781,10 +1781,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Yl_ocQEEQ2yg6Z0Y2CPRiw"],
-        "issued_at": "2018-10-25T18:24:22.775559Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["m1JJmWldRi-jfEwlSa_tMQ"],
+        "issued_at": "2018-11-01T18:33:06.338149Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:22 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:06 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -1799,7 +1799,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f22ffeeaf87641cab8f4c158f10a5090
+      - 4d912fe0e1a84da3b4a43681b04cc0c8
   response:
     status:
       code: 200
@@ -1810,7 +1810,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Thu, 25 Oct 2018 18:24:22 GMT
+      - Thu, 01 Nov 2018 18:33:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -1819,7 +1819,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:22 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:06 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -1837,15 +1837,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:24:22 GMT
+      - Thu, 01 Nov 2018 18:33:06 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 6b5c05cfcb6e40a18e2308332ed6c4cd
+      - a5f965a496cf4a419788e00cbb43201d
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-654c0263-ff2d-4ef4-9f48-9fbcf0049b45
+      - req-d996aa25-aee6-47ac-b6a3-6509ea62ee8e
       Content-Length:
       - '7278'
       Connection:
@@ -1857,7 +1857,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:24:23.073510Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:33:06.639843Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -1936,10 +1936,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["gx3j1SsgTDW3EjgwcJk18Q"],
-        "issued_at": "2018-10-25T18:24:23.073532Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["YjxNVfxeR_uQfG39uk-nTg"],
+        "issued_at": "2018-11-01T18:33:06.639865Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:23 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:06 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -1954,7 +1954,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6b5c05cfcb6e40a18e2308332ed6c4cd
+      - a5f965a496cf4a419788e00cbb43201d
   response:
     status:
       code: 200
@@ -1965,7 +1965,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Thu, 25 Oct 2018 18:24:23 GMT
+      - Thu, 01 Nov 2018 18:33:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -1974,7 +1974,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:23 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:06 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -1992,15 +1992,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:24:23 GMT
+      - Thu, 01 Nov 2018 18:33:06 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 62ac34c500f04a6595fa2a8d17ef49cb
+      - d96031484b7b4a5bbee8e0d081846d61
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-e1a6cd55-69b6-4475-9e7d-4b2d5e81e261
+      - req-79583a35-b8f2-4616-90d8-8a6e84bc75d8
       Content-Length:
       - '7265'
       Connection:
@@ -2012,7 +2012,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:24:23.346170Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:33:06.950687Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -2091,10 +2091,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["omB_FfprQ72BR1UBoCTVjA"],
-        "issued_at": "2018-10-25T18:24:23.346189Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["yv2dIBiaRd2b9v5SoVIxEg"],
+        "issued_at": "2018-11-01T18:33:06.950706Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:23 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:06 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -2109,7 +2109,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 62ac34c500f04a6595fa2a8d17ef49cb
+      - d96031484b7b4a5bbee8e0d081846d61
   response:
     status:
       code: 200
@@ -2120,7 +2120,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Thu, 25 Oct 2018 18:24:23 GMT
+      - Thu, 01 Nov 2018 18:33:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -2129,7 +2129,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:23 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:07 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -2147,15 +2147,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:24:23 GMT
+      - Thu, 01 Nov 2018 18:33:07 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 248f1080f6674a8da99923edaf11df50
+      - cdf0ca1b8ce64cfc86cfdf556e963a47
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-5e569c60-0e6b-4068-8026-d31cd0e0f83e
+      - req-fbf3a4ca-76d8-4d97-ac71-93e4b2f356ff
       Content-Length:
       - '7278'
       Connection:
@@ -2167,7 +2167,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:24:23.621924Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:33:07.244216Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -2246,10 +2246,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["WFr3uonCSIKDMVxI80ansA"],
-        "issued_at": "2018-10-25T18:24:23.621957Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["ue2CSfV-T5K9p-GoByL-yg"],
+        "issued_at": "2018-11-01T18:33:07.244236Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:23 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:07 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -2264,7 +2264,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 248f1080f6674a8da99923edaf11df50
+      - cdf0ca1b8ce64cfc86cfdf556e963a47
   response:
     status:
       code: 200
@@ -2275,7 +2275,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Thu, 25 Oct 2018 18:24:23 GMT
+      - Thu, 01 Nov 2018 18:33:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -2284,7 +2284,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:23 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:07 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -2302,15 +2302,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:24:23 GMT
+      - Thu, 01 Nov 2018 18:33:07 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 83b9bef3119c4db3bdca10a14e496c82
+      - f45b60a8cb4c4f6d8cec5678adea5745
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-39101b13-6067-4502-ad15-e63f195c0db1
+      - req-87140f43-4bc3-4b58-b120-331e04a6cb93
       Content-Length:
       - '7278'
       Connection:
@@ -2322,7 +2322,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:24:23.907370Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:33:07.549213Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -2401,10 +2401,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["9Hjsdc7AQKCwff_o7kcWZg"],
-        "issued_at": "2018-10-25T18:24:23.907393Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["B1QojkmAQAujqPJGVB3O9g"],
+        "issued_at": "2018-11-01T18:33:07.549233Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:23 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:07 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/0098405163cd4c9dbb42c2cb43eb6fd3/stacks?limit=1000&show_nested=true
@@ -2419,7 +2419,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 83b9bef3119c4db3bdca10a14e496c82
+      - f45b60a8cb4c4f6d8cec5678adea5745
   response:
     status:
       code: 200
@@ -2430,14 +2430,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-8b2c703b-15a4-44cb-a9ba-4a3127c78585
+      - req-82ef86ca-c347-43e5-b999-26abdd285955
       Date:
-      - Thu, 25 Oct 2018 18:24:24 GMT
+      - Thu, 01 Nov 2018 18:33:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:24 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:07 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -2455,15 +2455,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:24:24 GMT
+      - Thu, 01 Nov 2018 18:33:07 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 7065d17bd72f4115848ead57489d5630
+      - 165914508cdd4bdf967e974649fff2f5
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-4d525161-8723-4281-8382-2c85fe4d0b1a
+      - req-56d7c4bf-82c5-4f8d-905b-48ff27942d98
       Content-Length:
       - '7278'
       Connection:
@@ -2475,7 +2475,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:24:24.236698Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:33:07.890529Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -2554,10 +2554,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["UCS_4cLPQT25L56JXpjBLA"],
-        "issued_at": "2018-10-25T18:24:24.236719Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["sLmaKAyoS4KtqugzLduehw"],
+        "issued_at": "2018-11-01T18:33:07.890551Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:24 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:07 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/28db8f69ba9e4305b7fad82da4c86e74/stacks?limit=1000&show_nested=true
@@ -2572,7 +2572,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7065d17bd72f4115848ead57489d5630
+      - 165914508cdd4bdf967e974649fff2f5
   response:
     status:
       code: 200
@@ -2583,14 +2583,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-13d23c53-d21e-429c-886d-55a5f69bfd92
+      - req-d72e4c8b-bf31-45b9-8030-939e65f5edaf
       Date:
-      - Thu, 25 Oct 2018 18:24:24 GMT
+      - Thu, 01 Nov 2018 18:33:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:24 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:08 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -2608,15 +2608,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:24:24 GMT
+      - Thu, 01 Nov 2018 18:33:08 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 28a664af733546c6b39cc148a90dced9
+      - 425214a98f334ddc985e29cd34a242f7
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-4442e97c-1dd3-4fd0-9afd-7f7a0506cf88
+      - req-7e902353-2c90-4bd8-86af-17c8bb655429
       Content-Length:
       - '7264'
       Connection:
@@ -2628,7 +2628,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:24:24.566021Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:33:08.241512Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -2707,10 +2707,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["xi8WM6CMQfe0mYVwyUNfvQ"],
-        "issued_at": "2018-10-25T18:24:24.566043Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["m9nBiHH8SUaxTpmlRqQXeQ"],
+        "issued_at": "2018-11-01T18:33:08.241539Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:24 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:08 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks?limit=1000&show_nested=true
@@ -2725,7 +2725,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 28a664af733546c6b39cc148a90dced9
+      - 425214a98f334ddc985e29cd34a242f7
   response:
     status:
       code: 200
@@ -2736,9 +2736,9 @@ http_interactions:
       Content-Length:
       - '2559'
       X-Openstack-Request-Id:
-      - req-ce4825e0-1ade-481f-9cb8-8464ab076e84
+      - req-ae36bb02-3982-41af-ab69-915b3b34b1a4
       Date:
-      - Thu, 25 Oct 2018 18:24:24 GMT
+      - Thu, 01 Nov 2018 18:33:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": [{"description": "Heat WordPress template to support F20,
@@ -2772,7 +2772,7 @@ http_interactions:
         "rel": "self"}], "updated_time": null, "stack_owner": null, "stack_status":
         "CREATE_COMPLETE", "id": "7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:24 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:08 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks?limit=1000&marker=7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0&show_nested=true
@@ -2787,7 +2787,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 28a664af733546c6b39cc148a90dced9
+      - 425214a98f334ddc985e29cd34a242f7
   response:
     status:
       code: 200
@@ -2798,14 +2798,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-47302f5c-0d7d-493e-830b-f0cf80c19b03
+      - req-d84ca1e0-a581-4015-ab0a-0651b6abd9b5
       Date:
-      - Thu, 25 Oct 2018 18:24:24 GMT
+      - Thu, 01 Nov 2018 18:33:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:24 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:08 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -2823,15 +2823,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:24:24 GMT
+      - Thu, 01 Nov 2018 18:33:08 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 43d5ac9da18c4a1db5bc62720cb6521f
+      - e9d4a103cd1249f7b592b0c745012e84
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-6ced49b3-398e-4576-94d3-41509f70af1f
+      - req-32f8b220-2eee-4937-a317-e0173858c4da
       Content-Length:
       - '7278'
       Connection:
@@ -2843,7 +2843,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:24:25.053618Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:33:08.742436Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -2922,10 +2922,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["N84zJlAxQq6nLiV2p4su5Q"],
-        "issued_at": "2018-10-25T18:24:25.053643Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["N8pb0H8TR4u4jsbBVQ7GpQ"],
+        "issued_at": "2018-11-01T18:33:08.742456Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:25 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:08 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/52c452d7763a4295950527948232a3e5/stacks?limit=1000&show_nested=true
@@ -2940,7 +2940,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 43d5ac9da18c4a1db5bc62720cb6521f
+      - e9d4a103cd1249f7b592b0c745012e84
   response:
     status:
       code: 200
@@ -2951,14 +2951,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-103da0b8-b7da-4668-b8c0-fdcbcfc95a2d
+      - req-d5f68e5e-b89d-4c2a-bf58-41f92a4d5c06
       Date:
-      - Thu, 25 Oct 2018 18:24:25 GMT
+      - Thu, 01 Nov 2018 18:33:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:25 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:08 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/88ae57d444fd485ab2dfddd5a2615d52/stacks?limit=1000&show_nested=true
@@ -2973,7 +2973,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8f631613b3b74216a0536221a2db51aa
+      - ead9dc8827574fd58616d822d86eccaf
   response:
     status:
       code: 200
@@ -2984,14 +2984,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-ef054352-c6f2-4e5f-ac18-a4a0500fb3fc
+      - req-2f4749c2-b733-4903-8814-051d662d71b7
       Date:
-      - Thu, 25 Oct 2018 18:24:25 GMT
+      - Thu, 01 Nov 2018 18:33:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:25 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:09 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -3009,15 +3009,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:24:25 GMT
+      - Thu, 01 Nov 2018 18:33:09 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - ce9b5d758d3c4de2942aac6d7353cd81
+      - 421f9a53caab487a81fda2957ac30bd1
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-83a40a02-1d2e-4e59-8750-06010a9f9970
+      - req-007c3d61-7dfa-41c2-a243-f439519be557
       Content-Length:
       - '7265'
       Connection:
@@ -3029,7 +3029,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:24:25.497420Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:33:09.213653Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -3108,10 +3108,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["CtzJ6pXOQ6CMankVYZIQJg"],
-        "issued_at": "2018-10-25T18:24:25.497438Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["scCyN1_PTUuJQdeUnyXftg"],
+        "issued_at": "2018-11-01T18:33:09.213675Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:25 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:09 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/d09cbe26295d47ff848ea73c74264e23/stacks?limit=1000&show_nested=true
@@ -3126,7 +3126,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ce9b5d758d3c4de2942aac6d7353cd81
+      - 421f9a53caab487a81fda2957ac30bd1
   response:
     status:
       code: 200
@@ -3137,14 +3137,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-a2411855-0a41-4613-bf24-b6faa3346bbb
+      - req-702089b1-bcaa-4fc3-ba8a-2d767415befc
       Date:
-      - Thu, 25 Oct 2018 18:24:25 GMT
+      - Thu, 01 Nov 2018 18:33:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:25 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:09 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -3162,15 +3162,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:24:25 GMT
+      - Thu, 01 Nov 2018 18:33:09 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - e37e764546104afe88a3a014ee1600e6
+      - 5de4762765d44b76bf8f6676abed7a46
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-5f7771a7-da60-4006-b3ef-e3b8c9488c03
+      - req-4c2458f8-512d-45ec-968a-b84523efd4c9
       Content-Length:
       - '7278'
       Connection:
@@ -3182,7 +3182,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:24:25.815915Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:33:09.552151Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -3261,10 +3261,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["WheN_1poTjqNcpJwH-I1kQ"],
-        "issued_at": "2018-10-25T18:24:25.815946Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["gchrA08gQcOozQn2Iv15nQ"],
+        "issued_at": "2018-11-01T18:33:09.552171Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:25 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:09 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/ef2a3405d1ef4dfd9a3616993ef46a4d/stacks?limit=1000&show_nested=true
@@ -3279,7 +3279,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e37e764546104afe88a3a014ee1600e6
+      - 5de4762765d44b76bf8f6676abed7a46
   response:
     status:
       code: 200
@@ -3290,14 +3290,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-a335b942-47e3-4c67-8cc9-44b27eba09c5
+      - req-edf2b2b7-37dc-4f08-a0bc-f613795522ed
       Date:
-      - Thu, 25 Oct 2018 18:24:25 GMT
+      - Thu, 01 Nov 2018 18:33:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:25 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:09 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack3/00c5dc04-2c94-48d2-8031-db08934e9a44
@@ -3312,7 +3312,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 28a664af733546c6b39cc148a90dced9
+      - 425214a98f334ddc985e29cd34a242f7
   response:
     status:
       code: 200
@@ -3323,9 +3323,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-8a8776e4-6f29-41ef-bdc6-7b99bfcc5cc2
+      - req-4e29f73e-c1a9-44e5-b83b-c90da433a080
       Date:
-      - Thu, 25 Oct 2018 18:24:26 GMT
+      - Thu, 01 Nov 2018 18:33:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -3352,7 +3352,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:26 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:10 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack2/d6eba2a2-7b0d-4213-afbb-69c8f6dddd8d
@@ -3367,7 +3367,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 28a664af733546c6b39cc148a90dced9
+      - 425214a98f334ddc985e29cd34a242f7
   response:
     status:
       code: 200
@@ -3378,9 +3378,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-fa18f46e-46b7-4701-a298-1f290472b7e7
+      - req-ef951261-1155-4826-95da-c5c2062acf83
       Date:
-      - Thu, 25 Oct 2018 18:24:26 GMT
+      - Thu, 01 Nov 2018 18:33:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -3407,7 +3407,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:26 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:10 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack1/7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0
@@ -3422,7 +3422,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 28a664af733546c6b39cc148a90dced9
+      - 425214a98f334ddc985e29cd34a242f7
   response:
     status:
       code: 200
@@ -3433,9 +3433,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-84f955ae-5867-4c64-a693-cccd5dbcddd8
+      - req-61814f76-0117-4c2e-99dd-adbb98d0f342
       Date:
-      - Thu, 25 Oct 2018 18:24:26 GMT
+      - Thu, 01 Nov 2018 18:33:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -3462,7 +3462,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:26 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:10 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack3/00c5dc04-2c94-48d2-8031-db08934e9a44/template
@@ -3477,7 +3477,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 28a664af733546c6b39cc148a90dced9
+      - 425214a98f334ddc985e29cd34a242f7
   response:
     status:
       code: 200
@@ -3488,9 +3488,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-f8018cfd-ec2b-4907-98d7-12f3c92f0e14
+      - req-caf9112d-9ad0-4e7c-892a-1f046184a826
       Date:
-      - Thu, 25 Oct 2018 18:24:26 GMT
+      - Thu, 01 Nov 2018 18:33:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -3546,7 +3546,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:26 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:10 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack3/00c5dc04-2c94-48d2-8031-db08934e9a44/resources
@@ -3561,7 +3561,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 28a664af733546c6b39cc148a90dced9
+      - 425214a98f334ddc985e29cd34a242f7
   response:
     status:
       code: 200
@@ -3572,9 +3572,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-aa8d3b42-4c30-4430-afeb-0fbb1f5a6458
+      - req-78a3d926-f90b-4f76-8fb9-e9b14893f0db
       Date:
-      - Thu, 25 Oct 2018 18:24:27 GMT
+      - Thu, 01 Nov 2018 18:33:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -3586,7 +3586,7 @@ http_interactions:
         changed", "physical_resource_id": "40989f26-9c38-4f72-b739-afccb44397cf",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:27 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:10 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?all_tenants=True&limit=1000
@@ -3601,7 +3601,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 85dc3e037ff1478f99a91d0eec9026bd
+      - 3aa1e9306dfa4d11b62305024423fee7
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3614,9 +3614,9 @@ http_interactions:
       Content-Length:
       - '3998'
       X-Compute-Request-Id:
-      - req-40eee6a8-f9ec-4a3f-b220-33f1252485ec
+      - req-b91e6293-2756-4cf4-ba5f-a9f9036fe68b
       Date:
-      - Thu, 25 Oct 2018 18:24:27 GMT
+      - Thu, 01 Nov 2018 18:33:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?all_tenants=True&limit=1000&marker=43f23d3a-fe8d-4bbb-9d23-fe1c437c7813",
@@ -3662,7 +3662,7 @@ http_interactions:
         [], "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:27 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:11 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?all_tenants=True&limit=1000&marker=43f23d3a-fe8d-4bbb-9d23-fe1c437c7813
@@ -3677,7 +3677,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 85dc3e037ff1478f99a91d0eec9026bd
+      - 3aa1e9306dfa4d11b62305024423fee7
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3690,9 +3690,9 @@ http_interactions:
       Content-Length:
       - '4062'
       X-Compute-Request-Id:
-      - req-27cf51a9-6f4a-47a8-89a8-efefe9b887db
+      - req-3b5df715-8893-4a4d-9530-3dadb2993484
       Date:
-      - Thu, 25 Oct 2018 18:24:27 GMT
+      - Thu, 01 Nov 2018 18:33:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?all_tenants=True&limit=1000&marker=5d121f19-3e04-4743-8ed7-c5dfaa6ef71f",
@@ -3738,7 +3738,7 @@ http_interactions:
         [], "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 3, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:27 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:11 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?all_tenants=True&limit=1000&marker=5d121f19-3e04-4743-8ed7-c5dfaa6ef71f
@@ -3753,7 +3753,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 85dc3e037ff1478f99a91d0eec9026bd
+      - 3aa1e9306dfa4d11b62305024423fee7
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3766,9 +3766,9 @@ http_interactions:
       Content-Length:
       - '4144'
       X-Compute-Request-Id:
-      - req-80b382cb-5e80-44ba-ac44-861050245076
+      - req-cf2accda-3a1b-4615-96d3-046c33959dd0
       Date:
-      - Thu, 25 Oct 2018 18:24:27 GMT
+      - Thu, 01 Nov 2018 18:33:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?all_tenants=True&limit=1000&marker=7edb7855-d974-4e45-8ad2-88491541ab91",
@@ -3816,7 +3816,7 @@ http_interactions:
         "", "progress": 0, "OS-EXT-STS:power_state": 1, "config_drive": "", "metadata":
         {}}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:28 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:11 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?all_tenants=True&limit=1000&marker=7edb7855-d974-4e45-8ad2-88491541ab91
@@ -3831,7 +3831,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 85dc3e037ff1478f99a91d0eec9026bd
+      - 3aa1e9306dfa4d11b62305024423fee7
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3844,9 +3844,9 @@ http_interactions:
       Content-Length:
       - '3813'
       X-Compute-Request-Id:
-      - req-d157a117-1e72-43b7-b602-8b209b3c38c6
+      - req-16d453c0-51b9-4e67-8bc5-81d3ed661458
       Date:
-      - Thu, 25 Oct 2018 18:24:28 GMT
+      - Thu, 01 Nov 2018 18:33:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?all_tenants=True&limit=1000&marker=ad4f7eb0-9122-41a6-a0f7-55c1d4ca5e02",
@@ -3888,7 +3888,7 @@ http_interactions:
         "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:28 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:11 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?all_tenants=True&limit=1000&marker=ad4f7eb0-9122-41a6-a0f7-55c1d4ca5e02
@@ -3903,7 +3903,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 85dc3e037ff1478f99a91d0eec9026bd
+      - 3aa1e9306dfa4d11b62305024423fee7
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3916,9 +3916,9 @@ http_interactions:
       Content-Length:
       - '1816'
       X-Compute-Request-Id:
-      - req-c3859729-82c6-48d7-9931-43616b1e60a6
+      - req-1f72b51b-ff46-4407-b7bc-6c2115c25095
       Date:
-      - Thu, 25 Oct 2018 18:24:28 GMT
+      - Thu, 01 Nov 2018 18:33:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": [{"status": "SHUTOFF", "updated": "2017-05-22T16:01:49Z",
@@ -3941,7 +3941,7 @@ http_interactions:
         "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:28 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:12 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack2/d6eba2a2-7b0d-4213-afbb-69c8f6dddd8d/template
@@ -3956,7 +3956,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 28a664af733546c6b39cc148a90dced9
+      - 425214a98f334ddc985e29cd34a242f7
   response:
     status:
       code: 200
@@ -3967,9 +3967,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-71153074-ec16-4761-a5b1-35d5ea67389a
+      - req-1a05a710-12de-4d1f-bd7b-04dfdb64ae68
       Date:
-      - Thu, 25 Oct 2018 18:24:28 GMT
+      - Thu, 01 Nov 2018 18:33:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -4025,7 +4025,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:28 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:12 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack2/d6eba2a2-7b0d-4213-afbb-69c8f6dddd8d/resources
@@ -4040,7 +4040,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 28a664af733546c6b39cc148a90dced9
+      - 425214a98f334ddc985e29cd34a242f7
   response:
     status:
       code: 200
@@ -4051,9 +4051,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-fb5ccbb8-018d-4f49-8c52-1b8aed3b9dee
+      - req-6e312152-bd66-412a-a851-e25da8317295
       Date:
-      - Thu, 25 Oct 2018 18:24:28 GMT
+      - Thu, 01 Nov 2018 18:33:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -4065,7 +4065,7 @@ http_interactions:
         changed", "physical_resource_id": "ad4f7eb0-9122-41a6-a0f7-55c1d4ca5e02",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:28 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:12 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack1/7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0/template
@@ -4080,7 +4080,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 28a664af733546c6b39cc148a90dced9
+      - 425214a98f334ddc985e29cd34a242f7
   response:
     status:
       code: 200
@@ -4091,9 +4091,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-4624b644-891c-4427-8e71-6f1f1d3b7b47
+      - req-3a94d808-28c7-436e-a79b-213902d603f0
       Date:
-      - Thu, 25 Oct 2018 18:24:28 GMT
+      - Thu, 01 Nov 2018 18:33:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -4149,7 +4149,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:28 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:12 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack1/7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0/resources
@@ -4164,7 +4164,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 28a664af733546c6b39cc148a90dced9
+      - 425214a98f334ddc985e29cd34a242f7
   response:
     status:
       code: 200
@@ -4175,9 +4175,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-17cfbbdc-0e0d-4e81-a46d-d1b67b61becb
+      - req-09ccf0a1-2ced-4668-8828-371e869671ee
       Date:
-      - Thu, 25 Oct 2018 18:24:29 GMT
+      - Thu, 01 Nov 2018 18:33:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -4189,7 +4189,7 @@ http_interactions:
         changed", "physical_resource_id": "8022b967-813a-4e3b-8ff4-7c036957a8a0",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:29 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:13 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3//os-quota-sets/0098405163cd4c9dbb42c2cb43eb6fd3
@@ -4204,7 +4204,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 215d7b47250645168667d3794b615a62
+      - 72035a780da641f394196a98405b5b28
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4217,9 +4217,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-66f1975f-d703-45f4-95b9-3ea86108f700
+      - req-9cbd8661-d989-444b-8773-acb1ae3d69b8
       Date:
-      - Thu, 25 Oct 2018 18:24:29 GMT
+      - Thu, 01 Nov 2018 18:33:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -4228,7 +4228,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:29 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:13 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/28db8f69ba9e4305b7fad82da4c86e74//os-quota-sets/28db8f69ba9e4305b7fad82da4c86e74
@@ -4243,7 +4243,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ecf802efb0e841fa8ee3e7b01874f6d6
+      - 196abaf2f5df4332884fc06dcbdfb02d
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4256,9 +4256,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-a0a8bb50-e828-4402-b085-9905282ff7b0
+      - req-3329f9cb-c80a-4dae-96b1-27e9e40a4f02
       Date:
-      - Thu, 25 Oct 2018 18:24:29 GMT
+      - Thu, 01 Nov 2018 18:33:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -4267,7 +4267,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:29 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:13 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91//os-quota-sets/4637c33fee924ebea81f8d209e452c91
@@ -4282,7 +4282,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f22ffeeaf87641cab8f4c158f10a5090
+      - 4d912fe0e1a84da3b4a43681b04cc0c8
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4295,9 +4295,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-454d2af7-d93f-4faf-a556-e1f836b31cba
+      - req-1a5f607b-18be-45e7-902d-a053a32b6e45
       Date:
-      - Thu, 25 Oct 2018 18:24:29 GMT
+      - Thu, 01 Nov 2018 18:33:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -4306,7 +4306,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:29 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:13 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/52c452d7763a4295950527948232a3e5//os-quota-sets/52c452d7763a4295950527948232a3e5
@@ -4321,7 +4321,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6b5c05cfcb6e40a18e2308332ed6c4cd
+      - a5f965a496cf4a419788e00cbb43201d
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4334,9 +4334,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-885a357e-fd80-4b7f-817b-7a197641f6d6
+      - req-19cc68f7-f81e-44fb-a680-5c7cf53bf937
       Date:
-      - Thu, 25 Oct 2018 18:24:29 GMT
+      - Thu, 01 Nov 2018 18:33:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -4345,7 +4345,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:29 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:13 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52//os-quota-sets/88ae57d444fd485ab2dfddd5a2615d52
@@ -4360,7 +4360,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 85dc3e037ff1478f99a91d0eec9026bd
+      - 3aa1e9306dfa4d11b62305024423fee7
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4373,9 +4373,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-39c07e4b-9148-4434-8f93-3aa34cfeaf3f
+      - req-489e83b4-909f-4ad8-9c97-636fe1b14b9f
       Date:
-      - Thu, 25 Oct 2018 18:24:29 GMT
+      - Thu, 01 Nov 2018 18:33:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -4384,7 +4384,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:29 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:13 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/d09cbe26295d47ff848ea73c74264e23//os-quota-sets/d09cbe26295d47ff848ea73c74264e23
@@ -4399,7 +4399,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 62ac34c500f04a6595fa2a8d17ef49cb
+      - d96031484b7b4a5bbee8e0d081846d61
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4412,9 +4412,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-28d8c919-c776-4156-80ce-fb4ae684e648
+      - req-8a1b0317-147c-4166-a8a0-0d63bd99c0d3
       Date:
-      - Thu, 25 Oct 2018 18:24:29 GMT
+      - Thu, 01 Nov 2018 18:33:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -4423,7 +4423,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:29 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:13 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/ef2a3405d1ef4dfd9a3616993ef46a4d//os-quota-sets/ef2a3405d1ef4dfd9a3616993ef46a4d
@@ -4438,7 +4438,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 248f1080f6674a8da99923edaf11df50
+      - cdf0ca1b8ce64cfc86cfdf556e963a47
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4451,9 +4451,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-86f72f29-d0c2-4684-97e7-bdbafc626d73
+      - req-1bfba3e2-3f2d-45b4-8837-62dd7de8b4d9
       Date:
-      - Thu, 25 Oct 2018 18:24:29 GMT
+      - Thu, 01 Nov 2018 18:33:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -4462,7 +4462,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:29 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:13 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -4480,15 +4480,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:24:29 GMT
+      - Thu, 01 Nov 2018 18:33:13 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - d73c4ae451724292b5890961eabac120
+      - 5243e043744f4f00a5489d4aa006b0b9
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-415c58e5-0467-4933-b04c-9365c75bc630
+      - req-26f69bfa-c6b0-4005-a477-d3c1190a3e32
       Content-Length:
       - '7278'
       Connection:
@@ -4500,7 +4500,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:24:29.970452Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:33:14.011580Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -4579,10 +4579,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["tl7G18b0Sx2jB-sA0pUJrg"],
-        "issued_at": "2018-10-25T18:24:29.970473Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["U5MHX9ahSm2YsC4jXw6djA"],
+        "issued_at": "2018-11-01T18:33:14.011600Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:29 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:14 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3//os-quota-sets/0098405163cd4c9dbb42c2cb43eb6fd3
@@ -4597,22 +4597,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d73c4ae451724292b5890961eabac120
+      - 5243e043744f4f00a5489d4aa006b0b9
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-6149fe48-4665-47e3-9c6f-002fc6ea328c
+      - req-7435b8b4-6151-485c-b109-758bd36fe60f
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-6149fe48-4665-47e3-9c6f-002fc6ea328c
+      - req-7435b8b4-6151-485c-b109-758bd36fe60f
       Date:
-      - Thu, 25 Oct 2018 18:24:30 GMT
+      - Thu, 01 Nov 2018 18:33:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -4622,7 +4622,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "0098405163cd4c9dbb42c2cb43eb6fd3"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:30 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:14 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -4640,15 +4640,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:24:30 GMT
+      - Thu, 01 Nov 2018 18:33:14 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 2ec37d796c084b5294b455b807d3e376
+      - 8235873d4ac842158f818558c7d02092
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-9dd14219-c3be-4387-8fac-9e9ba4f80f98
+      - req-11bbdf89-ecbc-4001-af5f-5676e15e0d47
       Content-Length:
       - '7278'
       Connection:
@@ -4660,7 +4660,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:24:30.423923Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:33:14.514349Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -4739,10 +4739,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["wrKPrSFIR5iwP6rofAd5OQ"],
-        "issued_at": "2018-10-25T18:24:30.423962Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["z_n_IHNcSJu1CBBGWYLv2g"],
+        "issued_at": "2018-11-01T18:33:14.514370Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:30 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:14 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74//os-quota-sets/28db8f69ba9e4305b7fad82da4c86e74
@@ -4757,22 +4757,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2ec37d796c084b5294b455b807d3e376
+      - 8235873d4ac842158f818558c7d02092
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-9054b371-cc85-48f2-a498-fe05ccece5cf
+      - req-cc50df08-a469-4bdb-b6c1-7e446563dbb9
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-9054b371-cc85-48f2-a498-fe05ccece5cf
+      - req-cc50df08-a469-4bdb-b6c1-7e446563dbb9
       Date:
-      - Thu, 25 Oct 2018 18:24:30 GMT
+      - Thu, 01 Nov 2018 18:33:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -4782,7 +4782,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "28db8f69ba9e4305b7fad82da4c86e74"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:30 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:14 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -4800,15 +4800,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:24:30 GMT
+      - Thu, 01 Nov 2018 18:33:14 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 0f2173462a0f4bc5a235f87650140f77
+      - a8c3c923d9254953962fd73f11ab832b
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-a1c23e2f-6d1c-4709-a24c-39b676632a3e
+      - req-245625d4-b722-48c4-b86f-e492ce8f618b
       Content-Length:
       - '7264'
       Connection:
@@ -4820,7 +4820,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:24:30.868842Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:33:14.986256Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -4899,10 +4899,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["I-mp97FBSZmyzG6iV9z_2Q"],
-        "issued_at": "2018-10-25T18:24:30.868862Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["cuqpD5EiRKq9FhteepBG3g"],
+        "issued_at": "2018-11-01T18:33:14.986276Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:30 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:15 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91//os-quota-sets/4637c33fee924ebea81f8d209e452c91
@@ -4917,22 +4917,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0f2173462a0f4bc5a235f87650140f77
+      - a8c3c923d9254953962fd73f11ab832b
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-300fff51-b4f1-4817-9b2b-4c2e092cc71b
+      - req-541b942c-2515-4d2a-bf86-9eb11fc3bcc5
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-300fff51-b4f1-4817-9b2b-4c2e092cc71b
+      - req-541b942c-2515-4d2a-bf86-9eb11fc3bcc5
       Date:
-      - Thu, 25 Oct 2018 18:24:31 GMT
+      - Thu, 01 Nov 2018 18:33:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -4942,7 +4942,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "4637c33fee924ebea81f8d209e452c91"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:31 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:15 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -4960,15 +4960,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:24:31 GMT
+      - Thu, 01 Nov 2018 18:33:15 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 95ea9f26fdbb4388b0fd2cd01d6b33ca
+      - 46bbf2026a4e46c992b4381727afb54d
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-4b265be4-b1bb-451e-8f8f-27944f4df7b4
+      - req-6e3c6170-3e2a-40ca-b679-cab91a97ccc1
       Content-Length:
       - '7278'
       Connection:
@@ -4980,7 +4980,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:24:31.342286Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:33:15.457350Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -5059,10 +5059,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["WkBfe5ClRDOFfhSzhHvn6g"],
-        "issued_at": "2018-10-25T18:24:31.342305Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["WjP3sXe0Qtup9M7gy75BEA"],
+        "issued_at": "2018-11-01T18:33:15.457369Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:31 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:15 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5//os-quota-sets/52c452d7763a4295950527948232a3e5
@@ -5077,22 +5077,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 95ea9f26fdbb4388b0fd2cd01d6b33ca
+      - 46bbf2026a4e46c992b4381727afb54d
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-f57e5816-17fc-4c14-b331-53258f93ef9d
+      - req-ce9d488b-1731-4491-b791-fc1ce9ea2911
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-f57e5816-17fc-4c14-b331-53258f93ef9d
+      - req-ce9d488b-1731-4491-b791-fc1ce9ea2911
       Date:
-      - Thu, 25 Oct 2018 18:24:31 GMT
+      - Thu, 01 Nov 2018 18:33:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -5102,7 +5102,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "52c452d7763a4295950527948232a3e5"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:31 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:15 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52//os-quota-sets/88ae57d444fd485ab2dfddd5a2615d52
@@ -5117,22 +5117,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e717ded0b812448380d7dd4ddb0bd929
+      - f7ab4eb9dd0f43c2a676ffe90e43fdf3
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-6a5163d0-e466-46f0-883d-66da56d178a8
+      - req-25a9d6be-1602-4925-8ef5-ec1af975362f
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-6a5163d0-e466-46f0-883d-66da56d178a8
+      - req-25a9d6be-1602-4925-8ef5-ec1af975362f
       Date:
-      - Thu, 25 Oct 2018 18:24:31 GMT
+      - Thu, 01 Nov 2018 18:33:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -5142,7 +5142,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "88ae57d444fd485ab2dfddd5a2615d52"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:31 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:16 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -5160,15 +5160,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:24:32 GMT
+      - Thu, 01 Nov 2018 18:33:16 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 2d92f64e7990486c8b4166a8d4a543b2
+      - 84e32f661615411a8a4fa4ff8f9f5bcb
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-b0d4a9dc-9ef4-42b3-a24d-c2e23b6f33ae
+      - req-9cf0df41-61ee-434a-ac04-cc848299f4d8
       Content-Length:
       - '7265'
       Connection:
@@ -5180,7 +5180,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:24:32.094294Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:33:16.235375Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -5259,10 +5259,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["xTDxmSEuQF6Jt45LjL5gfA"],
-        "issued_at": "2018-10-25T18:24:32.094320Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["8RtcSFsXR2evJL2XJW3VtA"],
+        "issued_at": "2018-11-01T18:33:16.235397Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:32 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:16 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23//os-quota-sets/d09cbe26295d47ff848ea73c74264e23
@@ -5277,22 +5277,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2d92f64e7990486c8b4166a8d4a543b2
+      - 84e32f661615411a8a4fa4ff8f9f5bcb
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-efe6fe2f-5e87-493c-a967-a9aa9bdfff3c
+      - req-466834a0-b7b2-4a18-b7df-132e06ccb577
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-efe6fe2f-5e87-493c-a967-a9aa9bdfff3c
+      - req-466834a0-b7b2-4a18-b7df-132e06ccb577
       Date:
-      - Thu, 25 Oct 2018 18:24:32 GMT
+      - Thu, 01 Nov 2018 18:33:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -5302,7 +5302,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "d09cbe26295d47ff848ea73c74264e23"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:32 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:16 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -5320,15 +5320,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:24:32 GMT
+      - Thu, 01 Nov 2018 18:33:16 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - aac7d2ab68a54e88a47d0066fd3af272
+      - d0b566101cb94172af02c78d92a14ddc
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-110b6806-a401-40c6-9454-a52dd148ae14
+      - req-6c94ffb6-023f-48ba-9da4-0f824f424b2b
       Content-Length:
       - '7278'
       Connection:
@@ -5340,7 +5340,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:24:32.611702Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:33:16.747286Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -5419,10 +5419,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["22MO9eDwTeqGhXuKej1weA"],
-        "issued_at": "2018-10-25T18:24:32.611723Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["busu9KdESI-hoYDaTpSSdQ"],
+        "issued_at": "2018-11-01T18:33:16.747304Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:32 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:16 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d//os-quota-sets/ef2a3405d1ef4dfd9a3616993ef46a4d
@@ -5437,22 +5437,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - aac7d2ab68a54e88a47d0066fd3af272
+      - d0b566101cb94172af02c78d92a14ddc
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-7a748998-d9ab-40a8-9f53-6770dc466b07
+      - req-84fa66dc-a0ef-4777-b735-8e04255cae89
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-7a748998-d9ab-40a8-9f53-6770dc466b07
+      - req-84fa66dc-a0ef-4777-b735-8e04255cae89
       Date:
-      - Thu, 25 Oct 2018 18:24:32 GMT
+      - Thu, 01 Nov 2018 18:33:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -5462,7 +5462,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:32 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:17 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -5480,15 +5480,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:24:33 GMT
+      - Thu, 01 Nov 2018 18:33:17 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 93acd59eed8647aab155ab7de513bb03
+      - 61ce3fe6911d4b85bc57e8cf0beb6dba
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-b1d79e03-50ed-450b-85ff-6ee79ad7112a
+      - req-839e233a-45ca-4d67-8517-abd0459f4119
       Content-Length:
       - '7311'
       Connection:
@@ -5500,7 +5500,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-10-25T19:24:33.077352Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-11-01T19:33:17.211173Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -5579,10 +5579,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["V06A4ve2QEeXWfDz7WeSLA"],
-        "issued_at": "2018-10-25T18:24:33.077373Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["uH2R0jUQSueMLAD-IG8yyw"],
+        "issued_at": "2018-11-01T18:33:17.211194Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:33 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:17 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -5600,15 +5600,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:24:33 GMT
+      - Thu, 01 Nov 2018 18:33:17 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 2109b32d5b344faab594377ae81f1bc8
+      - f49fe2ff85d140349a27cabbbac53e48
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-c10f2e1c-7832-4c97-99c4-da8eee25c5a4
+      - req-0e3f02d6-0050-4e55-a9df-263021924a9d
       Content-Length:
       - '7278'
       Connection:
@@ -5620,7 +5620,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:24:33.278713Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:33:17.421739Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -5699,10 +5699,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["ylbHFN0tT8igZJNMKLDqBA"],
-        "issued_at": "2018-10-25T18:24:33.278734Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["A2SZe6xUQdq3mzH5yWtPlQ"],
+        "issued_at": "2018-11-01T18:33:17.421759Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:33 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:17 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/0098405163cd4c9dbb42c2cb43eb6fd3
@@ -5717,7 +5717,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2109b32d5b344faab594377ae81f1bc8
+      - f49fe2ff85d140349a27cabbbac53e48
   response:
     status:
       code: 200
@@ -5728,16 +5728,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-7380a4a1-7ebf-4f49-aa5e-d6a99bf361d4
+      - req-f4628d0e-5551-4889-965a-8e4febecb19b
       Date:
-      - Thu, 25 Oct 2018 18:24:33 GMT
+      - Thu, 01 Nov 2018 18:33:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:33 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:17 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -5755,15 +5755,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:24:33 GMT
+      - Thu, 01 Nov 2018 18:33:17 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - c5208794d7e54c319f90b9b15c1c21c5
+      - e760c7e371b249bc9b63ac9aa106129a
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-81ecdc49-29e8-40cf-b8ff-7e9141e30450
+      - req-a97a26e8-a776-4912-82da-5aedb863a40c
       Content-Length:
       - '7278'
       Connection:
@@ -5775,7 +5775,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:24:33.612114Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:33:17.753596Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -5854,10 +5854,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["5N-cQOBsSg2dsdQ01K_0DA"],
-        "issued_at": "2018-10-25T18:24:33.612135Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["jLQ2iwnFQFWroAVhbV4ktg"],
+        "issued_at": "2018-11-01T18:33:17.753627Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:33 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:17 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/28db8f69ba9e4305b7fad82da4c86e74
@@ -5872,7 +5872,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c5208794d7e54c319f90b9b15c1c21c5
+      - e760c7e371b249bc9b63ac9aa106129a
   response:
     status:
       code: 200
@@ -5883,16 +5883,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-ac9140d7-f077-4031-825f-c59f28153dd7
+      - req-a6e6e2f4-d3da-43de-aa87-892cef6067b8
       Date:
-      - Thu, 25 Oct 2018 18:24:33 GMT
+      - Thu, 01 Nov 2018 18:33:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:33 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:17 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -5910,15 +5910,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:24:33 GMT
+      - Thu, 01 Nov 2018 18:33:18 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - b78b80f4ca6849fa93ee3a3a5342a715
+      - 64c1f9a99eec4f8a85f384cc77588553
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-f9d6e4a9-460b-4cc1-80e9-79b98a7cf407
+      - req-9c9d64a3-d181-4b8d-8dd3-9c113615132a
       Content-Length:
       - '7264'
       Connection:
@@ -5930,7 +5930,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:24:33.940663Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:33:18.083760Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -6009,10 +6009,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["jhcq8L0TTzKYsjnH2sAXqQ"],
-        "issued_at": "2018-10-25T18:24:33.940685Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["wsp5047YSACW9O2n6EyDEA"],
+        "issued_at": "2018-11-01T18:33:18.083795Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:33 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:18 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/4637c33fee924ebea81f8d209e452c91
@@ -6027,7 +6027,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b78b80f4ca6849fa93ee3a3a5342a715
+      - 64c1f9a99eec4f8a85f384cc77588553
   response:
     status:
       code: 200
@@ -6038,16 +6038,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-dac9ce99-0ded-4043-92d0-7146d86a53ba
+      - req-5bf14725-75b3-48bf-a571-c5e8309000ce
       Date:
-      - Thu, 25 Oct 2018 18:24:34 GMT
+      - Thu, 01 Nov 2018 18:33:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 20, "network": 20, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:34 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:18 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -6065,15 +6065,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:24:34 GMT
+      - Thu, 01 Nov 2018 18:33:18 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 3a9f104271d7491ca96b2d9231aafaae
+      - 46cf06a11ae34b5a8d530863d57f6d90
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-bd303004-0ef1-4a16-9d90-bd5c89492e0a
+      - req-89358234-cc26-40ed-b65c-ed9b259564fe
       Content-Length:
       - '7278'
       Connection:
@@ -6085,7 +6085,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:24:34.251279Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:33:18.412015Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -6164,10 +6164,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["tAS1SpPrRoCU_l-jWgTboA"],
-        "issued_at": "2018-10-25T18:24:34.251299Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["g8W-VC8XQoiXT5sPYGB_EQ"],
+        "issued_at": "2018-11-01T18:33:18.412037Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:34 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:18 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/52c452d7763a4295950527948232a3e5
@@ -6182,7 +6182,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3a9f104271d7491ca96b2d9231aafaae
+      - 46cf06a11ae34b5a8d530863d57f6d90
   response:
     status:
       code: 200
@@ -6193,16 +6193,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-2ba1db3d-a416-4269-8d33-619dd7c91bce
+      - req-ed6b9d48-effb-49f1-882f-3b04a66d6230
       Date:
-      - Thu, 25 Oct 2018 18:24:34 GMT
+      - Thu, 01 Nov 2018 18:33:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:34 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:18 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/88ae57d444fd485ab2dfddd5a2615d52
@@ -6217,7 +6217,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 93acd59eed8647aab155ab7de513bb03
+      - 61ce3fe6911d4b85bc57e8cf0beb6dba
   response:
     status:
       code: 200
@@ -6228,16 +6228,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-ddd1acfc-f637-4caa-a2c1-b289950d624c
+      - req-921217bd-fd81-494c-aa88-56b464bdb4d1
       Date:
-      - Thu, 25 Oct 2018 18:24:34 GMT
+      - Thu, 01 Nov 2018 18:33:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:34 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:18 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -6255,15 +6255,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:24:34 GMT
+      - Thu, 01 Nov 2018 18:33:18 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 9d407b34c4744e9f974f920f80a87a77
+      - f8db570b546149d9a6db7bceea2a778d
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-40c7a3b7-4cf3-4846-96d4-75b89ad023f5
+      - req-5eeef0b0-f5f5-4a41-a993-3ce0b026071b
       Content-Length:
       - '7265'
       Connection:
@@ -6275,7 +6275,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:24:34.673415Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:33:18.874744Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -6354,10 +6354,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["pDpP0LCUS52nM0tDiDAWtA"],
-        "issued_at": "2018-10-25T18:24:34.673437Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["z_25eTQzSj29N9PthZzvhg"],
+        "issued_at": "2018-11-01T18:33:18.874773Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:34 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:18 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/d09cbe26295d47ff848ea73c74264e23
@@ -6372,7 +6372,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9d407b34c4744e9f974f920f80a87a77
+      - f8db570b546149d9a6db7bceea2a778d
   response:
     status:
       code: 200
@@ -6383,16 +6383,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-21813421-7c5d-4188-a88b-dfb44da03882
+      - req-9bc522fa-be85-4424-b3a7-b85b43cf6b14
       Date:
-      - Thu, 25 Oct 2018 18:24:34 GMT
+      - Thu, 01 Nov 2018 18:33:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:34 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:19 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -6410,15 +6410,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:24:34 GMT
+      - Thu, 01 Nov 2018 18:33:19 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 4fb7bb1c53b04382bb100113eaf333a1
+      - 0401ed34d20e42f39cd4d0d4314f125e
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-22abc5ca-5245-46e8-bb53-9e042f2bcfc4
+      - req-d0bbb445-774c-48b2-b628-19d86edf3dc9
       Content-Length:
       - '7278'
       Connection:
@@ -6430,7 +6430,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:24:35.027548Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:33:19.211858Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -6509,10 +6509,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["esawokgwRTqa4InjR7M8kQ"],
-        "issued_at": "2018-10-25T18:24:35.027574Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["LnKzjzX-T6qov-1MJYMfRw"],
+        "issued_at": "2018-11-01T18:33:19.211880Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:35 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:19 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/ef2a3405d1ef4dfd9a3616993ef46a4d
@@ -6527,7 +6527,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4fb7bb1c53b04382bb100113eaf333a1
+      - 0401ed34d20e42f39cd4d0d4314f125e
   response:
     status:
       code: 200
@@ -6538,16 +6538,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-c8efd62d-11ca-4cee-93f6-c3badfbbaed0
+      - req-6ce32485-dbf8-48bb-8048-93601ed8a5b5
       Date:
-      - Thu, 25 Oct 2018 18:24:35 GMT
+      - Thu, 01 Nov 2018 18:33:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:35 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:19 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-floating-ips
@@ -6562,7 +6562,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 85dc3e037ff1478f99a91d0eec9026bd
+      - 3aa1e9306dfa4d11b62305024423fee7
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6575,14 +6575,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-6c70ad78-396b-4e9a-9c23-4a224688ce7f
+      - req-dd05ba1e-7792-4b57-abee-26498d3c9910
       Date:
-      - Thu, 25 Oct 2018 18:24:35 GMT
+      - Thu, 01 Nov 2018 18:33:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:35 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:19 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-floating-ips
@@ -6597,7 +6597,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 85dc3e037ff1478f99a91d0eec9026bd
+      - 3aa1e9306dfa4d11b62305024423fee7
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6610,14 +6610,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-f1cb8d83-0c3b-4558-ac76-1b811425b029
+      - req-f366f0c0-c1e6-419f-9ae7-1a8bf352f2f3
       Date:
-      - Thu, 25 Oct 2018 18:24:35 GMT
+      - Thu, 01 Nov 2018 18:33:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:35 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:19 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-floating-ips
@@ -6632,7 +6632,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 85dc3e037ff1478f99a91d0eec9026bd
+      - 3aa1e9306dfa4d11b62305024423fee7
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6645,14 +6645,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-a54b7bbb-4dd2-4765-bef7-4c7b21548a37
+      - req-ed51627b-cfbb-4875-830f-f5712f761c32
       Date:
-      - Thu, 25 Oct 2018 18:24:35 GMT
+      - Thu, 01 Nov 2018 18:33:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:35 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:19 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-floating-ips
@@ -6667,7 +6667,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 85dc3e037ff1478f99a91d0eec9026bd
+      - 3aa1e9306dfa4d11b62305024423fee7
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6680,14 +6680,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-a0d45b4c-c894-4ca7-894e-2e2f18ee099f
+      - req-b6dec982-77a0-4f8f-8e8f-1c4e6621c1bb
       Date:
-      - Thu, 25 Oct 2018 18:24:35 GMT
+      - Thu, 01 Nov 2018 18:33:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:35 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:21 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-floating-ips
@@ -6702,7 +6702,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 85dc3e037ff1478f99a91d0eec9026bd
+      - 3aa1e9306dfa4d11b62305024423fee7
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6715,14 +6715,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-7c085150-9f34-4c40-b257-84eda70f29a9
+      - req-389e39fc-5cc0-4093-9392-e82938523789
       Date:
-      - Thu, 25 Oct 2018 18:24:35 GMT
+      - Thu, 01 Nov 2018 18:33:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:35 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:21 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/98b5cc33-7fb8-42b3-86f0-b35883e902aa/os-volume_attachments
@@ -6737,7 +6737,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 85dc3e037ff1478f99a91d0eec9026bd
+      - 3aa1e9306dfa4d11b62305024423fee7
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6750,15 +6750,15 @@ http_interactions:
       Content-Length:
       - '197'
       X-Compute-Request-Id:
-      - req-f86de59b-e1a6-46ea-8641-b561e65ef1f3
+      - req-2a1b21b4-c053-4dae-8526-7f68a1911104
       Date:
-      - Thu, 25 Oct 2018 18:24:35 GMT
+      - Thu, 01 Nov 2018 18:33:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumeAttachments": [{"device": "/dev/vda", "serverId": "98b5cc33-7fb8-42b3-86f0-b35883e902aa",
         "id": "032b36d1-3dfc-4ff8-af30-5fa74ff47a39", "volumeId": "032b36d1-3dfc-4ff8-af30-5fa74ff47a39"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:35 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:21 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-floating-ips
@@ -6773,7 +6773,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 85dc3e037ff1478f99a91d0eec9026bd
+      - 3aa1e9306dfa4d11b62305024423fee7
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6786,14 +6786,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-8f5406a2-9bee-4d10-84a5-b52783855e5b
+      - req-067cff6d-7176-4dff-b705-c0515de633ec
       Date:
-      - Thu, 25 Oct 2018 18:24:36 GMT
+      - Thu, 01 Nov 2018 18:33:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:36 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:21 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/7edb7855-d974-4e45-8ad2-88491541ab91/os-volume_attachments
@@ -6808,7 +6808,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 85dc3e037ff1478f99a91d0eec9026bd
+      - 3aa1e9306dfa4d11b62305024423fee7
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6821,15 +6821,15 @@ http_interactions:
       Content-Length:
       - '197'
       X-Compute-Request-Id:
-      - req-43d8b68b-ece7-43c8-a208-6002504f8929
+      - req-a60c2e19-8e2b-438e-8146-21883f9f5176
       Date:
-      - Thu, 25 Oct 2018 18:24:36 GMT
+      - Thu, 01 Nov 2018 18:33:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumeAttachments": [{"device": "/dev/vdd", "serverId": "7edb7855-d974-4e45-8ad2-88491541ab91",
         "id": "8791e24f-874d-4f1e-99ec-75fdb9d48ca5", "volumeId": "8791e24f-874d-4f1e-99ec-75fdb9d48ca5"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:36 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:21 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-floating-ips
@@ -6844,7 +6844,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 85dc3e037ff1478f99a91d0eec9026bd
+      - 3aa1e9306dfa4d11b62305024423fee7
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6857,14 +6857,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-ed61ca1e-56bc-4e79-bb38-6e0fa5d6952d
+      - req-7861d51b-f1e7-4049-9492-5b0a82797038
       Date:
-      - Thu, 25 Oct 2018 18:24:36 GMT
+      - Thu, 01 Nov 2018 18:33:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:36 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:21 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-floating-ips
@@ -6879,7 +6879,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 85dc3e037ff1478f99a91d0eec9026bd
+      - 3aa1e9306dfa4d11b62305024423fee7
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6892,14 +6892,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-c7d1828d-6cbc-4162-9870-3c784c0f84cb
+      - req-669166ae-d438-4bd6-a86b-06188c311eda
       Date:
-      - Thu, 25 Oct 2018 18:24:36 GMT
+      - Thu, 01 Nov 2018 18:33:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:36 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:22 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-floating-ips
@@ -6914,7 +6914,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 85dc3e037ff1478f99a91d0eec9026bd
+      - 3aa1e9306dfa4d11b62305024423fee7
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6927,14 +6927,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-f92a690b-5562-4253-90dc-58a3b449d118
+      - req-7f1df2e3-e6bd-4aed-ba9e-945b60daf609
       Date:
-      - Thu, 25 Oct 2018 18:24:36 GMT
+      - Thu, 01 Nov 2018 18:33:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:36 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:22 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -6952,15 +6952,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:24:36 GMT
+      - Thu, 01 Nov 2018 18:33:22 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - bee97f4b98254588a1860feb803f2e61
+      - 5bdaef81c8eb4a1fb36e38b87396ca4e
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-72f01e88-2fa1-4109-8179-ecde86e6761d
+      - req-125f46b5-cf7f-4eec-8707-3d01a160761a
       Content-Length:
       - '7311'
       Connection:
@@ -6972,7 +6972,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-10-25T19:24:36.812457Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-11-01T19:33:22.454643Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -7051,10 +7051,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["1HdPQuhrSiGtWbHYTORPGw"],
-        "issued_at": "2018-10-25T18:24:36.812478Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["MXW_IUK5RQGmCVUeNl75dA"],
+        "issued_at": "2018-11-01T18:33:22.454669Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:36 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:22 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -7072,15 +7072,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:24:36 GMT
+      - Thu, 01 Nov 2018 18:33:22 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - f9fd674928294735a9e6f02d81603830
+      - e140d415bbe04ecb9dbb9384feb2f193
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-a6fb3702-9991-47f4-b988-dc2e06316f66
+      - req-57df2c20-dc95-4bb8-8788-301aac38c2be
       Content-Length:
       - '7311'
       Connection:
@@ -7092,7 +7092,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-10-25T19:24:37.059973Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-11-01T19:33:22.701099Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -7171,10 +7171,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["9dJGz-QzRwGhHoVuEGXfFg"],
-        "issued_at": "2018-10-25T18:24:37.060010Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["5c0eMAvRSASgPnTH-34uRg"],
+        "issued_at": "2018-11-01T18:33:22.701123Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:37 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:22 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-aggregates
@@ -7189,7 +7189,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 85dc3e037ff1478f99a91d0eec9026bd
+      - 3aa1e9306dfa4d11b62305024423fee7
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -7202,14 +7202,14 @@ http_interactions:
       Content-Length:
       - '18'
       X-Compute-Request-Id:
-      - req-72ba8f47-9d85-465e-be20-61fb9e17406d
+      - req-738a7a0b-931e-4169-b9ab-415b93f08b67
       Date:
-      - Thu, 25 Oct 2018 18:24:37 GMT
+      - Thu, 01 Nov 2018 18:33:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"aggregates": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:37 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:22 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/volumes/detail?all_tenants=True&limit=1000&status=available
@@ -7224,22 +7224,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e717ded0b812448380d7dd4ddb0bd929
+      - f7ab4eb9dd0f43c2a676ffe90e43fdf3
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-1322c559-d290-4526-badc-25a2ab47b0fa
+      - req-ba18e38f-57ae-4318-a116-fdf7d3869d6e
       Content-Type:
       - application/json
       Content-Length:
       - '2740'
       X-Openstack-Request-Id:
-      - req-1322c559-d290-4526-badc-25a2ab47b0fa
+      - req-ba18e38f-57ae-4318-a116-fdf7d3869d6e
       Date:
-      - Thu, 25 Oct 2018 18:24:37 GMT
+      - Thu, 01 Nov 2018 18:33:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/volumes/detail?all_tenants=True&limit=1000&status=available&marker=f46458aa-309d-4f47-b996-a39db065030a",
@@ -7272,7 +7272,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-4", "bootable": "true", "created_at":
         "2016-08-19T08:37:45.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:37 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:22 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/volumes/detail?all_tenants=True&limit=1000&marker=f46458aa-309d-4f47-b996-a39db065030a&status=available
@@ -7287,22 +7287,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e717ded0b812448380d7dd4ddb0bd929
+      - f7ab4eb9dd0f43c2a676ffe90e43fdf3
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-31605f0b-a5b4-4ee2-8b28-522e30dd3b73
+      - req-f8b4e83b-758d-4c92-8b74-39b1be471354
       Content-Type:
       - application/json
       Content-Length:
       - '1180'
       X-Openstack-Request-Id:
-      - req-31605f0b-a5b4-4ee2-8b28-522e30dd3b73
+      - req-f8b4e83b-758d-4c92-8b74-39b1be471354
       Date:
-      - Thu, 25 Oct 2018 18:24:37 GMT
+      - Thu, 01 Nov 2018 18:33:23 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": [{"migration_status": null, "attachments": [], "links":
@@ -7319,7 +7319,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-FromSnapshot", "bootable": "false", "created_at":
         "2016-08-19T08:37:13.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:37 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:23 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/snapshots/detail
@@ -7334,27 +7334,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e717ded0b812448380d7dd4ddb0bd929
+      - f7ab4eb9dd0f43c2a676ffe90e43fdf3
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-4cf9e29e-e9bb-4288-81ba-a23089d3c6e1
+      - req-71fc0700-982e-4624-8fa4-6233d1a26e27
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-4cf9e29e-e9bb-4288-81ba-a23089d3c6e1
+      - req-71fc0700-982e-4624-8fa4-6233d1a26e27
       Date:
-      - Thu, 25 Oct 2018 18:24:37 GMT
+      - Thu, 01 Nov 2018 18:33:23 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:37 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:23 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/snapshots/detail?all_tenants=True&limit=1000&status=available
@@ -7369,22 +7369,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e717ded0b812448380d7dd4ddb0bd929
+      - f7ab4eb9dd0f43c2a676ffe90e43fdf3
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-5782a9b7-9ded-4d7f-8383-76f6a5017816
+      - req-df2ba2b1-e68a-48c5-a33d-fcf20171303a
       Content-Type:
       - application/json
       Content-Length:
       - '1098'
       X-Openstack-Request-Id:
-      - req-5782a9b7-9ded-4d7f-8383-76f6a5017816
+      - req-df2ba2b1-e68a-48c5-a33d-fcf20171303a
       Date:
-      - Thu, 25 Oct 2018 18:24:37 GMT
+      - Thu, 01 Nov 2018 18:33:23 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/snapshots/detail?all_tenants=True&limit=1000&status=available&marker=c44d3eb3-31fe-46ed-bfae-707920be171d",
@@ -7399,7 +7399,7 @@ http_interactions:
         "created_at": "2016-08-19T08:37:24.000000", "size": 1, "id": "c44d3eb3-31fe-46ed-bfae-707920be171d",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:37 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:23 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/volumes/detail?all_tenants=True&limit=1000
@@ -7414,22 +7414,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e717ded0b812448380d7dd4ddb0bd929
+      - f7ab4eb9dd0f43c2a676ffe90e43fdf3
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-f43324c8-e3e3-46ae-96f1-2a5b9f8fb5ec
+      - req-d84fda50-717a-4fdc-a2ce-b5bada94eb3a
       Content-Type:
       - application/json
       Content-Length:
       - '2723'
       X-Openstack-Request-Id:
-      - req-f43324c8-e3e3-46ae-96f1-2a5b9f8fb5ec
+      - req-d84fda50-717a-4fdc-a2ce-b5bada94eb3a
       Date:
-      - Thu, 25 Oct 2018 18:24:37 GMT
+      - Thu, 01 Nov 2018 18:33:23 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/volumes/detail?all_tenants=True&limit=1000&marker=f46458aa-309d-4f47-b996-a39db065030a",
@@ -7462,7 +7462,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-4", "bootable": "true", "created_at":
         "2016-08-19T08:37:45.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:37 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:23 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/volumes/detail?all_tenants=True&limit=1000&marker=f46458aa-309d-4f47-b996-a39db065030a
@@ -7477,22 +7477,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e717ded0b812448380d7dd4ddb0bd929
+      - f7ab4eb9dd0f43c2a676ffe90e43fdf3
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-b9957907-ddc5-4cae-99dc-168e50ab56e8
+      - req-a380e6dd-c4d4-4f18-9055-3cef11f5d1be
       Content-Type:
       - application/json
       Content-Length:
       - '3301'
       X-Openstack-Request-Id:
-      - req-b9957907-ddc5-4cae-99dc-168e50ab56e8
+      - req-a380e6dd-c4d4-4f18-9055-3cef11f5d1be
       Date:
-      - Thu, 25 Oct 2018 18:24:37 GMT
+      - Thu, 01 Nov 2018 18:33:23 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/volumes/detail?all_tenants=True&limit=1000&marker=476a0c89-4322-42aa-b7ce-3ac21be55af7",
@@ -7533,7 +7533,7 @@ http_interactions:
         "name": "EmsRefreshSpec-Volume-2", "bootable": "false", "created_at": "2016-08-19T08:37:33.000000",
         "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:37 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:23 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/volumes/detail?all_tenants=True&limit=1000&marker=476a0c89-4322-42aa-b7ce-3ac21be55af7
@@ -7548,22 +7548,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e717ded0b812448380d7dd4ddb0bd929
+      - f7ab4eb9dd0f43c2a676ffe90e43fdf3
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-ad84257d-e573-40ac-88a2-07b6e7f26783
+      - req-6210bb60-8f0d-4f5d-9dc5-9143582db3e2
       Content-Type:
       - application/json
       Content-Length:
       - '2770'
       X-Openstack-Request-Id:
-      - req-ad84257d-e573-40ac-88a2-07b6e7f26783
+      - req-6210bb60-8f0d-4f5d-9dc5-9143582db3e2
       Date:
-      - Thu, 25 Oct 2018 18:24:38 GMT
+      - Thu, 01 Nov 2018 18:33:23 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/volumes/detail?all_tenants=True&limit=1000&marker=8791e24f-874d-4f1e-99ec-75fdb9d48ca5",
@@ -7597,7 +7597,7 @@ http_interactions:
         "bootable": "false", "created_at": "2016-08-19T08:37:05.000000", "volume_type":
         "iscsi"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:38 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:23 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/volumes/detail?all_tenants=True&limit=1000&marker=8791e24f-874d-4f1e-99ec-75fdb9d48ca5
@@ -7612,27 +7612,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e717ded0b812448380d7dd4ddb0bd929
+      - f7ab4eb9dd0f43c2a676ffe90e43fdf3
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-d74769cd-b4a2-4c1b-a2ad-12570558cd87
+      - req-a4f379b5-aadb-4c0f-ab7c-575bb7ff1221
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-d74769cd-b4a2-4c1b-a2ad-12570558cd87
+      - req-a4f379b5-aadb-4c0f-ab7c-575bb7ff1221
       Date:
-      - Thu, 25 Oct 2018 18:24:38 GMT
+      - Thu, 01 Nov 2018 18:33:23 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:38 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:24 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -7650,15 +7650,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:24:39 GMT
+      - Thu, 01 Nov 2018 18:33:25 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - e9b99624860d4879977f409087aa95e5
+      - 46cf005ff1be40c18600f190b3794f69
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-5ca9dfc2-014c-4512-b393-c7a78347766b
+      - req-80dd3cb7-25f7-496c-a74a-e3718d4abfef
       Content-Length:
       - '7311'
       Connection:
@@ -7670,7 +7670,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-10-25T19:24:39.317680Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-11-01T19:33:25.337495Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -7749,10 +7749,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["qfJDDJTMQzGpWlEXKxqHJQ"],
-        "issued_at": "2018-10-25T18:24:39.317700Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["wFm9Jo-eTZSHY51WmAoSyw"],
+        "issued_at": "2018-11-01T18:33:25.337515Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:39 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:25 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -7770,15 +7770,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:24:39 GMT
+      - Thu, 01 Nov 2018 18:33:25 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 91bd1586cfbe4975af54c35a539820ba
+      - d135c59cd27b40e7b8b3558ef101d4d1
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-a1bdb101-803a-481c-9687-8ff52b93d839
+      - req-314dea14-802a-4398-9980-f0f509e5b7d0
       Content-Length:
       - '7311'
       Connection:
@@ -7790,7 +7790,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-10-25T19:24:39.513114Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-11-01T19:33:25.549305Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -7869,10 +7869,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["bp-qpZ14R_KTe2JmVM7RtQ"],
-        "issued_at": "2018-10-25T18:24:39.513144Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["OhJprPUpS--Oe1XVNqS63g"],
+        "issued_at": "2018-11-01T18:33:25.549325Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:39 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:25 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/networks
@@ -7887,7 +7887,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 91bd1586cfbe4975af54c35a539820ba
+      - d135c59cd27b40e7b8b3558ef101d4d1
   response:
     status:
       code: 200
@@ -7898,27 +7898,12 @@ http_interactions:
       Content-Length:
       - '5330'
       X-Openstack-Request-Id:
-      - req-c9417962-370e-4699-a08f-50f8ba9a7476
+      - req-889b66f0-bae4-458c-89fb-04eeaac33712
       Date:
-      - Thu, 25 Oct 2018 18:24:39 GMT
+      - Thu, 01 Nov 2018 18:33:25 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"networks": [{"status": "ACTIVE", "subnets": ["978d38ec-4845-45ce-b3e3-89e7c9d9109b",
-        "9801267c-cd57-437a-a852-b46640cb4332"], "name": "EmsRefreshSpec-IsolatedNetworkPrivate_2",
-        "provider:physical_network": null, "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
-        "vxlan", "id": "483c08c7-96b0-4e08-9db7-96d5650974ac", "provider:segmentation_id":
-        36}, {"status": "ACTIVE", "subnets": ["e96c89d2-810a-4cdb-a19b-93072db5dd20"],
-        "name": "EmsRefreshSpec-NetworkPrivate_3", "provider:physical_network": null,
-        "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
-        0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
-        "id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571", "provider:segmentation_id":
-        99}, {"status": "ACTIVE", "subnets": ["e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d"],
-        "name": "EmsRefreshSpec-NetworkPrivate_20", "provider:physical_network": null,
-        "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
-        0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
-        "id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "provider:segmentation_id":
-        31}, {"status": "ACTIVE", "subnets": ["53450d1a-8ecc-43aa-a641-95db25b6be2e"],
+      string: '{"networks": [{"status": "ACTIVE", "subnets": ["53450d1a-8ecc-43aa-a641-95db25b6be2e"],
         "name": "EmsRefreshSpec-NetworkPublic_40", "provider:physical_network": "public_net_4",
         "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
         0, "router:external": true, "shared": false, "provider:network_type": "flat",
@@ -7958,19 +7943,34 @@ http_interactions:
         "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
         0, "router:external": true, "shared": false, "provider:network_type": "flat",
         "id": "c66145df-4d9d-4898-9e35-12a102b66346", "provider:segmentation_id":
-        null}, {"status": "ACTIVE", "subnets": ["76d851f4-9cd9-49ca-93ac-bcc7b3c8153a"],
+        null}, {"status": "ACTIVE", "subnets": ["9801267c-cd57-437a-a852-b46640cb4332",
+        "978d38ec-4845-45ce-b3e3-89e7c9d9109b"], "name": "EmsRefreshSpec-IsolatedNetworkPrivate_2",
+        "provider:physical_network": null, "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
+        "vxlan", "id": "483c08c7-96b0-4e08-9db7-96d5650974ac", "provider:segmentation_id":
+        36}, {"status": "ACTIVE", "subnets": ["76d851f4-9cd9-49ca-93ac-bcc7b3c8153a"],
         "name": "EmsRefreshSpec-NetworkPublic_20", "provider:physical_network": "public_net_2",
         "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
         0, "router:external": true, "shared": false, "provider:network_type": "flat",
         "id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "provider:segmentation_id":
-        null}, {"status": "ACTIVE", "subnets": ["f4c17602-9618-4604-b3c9-9e4801d094d3",
-        "24c83610-eab6-4f68-99dd-ab22a638b4a0"], "name": "EmsRefreshSpec-NetworkPrivate",
+        null}, {"status": "ACTIVE", "subnets": ["e96c89d2-810a-4cdb-a19b-93072db5dd20"],
+        "name": "EmsRefreshSpec-NetworkPrivate_3", "provider:physical_network": null,
+        "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
+        0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
+        "id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571", "provider:segmentation_id":
+        99}, {"status": "ACTIVE", "subnets": ["e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d"],
+        "name": "EmsRefreshSpec-NetworkPrivate_20", "provider:physical_network": null,
+        "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
+        0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
+        "id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "provider:segmentation_id":
+        31}, {"status": "ACTIVE", "subnets": ["24c83610-eab6-4f68-99dd-ab22a638b4a0",
+        "f4c17602-9618-4604-b3c9-9e4801d094d3"], "name": "EmsRefreshSpec-NetworkPrivate",
         "provider:physical_network": null, "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
         "vxlan", "id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "provider:segmentation_id":
         11}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:39 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:25 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -7988,15 +7988,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:24:39 GMT
+      - Thu, 01 Nov 2018 18:33:25 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 9f7cb741750147aaa6007116878b29dd
+      - 3658ae8666ab4dfdb5969f71ec80d106
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-50fbdbcc-330c-4187-9226-ec8e6b604178
+      - req-04267650-57f7-4c63-a34a-9de2efcd4103
       Content-Length:
       - '7311'
       Connection:
@@ -8008,7 +8008,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-10-25T19:24:39.848896Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-11-01T19:33:25.906812Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -8087,10 +8087,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["K87rHEeoQ0W3ozSb-IVrgw"],
-        "issued_at": "2018-10-25T18:24:39.848918Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["U-4rUzBvQ0WOahX3thgToA"],
+        "issued_at": "2018-11-01T18:33:25.906834Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:39 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:25 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -8108,15 +8108,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:24:39 GMT
+      - Thu, 01 Nov 2018 18:33:26 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - c84eee5e7c854ef09ac5cb1bb7759abb
+      - 5aac7aab64d54e1b8d9ec99b85ca7752
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-cadda6d6-3250-4ba0-a531-2d1ccd7c70cc
+      - req-a4662c78-4722-4203-b9b3-89eb3ea64eeb
       Content-Length:
       - '297'
       Connection:
@@ -8125,12 +8125,12 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"token": {"methods": ["password"], "expires_at": "2018-10-25T19:24:40.021722Z",
+      string: '{"token": {"methods": ["password"], "expires_at": "2018-11-01T19:33:26.090020Z",
         "extras": {}, "user": {"domain": {"id": "default", "name": "Default"}, "id":
-        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["KCmagZR_QReASil9Kz9nxg"],
-        "issued_at": "2018-10-25T18:24:40.021740Z"}}'
+        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["h4d6gTx4QOSUfwHaWiy-ZA"],
+        "issued_at": "2018-11-01T18:33:26.090039Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:40 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:26 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects?domain_id=default
@@ -8145,20 +8145,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c84eee5e7c854ef09ac5cb1bb7759abb
+      - 5aac7aab64d54e1b8d9ec99b85ca7752
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:24:40 GMT
+      - Thu, 01 Nov 2018 18:33:26 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-e76d7994-8d9f-4f7b-821b-b625599ef542
+      - req-40470833-f9d1-4286-9c10-8e7bf4a495c0
       Content-Length:
       - '2475'
       Connection:
@@ -8191,7 +8191,7 @@ http_interactions:
         "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
         "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:40 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:26 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -8209,15 +8209,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:24:40 GMT
+      - Thu, 01 Nov 2018 18:33:26 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 31f4838f14934028b30996e04edabbc9
+      - 03fd5f661cb345c49ef49902cdd3535f
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-e52cedf7-d904-476c-b3cd-edb35d593fa7
+      - req-ce1daeed-7e44-4d23-84ce-20bacd7e3f3d
       Content-Length:
       - '7278'
       Connection:
@@ -8229,7 +8229,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:24:40.360982Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:33:26.476251Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -8308,10 +8308,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["LaNHOxHbTL-tKswuQ8f1Gg"],
-        "issued_at": "2018-10-25T18:24:40.361014Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["fkLGnC38Rzuvkw-3PMD8OA"],
+        "issued_at": "2018-11-01T18:33:26.476273Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:40 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:26 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -8329,15 +8329,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:24:40 GMT
+      - Thu, 01 Nov 2018 18:33:26 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - dd45f270fe1f40a7a82676a807df68dd
+      - dfe46dcab4ef4dc6a481cb7a68dc8b18
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-5f4e35b2-3397-4fff-8a5d-cbba89cae36c
+      - req-4731eaa0-68ae-4e4d-a8d3-206e9e4636f5
       Content-Length:
       - '7278'
       Connection:
@@ -8349,7 +8349,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:24:40.562344Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:33:26.692649Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -8428,10 +8428,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Kc2Hh5VtSZGr0zg6OnI-CA"],
-        "issued_at": "2018-10-25T18:24:40.562363Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["MuTd1B0IQsquECJpsXTHHA"],
+        "issued_at": "2018-11-01T18:33:26.692668Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:40 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:26 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -8449,15 +8449,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:24:40 GMT
+      - Thu, 01 Nov 2018 18:33:26 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - f8d5f8d20a324d75a6905926ee2755a4
+      - 23639a20d6224f958fbf58d8e39ce3f4
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-642a1ec4-7c86-4d09-a36f-7b340b2cf022
+      - req-6edf87e8-9a6e-4283-8cab-c50260304976
       Content-Length:
       - '7264'
       Connection:
@@ -8469,7 +8469,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:24:40.774485Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:33:26.903175Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -8548,10 +8548,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["BJazglNJSdGBu5Kd02nUmw"],
-        "issued_at": "2018-10-25T18:24:40.774506Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["6zlA4iuNQWeVEsLbrkjM-A"],
+        "issued_at": "2018-11-01T18:33:26.903194Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:40 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:26 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -8569,15 +8569,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:24:40 GMT
+      - Thu, 01 Nov 2018 18:33:27 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 9bb07db99770412981cd769521cd3469
+      - 1261cb74dca64293bb974bc5eccd6968
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-43fada40-6e55-4b7d-b3ef-7d3ea4bbf631
+      - req-b81a73fe-6521-443f-926c-ef091700b431
       Content-Length:
       - '7278'
       Connection:
@@ -8589,7 +8589,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:24:40.995333Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:33:27.121275Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -8668,10 +8668,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["9jATdXfvRfeY4JZ--k28lg"],
-        "issued_at": "2018-10-25T18:24:40.995359Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["wKXA-EraT6WTT5FF9kwOAg"],
+        "issued_at": "2018-11-01T18:33:27.121297Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:41 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:27 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -8689,15 +8689,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:24:41 GMT
+      - Thu, 01 Nov 2018 18:33:27 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 1db6de982d864a87b70abc95bb7ffe6c
+      - a78d7f78249148099783e075cc5740c6
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-d072044d-0919-445e-9d0b-5ff03d9c7410
+      - req-625fcdc7-caec-41d9-9cb1-822fc1515a78
       Content-Length:
       - '7265'
       Connection:
@@ -8709,7 +8709,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:24:41.394349Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:33:27.336094Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -8788,10 +8788,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["yWklFDHrT2KUJ5VsXCCM_w"],
-        "issued_at": "2018-10-25T18:24:41.394371Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["TLAutsFuT2i3SXZH7vnv8A"],
+        "issued_at": "2018-11-01T18:33:27.336115Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:41 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:27 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -8809,15 +8809,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:24:41 GMT
+      - Thu, 01 Nov 2018 18:33:27 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - ff009db10f7c47d5861d98e884acdd59
+      - 7028d63f1d3040488cfea5970bf72afa
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-bb1fa7af-267d-4559-ae71-ab713c2d3e38
+      - req-dede5fb0-fb1a-4460-a9ba-dea25376620a
       Content-Length:
       - '7278'
       Connection:
@@ -8829,7 +8829,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:24:41.598202Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:33:27.550254Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -8908,10 +8908,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["2WHZfEnjSVKNcoMxu8B18w"],
-        "issued_at": "2018-10-25T18:24:41.598221Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["cDr0yMnrR7Kmhme8evnRbg"],
+        "issued_at": "2018-11-01T18:33:27.550275Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:41 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:27 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -8929,15 +8929,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:24:41 GMT
+      - Thu, 01 Nov 2018 18:33:27 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - f5a0ad6d82de402cb41543adc8048b35
+      - 951fc5caa44d4d27baf3ce8bd6a12ab9
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-66442f00-feb1-4368-afa4-f28ff6c8bb33
+      - req-12cbfad1-9445-4623-8e8d-649f63ff90ee
       Content-Length:
       - '7278'
       Connection:
@@ -8949,7 +8949,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:24:41.795164Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:33:27.776254Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -9028,10 +9028,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["oS_8lCAHQKeCh19k5J_mBw"],
-        "issued_at": "2018-10-25T18:24:41.795186Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["yxkTZ9AlQHeaxu3qV64Etw"],
+        "issued_at": "2018-11-01T18:33:27.776274Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:41 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:27 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/0098405163cd4c9dbb42c2cb43eb6fd3/stacks?limit=1000&show_nested=true
@@ -9046,7 +9046,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f5a0ad6d82de402cb41543adc8048b35
+      - 951fc5caa44d4d27baf3ce8bd6a12ab9
   response:
     status:
       code: 200
@@ -9057,14 +9057,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-b69fbfdc-a9eb-4d58-925c-f7eb60335f74
+      - req-48b3db38-8a46-4545-a4e2-800b9f1bb057
       Date:
-      - Thu, 25 Oct 2018 18:24:41 GMT
+      - Thu, 01 Nov 2018 18:33:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:41 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:27 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -9082,15 +9082,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:24:42 GMT
+      - Thu, 01 Nov 2018 18:33:28 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 45bfced853114f97b03ca95eed68fef3
+      - 911cf3012de044d8a4fde3c17efc015a
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-d97332ba-b31a-4789-a659-7a346482455a
+      - req-e49ef28e-51f8-46f1-bfce-3c1b91eb7305
       Content-Length:
       - '7278'
       Connection:
@@ -9102,7 +9102,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:24:42.113962Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:33:28.123471Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -9181,10 +9181,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["bZrkOcXKRCaTRTlxTUI7jQ"],
-        "issued_at": "2018-10-25T18:24:42.113983Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["0pgoIiHkT3uhB1VPlmlswg"],
+        "issued_at": "2018-11-01T18:33:28.123492Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:42 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:28 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/28db8f69ba9e4305b7fad82da4c86e74/stacks?limit=1000&show_nested=true
@@ -9199,7 +9199,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 45bfced853114f97b03ca95eed68fef3
+      - 911cf3012de044d8a4fde3c17efc015a
   response:
     status:
       code: 200
@@ -9210,14 +9210,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-5737b34b-1135-43c6-b42d-c4c8f9cae82c
+      - req-95a6128f-b993-4384-b6b8-019c2adb9c17
       Date:
-      - Thu, 25 Oct 2018 18:24:42 GMT
+      - Thu, 01 Nov 2018 18:33:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:42 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:28 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -9235,15 +9235,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:24:42 GMT
+      - Thu, 01 Nov 2018 18:33:28 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - cb787a734c72415c8caf56b9965fb359
+      - 5af906bdf3e544889d9effafd6b444ba
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-9ecda7f5-a160-4d05-993b-82ef9637ee3d
+      - req-ad886212-a914-48da-b0ae-cf4ea26f0bcf
       Content-Length:
       - '7264'
       Connection:
@@ -9255,7 +9255,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:24:42.431242Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:33:28.516468Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -9334,10 +9334,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["D4JxcW4DR3uHlm6fjhDQVA"],
-        "issued_at": "2018-10-25T18:24:42.431262Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["v2cf-j0YQkWD_r54s_vo1Q"],
+        "issued_at": "2018-11-01T18:33:28.516492Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:42 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:28 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks?limit=1000&show_nested=true
@@ -9352,7 +9352,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cb787a734c72415c8caf56b9965fb359
+      - 5af906bdf3e544889d9effafd6b444ba
   response:
     status:
       code: 200
@@ -9363,9 +9363,9 @@ http_interactions:
       Content-Length:
       - '2559'
       X-Openstack-Request-Id:
-      - req-d2a5238d-1e6d-44d5-86f1-237633697b3c
+      - req-c15035c1-c8c5-4e59-b8b6-ab3697f8b1d2
       Date:
-      - Thu, 25 Oct 2018 18:24:42 GMT
+      - Thu, 01 Nov 2018 18:33:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": [{"description": "Heat WordPress template to support F20,
@@ -9399,7 +9399,7 @@ http_interactions:
         "rel": "self"}], "updated_time": null, "stack_owner": null, "stack_status":
         "CREATE_COMPLETE", "id": "7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:42 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:28 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks?limit=1000&marker=7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0&show_nested=true
@@ -9414,7 +9414,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cb787a734c72415c8caf56b9965fb359
+      - 5af906bdf3e544889d9effafd6b444ba
   response:
     status:
       code: 200
@@ -9425,14 +9425,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-d3b9e225-b6ff-4dd7-983d-9d98479f8323
+      - req-3fef835a-c0e3-4bb7-a6b3-f924065122f8
       Date:
-      - Thu, 25 Oct 2018 18:24:42 GMT
+      - Thu, 01 Nov 2018 18:33:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:42 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:28 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -9450,15 +9450,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:24:42 GMT
+      - Thu, 01 Nov 2018 18:33:28 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - d7a4cd3f915941808f7052b44627ef6b
+      - 95c36b8d7950406b988b3ad461d76fd9
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-0bba8821-1979-4bf6-8a9e-c1213e5e5436
+      - req-0c1c917a-2f98-42c8-a233-36114d9832a0
       Content-Length:
       - '7278'
       Connection:
@@ -9470,7 +9470,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:24:42.875435Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:33:28.999308Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -9549,10 +9549,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["924dF34gR1C6ofLEqPSQbQ"],
-        "issued_at": "2018-10-25T18:24:42.875457Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["BpqhzyNaSQS7jnSbQ85seA"],
+        "issued_at": "2018-11-01T18:33:28.999328Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:42 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:29 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/52c452d7763a4295950527948232a3e5/stacks?limit=1000&show_nested=true
@@ -9567,7 +9567,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d7a4cd3f915941808f7052b44627ef6b
+      - 95c36b8d7950406b988b3ad461d76fd9
   response:
     status:
       code: 200
@@ -9578,14 +9578,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-04f546c2-1412-4ead-a026-2e12fc9a9967
+      - req-8a5d181e-c3f7-4163-8a77-50c8c3c0ed16
       Date:
-      - Thu, 25 Oct 2018 18:24:43 GMT
+      - Thu, 01 Nov 2018 18:33:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:43 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:29 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/88ae57d444fd485ab2dfddd5a2615d52/stacks?limit=1000&show_nested=true
@@ -9600,7 +9600,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9f7cb741750147aaa6007116878b29dd
+      - 3658ae8666ab4dfdb5969f71ec80d106
   response:
     status:
       code: 200
@@ -9611,14 +9611,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-eabfdbe8-edcd-4793-ab6c-24fb6b218a5b
+      - req-ed41a1ce-d4e9-4577-b442-9a7038263af1
       Date:
-      - Thu, 25 Oct 2018 18:24:43 GMT
+      - Thu, 01 Nov 2018 18:33:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:43 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:29 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -9636,15 +9636,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:24:43 GMT
+      - Thu, 01 Nov 2018 18:33:29 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 515c1e2d336f46c4836a2dd9168b2ac2
+      - f9bd08e5fbcc4a35b33cc94df2b6d09b
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-ea8d80fc-7db1-4f0a-9faa-4cb801a7a9c0
+      - req-b7527407-c405-4a6a-b3d6-b1b128016980
       Content-Length:
       - '7265'
       Connection:
@@ -9656,7 +9656,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:24:43.344754Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:33:29.465081Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -9735,10 +9735,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["fyntQNjxQMWqdFtpCP-IUg"],
-        "issued_at": "2018-10-25T18:24:43.344802Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["sd1qGd2NT2OJyRCfgH3big"],
+        "issued_at": "2018-11-01T18:33:29.465102Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:43 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:29 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/d09cbe26295d47ff848ea73c74264e23/stacks?limit=1000&show_nested=true
@@ -9753,7 +9753,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 515c1e2d336f46c4836a2dd9168b2ac2
+      - f9bd08e5fbcc4a35b33cc94df2b6d09b
   response:
     status:
       code: 200
@@ -9764,14 +9764,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-67fc4dcd-22ef-4a4e-82ad-63b411cbbe0c
+      - req-51d55d26-8016-4e7d-90ed-5da369122117
       Date:
-      - Thu, 25 Oct 2018 18:24:43 GMT
+      - Thu, 01 Nov 2018 18:33:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:43 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:29 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -9789,15 +9789,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:24:43 GMT
+      - Thu, 01 Nov 2018 18:33:29 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - a3638bcf6e894322bd1bb3c5ec6612ee
+      - c651d95755d749df9b7ad17238059d88
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-10615d64-1386-47ec-91a8-9493469ad3e0
+      - req-a2cabdd3-8251-49c7-aca8-d05cc614ac8c
       Content-Length:
       - '7278'
       Connection:
@@ -9809,7 +9809,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:24:43.684412Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:33:29.804255Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -9888,10 +9888,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["EP-xOQP_TJyxYwO4mJ8Q_w"],
-        "issued_at": "2018-10-25T18:24:43.684436Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["M7hPcPluQHq1CIBV8_CB4Q"],
+        "issued_at": "2018-11-01T18:33:29.804276Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:43 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:29 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/ef2a3405d1ef4dfd9a3616993ef46a4d/stacks?limit=1000&show_nested=true
@@ -9906,7 +9906,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a3638bcf6e894322bd1bb3c5ec6612ee
+      - c651d95755d749df9b7ad17238059d88
   response:
     status:
       code: 200
@@ -9917,14 +9917,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-8f818257-5899-4278-8666-f97a60490eb2
+      - req-c91c287f-84f0-4481-a89d-b02730d48a67
       Date:
-      - Thu, 25 Oct 2018 18:24:43 GMT
+      - Thu, 01 Nov 2018 18:33:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:43 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:29 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack3/00c5dc04-2c94-48d2-8031-db08934e9a44
@@ -9939,7 +9939,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cb787a734c72415c8caf56b9965fb359
+      - 5af906bdf3e544889d9effafd6b444ba
   response:
     status:
       code: 200
@@ -9950,9 +9950,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-51f7d36f-5991-40d6-b47a-60ab40282816
+      - req-3ed4b39b-8b9e-4ffc-8c87-08bb4086a995
       Date:
-      - Thu, 25 Oct 2018 18:24:44 GMT
+      - Thu, 01 Nov 2018 18:33:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -9979,7 +9979,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:44 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:30 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack2/d6eba2a2-7b0d-4213-afbb-69c8f6dddd8d
@@ -9994,7 +9994,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cb787a734c72415c8caf56b9965fb359
+      - 5af906bdf3e544889d9effafd6b444ba
   response:
     status:
       code: 200
@@ -10005,9 +10005,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-bb6aec30-7a0d-4964-bce3-f0e3a608fafa
+      - req-ce0bfa96-dc2b-443e-87c6-7961be32422c
       Date:
-      - Thu, 25 Oct 2018 18:24:44 GMT
+      - Thu, 01 Nov 2018 18:33:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -10034,7 +10034,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:44 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:30 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack1/7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0
@@ -10049,7 +10049,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cb787a734c72415c8caf56b9965fb359
+      - 5af906bdf3e544889d9effafd6b444ba
   response:
     status:
       code: 200
@@ -10060,9 +10060,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-f80c1c2b-ec37-4008-9807-411e77aa0e3f
+      - req-d9e81bae-26d3-4809-9b1c-4106278d93ab
       Date:
-      - Thu, 25 Oct 2018 18:24:44 GMT
+      - Thu, 01 Nov 2018 18:33:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -10089,7 +10089,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:44 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:30 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack3/00c5dc04-2c94-48d2-8031-db08934e9a44/resources
@@ -10104,7 +10104,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cb787a734c72415c8caf56b9965fb359
+      - 5af906bdf3e544889d9effafd6b444ba
   response:
     status:
       code: 200
@@ -10115,9 +10115,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-1ecaa521-208d-460a-b684-b20fff6858cf
+      - req-081b37d0-80d2-4ad3-9eb5-d230b75716f3
       Date:
-      - Thu, 25 Oct 2018 18:24:44 GMT
+      - Thu, 01 Nov 2018 18:33:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -10129,7 +10129,7 @@ http_interactions:
         changed", "physical_resource_id": "40989f26-9c38-4f72-b739-afccb44397cf",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:44 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:30 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack2/d6eba2a2-7b0d-4213-afbb-69c8f6dddd8d/resources
@@ -10144,7 +10144,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cb787a734c72415c8caf56b9965fb359
+      - 5af906bdf3e544889d9effafd6b444ba
   response:
     status:
       code: 200
@@ -10155,9 +10155,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-56275585-af72-4b95-be27-119ced2fcc4b
+      - req-280b9d84-2952-4df9-b92f-a84248d5adaa
       Date:
-      - Thu, 25 Oct 2018 18:24:44 GMT
+      - Thu, 01 Nov 2018 18:33:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -10169,7 +10169,7 @@ http_interactions:
         changed", "physical_resource_id": "ad4f7eb0-9122-41a6-a0f7-55c1d4ca5e02",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:44 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:31 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack1/7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0/resources
@@ -10184,7 +10184,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cb787a734c72415c8caf56b9965fb359
+      - 5af906bdf3e544889d9effafd6b444ba
   response:
     status:
       code: 200
@@ -10195,9 +10195,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-13aba2ce-2f13-465d-a0ff-2b1ec78fb066
+      - req-72293b2a-b49e-41e0-9f96-bf5a2807dad3
       Date:
-      - Thu, 25 Oct 2018 18:24:45 GMT
+      - Thu, 01 Nov 2018 18:33:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -10209,7 +10209,7 @@ http_interactions:
         changed", "physical_resource_id": "8022b967-813a-4e3b-8ff4-7c036957a8a0",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:45 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:31 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/subnets?all_tenants=True&limit=1000
@@ -10224,7 +10224,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 91bd1586cfbe4975af54c35a539820ba
+      - d135c59cd27b40e7b8b3558ef101d4d1
   response:
     status:
       code: 200
@@ -10235,9 +10235,9 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-295996cb-7ddb-4fa5-83dd-c1166b77897c
+      - req-65a8de05-f039-4b94-a4b1-9eed51d5f794
       Date:
-      - Thu, 25 Oct 2018 18:24:45 GMT
+      - Thu, 01 Nov 2018 18:33:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
@@ -10341,7 +10341,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:45 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:31 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/subnets?all_tenants=True&limit=1000&marker=24c83610-eab6-4f68-99dd-ab22a638b4a0
@@ -10356,7 +10356,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 91bd1586cfbe4975af54c35a539820ba
+      - d135c59cd27b40e7b8b3558ef101d4d1
   response:
     status:
       code: 200
@@ -10367,74 +10367,28 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-396e7740-d888-4a80-a7ee-83bdd0f5da0a
+      - req-f575a878-0976-426f-941e-4060c787a3d4
       Date:
-      - Thu, 25 Oct 2018 18:24:45 GMT
+      - Thu, 01 Nov 2018 18:33:31 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
-        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "9801267c-cd57-437a-a852-b46640cb4332",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
-        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.20.0/24", "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21",
-        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.51.2",
-        "end": "192.168.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.51.0/24", "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
-        true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
-        "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
         "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
         "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
         [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
         "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp": false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49",
+        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e",
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.18.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2",
-        "end": "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
+        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
         false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
@@ -10448,6 +10402,12 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
         [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
         "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.8",
+        "end": "192.168.3.10"}, {"start": "192.168.3.2", "end": "192.168.3.6"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
         "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
@@ -10459,20 +10419,193 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
         "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
+        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
+        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.8", "end": "192.168.0.8"},
+        {"start": "192.168.0.3", "end": "192.168.0.5"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
         null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}]}'
+        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:45 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:31 GMT
+- request:
+    method: get
+    uri: http://10.8.99.206:9696/v2.0/subnets?all_tenants=True&limit=1000&marker=f4c17602-9618-4604-b3c9-9e4801d094d3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - d135c59cd27b40e7b8b3558ef101d4d1
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-3c746b72-c0d3-43b6-a2b5-4bf20c2d79e8
+      Date:
+      - Thu, 01 Nov 2018 18:33:31 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
+        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.8",
+        "end": "192.168.3.10"}, {"start": "192.168.3.2", "end": "192.168.3.6"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
+        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
+        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.8", "end": "192.168.0.8"},
+        {"start": "192.168.0.3", "end": "192.168.0.5"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 01 Nov 2018 18:33:31 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/floatingips?all_tenants=True&limit=1000
@@ -10487,7 +10620,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 91bd1586cfbe4975af54c35a539820ba
+      - d135c59cd27b40e7b8b3558ef101d4d1
   response:
     status:
       code: 200
@@ -10498,9 +10631,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-18c3bd1f-77ae-40ab-827d-42bb11dba711
+      - req-ecc69728-309e-46c8-b976-81d912f00efa
       Date:
-      - Thu, 25 Oct 2018 18:24:45 GMT
+      - Thu, 01 Nov 2018 18:33:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
@@ -10542,7 +10675,7 @@ http_interactions:
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:45 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:31 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/floatingips?all_tenants=True&limit=1000&marker=e5a4a7fd-b2c7-4a38-b725-a666d4f90f60
@@ -10557,7 +10690,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 91bd1586cfbe4975af54c35a539820ba
+      - d135c59cd27b40e7b8b3558ef101d4d1
   response:
     status:
       code: 200
@@ -10568,9 +10701,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-8c811bd4-64d2-48d3-a1ac-eac592389d63
+      - req-bd12a613-a60d-42ec-9aaa-54ea61a5ef0f
       Date:
-      - Thu, 25 Oct 2018 18:24:45 GMT
+      - Thu, 01 Nov 2018 18:33:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
@@ -10612,7 +10745,7 @@ http_interactions:
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:45 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:31 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/ports?all_tenants=True&limit=1000
@@ -10627,7 +10760,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 91bd1586cfbe4975af54c35a539820ba
+      - d135c59cd27b40e7b8b3558ef101d4d1
   response:
     status:
       code: 200
@@ -10638,9 +10771,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-10a757e2-97c0-4f92-8d5c-871d9978d7fc
+      - req-62f27e72-620a-4dd4-bb2d-db0d2254486d
       Date:
-      - Thu, 25 Oct 2018 18:24:45 GMT
+      - Thu, 01 Nov 2018 18:33:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -11043,7 +11176,7 @@ http_interactions:
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:45 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:32 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/ports?all_tenants=True&limit=1000&marker=fb9152f8-5f19-4171-9b8e-f1e594c24d64
@@ -11058,7 +11191,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 91bd1586cfbe4975af54c35a539820ba
+      - d135c59cd27b40e7b8b3558ef101d4d1
   response:
     status:
       code: 200
@@ -11069,9 +11202,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-570d4d80-0263-4c7e-92d0-ebed15bd78e8
+      - req-0f139675-9651-4d23-aed1-0c6912bd3abc
       Date:
-      - Thu, 25 Oct 2018 18:24:45 GMT
+      - Thu, 01 Nov 2018 18:33:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -11474,7 +11607,7 @@ http_interactions:
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:45 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:32 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/routers?all_tenants=True&limit=1000
@@ -11489,7 +11622,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 91bd1586cfbe4975af54c35a539820ba
+      - d135c59cd27b40e7b8b3558ef101d4d1
   response:
     status:
       code: 200
@@ -11500,9 +11633,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-11108833-40a1-4b06-a661-f922b688c0f4
+      - req-71dba13d-939a-4d39-ac89-9cf2adb84918
       Date:
-      - Thu, 25 Oct 2018 18:24:46 GMT
+      - Thu, 01 Nov 2018 18:33:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -11534,7 +11667,7 @@ http_interactions:
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:46 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:32 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/routers?all_tenants=True&limit=1000&marker=e49f1a18-9fd8-4130-9e9f-f13b5190f9fd
@@ -11549,7 +11682,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 91bd1586cfbe4975af54c35a539820ba
+      - d135c59cd27b40e7b8b3558ef101d4d1
   response:
     status:
       code: 200
@@ -11560,9 +11693,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-12fdd5da-b051-4528-992c-991467fcf1fa
+      - req-d9009b92-c29f-4b15-a4a1-7a5f65e9f472
       Date:
-      - Thu, 25 Oct 2018 18:24:46 GMT
+      - Thu, 01 Nov 2018 18:33:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -11594,7 +11727,7 @@ http_interactions:
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:46 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:32 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000
@@ -11609,7 +11742,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 91bd1586cfbe4975af54c35a539820ba
+      - d135c59cd27b40e7b8b3558ef101d4d1
   response:
     status:
       code: 200
@@ -11620,9 +11753,9 @@ http_interactions:
       Content-Length:
       - '2751'
       X-Openstack-Request-Id:
-      - req-f03a65d1-2871-4d62-a76e-3cf27a7cc3ac
+      - req-6ccd2d1d-faa7-41ad-9d88-0aead16443d1
       Date:
-      - Thu, 25 Oct 2018 18:24:46 GMT
+      - Thu, 01 Nov 2018 18:33:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=2e57d382-aeb2-4107-85cd-9dbde325f8f7",
@@ -11657,7 +11790,7 @@ http_interactions:
         null, "port_range_min": null, "id": "7e354503-9d45-4cc4-a742-4ff9501ba396",
         "security_group_id": "2e57d382-aeb2-4107-85cd-9dbde325f8f7"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:46 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:32 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=2e57d382-aeb2-4107-85cd-9dbde325f8f7
@@ -11672,7 +11805,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 91bd1586cfbe4975af54c35a539820ba
+      - d135c59cd27b40e7b8b3558ef101d4d1
   response:
     status:
       code: 200
@@ -11683,9 +11816,9 @@ http_interactions:
       Content-Length:
       - '3418'
       X-Openstack-Request-Id:
-      - req-7020a4d5-2a38-47f9-92af-0fa974ec5c72
+      - req-a52fd9ad-98e4-4730-89f8-32fd33ccb74f
       Date:
-      - Thu, 25 Oct 2018 18:24:46 GMT
+      - Thu, 01 Nov 2018 18:33:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=42bcab35-fe98-49f3-ba0e-705a2737b81d",
@@ -11728,7 +11861,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "f87c3733-0682-46d9-8df1-05f1207541d1",
         "security_group_id": "42bcab35-fe98-49f3-ba0e-705a2737b81d"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:46 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:32 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=42bcab35-fe98-49f3-ba0e-705a2737b81d
@@ -11743,7 +11876,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 91bd1586cfbe4975af54c35a539820ba
+      - d135c59cd27b40e7b8b3558ef101d4d1
   response:
     status:
       code: 200
@@ -11754,9 +11887,9 @@ http_interactions:
       Content-Length:
       - '3418'
       X-Openstack-Request-Id:
-      - req-f2cc2358-900c-4573-8fa4-0a7a924be092
+      - req-dd488da2-d4d7-4d9e-9ce2-2a5aa5c62333
       Date:
-      - Thu, 25 Oct 2018 18:24:46 GMT
+      - Thu, 01 Nov 2018 18:33:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=7250f04f-facd-4731-b072-f346b1cc7a80",
@@ -11799,7 +11932,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "d0ee1562-3ff7-4ad5-b29f-8dd350ed221f",
         "security_group_id": "7250f04f-facd-4731-b072-f346b1cc7a80"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:46 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:32 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=7250f04f-facd-4731-b072-f346b1cc7a80
@@ -11814,7 +11947,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 91bd1586cfbe4975af54c35a539820ba
+      - d135c59cd27b40e7b8b3558ef101d4d1
   response:
     status:
       code: 200
@@ -11825,9 +11958,9 @@ http_interactions:
       Content-Length:
       - '8771'
       X-Openstack-Request-Id:
-      - req-a9837746-038c-443c-846e-acb7329a29df
+      - req-e6762023-9a4d-4440-bb65-5e06ce47d89d
       Date:
-      - Thu, 25 Oct 2018 18:24:46 GMT
+      - Thu, 01 Nov 2018 18:33:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d",
@@ -11934,7 +12067,7 @@ http_interactions:
         "port_range_max": 65535, "port_range_min": 1, "id": "e483857b-5eb5-4cb0-94d6-b431a2f0cb10",
         "security_group_id": "8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:46 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:33 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d
@@ -11949,7 +12082,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 91bd1586cfbe4975af54c35a539820ba
+      - d135c59cd27b40e7b8b3558ef101d4d1
   response:
     status:
       code: 200
@@ -11960,9 +12093,9 @@ http_interactions:
       Content-Length:
       - '3418'
       X-Openstack-Request-Id:
-      - req-3c29a382-c163-4104-87bd-8b62fce3ad63
+      - req-2e9cefd4-af2b-471b-ad02-6a2039ea8286
       Date:
-      - Thu, 25 Oct 2018 18:24:46 GMT
+      - Thu, 01 Nov 2018 18:33:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=bab65d2f-4717-47eb-bfb2-95100b254563",
@@ -12004,7 +12137,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "e1aa03c0-0758-42ca-b030-a3d62800e578",
         "security_group_id": "bab65d2f-4717-47eb-bfb2-95100b254563"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:46 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:33 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=bab65d2f-4717-47eb-bfb2-95100b254563
@@ -12019,7 +12152,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 91bd1586cfbe4975af54c35a539820ba
+      - d135c59cd27b40e7b8b3558ef101d4d1
   response:
     status:
       code: 200
@@ -12030,15 +12163,15 @@ http_interactions:
       Content-Length:
       - '173'
       X-Openstack-Request-Id:
-      - req-31e32d51-a98f-468f-b9ab-f17af7a489a7
+      - req-fc0f2256-9c44-41d0-ade0-ddea1024fa71
       Date:
-      - Thu, 25 Oct 2018 18:24:46 GMT
+      - Thu, 01 Nov 2018 18:33:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&page_reverse=True",
         "rel": "previous"}], "security_groups": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:46 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:33 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -12056,15 +12189,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:24:52 GMT
+      - Thu, 01 Nov 2018 18:33:33 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 50057eebd80f4b3699686afc4348e081
+      - ed3c03f1865c46fbace18c9fc6d03ba1
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-cf90b6f7-678d-4c2e-ae22-f1970cb1aa6c
+      - req-a87f35af-b737-4f22-b4f1-9567fa9373e6
       Content-Length:
       - '7311'
       Connection:
@@ -12076,7 +12209,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-10-25T19:24:52.471127Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-11-01T19:33:34.068944Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -12155,10 +12288,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["UIf3Zt8ARKmLAj3v-gWSUw"],
-        "issued_at": "2018-10-25T18:24:52.471145Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["irICxsDRTc6KOCST1q4pdw"],
+        "issued_at": "2018-11-01T18:33:34.068973Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:52 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:34 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -12176,15 +12309,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:24:52 GMT
+      - Thu, 01 Nov 2018 18:33:34 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 97fb334395364de4841644a3658296f2
+      - d2ffe469fd4f4f518a08260c4fecaa1c
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-84f44071-95a5-4015-99a6-47310a1140d6
+      - req-8d8a151d-8a3b-4ae2-aa7a-c5445451a0d1
       Content-Length:
       - '7311'
       Connection:
@@ -12196,7 +12329,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-10-25T19:24:52.672406Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-11-01T19:33:34.284505Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -12275,10 +12408,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["jkoP-0AYT3yn0MmiM_VDXA"],
-        "issued_at": "2018-10-25T18:24:52.672427Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["S9TdQoB6QI6p8a6YkwcSCQ"],
+        "issued_at": "2018-11-01T18:33:34.284526Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:52 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:34 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -12296,15 +12429,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:24:52 GMT
+      - Thu, 01 Nov 2018 18:33:34 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 67852836223e49d0a4664c5c9f41b4e4
+      - 78c01e548c4e46a290eec19d93e8aabf
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-2abdcbdf-6388-495b-9522-5f5a57d7af74
+      - req-82dab80c-8655-4fe0-beb9-5478575eba17
       Content-Length:
       - '297'
       Connection:
@@ -12313,12 +12446,12 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"token": {"methods": ["password"], "expires_at": "2018-10-25T19:24:52.836352Z",
+      string: '{"token": {"methods": ["password"], "expires_at": "2018-11-01T19:33:34.478222Z",
         "extras": {}, "user": {"domain": {"id": "default", "name": "Default"}, "id":
-        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["2MAj7QleQvKx_hibETc1fQ"],
-        "issued_at": "2018-10-25T18:24:52.836372Z"}}'
+        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["1aAo6M5CQ-y9889YXUeMQQ"],
+        "issued_at": "2018-11-01T18:33:34.478242Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:52 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:34 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects?domain_id=default
@@ -12333,20 +12466,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 67852836223e49d0a4664c5c9f41b4e4
+      - 78c01e548c4e46a290eec19d93e8aabf
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:24:52 GMT
+      - Thu, 01 Nov 2018 18:33:34 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-28e16123-72b5-4121-944f-6836c968dd53
+      - req-bd0b12ce-1ae5-4a89-a792-1e72e1a0e061
       Content-Length:
       - '2475'
       Connection:
@@ -12379,7 +12512,7 @@ http_interactions:
         "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
         "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:53 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:34 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -12397,15 +12530,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:24:53 GMT
+      - Thu, 01 Nov 2018 18:33:34 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 6c30ecd132e940a7906391fc5783942d
+      - f002417ae4824bb7a2c88fe5211ef691
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-7f2b6c28-f359-4354-9b6e-47690a9d46c8
+      - req-b356f790-18b5-4a79-91e0-150a3967b6bc
       Content-Length:
       - '7278'
       Connection:
@@ -12417,7 +12550,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:24:53.181255Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:33:34.822892Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -12496,10 +12629,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["k2ULu4cqT2KPV1hselgwiQ"],
-        "issued_at": "2018-10-25T18:24:53.181276Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["lcvheQe5Ra2BSeMOSrkGzQ"],
+        "issued_at": "2018-11-01T18:33:34.822910Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:53 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:34 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -12517,15 +12650,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:24:53 GMT
+      - Thu, 01 Nov 2018 18:33:34 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - ee425fc2bdad456194488a5b6d5cf054
+      - '0059e49113a7423d83acbf9b042aa715'
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-146aba31-224d-40e0-a3be-6385fe86ea8d
+      - req-1b31d2d6-34ab-4353-b141-7a6d933cc922
       Content-Length:
       - '7278'
       Connection:
@@ -12537,7 +12670,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:24:53.376041Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:33:35.022038Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -12616,10 +12749,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["qGQUm6nzQHCbWAgPEI1mmA"],
-        "issued_at": "2018-10-25T18:24:53.376060Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["0RdO9AP3TxWFdfE-16NZKA"],
+        "issued_at": "2018-11-01T18:33:35.022059Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:53 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:35 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -12637,15 +12770,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:24:53 GMT
+      - Thu, 01 Nov 2018 18:33:35 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 1ffd6cb779ab4c7f9359e1c98ae50570
+      - 2a637e597c424348bc6b27e441e1825b
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-f0cd47ad-84df-4621-a125-a2c54db84e16
+      - req-299fd9aa-5464-4712-af24-4a9dbd979c76
       Content-Length:
       - '7264'
       Connection:
@@ -12657,7 +12790,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:24:53.562194Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:33:35.228858Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -12736,10 +12869,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["2JjCQ3-cTRGSlqA6FeKaQw"],
-        "issued_at": "2018-10-25T18:24:53.562212Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["XZRprdRmRxOt3FGTEMx7nA"],
+        "issued_at": "2018-11-01T18:33:35.228878Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:53 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:35 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -12757,15 +12890,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:24:53 GMT
+      - Thu, 01 Nov 2018 18:33:35 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 2b8da97001c246c798e5c1126604e308
+      - 45ee0c63cec24803ac74617f5de053f4
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-cd6a589d-4eee-4354-8cda-c521a0907997
+      - req-57d57f19-a871-4fe6-a631-55df893fa7e4
       Content-Length:
       - '7278'
       Connection:
@@ -12777,7 +12910,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:24:53.760071Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:33:35.446737Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -12856,10 +12989,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["RBdozHpJQG-_ETyoLLm6gg"],
-        "issued_at": "2018-10-25T18:24:53.760091Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Or1LvufbQAWfjm8ixmItwQ"],
+        "issued_at": "2018-11-01T18:33:35.446758Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:53 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:35 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -12877,15 +13010,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:24:53 GMT
+      - Thu, 01 Nov 2018 18:33:35 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 18783c43739341c38611c928ee11cb37
+      - 0ca83172d65a41638ec54b37a4f52e1f
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-bbb98e5a-a4ed-4a9f-9e52-92c565f74697
+      - req-bbae415c-d623-41a0-b9d9-d17348beaf8c
       Content-Length:
       - '7265'
       Connection:
@@ -12897,7 +13030,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:24:53.970821Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:33:35.655390Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -12976,10 +13109,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["C6KOtLQeTbW-sALo9MvU8A"],
-        "issued_at": "2018-10-25T18:24:53.970842Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["RMUPBbeeQW-9asBxDWyrxg"],
+        "issued_at": "2018-11-01T18:33:35.655412Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:53 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:35 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -12997,15 +13130,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:24:54 GMT
+      - Thu, 01 Nov 2018 18:33:35 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 459a2c10cf894f0faa2f40434aeae98f
+      - 2b4f4351b8554e89a6ddeb8a4c73faa2
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-c34be94f-f9e6-482f-93ba-0b0f1600b9bb
+      - req-aae3de6f-45c1-4e9d-9272-9cb0827d681c
       Content-Length:
       - '7278'
       Connection:
@@ -13017,7 +13150,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:24:54.174919Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:33:35.859709Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -13096,10 +13229,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["jhacm6gKScmsaDzbHHzCEA"],
-        "issued_at": "2018-10-25T18:24:54.174953Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["mAzXj65FSDKfF6tMMXGEnQ"],
+        "issued_at": "2018-11-01T18:33:35.859728Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:54 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:35 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -13117,15 +13250,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:24:54 GMT
+      - Thu, 01 Nov 2018 18:33:36 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 66d78d5372f34b039efb4bf9d45d6de7
+      - 46c1c73654b14cd5872bb6ad3c8d3908
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-ca4f551c-84bb-42e1-ac32-d307bdf4959f
+      - req-5c21afc4-e39b-4314-a960-b7eb6e206680
       Content-Length:
       - '7278'
       Connection:
@@ -13137,7 +13270,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:24:54.398437Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:33:36.096615Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -13216,10 +13349,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["62rCEuS4S6WNu7QI6ZskHw"],
-        "issued_at": "2018-10-25T18:24:54.398465Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["xvdiuUmGQJ-YbTwmzWXUlg"],
+        "issued_at": "2018-11-01T18:33:36.096635Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:54 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:36 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/volumes/detail?limit=1000
@@ -13234,27 +13367,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 66d78d5372f34b039efb4bf9d45d6de7
+      - 46c1c73654b14cd5872bb6ad3c8d3908
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-ad832a30-16a9-42ce-888b-e787437aea23
+      - req-cb3e0e44-3f82-420f-a7b5-b6cf7fd9e84c
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-ad832a30-16a9-42ce-888b-e787437aea23
+      - req-cb3e0e44-3f82-420f-a7b5-b6cf7fd9e84c
       Date:
-      - Thu, 25 Oct 2018 18:24:54 GMT
+      - Thu, 01 Nov 2018 18:33:36 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:54 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:36 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -13272,15 +13405,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:24:54 GMT
+      - Thu, 01 Nov 2018 18:33:36 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 58d39212c3ae4750aa4abdfe6e7f15ad
+      - 57074fc61cfd4ab382addf7d7cfaec90
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-83a7b458-17ad-4ede-8a1b-2a9d1555b264
+      - req-22fffd11-e743-4e24-9841-507c42532d9b
       Content-Length:
       - '7278'
       Connection:
@@ -13292,7 +13425,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:24:54.763718Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:33:36.512613Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -13371,10 +13504,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["g2fW1T-tSvCv8iXYrbAClw"],
-        "issued_at": "2018-10-25T18:24:54.763744Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["_Fjh8_SHTx2DIAO5YkUEEw"],
+        "issued_at": "2018-11-01T18:33:36.512638Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:54 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:36 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/volumes/detail?limit=1000
@@ -13389,27 +13522,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 58d39212c3ae4750aa4abdfe6e7f15ad
+      - 57074fc61cfd4ab382addf7d7cfaec90
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-c39ec7f8-1476-4227-88ee-9b60d93dfea7
+      - req-297b7506-efdb-4993-8576-5ebd0168700f
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-c39ec7f8-1476-4227-88ee-9b60d93dfea7
+      - req-297b7506-efdb-4993-8576-5ebd0168700f
       Date:
-      - Thu, 25 Oct 2018 18:24:54 GMT
+      - Thu, 01 Nov 2018 18:33:36 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:54 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:36 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -13427,15 +13560,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:24:55 GMT
+      - Thu, 01 Nov 2018 18:33:36 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 8bbe93ed60bb4c8787cb615eb319dc7f
+      - 57799e8eef7d44bfb5dd42ac807e1be5
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-4d1b1e05-3dda-4883-b7ea-91154b2bc3c0
+      - req-0f17165a-9ff8-4f41-a670-8d38fe33ca80
       Content-Length:
       - '7264'
       Connection:
@@ -13447,7 +13580,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:24:55.127517Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:33:36.881953Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -13526,10 +13659,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["9Q8Wfm06TXGcYfMkwPsNnw"],
-        "issued_at": "2018-10-25T18:24:55.127539Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["IwBIVw3-RWaLenbMQh5GPA"],
+        "issued_at": "2018-11-01T18:33:36.881971Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:55 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:36 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000
@@ -13544,22 +13677,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8bbe93ed60bb4c8787cb615eb319dc7f
+      - 57799e8eef7d44bfb5dd42ac807e1be5
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-82c26ebc-55e3-4973-81d5-d53974625eca
+      - req-d28611dc-d23f-4f26-b69e-2241b8bb7786
       Content-Type:
       - application/json
       Content-Length:
       - '2706'
       X-Openstack-Request-Id:
-      - req-82c26ebc-55e3-4973-81d5-d53974625eca
+      - req-d28611dc-d23f-4f26-b69e-2241b8bb7786
       Date:
-      - Thu, 25 Oct 2018 18:24:55 GMT
+      - Thu, 01 Nov 2018 18:33:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=f46458aa-309d-4f47-b996-a39db065030a",
@@ -13592,7 +13725,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-4", "bootable": "true", "created_at":
         "2016-08-19T08:37:45.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:55 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:37 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=f46458aa-309d-4f47-b996-a39db065030a
@@ -13607,22 +13740,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8bbe93ed60bb4c8787cb615eb319dc7f
+      - 57799e8eef7d44bfb5dd42ac807e1be5
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-dc4d8c0d-1fad-4503-a6c9-ae45af443659
+      - req-a9b73941-0797-4adc-806f-075bad63fffb
       Content-Type:
       - application/json
       Content-Length:
       - '3284'
       X-Openstack-Request-Id:
-      - req-dc4d8c0d-1fad-4503-a6c9-ae45af443659
+      - req-a9b73941-0797-4adc-806f-075bad63fffb
       Date:
-      - Thu, 25 Oct 2018 18:24:55 GMT
+      - Thu, 01 Nov 2018 18:33:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=476a0c89-4322-42aa-b7ce-3ac21be55af7",
@@ -13663,7 +13796,7 @@ http_interactions:
         "name": "EmsRefreshSpec-Volume-2", "bootable": "false", "created_at": "2016-08-19T08:37:33.000000",
         "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:55 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:37 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=476a0c89-4322-42aa-b7ce-3ac21be55af7
@@ -13678,22 +13811,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8bbe93ed60bb4c8787cb615eb319dc7f
+      - 57799e8eef7d44bfb5dd42ac807e1be5
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-443070da-5b1c-4a70-bc7e-17ca96455c36
+      - req-bebefcdb-665c-4684-8a61-9f14cb46d6ec
       Content-Type:
       - application/json
       Content-Length:
       - '2753'
       X-Openstack-Request-Id:
-      - req-443070da-5b1c-4a70-bc7e-17ca96455c36
+      - req-bebefcdb-665c-4684-8a61-9f14cb46d6ec
       Date:
-      - Thu, 25 Oct 2018 18:24:55 GMT
+      - Thu, 01 Nov 2018 18:33:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=8791e24f-874d-4f1e-99ec-75fdb9d48ca5",
@@ -13727,7 +13860,7 @@ http_interactions:
         "bootable": "false", "created_at": "2016-08-19T08:37:05.000000", "volume_type":
         "iscsi"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:55 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:37 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=8791e24f-874d-4f1e-99ec-75fdb9d48ca5
@@ -13742,27 +13875,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8bbe93ed60bb4c8787cb615eb319dc7f
+      - 57799e8eef7d44bfb5dd42ac807e1be5
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-633e6d21-ef01-41cc-beff-c61bad6da9af
+      - req-bd7b33c8-49e7-4239-80a9-ec73f5b8c197
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-633e6d21-ef01-41cc-beff-c61bad6da9af
+      - req-bd7b33c8-49e7-4239-80a9-ec73f5b8c197
       Date:
-      - Thu, 25 Oct 2018 18:24:55 GMT
+      - Thu, 01 Nov 2018 18:33:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:55 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:37 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -13780,15 +13913,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:24:55 GMT
+      - Thu, 01 Nov 2018 18:33:37 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 0d584a6e72e0453ca655611babf4c1e0
+      - 770e131427254b8c9bdedb6232f50d2a
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-a21804b3-2f53-4c2f-90c3-37f71223ea96
+      - req-432ab371-ee9a-40ee-a3b9-683097a27cbb
       Content-Length:
       - '7278'
       Connection:
@@ -13800,7 +13933,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:24:55.958472Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:33:37.761577Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -13879,10 +14012,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["bNqsEUvbT964Xhb8us-JUA"],
-        "issued_at": "2018-10-25T18:24:55.958495Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["pgaF9Tg8QVipBUB4O8A7Jw"],
+        "issued_at": "2018-11-01T18:33:37.761598Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:55 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:37 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/volumes/detail?limit=1000
@@ -13897,27 +14030,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0d584a6e72e0453ca655611babf4c1e0
+      - 770e131427254b8c9bdedb6232f50d2a
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-51d5b2c7-34bf-4d67-9387-a43195458f30
+      - req-ca12cf4a-e515-4c17-ae14-175db4b14853
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-51d5b2c7-34bf-4d67-9387-a43195458f30
+      - req-ca12cf4a-e515-4c17-ae14-175db4b14853
       Date:
-      - Thu, 25 Oct 2018 18:24:56 GMT
+      - Thu, 01 Nov 2018 18:33:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:56 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:37 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/volumes/detail?limit=1000
@@ -13932,27 +14065,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 97fb334395364de4841644a3658296f2
+      - d2ffe469fd4f4f518a08260c4fecaa1c
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-799b2fda-7c40-4033-9671-186189cded9b
+      - req-a48b4691-ab23-4bfe-b12d-10c2eeea0a6d
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-799b2fda-7c40-4033-9671-186189cded9b
+      - req-a48b4691-ab23-4bfe-b12d-10c2eeea0a6d
       Date:
-      - Thu, 25 Oct 2018 18:24:56 GMT
+      - Thu, 01 Nov 2018 18:33:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:56 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:38 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -13970,15 +14103,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:24:56 GMT
+      - Thu, 01 Nov 2018 18:33:38 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - c2513f10c5e64fa58f4e2023691ba673
+      - ffdaf893a3f841478da70890884065a1
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-c28ad2d9-618f-483b-9619-85761d670a4e
+      - req-575d28b0-8c67-4529-9468-2a44a15c673f
       Content-Length:
       - '7265'
       Connection:
@@ -13990,7 +14123,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:24:56.439794Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:33:38.262588Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -14069,10 +14202,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["R1evFAgiQ2uNOpC9Ra5xIQ"],
-        "issued_at": "2018-10-25T18:24:56.439831Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Oh8NON7jRyqzGnJ0k18xJg"],
+        "issued_at": "2018-11-01T18:33:38.262607Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:56 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:38 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/volumes/detail?limit=1000
@@ -14087,27 +14220,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c2513f10c5e64fa58f4e2023691ba673
+      - ffdaf893a3f841478da70890884065a1
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-6ea054cf-e26e-494c-9cd2-a4405de2c127
+      - req-f4854c8a-f912-4a7a-a7c5-725e9e4462c2
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-6ea054cf-e26e-494c-9cd2-a4405de2c127
+      - req-f4854c8a-f912-4a7a-a7c5-725e9e4462c2
       Date:
-      - Thu, 25 Oct 2018 18:24:56 GMT
+      - Thu, 01 Nov 2018 18:33:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:56 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:38 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -14125,15 +14258,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:24:56 GMT
+      - Thu, 01 Nov 2018 18:33:38 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - ec062c9b9a664f26b0fad1ef0d9b9423
+      - 115a05b0d3904436ad56e76908641067
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-73d3ec1a-abc1-416d-b8a8-65fd832b7f68
+      - req-ef0ecf3f-f34f-48e3-bd4b-67133d3c795b
       Content-Length:
       - '7278'
       Connection:
@@ -14145,7 +14278,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:24:56.774898Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:33:38.615158Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -14224,10 +14357,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["WqnU36xnQDyVKytBYNO-ZA"],
-        "issued_at": "2018-10-25T18:24:56.774919Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["TPbw7R6XQQeg2XtE28zKZg"],
+        "issued_at": "2018-11-01T18:33:38.615179Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:56 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:38 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/volumes/detail?limit=1000
@@ -14242,27 +14375,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ec062c9b9a664f26b0fad1ef0d9b9423
+      - 115a05b0d3904436ad56e76908641067
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-90ea06b0-56c0-48e1-9ff8-b55b82707ea8
+      - req-017bc0a9-836c-48e3-95a6-79d37233c04e
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-90ea06b0-56c0-48e1-9ff8-b55b82707ea8
+      - req-017bc0a9-836c-48e3-95a6-79d37233c04e
       Date:
-      - Thu, 25 Oct 2018 18:24:56 GMT
+      - Thu, 01 Nov 2018 18:33:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:56 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:38 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/snapshots/detail
@@ -14277,27 +14410,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 66d78d5372f34b039efb4bf9d45d6de7
+      - 46c1c73654b14cd5872bb6ad3c8d3908
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-cf02126b-ea9a-40dd-97c5-fab6ab762ef5
+      - req-35585b63-17c8-4d1a-8fa5-775aa01ab5a4
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-cf02126b-ea9a-40dd-97c5-fab6ab762ef5
+      - req-35585b63-17c8-4d1a-8fa5-775aa01ab5a4
       Date:
-      - Thu, 25 Oct 2018 18:24:57 GMT
+      - Thu, 01 Nov 2018 18:33:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:57 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:38 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/snapshots/detail?limit=1000
@@ -14312,27 +14445,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 66d78d5372f34b039efb4bf9d45d6de7
+      - 46c1c73654b14cd5872bb6ad3c8d3908
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-673f75e5-82ff-476a-a805-2162aa307542
+      - req-830d7783-4c60-441d-9c27-7747af5ffd64
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-673f75e5-82ff-476a-a805-2162aa307542
+      - req-830d7783-4c60-441d-9c27-7747af5ffd64
       Date:
-      - Thu, 25 Oct 2018 18:24:57 GMT
+      - Thu, 01 Nov 2018 18:33:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:57 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:39 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/snapshots/detail
@@ -14347,27 +14480,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 58d39212c3ae4750aa4abdfe6e7f15ad
+      - 57074fc61cfd4ab382addf7d7cfaec90
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-02d3be93-e247-4f84-a825-684c6a14e664
+      - req-1e890f54-2b68-4c49-885a-5c9ee8318f01
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-02d3be93-e247-4f84-a825-684c6a14e664
+      - req-1e890f54-2b68-4c49-885a-5c9ee8318f01
       Date:
-      - Thu, 25 Oct 2018 18:24:57 GMT
+      - Thu, 01 Nov 2018 18:33:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:57 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:39 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/snapshots/detail?limit=1000
@@ -14382,27 +14515,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 58d39212c3ae4750aa4abdfe6e7f15ad
+      - 57074fc61cfd4ab382addf7d7cfaec90
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-da8c15ce-6819-4b7a-9e1c-9d69a5b86b74
+      - req-6d3e1bea-f45e-4979-8911-1c9976958d30
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-da8c15ce-6819-4b7a-9e1c-9d69a5b86b74
+      - req-6d3e1bea-f45e-4979-8911-1c9976958d30
       Date:
-      - Thu, 25 Oct 2018 18:24:57 GMT
+      - Thu, 01 Nov 2018 18:33:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:57 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:39 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/snapshots/detail
@@ -14417,22 +14550,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8bbe93ed60bb4c8787cb615eb319dc7f
+      - 57799e8eef7d44bfb5dd42ac807e1be5
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-32d9f022-ea10-480e-b495-301294b549d9
+      - req-263a10b8-0146-4161-8230-2dc03660b116
       Content-Type:
       - application/json
       Content-Length:
       - '1053'
       X-Openstack-Request-Id:
-      - req-32d9f022-ea10-480e-b495-301294b549d9
+      - req-263a10b8-0146-4161-8230-2dc03660b116
       Date:
-      - Thu, 25 Oct 2018 18:24:57 GMT
+      - Thu, 01 Nov 2018 18:33:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/snapshots/detail?marker=c44d3eb3-31fe-46ed-bfae-707920be171d",
@@ -14447,7 +14580,7 @@ http_interactions:
         "created_at": "2016-08-19T08:37:24.000000", "size": 1, "id": "c44d3eb3-31fe-46ed-bfae-707920be171d",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:57 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:39 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/snapshots/detail?limit=1000
@@ -14462,22 +14595,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8bbe93ed60bb4c8787cb615eb319dc7f
+      - 57799e8eef7d44bfb5dd42ac807e1be5
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-73a34845-6da4-4141-954c-57e4d6667a58
+      - req-a29c4c69-0c13-4bb5-b45b-ac0823b2891a
       Content-Type:
       - application/json
       Content-Length:
       - '1064'
       X-Openstack-Request-Id:
-      - req-73a34845-6da4-4141-954c-57e4d6667a58
+      - req-a29c4c69-0c13-4bb5-b45b-ac0823b2891a
       Date:
-      - Thu, 25 Oct 2018 18:24:57 GMT
+      - Thu, 01 Nov 2018 18:33:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/snapshots/detail?limit=1000&marker=c44d3eb3-31fe-46ed-bfae-707920be171d",
@@ -14492,7 +14625,7 @@ http_interactions:
         "created_at": "2016-08-19T08:37:24.000000", "size": 1, "id": "c44d3eb3-31fe-46ed-bfae-707920be171d",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:57 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:39 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/snapshots/detail
@@ -14507,27 +14640,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0d584a6e72e0453ca655611babf4c1e0
+      - 770e131427254b8c9bdedb6232f50d2a
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-1ac602c5-b19a-4098-bd02-aaafff099cfe
+      - req-d36a0fe6-9338-4734-b533-c8dc82d27285
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-1ac602c5-b19a-4098-bd02-aaafff099cfe
+      - req-d36a0fe6-9338-4734-b533-c8dc82d27285
       Date:
-      - Thu, 25 Oct 2018 18:24:57 GMT
+      - Thu, 01 Nov 2018 18:33:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:57 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:39 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/snapshots/detail?limit=1000
@@ -14542,27 +14675,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0d584a6e72e0453ca655611babf4c1e0
+      - 770e131427254b8c9bdedb6232f50d2a
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-027a3509-2240-4dab-aa69-d2219ae2c48e
+      - req-d0063566-bc13-4912-85ae-88bf5879b471
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-027a3509-2240-4dab-aa69-d2219ae2c48e
+      - req-d0063566-bc13-4912-85ae-88bf5879b471
       Date:
-      - Thu, 25 Oct 2018 18:24:57 GMT
+      - Thu, 01 Nov 2018 18:33:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:57 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:39 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/snapshots/detail
@@ -14577,27 +14710,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 97fb334395364de4841644a3658296f2
+      - d2ffe469fd4f4f518a08260c4fecaa1c
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-2f2aeaa1-7782-4e60-b851-98f074350f83
+      - req-f24e8bdb-4187-44cf-8738-f532fa2b0f41
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-2f2aeaa1-7782-4e60-b851-98f074350f83
+      - req-f24e8bdb-4187-44cf-8738-f532fa2b0f41
       Date:
-      - Thu, 25 Oct 2018 18:24:57 GMT
+      - Thu, 01 Nov 2018 18:33:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:57 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:39 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/snapshots/detail?limit=1000
@@ -14612,27 +14745,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 97fb334395364de4841644a3658296f2
+      - d2ffe469fd4f4f518a08260c4fecaa1c
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-2da8d19e-76fa-4a21-b131-2cfbe21612c5
+      - req-a1c7b316-17a2-4388-b6ae-c958d7f6407a
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-2da8d19e-76fa-4a21-b131-2cfbe21612c5
+      - req-a1c7b316-17a2-4388-b6ae-c958d7f6407a
       Date:
-      - Thu, 25 Oct 2018 18:24:58 GMT
+      - Thu, 01 Nov 2018 18:33:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:58 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:39 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/snapshots/detail
@@ -14647,27 +14780,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c2513f10c5e64fa58f4e2023691ba673
+      - ffdaf893a3f841478da70890884065a1
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-556fce7b-1c25-4914-a7fa-8cad6fbf10a3
+      - req-87b917ec-1f66-4393-88ba-c403ce19085a
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-556fce7b-1c25-4914-a7fa-8cad6fbf10a3
+      - req-87b917ec-1f66-4393-88ba-c403ce19085a
       Date:
-      - Thu, 25 Oct 2018 18:24:58 GMT
+      - Thu, 01 Nov 2018 18:33:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:58 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:39 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/snapshots/detail?limit=1000
@@ -14682,27 +14815,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c2513f10c5e64fa58f4e2023691ba673
+      - ffdaf893a3f841478da70890884065a1
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-a4881985-1299-40d8-a548-29ceb6a607fa
+      - req-b52b88d7-0cdf-43c4-8c95-891492bb75c5
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-a4881985-1299-40d8-a548-29ceb6a607fa
+      - req-b52b88d7-0cdf-43c4-8c95-891492bb75c5
       Date:
-      - Thu, 25 Oct 2018 18:24:58 GMT
+      - Thu, 01 Nov 2018 18:33:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:58 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:40 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/snapshots/detail
@@ -14717,27 +14850,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ec062c9b9a664f26b0fad1ef0d9b9423
+      - 115a05b0d3904436ad56e76908641067
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-ab3e4817-bbe6-4510-a359-26a3fe63ac16
+      - req-34420829-0ef2-4e0b-93a1-a11f23797558
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-ab3e4817-bbe6-4510-a359-26a3fe63ac16
+      - req-34420829-0ef2-4e0b-93a1-a11f23797558
       Date:
-      - Thu, 25 Oct 2018 18:24:58 GMT
+      - Thu, 01 Nov 2018 18:33:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:58 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:40 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/snapshots/detail?limit=1000
@@ -14752,27 +14885,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ec062c9b9a664f26b0fad1ef0d9b9423
+      - 115a05b0d3904436ad56e76908641067
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-6cdd7e13-7534-4065-8115-6498ef8be203
+      - req-c16429f0-23e2-4d3e-bfb0-86c15d1ebb84
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-6cdd7e13-7534-4065-8115-6498ef8be203
+      - req-c16429f0-23e2-4d3e-bfb0-86c15d1ebb84
       Date:
-      - Thu, 25 Oct 2018 18:24:58 GMT
+      - Thu, 01 Nov 2018 18:33:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:58 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:40 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/backups/detail
@@ -14787,27 +14920,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 66d78d5372f34b039efb4bf9d45d6de7
+      - 46c1c73654b14cd5872bb6ad3c8d3908
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-f569146e-bbef-4061-a23f-f8d9ece0d09d
+      - req-7e41dd4d-7a4d-423a-83c6-b442a166279e
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-f569146e-bbef-4061-a23f-f8d9ece0d09d
+      - req-7e41dd4d-7a4d-423a-83c6-b442a166279e
       Date:
-      - Thu, 25 Oct 2018 18:24:58 GMT
+      - Thu, 01 Nov 2018 18:33:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:58 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:40 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/backups/detail?limit=1000
@@ -14822,27 +14955,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 66d78d5372f34b039efb4bf9d45d6de7
+      - 46c1c73654b14cd5872bb6ad3c8d3908
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-8bebdc10-909f-4e7f-b757-4f6a53b2e3c0
+      - req-7de3f7ef-18d0-4ad4-bfd1-e143e76ea755
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-8bebdc10-909f-4e7f-b757-4f6a53b2e3c0
+      - req-7de3f7ef-18d0-4ad4-bfd1-e143e76ea755
       Date:
-      - Thu, 25 Oct 2018 18:24:58 GMT
+      - Thu, 01 Nov 2018 18:33:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:58 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:40 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/backups/detail
@@ -14857,27 +14990,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 58d39212c3ae4750aa4abdfe6e7f15ad
+      - 57074fc61cfd4ab382addf7d7cfaec90
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-b9659a17-2032-45d0-82ed-6fa93846b8a8
+      - req-e66bfe19-83da-44ee-b2ef-250d7b5a9284
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-b9659a17-2032-45d0-82ed-6fa93846b8a8
+      - req-e66bfe19-83da-44ee-b2ef-250d7b5a9284
       Date:
-      - Thu, 25 Oct 2018 18:24:58 GMT
+      - Thu, 01 Nov 2018 18:33:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:58 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:41 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/backups/detail?limit=1000
@@ -14892,27 +15025,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 58d39212c3ae4750aa4abdfe6e7f15ad
+      - 57074fc61cfd4ab382addf7d7cfaec90
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-adb9f7b5-52bf-4938-a8c4-c01fbff9994d
+      - req-a4575584-d500-4064-910e-c6758f5f0284
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-adb9f7b5-52bf-4938-a8c4-c01fbff9994d
+      - req-a4575584-d500-4064-910e-c6758f5f0284
       Date:
-      - Thu, 25 Oct 2018 18:24:58 GMT
+      - Thu, 01 Nov 2018 18:33:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:58 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:41 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/backups/detail
@@ -14927,27 +15060,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8bbe93ed60bb4c8787cb615eb319dc7f
+      - 57799e8eef7d44bfb5dd42ac807e1be5
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-dc6f94bd-17cd-47c7-a5a2-d672713b28af
+      - req-8de34484-537b-47c2-aa6f-9b6d13ef9d3a
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-dc6f94bd-17cd-47c7-a5a2-d672713b28af
+      - req-8de34484-537b-47c2-aa6f-9b6d13ef9d3a
       Date:
-      - Thu, 25 Oct 2018 18:24:58 GMT
+      - Thu, 01 Nov 2018 18:33:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:58 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:41 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/backups/detail?limit=1000
@@ -14962,27 +15095,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8bbe93ed60bb4c8787cb615eb319dc7f
+      - 57799e8eef7d44bfb5dd42ac807e1be5
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-8d8eeb93-b2d3-43f9-a8ba-65542dbb019c
+      - req-33d4b58e-d87d-40e9-8461-21a9385d20f9
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-8d8eeb93-b2d3-43f9-a8ba-65542dbb019c
+      - req-33d4b58e-d87d-40e9-8461-21a9385d20f9
       Date:
-      - Thu, 25 Oct 2018 18:24:59 GMT
+      - Thu, 01 Nov 2018 18:33:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:59 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:41 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/backups/detail
@@ -14997,27 +15130,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0d584a6e72e0453ca655611babf4c1e0
+      - 770e131427254b8c9bdedb6232f50d2a
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-12726a8a-8ad9-444c-bf15-a07edb174774
+      - req-50ccf8ae-a328-4589-9898-7c559a266f43
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-12726a8a-8ad9-444c-bf15-a07edb174774
+      - req-50ccf8ae-a328-4589-9898-7c559a266f43
       Date:
-      - Thu, 25 Oct 2018 18:24:59 GMT
+      - Thu, 01 Nov 2018 18:33:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:59 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:41 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/backups/detail?limit=1000
@@ -15032,27 +15165,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0d584a6e72e0453ca655611babf4c1e0
+      - 770e131427254b8c9bdedb6232f50d2a
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-149d0623-29a3-4359-bdd9-e84f6afccb95
+      - req-c6d4dc67-e6e5-4d88-a8d3-96dc731b9eb7
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-149d0623-29a3-4359-bdd9-e84f6afccb95
+      - req-c6d4dc67-e6e5-4d88-a8d3-96dc731b9eb7
       Date:
-      - Thu, 25 Oct 2018 18:24:59 GMT
+      - Thu, 01 Nov 2018 18:33:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:59 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:41 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/backups/detail
@@ -15067,27 +15200,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 97fb334395364de4841644a3658296f2
+      - d2ffe469fd4f4f518a08260c4fecaa1c
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-c5c36d7d-b9c7-4b15-b474-587826463f47
+      - req-c039d3b9-5d35-4196-988c-f89e65385e03
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-c5c36d7d-b9c7-4b15-b474-587826463f47
+      - req-c039d3b9-5d35-4196-988c-f89e65385e03
       Date:
-      - Thu, 25 Oct 2018 18:24:59 GMT
+      - Thu, 01 Nov 2018 18:33:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:59 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:41 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/backups/detail?limit=1000
@@ -15102,27 +15235,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 97fb334395364de4841644a3658296f2
+      - d2ffe469fd4f4f518a08260c4fecaa1c
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-c81bb183-d350-4dc7-8492-f98f710bb57f
+      - req-797a1f9c-95ff-4d35-b964-7309c85c6004
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-c81bb183-d350-4dc7-8492-f98f710bb57f
+      - req-797a1f9c-95ff-4d35-b964-7309c85c6004
       Date:
-      - Thu, 25 Oct 2018 18:24:59 GMT
+      - Thu, 01 Nov 2018 18:33:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:59 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:41 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/backups/detail
@@ -15137,27 +15270,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c2513f10c5e64fa58f4e2023691ba673
+      - ffdaf893a3f841478da70890884065a1
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-936881dc-db37-47d2-9d3d-8dd443983bf2
+      - req-e8f25fa5-6dd7-4ca0-9400-c0bf77cbab77
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-936881dc-db37-47d2-9d3d-8dd443983bf2
+      - req-e8f25fa5-6dd7-4ca0-9400-c0bf77cbab77
       Date:
-      - Thu, 25 Oct 2018 18:24:59 GMT
+      - Thu, 01 Nov 2018 18:33:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:59 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:41 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/backups/detail?limit=1000
@@ -15172,27 +15305,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c2513f10c5e64fa58f4e2023691ba673
+      - ffdaf893a3f841478da70890884065a1
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-1e053a37-8d81-4d99-8cf6-690f2f9f91d8
+      - req-4970b4ac-557b-4a36-8fa4-7471449d961e
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-1e053a37-8d81-4d99-8cf6-690f2f9f91d8
+      - req-4970b4ac-557b-4a36-8fa4-7471449d961e
       Date:
-      - Thu, 25 Oct 2018 18:24:59 GMT
+      - Thu, 01 Nov 2018 18:33:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:59 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:41 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/backups/detail
@@ -15207,27 +15340,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ec062c9b9a664f26b0fad1ef0d9b9423
+      - 115a05b0d3904436ad56e76908641067
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-6cda575b-0cae-4179-a1d7-8360ec37198c
+      - req-b6afc8be-9eda-4fed-bdc9-987513d9434b
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-6cda575b-0cae-4179-a1d7-8360ec37198c
+      - req-b6afc8be-9eda-4fed-bdc9-987513d9434b
       Date:
-      - Thu, 25 Oct 2018 18:24:59 GMT
+      - Thu, 01 Nov 2018 18:33:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:59 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:42 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/backups/detail?limit=1000
@@ -15242,27 +15375,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ec062c9b9a664f26b0fad1ef0d9b9423
+      - 115a05b0d3904436ad56e76908641067
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-526dd69e-7f7b-48dc-a3a0-32e3a09df9a6
+      - req-23e8d9fb-75ef-4822-898b-b4747404ea9f
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-526dd69e-7f7b-48dc-a3a0-32e3a09df9a6
+      - req-23e8d9fb-75ef-4822-898b-b4747404ea9f
       Date:
-      - Thu, 25 Oct 2018 18:24:59 GMT
+      - Thu, 01 Nov 2018 18:33:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:59 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:42 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/types?limit=1000
@@ -15277,22 +15410,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 66d78d5372f34b039efb4bf9d45d6de7
+      - 46c1c73654b14cd5872bb6ad3c8d3908
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-067a7835-a9a0-4bfc-90b7-fd9f757c4dfc
+      - req-c484891e-af0f-4c8d-9d6c-18bf2f88d3c1
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-067a7835-a9a0-4bfc-90b7-fd9f757c4dfc
+      - req-c484891e-af0f-4c8d-9d6c-18bf2f88d3c1
       Date:
-      - Thu, 25 Oct 2018 18:24:59 GMT
+      - Thu, 01 Nov 2018 18:33:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -15304,7 +15437,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:59 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:42 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/types?limit=1000&marker=b953db40-aeea-4a55-9bd9-c08dcafd6f7e
@@ -15319,22 +15452,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 66d78d5372f34b039efb4bf9d45d6de7
+      - 46c1c73654b14cd5872bb6ad3c8d3908
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-4d867f30-b86b-473b-810b-f00ac0c0f4a8
+      - req-27b6929d-6a44-40dc-b863-0b6332356995
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-4d867f30-b86b-473b-810b-f00ac0c0f4a8
+      - req-27b6929d-6a44-40dc-b863-0b6332356995
       Date:
-      - Thu, 25 Oct 2018 18:24:59 GMT
+      - Thu, 01 Nov 2018 18:33:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -15346,7 +15479,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:24:59 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:42 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/types?limit=1000
@@ -15361,22 +15494,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 58d39212c3ae4750aa4abdfe6e7f15ad
+      - 57074fc61cfd4ab382addf7d7cfaec90
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-5e0739bd-dd04-458a-8259-5773eeea2cb4
+      - req-4158175d-0000-43b7-b836-b3ce93e6cc5a
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-5e0739bd-dd04-458a-8259-5773eeea2cb4
+      - req-4158175d-0000-43b7-b836-b3ce93e6cc5a
       Date:
-      - Thu, 25 Oct 2018 18:25:00 GMT
+      - Thu, 01 Nov 2018 18:33:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -15388,7 +15521,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:25:00 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:42 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/types?limit=1000&marker=b953db40-aeea-4a55-9bd9-c08dcafd6f7e
@@ -15403,22 +15536,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 58d39212c3ae4750aa4abdfe6e7f15ad
+      - 57074fc61cfd4ab382addf7d7cfaec90
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-cd880e11-1160-4a98-bcbe-b9c67d560b6f
+      - req-a0241181-652c-43b9-a000-c47a47cc5070
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-cd880e11-1160-4a98-bcbe-b9c67d560b6f
+      - req-a0241181-652c-43b9-a000-c47a47cc5070
       Date:
-      - Thu, 25 Oct 2018 18:25:00 GMT
+      - Thu, 01 Nov 2018 18:33:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -15430,7 +15563,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:25:00 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:42 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/types?limit=1000
@@ -15445,22 +15578,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8bbe93ed60bb4c8787cb615eb319dc7f
+      - 57799e8eef7d44bfb5dd42ac807e1be5
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-58aa7260-8941-4d1b-a3c0-024a7a15a7ab
+      - req-52c606d5-91d2-4bc6-a707-984ed621a57f
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-58aa7260-8941-4d1b-a3c0-024a7a15a7ab
+      - req-52c606d5-91d2-4bc6-a707-984ed621a57f
       Date:
-      - Thu, 25 Oct 2018 18:25:00 GMT
+      - Thu, 01 Nov 2018 18:33:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -15472,7 +15605,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:25:00 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:42 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/types?limit=1000&marker=b953db40-aeea-4a55-9bd9-c08dcafd6f7e
@@ -15487,22 +15620,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8bbe93ed60bb4c8787cb615eb319dc7f
+      - 57799e8eef7d44bfb5dd42ac807e1be5
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-ffcc44b1-4cbb-4a7c-8866-b6832dcaea46
+      - req-f07ccd31-4cf8-48eb-a29e-bb8a105a701d
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-ffcc44b1-4cbb-4a7c-8866-b6832dcaea46
+      - req-f07ccd31-4cf8-48eb-a29e-bb8a105a701d
       Date:
-      - Thu, 25 Oct 2018 18:25:00 GMT
+      - Thu, 01 Nov 2018 18:33:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -15514,7 +15647,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:25:00 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:42 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/types?limit=1000
@@ -15529,22 +15662,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0d584a6e72e0453ca655611babf4c1e0
+      - 770e131427254b8c9bdedb6232f50d2a
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-bc77b96b-f03c-4064-bf1e-69ee2b9ae908
+      - req-d3eb055d-089d-436a-9b2f-da5242cb4bd0
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-bc77b96b-f03c-4064-bf1e-69ee2b9ae908
+      - req-d3eb055d-089d-436a-9b2f-da5242cb4bd0
       Date:
-      - Thu, 25 Oct 2018 18:25:00 GMT
+      - Thu, 01 Nov 2018 18:33:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -15556,7 +15689,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:25:00 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:42 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/types?limit=1000&marker=b953db40-aeea-4a55-9bd9-c08dcafd6f7e
@@ -15571,22 +15704,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0d584a6e72e0453ca655611babf4c1e0
+      - 770e131427254b8c9bdedb6232f50d2a
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-18161b35-dc33-4fe9-9c56-d601df4857c6
+      - req-b91ad9f0-ce06-4ae9-a9f8-4ac077cc8ad2
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-18161b35-dc33-4fe9-9c56-d601df4857c6
+      - req-b91ad9f0-ce06-4ae9-a9f8-4ac077cc8ad2
       Date:
-      - Thu, 25 Oct 2018 18:25:00 GMT
+      - Thu, 01 Nov 2018 18:33:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -15598,7 +15731,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:25:00 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:42 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/types?limit=1000
@@ -15613,22 +15746,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 97fb334395364de4841644a3658296f2
+      - d2ffe469fd4f4f518a08260c4fecaa1c
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-8bcfef16-27fe-4925-b561-620d6d6506a1
+      - req-6a1aac47-6ff3-446b-8f97-8bfedd85ddbf
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-8bcfef16-27fe-4925-b561-620d6d6506a1
+      - req-6a1aac47-6ff3-446b-8f97-8bfedd85ddbf
       Date:
-      - Thu, 25 Oct 2018 18:25:00 GMT
+      - Thu, 01 Nov 2018 18:33:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -15640,7 +15773,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:25:00 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:43 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/types?limit=1000&marker=b953db40-aeea-4a55-9bd9-c08dcafd6f7e
@@ -15655,22 +15788,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 97fb334395364de4841644a3658296f2
+      - d2ffe469fd4f4f518a08260c4fecaa1c
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-6db00f61-8dcf-40e0-acc8-49bbf4ea5f95
+      - req-0fe9e449-9408-4b69-b99f-f4bae82b8ee5
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-6db00f61-8dcf-40e0-acc8-49bbf4ea5f95
+      - req-0fe9e449-9408-4b69-b99f-f4bae82b8ee5
       Date:
-      - Thu, 25 Oct 2018 18:25:00 GMT
+      - Thu, 01 Nov 2018 18:33:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -15682,7 +15815,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:25:00 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:43 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/types?limit=1000
@@ -15697,22 +15830,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c2513f10c5e64fa58f4e2023691ba673
+      - ffdaf893a3f841478da70890884065a1
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-1850cc80-6673-4220-8c70-b4b47375b78e
+      - req-0bc71e45-b27f-45f4-b941-a111c1c89938
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-1850cc80-6673-4220-8c70-b4b47375b78e
+      - req-0bc71e45-b27f-45f4-b941-a111c1c89938
       Date:
-      - Thu, 25 Oct 2018 18:25:00 GMT
+      - Thu, 01 Nov 2018 18:33:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -15724,7 +15857,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:25:00 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:43 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/types?limit=1000&marker=b953db40-aeea-4a55-9bd9-c08dcafd6f7e
@@ -15739,22 +15872,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c2513f10c5e64fa58f4e2023691ba673
+      - ffdaf893a3f841478da70890884065a1
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-692e2ae8-f19a-4dc1-aa17-220838021ce1
+      - req-120ea81b-64cb-443c-a8d3-8a5521919762
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-692e2ae8-f19a-4dc1-aa17-220838021ce1
+      - req-120ea81b-64cb-443c-a8d3-8a5521919762
       Date:
-      - Thu, 25 Oct 2018 18:25:00 GMT
+      - Thu, 01 Nov 2018 18:33:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -15766,7 +15899,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:25:00 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:43 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/types?limit=1000
@@ -15781,22 +15914,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ec062c9b9a664f26b0fad1ef0d9b9423
+      - 115a05b0d3904436ad56e76908641067
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-61964cb3-525a-4f71-aa64-80fd44b1fdd5
+      - req-f580f86b-5280-4064-b8e3-a41daebde00b
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-61964cb3-525a-4f71-aa64-80fd44b1fdd5
+      - req-f580f86b-5280-4064-b8e3-a41daebde00b
       Date:
-      - Thu, 25 Oct 2018 18:25:00 GMT
+      - Thu, 01 Nov 2018 18:33:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -15808,7 +15941,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:25:00 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:43 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/types?limit=1000&marker=b953db40-aeea-4a55-9bd9-c08dcafd6f7e
@@ -15823,22 +15956,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ec062c9b9a664f26b0fad1ef0d9b9423
+      - 115a05b0d3904436ad56e76908641067
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-b336f21b-fa7d-4db7-8824-4b65fadbd1d2
+      - req-e540a187-a172-4c25-b4f9-7a08c9a15d28
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-b336f21b-fa7d-4db7-8824-4b65fadbd1d2
+      - req-e540a187-a172-4c25-b4f9-7a08c9a15d28
       Date:
-      - Thu, 25 Oct 2018 18:25:01 GMT
+      - Thu, 01 Nov 2018 18:33:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -15850,7 +15983,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:25:01 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:43 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -15868,15 +16001,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:25:01 GMT
+      - Thu, 01 Nov 2018 18:33:43 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - d4b90b3dbb28415ebc17f646beebd2aa
+      - 3384cbde377e4f23b55de5f84c3a066e
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-fb75068b-d3e0-498e-9749-4b068981f2ce
+      - req-91f3e08e-970a-4bfd-bf3e-0c1b27bd4f0a
       Content-Length:
       - '7311'
       Connection:
@@ -15888,7 +16021,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-10-25T19:25:01.288180Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-11-01T19:33:43.893282Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -15967,10 +16100,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["-mV5aVQiT3mBRz2jgdD4Tg"],
-        "issued_at": "2018-10-25T18:25:01.288201Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["MQHltVjSQCeihlB9uKR3cQ"],
+        "issued_at": "2018-11-01T18:33:43.893302Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:25:01 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:43 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -15988,15 +16121,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:25:01 GMT
+      - Thu, 01 Nov 2018 18:33:44 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 744af499dd6f4376afe4356058b9277b
+      - 4801ca7bd6db413e9b556316b68ebe11
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-a71082c3-cdf4-4f82-bcae-0508124961ba
+      - req-90d2838a-0a28-4b1c-9421-debf15fe0381
       Content-Length:
       - '7311'
       Connection:
@@ -16008,7 +16141,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-10-25T19:25:01.510629Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-11-01T19:33:44.111034Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -16087,10 +16220,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["DHXy9Hw6S9KPTuETkcpGWQ"],
-        "issued_at": "2018-10-25T18:25:01.510652Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["A3v1eKl2QemDBn9KldeIqQ"],
+        "issued_at": "2018-11-01T18:33:44.111054Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:25:01 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:44 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -16108,15 +16241,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:25:01 GMT
+      - Thu, 01 Nov 2018 18:33:44 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - d77bf615e1a74342bfa82822216bc60c
+      - e2b78cb2bb31467e918801984808d2cc
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-1b73adb1-4118-4b7b-9655-f574cbc514b6
+      - req-442e628d-9178-4f7a-a1b3-b549a282c605
       Content-Length:
       - '297'
       Connection:
@@ -16125,12 +16258,12 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"token": {"methods": ["password"], "expires_at": "2018-10-25T19:25:01.679574Z",
+      string: '{"token": {"methods": ["password"], "expires_at": "2018-11-01T19:33:44.288290Z",
         "extras": {}, "user": {"domain": {"id": "default", "name": "Default"}, "id":
-        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["RNoToxvQRHeb3cDz0D1mtA"],
-        "issued_at": "2018-10-25T18:25:01.679596Z"}}'
+        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["uiEn610YRtOnLc8b0TeDrw"],
+        "issued_at": "2018-11-01T18:33:44.288310Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:25:01 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:44 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects?domain_id=default
@@ -16145,20 +16278,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d77bf615e1a74342bfa82822216bc60c
+      - e2b78cb2bb31467e918801984808d2cc
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:25:01 GMT
+      - Thu, 01 Nov 2018 18:33:44 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-e1deb9ed-0017-49d1-922f-d50d60045745
+      - req-c4b7b152-3a82-4077-8aeb-20832965aa49
       Content-Length:
       - '2475'
       Connection:
@@ -16191,7 +16324,7 @@ http_interactions:
         "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
         "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:25:01 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:44 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -16209,15 +16342,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:25:01 GMT
+      - Thu, 01 Nov 2018 18:33:44 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - a8a2578e434e472da6c400d95d8b133a
+      - d04ee213b4a64be29b8fd6a40f74c658
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-a73e7eee-e034-463b-a4c7-6df9324dab1f
+      - req-339677e6-f128-4245-b293-a3cf7d3cd0fd
       Content-Length:
       - '7278'
       Connection:
@@ -16229,7 +16362,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:25:02.012001Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:33:44.652744Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -16308,10 +16441,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["gJRSCUxRRvadZprW1kbuIQ"],
-        "issued_at": "2018-10-25T18:25:02.012029Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["09Vcqd2FR-e5lLX_ni7bLw"],
+        "issued_at": "2018-11-01T18:33:44.652784Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:25:02 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:44 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -16329,15 +16462,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:25:02 GMT
+      - Thu, 01 Nov 2018 18:33:44 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 0cd55a50f29b4b3eaafb6167696a4f1e
+      - 7fc628e8cbd7403dabff92f8a4c50c0d
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-0b515586-37c5-4306-aee5-a97271712ba5
+      - req-9fce40ec-2cde-4a82-99d9-ba8dc710781a
       Content-Length:
       - '7278'
       Connection:
@@ -16349,7 +16482,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:25:02.222794Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:33:44.861855Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -16428,10 +16561,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["v6zMFO7HTj6EG29Dq8ncNA"],
-        "issued_at": "2018-10-25T18:25:02.222816Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["vZA7feJGQSWMB3oYITViWw"],
+        "issued_at": "2018-11-01T18:33:44.861874Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:25:02 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:44 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -16449,15 +16582,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:25:02 GMT
+      - Thu, 01 Nov 2018 18:33:45 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - f482c0f9c7b54a60a9c347bd20f44d34
+      - 10d37f26388e4fd3b9a7e68b6a39eaa6
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-01f7a4ab-1c40-4496-8764-520a6567cad5
+      - req-025d993c-2c18-4731-8526-bd833150cabf
       Content-Length:
       - '7264'
       Connection:
@@ -16469,7 +16602,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:25:02.424743Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:33:45.070428Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -16548,10 +16681,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["NW08xRLRTC26NAhUVa4Bbw"],
-        "issued_at": "2018-10-25T18:25:02.424764Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["ESsY7A2QQYaAS-SNinK76Q"],
+        "issued_at": "2018-11-01T18:33:45.070448Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:25:02 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:45 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -16569,15 +16702,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:25:02 GMT
+      - Thu, 01 Nov 2018 18:33:45 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - b0d9cabfa4bb41e395eb1134ab768304
+      - 1b41fb0f41cd45f8b2f15576eeef8fe7
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-11a24ff4-f084-4080-b3a7-cafb222edc78
+      - req-693c89de-835d-4f6a-a054-6e43d35eab10
       Content-Length:
       - '7278'
       Connection:
@@ -16589,7 +16722,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:25:02.648004Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:33:45.276132Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -16668,10 +16801,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["tJ5sns0eSZa5MHo18AT-yA"],
-        "issued_at": "2018-10-25T18:25:02.648024Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["eQSvpq_3Q6SS6d6XGxFiIQ"],
+        "issued_at": "2018-11-01T18:33:45.276164Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:25:02 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:45 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -16689,15 +16822,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:25:02 GMT
+      - Thu, 01 Nov 2018 18:33:45 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 95d1254eb61b4beab0f99e283ddfd2c5
+      - a0f0409aacc04c8982f61efac7520092
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-90fabb3d-ed60-426a-bb43-b6dc0bec69ab
+      - req-0669677a-8e3c-4a46-9818-b35c380db5dd
       Content-Length:
       - '7265'
       Connection:
@@ -16709,7 +16842,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:25:02.844953Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:33:45.476225Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -16788,10 +16921,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["WsOfGh7UTRi2G0a1rom46Q"],
-        "issued_at": "2018-10-25T18:25:02.844973Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["0L6iDMGAQFesrYUHiDE96Q"],
+        "issued_at": "2018-11-01T18:33:45.476254Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:25:02 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:45 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -16809,15 +16942,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:25:02 GMT
+      - Thu, 01 Nov 2018 18:33:45 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 2152d533f66141e9b07327b7ab257f35
+      - a08f7ee298614445bec55f551176de05
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-2c620caa-a6cd-407a-af8c-dec0945c773b
+      - req-aae41702-7a04-4b00-bd40-87905f49f931
       Content-Length:
       - '7278'
       Connection:
@@ -16829,7 +16962,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:25:03.060421Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:33:45.685717Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -16908,10 +17041,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["a8xN4qrORzSneLTJ4-_gYw"],
-        "issued_at": "2018-10-25T18:25:03.060445Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["xH9S6co3Rty5jjNfi7HINQ"],
+        "issued_at": "2018-11-01T18:33:45.685737Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:25:03 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:45 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -16929,15 +17062,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:25:03 GMT
+      - Thu, 01 Nov 2018 18:33:45 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 9b4f4543f9714fb0bc2c362fc0aff212
+      - 1891390e7bb747b9b6acc95e54040e3c
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-12821e81-4cf8-4334-9114-83b9c676d88f
+      - req-8cfab3e2-13af-4d98-9ade-4db59a132554
       Content-Length:
       - '7278'
       Connection:
@@ -16949,7 +17082,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:25:03.259946Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:33:45.903443Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -17028,10 +17161,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["SFUSPrrWTrSnttAGihIrQQ"],
-        "issued_at": "2018-10-25T18:25:03.259967Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Kx9TF0xKRPqq0OvheFy_pg"],
+        "issued_at": "2018-11-01T18:33:45.903474Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:25:03 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:45 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_0098405163cd4c9dbb42c2cb43eb6fd3/?format=json&limit=1000
@@ -17046,7 +17179,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9b4f4543f9714fb0bc2c362fc0aff212
+      - 1891390e7bb747b9b6acc95e54040e3c
   response:
     status:
       code: 200
@@ -17059,22 +17192,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1540491903.38693'
+      - '1541097226.03995'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1540491903.38693'
+      - '1541097226.03995'
       X-Trans-Id:
-      - txd373f8e5135a40fda5dd6-005bd20a7f
+      - tx47ada8d5b27c4a9b9d0a7-005bdb470a
       Date:
-      - Thu, 25 Oct 2018 18:25:03 GMT
+      - Thu, 01 Nov 2018 18:33:46 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:25:03 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:46 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -17092,15 +17225,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:25:03 GMT
+      - Thu, 01 Nov 2018 18:33:46 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 0ecd39c7812c4a0bb63baa5ccf6e84c0
+      - 72bb9ddfaf8946bca1d9131f7523c371
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-5d26573d-13cc-4792-8c6b-2d7533277083
+      - req-92d9bfec-102e-4f75-bc76-78bdbe8c019e
       Content-Length:
       - '7278'
       Connection:
@@ -17112,7 +17245,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:25:03.574794Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:33:46.240691Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -17191,10 +17324,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["OjUV0TEETdqrmL17MhGDWQ"],
-        "issued_at": "2018-10-25T18:25:03.574814Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["6_jCLZKuQ12n19_1hQ0ajQ"],
+        "issued_at": "2018-11-01T18:33:46.240713Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:25:03 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:46 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_28db8f69ba9e4305b7fad82da4c86e74/?format=json&limit=1000
@@ -17209,7 +17342,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0ecd39c7812c4a0bb63baa5ccf6e84c0
+      - 72bb9ddfaf8946bca1d9131f7523c371
   response:
     status:
       code: 200
@@ -17222,22 +17355,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1540491903.70125'
+      - '1541097226.37003'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1540491903.70125'
+      - '1541097226.37003'
       X-Trans-Id:
-      - tx7c7e093a25ad4b11b4884-005bd20a7f
+      - txd82c0a95165c44579c518-005bdb470a
       Date:
-      - Thu, 25 Oct 2018 18:25:03 GMT
+      - Thu, 01 Nov 2018 18:33:46 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:25:03 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:46 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -17255,15 +17388,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:25:03 GMT
+      - Thu, 01 Nov 2018 18:33:46 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - f7a729d23187437396350e3b549696ae
+      - 9044e837ecc7402696a2e297b1b25b2e
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-94e2bca6-09d1-4d86-a23d-666e28425359
+      - req-594283ad-17fe-4917-a37a-fcfe21700f7d
       Content-Length:
       - '7264'
       Connection:
@@ -17275,7 +17408,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:25:03.899294Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:33:46.567320Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -17354,10 +17487,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["vIfoWvuERiKxN0AmL2MeqA"],
-        "issued_at": "2018-10-25T18:25:03.899317Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["sBbs0Ys7R3GpZwVWdV024g"],
+        "issued_at": "2018-11-01T18:33:46.567341Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:25:03 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:46 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_4637c33fee924ebea81f8d209e452c91/?format=json&limit=1000
@@ -17372,7 +17505,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f7a729d23187437396350e3b549696ae
+      - 9044e837ecc7402696a2e297b1b25b2e
   response:
     status:
       code: 200
@@ -17401,15 +17534,15 @@ http_interactions:
       X-Account-Project-Domain-Id:
       - default
       X-Trans-Id:
-      - tx6f1d78f4d5a448ac94e1f-005bd20a7f
+      - txae916ef3106744c9bceaf-005bdb470a
       Date:
-      - Thu, 25 Oct 2018 18:25:04 GMT
+      - Thu, 01 Nov 2018 18:33:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '[{"count": 3, "bytes": 33, "name": "dir_1"}, {"count": 0, "bytes":
         0, "name": "dir_2"}, {"count": 0, "bytes": 0, "name": "dir_3"}]'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:25:04 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:46 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_4637c33fee924ebea81f8d209e452c91/?format=json&limit=1000&marker=dir_3
@@ -17424,7 +17557,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f7a729d23187437396350e3b549696ae
+      - 9044e837ecc7402696a2e297b1b25b2e
   response:
     status:
       code: 200
@@ -17453,14 +17586,14 @@ http_interactions:
       X-Account-Project-Domain-Id:
       - default
       X-Trans-Id:
-      - txccf7937a99e44785b4f47-005bd20a80
+      - txc4b26e7f7ea848e99b54c-005bdb470a
       Date:
-      - Thu, 25 Oct 2018 18:25:04 GMT
+      - Thu, 01 Nov 2018 18:33:46 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:25:04 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:46 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -17478,15 +17611,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:25:04 GMT
+      - Thu, 01 Nov 2018 18:33:46 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 053b8fe31abf46dc9ce4d128ae6bac09
+      - cf0a99f3d2974342887694683d6ce4fa
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-dad70928-2ac8-4e1a-8356-1cdceaec8618
+      - req-c97d8f58-470d-4eaa-b8a2-726abf0e21d5
       Content-Length:
       - '7278'
       Connection:
@@ -17498,7 +17631,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:25:04.306216Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:33:46.987384Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -17577,10 +17710,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["IPmd7ivTQpCIlCCaI3x8Jg"],
-        "issued_at": "2018-10-25T18:25:04.306236Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["ldON6LmJT62QpDlilZmCqw"],
+        "issued_at": "2018-11-01T18:33:46.987403Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:25:04 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:47 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_52c452d7763a4295950527948232a3e5/?format=json&limit=1000
@@ -17595,7 +17728,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 053b8fe31abf46dc9ce4d128ae6bac09
+      - cf0a99f3d2974342887694683d6ce4fa
   response:
     status:
       code: 200
@@ -17608,22 +17741,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1540491904.44033'
+      - '1541097227.12126'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1540491904.44033'
+      - '1541097227.12126'
       X-Trans-Id:
-      - txb5db464df8ca4c42a82bf-005bd20a80
+      - txf82c310ba7af4fb79cd59-005bdb470b
       Date:
-      - Thu, 25 Oct 2018 18:25:04 GMT
+      - Thu, 01 Nov 2018 18:33:47 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:25:04 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:47 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_88ae57d444fd485ab2dfddd5a2615d52/?format=json&limit=1000
@@ -17638,7 +17771,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 744af499dd6f4376afe4356058b9277b
+      - 4801ca7bd6db413e9b556316b68ebe11
   response:
     status:
       code: 200
@@ -17651,22 +17784,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1540491904.54913'
+      - '1541097227.24070'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1540491904.54913'
+      - '1541097227.24070'
       X-Trans-Id:
-      - tx769fe5bfa46843b68914f-005bd20a80
+      - tx7f281ff8c60e48f19cfa1-005bdb470b
       Date:
-      - Thu, 25 Oct 2018 18:25:04 GMT
+      - Thu, 01 Nov 2018 18:33:47 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:25:04 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:47 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -17684,15 +17817,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:25:04 GMT
+      - Thu, 01 Nov 2018 18:33:47 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 744abf2e498645f9968950d8de125c4f
+      - 5d9eeb9a04974942a5f7514152d93c72
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-423237c0-606a-4a2c-ba55-797a433a5f8f
+      - req-1728b02e-78e6-46a3-9cc5-e37929f3fada
       Content-Length:
       - '7265'
       Connection:
@@ -17704,7 +17837,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:25:04.741361Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:33:47.475970Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -17783,10 +17916,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["_uuEaGwdSIuLcavHX73Bew"],
-        "issued_at": "2018-10-25T18:25:04.741381Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["yPmWOwgIQB-83FoWsZ_Obg"],
+        "issued_at": "2018-11-01T18:33:47.476001Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:25:04 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:47 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_d09cbe26295d47ff848ea73c74264e23/?format=json&limit=1000
@@ -17801,7 +17934,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 744abf2e498645f9968950d8de125c4f
+      - 5d9eeb9a04974942a5f7514152d93c72
   response:
     status:
       code: 200
@@ -17814,22 +17947,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1540491904.87761'
+      - '1541097227.60660'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1540491904.87761'
+      - '1541097227.60660'
       X-Trans-Id:
-      - txe9b1618b91444020a8c04-005bd20a80
+      - tx97a56a36427e4eedae5fd-005bdb470b
       Date:
-      - Thu, 25 Oct 2018 18:25:04 GMT
+      - Thu, 01 Nov 2018 18:33:47 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:25:04 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:47 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -17847,15 +17980,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:25:05 GMT
+      - Thu, 01 Nov 2018 18:33:47 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - c6b333322d52418bad34755e6c21d703
+      - 176100a3d58b4ff7a1d26a1e612d1d12
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-c03106bb-5d91-42e4-9533-1318dd7c1036
+      - req-cf4a6d3b-94e4-4046-90e2-050eb3c519af
       Content-Length:
       - '7278'
       Connection:
@@ -17867,7 +18000,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:25:05.083680Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:33:47.807483Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -17946,10 +18079,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["NT0Lp-EiR0Cnrcqi13zxgQ"],
-        "issued_at": "2018-10-25T18:25:05.083699Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["0bT6L4cyRb2em0HMyXOliQ"],
+        "issued_at": "2018-11-01T18:33:47.807504Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:25:05 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:47 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_ef2a3405d1ef4dfd9a3616993ef46a4d/?format=json&limit=1000
@@ -17964,7 +18097,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c6b333322d52418bad34755e6c21d703
+      - 176100a3d58b4ff7a1d26a1e612d1d12
   response:
     status:
       code: 200
@@ -17977,22 +18110,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1540491905.21053'
+      - '1541097227.94496'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1540491905.21053'
+      - '1541097227.94496'
       X-Trans-Id:
-      - tx3b6a449f63a24242995f6-005bd20a81
+      - txa690cfe74d4b40e7b6889-005bdb470b
       Date:
-      - Thu, 25 Oct 2018 18:25:05 GMT
+      - Thu, 01 Nov 2018 18:33:47 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:25:05 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:47 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_4637c33fee924ebea81f8d209e452c91/dir_1?format=json
@@ -18007,7 +18140,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f7a729d23187437396350e3b549696ae
+      - 9044e837ecc7402696a2e297b1b25b2e
   response:
     status:
       code: 200
@@ -18028,9 +18161,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - tx39174810508f4b28ae123-005bd20a81
+      - tx7a6825b087824965af6a3-005bdb470c
       Date:
-      - Thu, 25 Oct 2018 18:25:05 GMT
+      - Thu, 01 Nov 2018 18:33:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '[{"hash": "61257bf228e2f6802a196c9a460d19a8", "last_modified": "2016-08-19T08:37:59.564460",
@@ -18040,7 +18173,7 @@ http_interactions:
         {"hash": "1727a9b61bddf85bbe7a5710c9f45691", "last_modified": "2016-08-19T08:38:00.995870",
         "bytes": 11, "name": "file_3", "content_type": "application/octet-stream"}]'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:25:05 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:48 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_4637c33fee924ebea81f8d209e452c91/dir_2?format=json
@@ -18055,7 +18188,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f7a729d23187437396350e3b549696ae
+      - 9044e837ecc7402696a2e297b1b25b2e
   response:
     status:
       code: 200
@@ -18076,14 +18209,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - txbe76fbce4cce47e8a2fc8-005bd20a81
+      - tx9fa6e3ca45bd4585b7694-005bdb470c
       Date:
-      - Thu, 25 Oct 2018 18:25:05 GMT
+      - Thu, 01 Nov 2018 18:33:48 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:25:05 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:48 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_4637c33fee924ebea81f8d209e452c91/dir_3?format=json
@@ -18098,7 +18231,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f7a729d23187437396350e3b549696ae
+      - 9044e837ecc7402696a2e297b1b25b2e
   response:
     status:
       code: 200
@@ -18119,12 +18252,12 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - tx8fffc41eb7b443f5a5e45-005bd20a81
+      - txacbdb7e5229b4446814f2-005bdb470c
       Date:
-      - Thu, 25 Oct 2018 18:25:05 GMT
+      - Thu, 01 Nov 2018 18:33:48 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:25:05 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:48 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_keystone_v3_legacy_fast_refresh.yml
+++ b/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_keystone_v3_legacy_fast_refresh.yml
@@ -17,15 +17,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:22:22 GMT
+      - Thu, 01 Nov 2018 18:30:41 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - d76a653d8e4441508612294af96ce283
+      - a7e72dfbdd7849359bde7e944e5fa25a
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-18533d3f-afc0-4955-8b52-8b1fd28650f6
+      - req-42d00186-84fa-4ea2-9dc0-45b1c55960a6
       Content-Length:
       - '7311'
       Connection:
@@ -37,7 +37,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-10-25T19:22:22.219019Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-11-01T19:30:41.176131Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -116,10 +116,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["eVhLnFseRpCYq4XgFYSj8Q"],
-        "issued_at": "2018-10-25T18:22:22.219041Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["2lqWJSKsQmqwJKSK42Ml1w"],
+        "issued_at": "2018-11-01T18:30:41.176153Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:22 GMT
+  recorded_at: Thu, 01 Nov 2018 18:30:41 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -134,7 +134,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d76a653d8e4441508612294af96ce283
+      - a7e72dfbdd7849359bde7e944e5fa25a
   response:
     status:
       code: 200
@@ -145,7 +145,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Thu, 25 Oct 2018 18:22:22 GMT
+      - Thu, 01 Nov 2018 18:30:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -154,7 +154,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:22 GMT
+  recorded_at: Thu, 01 Nov 2018 18:30:41 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -172,15 +172,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:22:22 GMT
+      - Thu, 01 Nov 2018 18:30:41 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 91fcf3848c964188815a274cb6062deb
+      - 65d16c672d53490597eb75387b64dcd4
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-2eefb1c3-e0e7-4818-9886-44ed1d3dab5d
+      - req-2e6f3cb0-1dd0-4a89-92b7-4164d1ea190a
       Content-Length:
       - '7311'
       Connection:
@@ -192,7 +192,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-10-25T19:22:22.514874Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-11-01T19:30:41.809683Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -271,10 +271,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["eX4TU3FJSKK7sW2uYavsag"],
-        "issued_at": "2018-10-25T18:22:22.514894Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["fqIGPo7fRX2cKBT1iRMVTg"],
+        "issued_at": "2018-11-01T18:30:41.809704Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:22 GMT
+  recorded_at: Thu, 01 Nov 2018 18:30:41 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -292,15 +292,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:22:22 GMT
+      - Thu, 01 Nov 2018 18:30:41 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 630d0150087049f6aa2275d627a16c4f
+      - d77a42fbac784ae9b96647ff3d27d7ac
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-214b46fa-777d-4cca-8675-c1eb09b5b44d
+      - req-77361c06-b5a2-43ba-a346-54517552c9bc
       Content-Length:
       - '7311'
       Connection:
@@ -312,7 +312,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-10-25T19:22:22.706812Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-11-01T19:30:42.047079Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -391,10 +391,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["tvWwo4NLSQuHIBbHJsAiBQ"],
-        "issued_at": "2018-10-25T18:22:22.706830Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["h6CuMV28RXWDdJmiOUT1gg"],
+        "issued_at": "2018-11-01T18:30:42.047099Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:22 GMT
+  recorded_at: Thu, 01 Nov 2018 18:30:42 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -412,15 +412,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:22:22 GMT
+      - Thu, 01 Nov 2018 18:30:42 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 36b6f29c59bf47458d04bf115e27e853
+      - 7cafec443b2443c5bfde5bcda2370a8d
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-0c6070a7-f76d-4128-bb44-61088f2141f2
+      - req-931227b0-c123-4b31-aa27-a153bb760e74
       Content-Length:
       - '7311'
       Connection:
@@ -432,7 +432,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-10-25T19:22:22.908544Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-11-01T19:30:42.307617Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -511,10 +511,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["D1Tw52kRSpqk6XHc7iY13g"],
-        "issued_at": "2018-10-25T18:22:22.908563Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["757k3TFERH-vk_-jWaArCA"],
+        "issued_at": "2018-11-01T18:30:42.307639Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:22 GMT
+  recorded_at: Thu, 01 Nov 2018 18:30:42 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -532,15 +532,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:22:23 GMT
+      - Thu, 01 Nov 2018 18:30:42 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - a1b4e66dd577428086a09243c0307fa4
+      - af87d2f2fdcb499fa2b5c0a07bbcd2ee
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-c98073b9-11b7-4a72-912f-9a74615ec736
+      - req-5baf308a-7eaa-41d0-a650-070494fda1a6
       Content-Length:
       - '7311'
       Connection:
@@ -552,7 +552,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-10-25T19:22:23.118865Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-11-01T19:30:42.746864Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -631,10 +631,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["T84pCiw8R0yJy0dM0mXwsg"],
-        "issued_at": "2018-10-25T18:22:23.118886Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Z8I7aoUITzqk60mCEGGUag"],
+        "issued_at": "2018-11-01T18:30:42.746884Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:23 GMT
+  recorded_at: Thu, 01 Nov 2018 18:30:42 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -652,15 +652,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:22:23 GMT
+      - Thu, 01 Nov 2018 18:30:42 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 40ed08ea20d34fcf885d7f17f951e54c
+      - 2d8d94868ecc4f1bad0db117607a58bd
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-a5a5cbb0-5058-4c1e-90b9-815909d6df48
+      - req-068b2afc-b001-473b-bcb9-d0a185e1a7e6
       Content-Length:
       - '7311'
       Connection:
@@ -672,7 +672,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-10-25T19:22:23.332056Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-11-01T19:30:43.061308Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -751,10 +751,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["b6xXX16gQ_6JYDhO_LI0wg"],
-        "issued_at": "2018-10-25T18:22:23.332076Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["QwGKYXsbRDC3pGYVeXn9Dg"],
+        "issued_at": "2018-11-01T18:30:43.061329Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:23 GMT
+  recorded_at: Thu, 01 Nov 2018 18:30:43 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -772,15 +772,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:22:23 GMT
+      - Thu, 01 Nov 2018 18:30:43 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 4ae5caee37854569bb35e7f8dfe116b3
+      - 07badd5c2d124eeb9375f0fb8f120c89
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-90cc2379-c318-468a-9ca8-00811370c350
+      - req-550508fe-8b50-4d40-b154-11640dda07b3
       Content-Length:
       - '7311'
       Connection:
@@ -792,7 +792,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-10-25T19:22:23.686291Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-11-01T19:30:43.515800Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -871,10 +871,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["h_89j19JSkaT0osjf13i-A"],
-        "issued_at": "2018-10-25T18:22:23.686313Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["onbhwHgtQIK_K1TYvDqPSw"],
+        "issued_at": "2018-11-01T18:30:43.515821Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:23 GMT
+  recorded_at: Thu, 01 Nov 2018 18:30:43 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -892,15 +892,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:22:23 GMT
+      - Thu, 01 Nov 2018 18:30:43 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 1ca552d7955a475cb4e5ad6ab71b445a
+      - 525f9444b6b94752a1d1f510957407a6
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-f134ef67-311a-433c-8bf9-b7298b931268
+      - req-cd37a8a4-265d-4abb-9c8b-19745a1278c2
       Content-Length:
       - '7311'
       Connection:
@@ -912,7 +912,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-10-25T19:22:23.917985Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-11-01T19:30:43.836887Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -991,10 +991,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["EaijN67lTvqSmN3_pc_gog"],
-        "issued_at": "2018-10-25T18:22:23.918006Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["BR86RSyBSz-0bxb3DB9mVQ"],
+        "issued_at": "2018-11-01T18:30:43.836909Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:23 GMT
+  recorded_at: Thu, 01 Nov 2018 18:30:43 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -1012,15 +1012,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:22:24 GMT
+      - Thu, 01 Nov 2018 18:30:43 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 823bc6b7c9bb46eb91859ceccaf3db70
+      - afc4380983554376865a2671471c7400
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-7ccf3420-f2a0-483d-bb66-0da028f6549c
+      - req-77b6514c-5e87-440a-85aa-17ea54d67abc
       Content-Length:
       - '297'
       Connection:
@@ -1029,12 +1029,12 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"token": {"methods": ["password"], "expires_at": "2018-10-25T19:22:24.095227Z",
+      string: '{"token": {"methods": ["password"], "expires_at": "2018-11-01T19:30:44.024173Z",
         "extras": {}, "user": {"domain": {"id": "default", "name": "Default"}, "id":
-        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["OJBiF3UXSiKWtbpl6cSvHw"],
-        "issued_at": "2018-10-25T18:22:24.095246Z"}}'
+        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["gY_7TF1yTT-2k-13YgOdgA"],
+        "issued_at": "2018-11-01T18:30:44.024192Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:24 GMT
+  recorded_at: Thu, 01 Nov 2018 18:30:44 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects?domain_id=default
@@ -1049,20 +1049,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 823bc6b7c9bb46eb91859ceccaf3db70
+      - afc4380983554376865a2671471c7400
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:22:24 GMT
+      - Thu, 01 Nov 2018 18:30:44 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-1bc4931c-728f-424c-8e2a-5395da290f7f
+      - req-de8758d8-4d44-474c-a3b3-8b28e28bbbd7
       Content-Length:
       - '2475'
       Connection:
@@ -1095,7 +1095,7 @@ http_interactions:
         "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
         "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:24 GMT
+  recorded_at: Thu, 01 Nov 2018 18:30:44 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -1113,15 +1113,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:22:24 GMT
+      - Thu, 01 Nov 2018 18:30:44 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 2a855951192c4ceab849dca2a5eaa435
+      - b7f6824b76334b16ac6166ad629c2c61
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-97df81cb-7d86-4494-a81b-bdf7c8563a85
+      - req-74c1288a-b9a7-4946-9b8f-853b237794df
       Content-Length:
       - '7278'
       Connection:
@@ -1133,7 +1133,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:22:24.444661Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:30:44.375169Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -1212,10 +1212,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["rfjpJ8XnRIqVxRjpnkR9yw"],
-        "issued_at": "2018-10-25T18:22:24.444682Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["FTq3njZZSW2UppzuK9-JLw"],
+        "issued_at": "2018-11-01T18:30:44.375190Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:24 GMT
+  recorded_at: Thu, 01 Nov 2018 18:30:44 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -1230,7 +1230,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2a855951192c4ceab849dca2a5eaa435
+      - b7f6824b76334b16ac6166ad629c2c61
   response:
     status:
       code: 200
@@ -1241,7 +1241,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Thu, 25 Oct 2018 18:22:24 GMT
+      - Thu, 01 Nov 2018 18:30:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -1250,7 +1250,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:24 GMT
+  recorded_at: Thu, 01 Nov 2018 18:30:44 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -1268,15 +1268,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:22:24 GMT
+      - Thu, 01 Nov 2018 18:30:44 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 3973913b005d45869badb592a073865c
+      - ee6e1ea9864a4cb89f78669eb9acd103
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-a0ac4897-9999-4b65-bd04-bf3043350f2f
+      - req-c4f0b869-b554-4e5f-87ed-ad7da2aecad1
       Content-Length:
       - '7278'
       Connection:
@@ -1288,7 +1288,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:22:24.727425Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:30:44.683831Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -1367,10 +1367,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["zAppBYiKQ4ON_fx30UqJJw"],
-        "issued_at": "2018-10-25T18:22:24.727457Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["V2heOPZbRvKg38khji-6rg"],
+        "issued_at": "2018-11-01T18:30:44.683852Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:24 GMT
+  recorded_at: Thu, 01 Nov 2018 18:30:44 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -1385,7 +1385,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3973913b005d45869badb592a073865c
+      - ee6e1ea9864a4cb89f78669eb9acd103
   response:
     status:
       code: 200
@@ -1396,7 +1396,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Thu, 25 Oct 2018 18:22:24 GMT
+      - Thu, 01 Nov 2018 18:30:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -1405,7 +1405,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:24 GMT
+  recorded_at: Thu, 01 Nov 2018 18:30:44 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -1423,15 +1423,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:22:24 GMT
+      - Thu, 01 Nov 2018 18:30:44 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - e725f10b870d40f6b553a3e099427814
+      - 05b65614b3ff4472a9616acb1813d470
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-dddc2fd2-3a28-452b-9ab9-4dd376e45da5
+      - req-45ac21b4-d62c-4dc6-a4aa-4e611988e451
       Content-Length:
       - '7264'
       Connection:
@@ -1443,7 +1443,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:22:25.045405Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:30:44.981385Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -1522,10 +1522,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["jEaUH4RjTSGDeeK1PXoY-Q"],
-        "issued_at": "2018-10-25T18:22:25.045429Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["sDpAQrHCS8-2BxIgiTyGCw"],
+        "issued_at": "2018-11-01T18:30:44.981405Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:25 GMT
+  recorded_at: Thu, 01 Nov 2018 18:30:45 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -1540,7 +1540,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e725f10b870d40f6b553a3e099427814
+      - 05b65614b3ff4472a9616acb1813d470
   response:
     status:
       code: 200
@@ -1551,7 +1551,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Thu, 25 Oct 2018 18:22:25 GMT
+      - Thu, 01 Nov 2018 18:30:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -1560,7 +1560,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:25 GMT
+  recorded_at: Thu, 01 Nov 2018 18:30:46 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -1578,15 +1578,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:22:25 GMT
+      - Thu, 01 Nov 2018 18:30:46 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 2be3fc38002b49cfa2684c1bffd8cc8a
+      - e3b52520a2ec4b9480cb212951dd64ed
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-0d409d99-e3f0-4420-bf03-324761846efd
+      - req-c97a006e-755f-4335-ba48-01e356e0606b
       Content-Length:
       - '7278'
       Connection:
@@ -1598,7 +1598,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:22:25.326766Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:30:46.371609Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -1677,10 +1677,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["SGmrlEPHQcu1z-zMIjWNrw"],
-        "issued_at": "2018-10-25T18:22:25.326797Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["1ElVEn2WSl64N_tR7mz3zA"],
+        "issued_at": "2018-11-01T18:30:46.371636Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:25 GMT
+  recorded_at: Thu, 01 Nov 2018 18:30:46 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -1695,7 +1695,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2be3fc38002b49cfa2684c1bffd8cc8a
+      - e3b52520a2ec4b9480cb212951dd64ed
   response:
     status:
       code: 200
@@ -1706,7 +1706,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Thu, 25 Oct 2018 18:22:25 GMT
+      - Thu, 01 Nov 2018 18:30:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -1715,7 +1715,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:25 GMT
+  recorded_at: Thu, 01 Nov 2018 18:30:46 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -1733,15 +1733,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:22:25 GMT
+      - Thu, 01 Nov 2018 18:30:46 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 4b5704090f3442449577f7b2f60d6f80
+      - 0b0b82a05e0e41c288ce01a3a6fda514
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-f52146f8-04b8-4f7c-a072-fe52ec0e5d45
+      - req-d6cfac95-63d9-4f32-95f3-6f574dd706ff
       Content-Length:
       - '7265'
       Connection:
@@ -1753,7 +1753,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:22:25.606437Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:30:46.664265Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -1832,10 +1832,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["7o0w06DCSR6zmuvFydURKg"],
-        "issued_at": "2018-10-25T18:22:25.606458Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["fMMPMoeHTxGZQ8t2HntuyA"],
+        "issued_at": "2018-11-01T18:30:46.664284Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:25 GMT
+  recorded_at: Thu, 01 Nov 2018 18:30:46 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -1850,7 +1850,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4b5704090f3442449577f7b2f60d6f80
+      - 0b0b82a05e0e41c288ce01a3a6fda514
   response:
     status:
       code: 200
@@ -1861,7 +1861,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Thu, 25 Oct 2018 18:22:25 GMT
+      - Thu, 01 Nov 2018 18:30:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -1870,7 +1870,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:25 GMT
+  recorded_at: Thu, 01 Nov 2018 18:30:46 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -1888,15 +1888,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:22:25 GMT
+      - Thu, 01 Nov 2018 18:30:46 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 1446d2cfcd0149d18b6e1e3db7ee0fb7
+      - abb7d9a9d7e842ddbc76e7a32f7910cd
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-8fd2eca7-5b37-43c7-bd49-1aa1b8554a7b
+      - req-19d2a925-feef-4652-bbfd-9b9102fb93db
       Content-Length:
       - '7278'
       Connection:
@@ -1908,7 +1908,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:22:25.934966Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:30:46.967456Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -1987,10 +1987,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["44GNQzObQDKW2qgGg9jBbw"],
-        "issued_at": "2018-10-25T18:22:25.934999Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["fGq3LhYiR1--sPvHqhPZSw"],
+        "issued_at": "2018-11-01T18:30:46.967477Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:25 GMT
+  recorded_at: Thu, 01 Nov 2018 18:30:46 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -2005,7 +2005,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1446d2cfcd0149d18b6e1e3db7ee0fb7
+      - abb7d9a9d7e842ddbc76e7a32f7910cd
   response:
     status:
       code: 200
@@ -2016,7 +2016,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Thu, 25 Oct 2018 18:22:26 GMT
+      - Thu, 01 Nov 2018 18:30:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -2025,7 +2025,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:26 GMT
+  recorded_at: Thu, 01 Nov 2018 18:30:47 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000
@@ -2040,7 +2040,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d76a653d8e4441508612294af96ce283
+      - a7e72dfbdd7849359bde7e944e5fa25a
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2053,9 +2053,9 @@ http_interactions:
       Content-Length:
       - '1010'
       X-Compute-Request-Id:
-      - req-dafffb78-10e8-4d4b-bd70-20ca8481f8eb
+      - req-2a00e0e0-afbb-403d-8899-d94cef79b430
       Date:
-      - Thu, 25 Oct 2018 18:22:26 GMT
+      - Thu, 01 Nov 2018 18:30:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.tiny", "links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/1",
@@ -2069,7 +2069,7 @@ http_interactions:
         0, "disk": 20, "id": "2"}], "flavors_links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=2",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:26 GMT
+  recorded_at: Thu, 01 Nov 2018 18:30:47 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=2
@@ -2084,7 +2084,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d76a653d8e4441508612294af96ce283
+      - a7e72dfbdd7849359bde7e944e5fa25a
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2097,9 +2097,9 @@ http_interactions:
       Content-Length:
       - '1014'
       X-Compute-Request-Id:
-      - req-cb7d1355-c170-49d5-98bf-829e70ac3e22
+      - req-a89021f0-ce9b-4a81-af46-4791be45cf3a
       Date:
-      - Thu, 25 Oct 2018 18:22:26 GMT
+      - Thu, 01 Nov 2018 18:30:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.medium", "links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/3",
@@ -2113,7 +2113,7 @@ http_interactions:
         0, "disk": 80, "id": "4"}], "flavors_links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=4",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:26 GMT
+  recorded_at: Thu, 01 Nov 2018 18:30:47 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=4
@@ -2128,7 +2128,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d76a653d8e4441508612294af96ce283
+      - a7e72dfbdd7849359bde7e944e5fa25a
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2141,9 +2141,9 @@ http_interactions:
       Content-Length:
       - '1026'
       X-Compute-Request-Id:
-      - req-887af60a-d6e8-4d27-a3b9-abfc98065181
+      - req-70c140f8-7116-4a30-aec8-70359b5d4ed7
       Date:
-      - Thu, 25 Oct 2018 18:22:26 GMT
+      - Thu, 01 Nov 2018 18:30:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.xlarge", "links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/5",
@@ -2158,7 +2158,7 @@ http_interactions:
         1, "disk": 1, "id": "6"}], "flavors_links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=6",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:26 GMT
+  recorded_at: Thu, 01 Nov 2018 18:30:47 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=6
@@ -2173,7 +2173,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d76a653d8e4441508612294af96ce283
+      - a7e72dfbdd7849359bde7e944e5fa25a
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2186,9 +2186,9 @@ http_interactions:
       Content-Length:
       - '448'
       X-Compute-Request-Id:
-      - req-f6ec65ba-4d29-4197-a09e-7360b52a3adc
+      - req-9e7b1fe4-ba72-455c-a8cb-f8779e9e6f43
       Date:
-      - Thu, 25 Oct 2018 18:22:26 GMT
+      - Thu, 01 Nov 2018 18:30:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.ems_refresh_spec_private", "links": [{"href":
@@ -2198,7 +2198,7 @@ http_interactions:
         8, "swap": "", "os-flavor-access:is_public": false, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         0, "disk": 160, "id": "7"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:26 GMT
+  recorded_at: Thu, 01 Nov 2018 18:30:47 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/7/os-flavor-access
@@ -2213,7 +2213,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d76a653d8e4441508612294af96ce283
+      - a7e72dfbdd7849359bde7e944e5fa25a
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2226,15 +2226,15 @@ http_interactions:
       Content-Length:
       - '88'
       X-Compute-Request-Id:
-      - req-9662da46-c2ce-4357-9ce3-01f7b8524dfd
+      - req-43f77a0e-7fd5-483d-8c84-d21794f24812
       Date:
-      - Thu, 25 Oct 2018 18:22:26 GMT
+      - Thu, 01 Nov 2018 18:30:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavor_access": [{"tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "flavor_id": "7"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:26 GMT
+  recorded_at: Thu, 01 Nov 2018 18:30:47 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-availability-zone
@@ -2249,7 +2249,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d76a653d8e4441508612294af96ce283
+      - a7e72dfbdd7849359bde7e944e5fa25a
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2262,15 +2262,15 @@ http_interactions:
       Content-Length:
       - '97'
       X-Compute-Request-Id:
-      - req-f08e1182-9c57-4956-ab8a-ca5268037884
+      - req-f20514a4-4fac-464c-aba7-bf8a94189822
       Date:
-      - Thu, 25 Oct 2018 18:22:26 GMT
+      - Thu, 01 Nov 2018 18:30:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"availabilityZoneInfo": [{"zoneState": {"available": true}, "hosts":
         null, "zoneName": "nova"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:26 GMT
+  recorded_at: Thu, 01 Nov 2018 18:30:47 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/os-availability-zone.json
@@ -2285,28 +2285,28 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a1b4e66dd577428086a09243c0307fa4
+      - af87d2f2fdcb499fa2b5c0a07bbcd2ee
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-538efe8c-f1db-41fb-ab46-1221012e8595
+      - req-e6ac3804-b76b-4a37-93e5-b73f1222c883
       Content-Type:
       - application/json
       Content-Length:
       - '82'
       X-Openstack-Request-Id:
-      - req-538efe8c-f1db-41fb-ab46-1221012e8595
+      - req-e6ac3804-b76b-4a37-93e5-b73f1222c883
       Date:
-      - Thu, 25 Oct 2018 18:22:26 GMT
+      - Thu, 01 Nov 2018 18:30:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"availabilityZoneInfo": [{"zoneState": {"available": true}, "zoneName":
         "nova"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:26 GMT
+  recorded_at: Thu, 01 Nov 2018 18:30:47 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-aggregates
@@ -2321,7 +2321,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d76a653d8e4441508612294af96ce283
+      - a7e72dfbdd7849359bde7e944e5fa25a
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2334,14 +2334,14 @@ http_interactions:
       Content-Length:
       - '18'
       X-Compute-Request-Id:
-      - req-4cf6f518-11c0-4cb8-aa72-eafe388f43a4
+      - req-ee7593e3-cb91-4033-aae8-e54e18df8f96
       Date:
-      - Thu, 25 Oct 2018 18:22:26 GMT
+      - Thu, 01 Nov 2018 18:30:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"aggregates": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:27 GMT
+  recorded_at: Thu, 01 Nov 2018 18:30:48 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3//os-quota-sets/0098405163cd4c9dbb42c2cb43eb6fd3
@@ -2356,7 +2356,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2a855951192c4ceab849dca2a5eaa435
+      - b7f6824b76334b16ac6166ad629c2c61
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2369,9 +2369,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-9325481d-52b0-4ba0-b1db-9af29fabd325
+      - req-4c9d2af4-6362-4774-82a7-ef5afc2894c3
       Date:
-      - Thu, 25 Oct 2018 18:22:27 GMT
+      - Thu, 01 Nov 2018 18:30:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -2380,7 +2380,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:27 GMT
+  recorded_at: Thu, 01 Nov 2018 18:30:48 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/28db8f69ba9e4305b7fad82da4c86e74//os-quota-sets/28db8f69ba9e4305b7fad82da4c86e74
@@ -2395,7 +2395,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3973913b005d45869badb592a073865c
+      - ee6e1ea9864a4cb89f78669eb9acd103
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2408,9 +2408,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-f49abd96-80bf-4ee3-9f8d-a7e627d93cb0
+      - req-9a6ac86e-d395-45f3-89f1-7b9060220318
       Date:
-      - Thu, 25 Oct 2018 18:22:27 GMT
+      - Thu, 01 Nov 2018 18:30:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -2419,7 +2419,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:27 GMT
+  recorded_at: Thu, 01 Nov 2018 18:30:48 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91//os-quota-sets/4637c33fee924ebea81f8d209e452c91
@@ -2434,7 +2434,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e725f10b870d40f6b553a3e099427814
+      - 05b65614b3ff4472a9616acb1813d470
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2447,9 +2447,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-301aeb86-47f6-41ee-ab5a-75b0c5d0dd22
+      - req-d76b10e6-21d9-4fb4-9802-84040aa4a75f
       Date:
-      - Thu, 25 Oct 2018 18:22:27 GMT
+      - Thu, 01 Nov 2018 18:30:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -2458,7 +2458,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:27 GMT
+  recorded_at: Thu, 01 Nov 2018 18:30:48 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/52c452d7763a4295950527948232a3e5//os-quota-sets/52c452d7763a4295950527948232a3e5
@@ -2473,7 +2473,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2be3fc38002b49cfa2684c1bffd8cc8a
+      - e3b52520a2ec4b9480cb212951dd64ed
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2486,9 +2486,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-009af2c3-eaca-4fdc-b7e7-6b5419ca7eee
+      - req-218e5c51-2298-421c-9f4a-0caf43c95f18
       Date:
-      - Thu, 25 Oct 2018 18:22:27 GMT
+      - Thu, 01 Nov 2018 18:30:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -2497,7 +2497,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:27 GMT
+  recorded_at: Thu, 01 Nov 2018 18:30:48 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52//os-quota-sets/88ae57d444fd485ab2dfddd5a2615d52
@@ -2512,7 +2512,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d76a653d8e4441508612294af96ce283
+      - a7e72dfbdd7849359bde7e944e5fa25a
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2525,9 +2525,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-20d186aa-c540-4875-aeff-51d7871002c7
+      - req-7f924e6a-c02e-46a2-bf7c-1f754a7a56e8
       Date:
-      - Thu, 25 Oct 2018 18:22:27 GMT
+      - Thu, 01 Nov 2018 18:30:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -2536,7 +2536,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:27 GMT
+  recorded_at: Thu, 01 Nov 2018 18:30:48 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/d09cbe26295d47ff848ea73c74264e23//os-quota-sets/d09cbe26295d47ff848ea73c74264e23
@@ -2551,7 +2551,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4b5704090f3442449577f7b2f60d6f80
+      - 0b0b82a05e0e41c288ce01a3a6fda514
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2564,9 +2564,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-4e40ee5a-9e6e-442f-a0d1-1534befa9d11
+      - req-e4ba00ec-f952-4aba-8924-03096621b09a
       Date:
-      - Thu, 25 Oct 2018 18:22:27 GMT
+      - Thu, 01 Nov 2018 18:30:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -2575,7 +2575,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:27 GMT
+  recorded_at: Thu, 01 Nov 2018 18:30:49 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/ef2a3405d1ef4dfd9a3616993ef46a4d//os-quota-sets/ef2a3405d1ef4dfd9a3616993ef46a4d
@@ -2590,7 +2590,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1446d2cfcd0149d18b6e1e3db7ee0fb7
+      - abb7d9a9d7e842ddbc76e7a32f7910cd
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2603,9 +2603,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-89c2d1a6-f021-4010-bcd5-021366a1022b
+      - req-4de8e276-bd48-476f-81d5-e14837cc9830
       Date:
-      - Thu, 25 Oct 2018 18:22:27 GMT
+      - Thu, 01 Nov 2018 18:30:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -2614,7 +2614,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:27 GMT
+  recorded_at: Thu, 01 Nov 2018 18:30:49 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -2632,15 +2632,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:22:27 GMT
+      - Thu, 01 Nov 2018 18:30:49 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 668f838b9a62404c96c56b87ef49fc39
+      - c4b503de4595481e98bb81264d94788a
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-c094a232-cc39-4bd1-8ec8-99e64452a4ec
+      - req-4081bb38-bbe1-46cb-b6a8-633b3ee946d2
       Content-Length:
       - '7278'
       Connection:
@@ -2652,7 +2652,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:22:27.982329Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:30:49.312600Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -2731,10 +2731,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Zyrzmbl6ToablfslGQ6a-Q"],
-        "issued_at": "2018-10-25T18:22:27.982351Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["w7aZZKzyRhKAa00MZIdT-g"],
+        "issued_at": "2018-11-01T18:30:49.312621Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:28 GMT
+  recorded_at: Thu, 01 Nov 2018 18:30:49 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3//os-quota-sets/0098405163cd4c9dbb42c2cb43eb6fd3
@@ -2749,22 +2749,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 668f838b9a62404c96c56b87ef49fc39
+      - c4b503de4595481e98bb81264d94788a
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-38c63bf0-3385-4817-acf1-2601575e56fc
+      - req-022eb091-6850-4f8a-9e0c-9096133f1ace
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-38c63bf0-3385-4817-acf1-2601575e56fc
+      - req-022eb091-6850-4f8a-9e0c-9096133f1ace
       Date:
-      - Thu, 25 Oct 2018 18:22:28 GMT
+      - Thu, 01 Nov 2018 18:30:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -2774,7 +2774,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "0098405163cd4c9dbb42c2cb43eb6fd3"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:28 GMT
+  recorded_at: Thu, 01 Nov 2018 18:30:49 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -2792,15 +2792,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:22:28 GMT
+      - Thu, 01 Nov 2018 18:30:49 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - eef6fdf6077c4aaaa3aad31601c30bb4
+      - f94f8bceebd5414a87e01a5750184792
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-af992878-b252-4a19-83c5-88bac901ddb7
+      - req-02963c4d-e24f-4b88-9283-e17793d5a9fd
       Content-Length:
       - '7278'
       Connection:
@@ -2812,7 +2812,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:22:28.538832Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:30:49.798599Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -2891,10 +2891,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["GMXp7GjrTSurg3akMorIJw"],
-        "issued_at": "2018-10-25T18:22:28.538853Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["K7tJ5TYGQdSCcy2hff4o4w"],
+        "issued_at": "2018-11-01T18:30:49.798617Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:28 GMT
+  recorded_at: Thu, 01 Nov 2018 18:30:49 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74//os-quota-sets/28db8f69ba9e4305b7fad82da4c86e74
@@ -2909,22 +2909,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - eef6fdf6077c4aaaa3aad31601c30bb4
+      - f94f8bceebd5414a87e01a5750184792
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-5e39e15b-e0a8-47ab-9270-b94d330f3403
+      - req-e3c908b4-fb9a-4c55-bda3-c4c3991aa465
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-5e39e15b-e0a8-47ab-9270-b94d330f3403
+      - req-e3c908b4-fb9a-4c55-bda3-c4c3991aa465
       Date:
-      - Thu, 25 Oct 2018 18:22:28 GMT
+      - Thu, 01 Nov 2018 18:30:50 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -2934,7 +2934,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "28db8f69ba9e4305b7fad82da4c86e74"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:28 GMT
+  recorded_at: Thu, 01 Nov 2018 18:30:50 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -2952,15 +2952,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:22:28 GMT
+      - Thu, 01 Nov 2018 18:30:50 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - bc8408788a264c4cb365378037c36b8d
+      - d23c47d5f83740fc9832222e5a61c5f7
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-8deb6f30-2d80-463e-ab20-6e497abe7309
+      - req-2859e358-8391-4bff-9f12-26d6d57c4991
       Content-Length:
       - '7264'
       Connection:
@@ -2972,7 +2972,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:22:29.030756Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:30:50.261289Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -3051,10 +3051,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["nI0tWavETde5n1oCJM5Yaw"],
-        "issued_at": "2018-10-25T18:22:29.030794Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["gEhvPQ7PRm6561qqDGrD5A"],
+        "issued_at": "2018-11-01T18:30:50.261310Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:29 GMT
+  recorded_at: Thu, 01 Nov 2018 18:30:50 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91//os-quota-sets/4637c33fee924ebea81f8d209e452c91
@@ -3069,22 +3069,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bc8408788a264c4cb365378037c36b8d
+      - d23c47d5f83740fc9832222e5a61c5f7
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-95ec3e03-b53a-4e77-9a59-64735cab9467
+      - req-4f15b53f-adf2-4ad0-aa4c-75d6d0fe68b8
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-95ec3e03-b53a-4e77-9a59-64735cab9467
+      - req-4f15b53f-adf2-4ad0-aa4c-75d6d0fe68b8
       Date:
-      - Thu, 25 Oct 2018 18:22:29 GMT
+      - Thu, 01 Nov 2018 18:30:50 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -3094,7 +3094,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "4637c33fee924ebea81f8d209e452c91"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:29 GMT
+  recorded_at: Thu, 01 Nov 2018 18:30:50 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -3112,15 +3112,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:22:29 GMT
+      - Thu, 01 Nov 2018 18:30:50 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - db662ad583834974918c01f7f15b44a7
+      - 6bb76858429d451ea80d447747563028
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-a9dd501b-bdbc-4773-a7c7-32312b4f477a
+      - req-49e61e38-f100-4974-b5fc-d8b0eba1fcb7
       Content-Length:
       - '7278'
       Connection:
@@ -3132,7 +3132,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:22:29.507612Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:30:50.795806Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -3211,10 +3211,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["-fYJqvBnQkOBJkJRnh-i-Q"],
-        "issued_at": "2018-10-25T18:22:29.507632Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["zWHAN0WFQMSq6vJNaiWGIw"],
+        "issued_at": "2018-11-01T18:30:50.795831Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:29 GMT
+  recorded_at: Thu, 01 Nov 2018 18:30:50 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5//os-quota-sets/52c452d7763a4295950527948232a3e5
@@ -3229,22 +3229,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - db662ad583834974918c01f7f15b44a7
+      - 6bb76858429d451ea80d447747563028
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-27a06c1c-0b4d-4f99-b126-b0f7e38bee6c
+      - req-6f5ca37a-72c9-4669-aaa1-770e58991306
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-27a06c1c-0b4d-4f99-b126-b0f7e38bee6c
+      - req-6f5ca37a-72c9-4669-aaa1-770e58991306
       Date:
-      - Thu, 25 Oct 2018 18:22:29 GMT
+      - Thu, 01 Nov 2018 18:30:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -3254,7 +3254,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "52c452d7763a4295950527948232a3e5"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:29 GMT
+  recorded_at: Thu, 01 Nov 2018 18:30:51 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52//os-quota-sets/88ae57d444fd485ab2dfddd5a2615d52
@@ -3269,22 +3269,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a1b4e66dd577428086a09243c0307fa4
+      - af87d2f2fdcb499fa2b5c0a07bbcd2ee
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-03d3bdd3-7e97-4522-959b-67fab1bd012c
+      - req-bf5ebd08-56d1-4450-81da-99d944503c93
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-03d3bdd3-7e97-4522-959b-67fab1bd012c
+      - req-bf5ebd08-56d1-4450-81da-99d944503c93
       Date:
-      - Thu, 25 Oct 2018 18:22:30 GMT
+      - Thu, 01 Nov 2018 18:30:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -3294,7 +3294,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "88ae57d444fd485ab2dfddd5a2615d52"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:30 GMT
+  recorded_at: Thu, 01 Nov 2018 18:30:51 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -3312,15 +3312,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:22:30 GMT
+      - Thu, 01 Nov 2018 18:30:51 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - a9032f2af86248b69dc3957df2069bb0
+      - 86c58b82d2ef4ae3b0455a395e8ede67
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-c2125637-395d-4ab6-8b75-f2e53a73ce20
+      - req-ab08650a-b1d0-44e6-92a3-6de5fdf852c3
       Content-Length:
       - '7265'
       Connection:
@@ -3332,7 +3332,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:22:30.265007Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:30:51.649247Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -3411,10 +3411,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["cePaKZXpRJ6nIi12CDRwtg"],
-        "issued_at": "2018-10-25T18:22:30.265029Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["DoVIWOe-RbKR4ShB4TwSog"],
+        "issued_at": "2018-11-01T18:30:51.649268Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:30 GMT
+  recorded_at: Thu, 01 Nov 2018 18:30:51 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23//os-quota-sets/d09cbe26295d47ff848ea73c74264e23
@@ -3429,22 +3429,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a9032f2af86248b69dc3957df2069bb0
+      - 86c58b82d2ef4ae3b0455a395e8ede67
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-fe90600b-2902-4882-a268-59f7c8b6748c
+      - req-03f90f00-4d06-47e1-9e5f-9ec25f663be6
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-fe90600b-2902-4882-a268-59f7c8b6748c
+      - req-03f90f00-4d06-47e1-9e5f-9ec25f663be6
       Date:
-      - Thu, 25 Oct 2018 18:22:30 GMT
+      - Thu, 01 Nov 2018 18:30:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -3454,7 +3454,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "d09cbe26295d47ff848ea73c74264e23"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:30 GMT
+  recorded_at: Thu, 01 Nov 2018 18:30:51 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -3472,15 +3472,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:22:30 GMT
+      - Thu, 01 Nov 2018 18:30:52 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 62ef31a2548941e8aff76f3334a72006
+      - 8886b159c935401ba9b40432a729c795
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-3968602c-8d7c-4a2a-ae03-bf34b9be8aec
+      - req-441c469c-33e3-4981-ae13-161427774c90
       Content-Length:
       - '7278'
       Connection:
@@ -3492,7 +3492,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:22:30.725358Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:30:52.135782Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -3571,10 +3571,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["O4zLOCyIQ82RvNKckvJhFg"],
-        "issued_at": "2018-10-25T18:22:30.725377Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["4SofpKtiSQyFSXp_nzeUDw"],
+        "issued_at": "2018-11-01T18:30:52.135804Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:30 GMT
+  recorded_at: Thu, 01 Nov 2018 18:30:52 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d//os-quota-sets/ef2a3405d1ef4dfd9a3616993ef46a4d
@@ -3589,22 +3589,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 62ef31a2548941e8aff76f3334a72006
+      - 8886b159c935401ba9b40432a729c795
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-9eaf0290-4bb5-4835-92bd-47c205eb3308
+      - req-c01b2427-0d08-43b6-9f19-256658119c08
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-9eaf0290-4bb5-4835-92bd-47c205eb3308
+      - req-c01b2427-0d08-43b6-9f19-256658119c08
       Date:
-      - Thu, 25 Oct 2018 18:22:31 GMT
+      - Thu, 01 Nov 2018 18:30:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -3614,7 +3614,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:31 GMT
+  recorded_at: Thu, 01 Nov 2018 18:30:52 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -3632,15 +3632,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:22:31 GMT
+      - Thu, 01 Nov 2018 18:30:52 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 3aa9c5a323a14e9ca44467a8502b46de
+      - 89dd82204d194c7f9df0e96cc775ea87
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-e5862bd0-45cf-4349-a5f6-3856506be84b
+      - req-47dffe70-eccb-4aa1-be8e-eb5c4950d894
       Content-Length:
       - '7278'
       Connection:
@@ -3652,7 +3652,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:22:31.212393Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:30:52.616005Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -3731,10 +3731,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["bnN6ytMVR_a1rJDgfNTBrA"],
-        "issued_at": "2018-10-25T18:22:31.212415Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["WT9pfz57Th2_MDZH5rViUQ"],
+        "issued_at": "2018-11-01T18:30:52.616026Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:31 GMT
+  recorded_at: Thu, 01 Nov 2018 18:30:52 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/0098405163cd4c9dbb42c2cb43eb6fd3
@@ -3749,7 +3749,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3aa9c5a323a14e9ca44467a8502b46de
+      - 89dd82204d194c7f9df0e96cc775ea87
   response:
     status:
       code: 200
@@ -3760,16 +3760,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-56e7775d-e3b5-4e7c-9828-56f25272824e
+      - req-c06db335-f87a-4b91-8039-3f526bf09aec
       Date:
-      - Thu, 25 Oct 2018 18:22:31 GMT
+      - Thu, 01 Nov 2018 18:30:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:31 GMT
+  recorded_at: Thu, 01 Nov 2018 18:30:52 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -3787,15 +3787,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:22:31 GMT
+      - Thu, 01 Nov 2018 18:30:52 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - e9089c1246334756885e9ce3dd46cd29
+      - 519cb58d6db44e079d4ed4b6fdaa945a
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-54e826ca-66c4-45a0-a93d-b7e2226a7424
+      - req-e790bbf8-8c66-41a4-95b8-0bf0ffd5c72a
       Content-Length:
       - '7278'
       Connection:
@@ -3807,7 +3807,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:22:31.523000Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:30:52.939876Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -3886,10 +3886,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["3_FSSiwUTG6MShhvE2_cFw"],
-        "issued_at": "2018-10-25T18:22:31.523021Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["rRH8eTMaS4qH-umArjNtng"],
+        "issued_at": "2018-11-01T18:30:52.939898Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:31 GMT
+  recorded_at: Thu, 01 Nov 2018 18:30:52 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/28db8f69ba9e4305b7fad82da4c86e74
@@ -3904,7 +3904,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e9089c1246334756885e9ce3dd46cd29
+      - 519cb58d6db44e079d4ed4b6fdaa945a
   response:
     status:
       code: 200
@@ -3915,16 +3915,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-ee51deb4-80ac-4d18-b5da-96a6504cb7a2
+      - req-4df7ca17-981d-40fd-b82e-8a832d82afc1
       Date:
-      - Thu, 25 Oct 2018 18:22:31 GMT
+      - Thu, 01 Nov 2018 18:30:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:31 GMT
+  recorded_at: Thu, 01 Nov 2018 18:30:53 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -3942,15 +3942,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:22:31 GMT
+      - Thu, 01 Nov 2018 18:30:53 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 65a87cdeaf364b41b1b0da85ae353c41
+      - 78513d3a3ffe4c02b5cf0f8a1c4868cb
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-7ac7d7e7-3abe-4906-8eee-2706854195ef
+      - req-a7162f10-67d8-4159-a6f2-bdd1105cb5a5
       Content-Length:
       - '7264'
       Connection:
@@ -3962,7 +3962,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:22:31.835476Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:30:53.273361Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -4041,10 +4041,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Ha8BpZWhRiC3QhrnoamhjA"],
-        "issued_at": "2018-10-25T18:22:31.835497Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["jrjd-DHYRFqy5AG7_09_ig"],
+        "issued_at": "2018-11-01T18:30:53.273383Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:31 GMT
+  recorded_at: Thu, 01 Nov 2018 18:30:53 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/4637c33fee924ebea81f8d209e452c91
@@ -4059,7 +4059,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 65a87cdeaf364b41b1b0da85ae353c41
+      - 78513d3a3ffe4c02b5cf0f8a1c4868cb
   response:
     status:
       code: 200
@@ -4070,16 +4070,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-77e6004c-ff24-46b8-9e4a-65ff137161ea
+      - req-2deba14f-99a2-4bfb-a388-c4a75f91eeb1
       Date:
-      - Thu, 25 Oct 2018 18:22:31 GMT
+      - Thu, 01 Nov 2018 18:30:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 20, "network": 20, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:31 GMT
+  recorded_at: Thu, 01 Nov 2018 18:30:53 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -4097,15 +4097,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:22:32 GMT
+      - Thu, 01 Nov 2018 18:30:53 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 3683d8f0ac6f46b78ee5f8bd5b032d73
+      - f5e848844fcc47f7b3aee8d841362058
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-62de84f3-1a9b-4b9b-9067-096616a5c519
+      - req-031ff213-01e0-491d-93b6-6c711f6c71c0
       Content-Length:
       - '7278'
       Connection:
@@ -4117,7 +4117,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:22:32.148323Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:30:53.600256Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -4196,10 +4196,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["mRIbFfKiSvu8ZUF95jRThA"],
-        "issued_at": "2018-10-25T18:22:32.148343Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["LM3Zf1zqT2-_mc86q9URAw"],
+        "issued_at": "2018-11-01T18:30:53.600277Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:32 GMT
+  recorded_at: Thu, 01 Nov 2018 18:30:53 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/52c452d7763a4295950527948232a3e5
@@ -4214,7 +4214,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3683d8f0ac6f46b78ee5f8bd5b032d73
+      - f5e848844fcc47f7b3aee8d841362058
   response:
     status:
       code: 200
@@ -4225,16 +4225,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-bc545e17-aac4-4ab2-9a75-0caa7b04aaf3
+      - req-32c1bea4-505d-4f6a-9500-013c377034e7
       Date:
-      - Thu, 25 Oct 2018 18:22:32 GMT
+      - Thu, 01 Nov 2018 18:30:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:32 GMT
+  recorded_at: Thu, 01 Nov 2018 18:30:53 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/88ae57d444fd485ab2dfddd5a2615d52
@@ -4249,7 +4249,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 91fcf3848c964188815a274cb6062deb
+      - 65d16c672d53490597eb75387b64dcd4
   response:
     status:
       code: 200
@@ -4260,16 +4260,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-b2f6d236-6700-4d7e-b448-4cff47f9382d
+      - req-2f915b97-7f51-483a-9c15-a3af2061c702
       Date:
-      - Thu, 25 Oct 2018 18:22:32 GMT
+      - Thu, 01 Nov 2018 18:30:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:32 GMT
+  recorded_at: Thu, 01 Nov 2018 18:30:53 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -4287,15 +4287,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:22:32 GMT
+      - Thu, 01 Nov 2018 18:30:53 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 8a10d8753ae94feeb9299ed94106b12b
+      - 13b7aeb88237456cb7603f1c6affbd45
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-18698374-f990-4481-8a64-49513b6a7f9a
+      - req-cf8044d7-5890-4582-853b-5e8066f9d4dc
       Content-Length:
       - '7265'
       Connection:
@@ -4307,7 +4307,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:22:32.822465Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:30:54.042913Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -4386,10 +4386,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["A9PBO1mKTmiwM7bdjF-Wqg"],
-        "issued_at": "2018-10-25T18:22:32.822497Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["j0v6K2PJQ0ONmPlu4zJr5Q"],
+        "issued_at": "2018-11-01T18:30:54.042934Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:32 GMT
+  recorded_at: Thu, 01 Nov 2018 18:30:54 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/d09cbe26295d47ff848ea73c74264e23
@@ -4404,7 +4404,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8a10d8753ae94feeb9299ed94106b12b
+      - 13b7aeb88237456cb7603f1c6affbd45
   response:
     status:
       code: 200
@@ -4415,16 +4415,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-5a44abe5-ab11-48ae-bd1f-753b0ad28a04
+      - req-96900193-9866-4764-9b77-bbcc6092da67
       Date:
-      - Thu, 25 Oct 2018 18:22:32 GMT
+      - Thu, 01 Nov 2018 18:30:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:32 GMT
+  recorded_at: Thu, 01 Nov 2018 18:30:54 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -4442,15 +4442,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:22:33 GMT
+      - Thu, 01 Nov 2018 18:30:54 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 7b36ed44ac2b4da58e47edf879eac0f5
+      - '08ad1e5adec44c62ba214b9d02ea1481'
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-a5481ee6-f2fd-4c56-8f00-7664086b1c30
+      - req-b4f2906f-7a47-43fc-889d-f2f6005036c6
       Content-Length:
       - '7278'
       Connection:
@@ -4462,7 +4462,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:22:33.150362Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:30:54.375192Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -4541,10 +4541,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["0EVi8H5TTh-gSmq0u_Pxuw"],
-        "issued_at": "2018-10-25T18:22:33.150380Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["1e88icNTQYaWkSnp1DU0xg"],
+        "issued_at": "2018-11-01T18:30:54.375213Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:33 GMT
+  recorded_at: Thu, 01 Nov 2018 18:30:54 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/ef2a3405d1ef4dfd9a3616993ef46a4d
@@ -4559,7 +4559,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7b36ed44ac2b4da58e47edf879eac0f5
+      - '08ad1e5adec44c62ba214b9d02ea1481'
   response:
     status:
       code: 200
@@ -4570,16 +4570,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-18c54d1a-333e-4732-ab0c-62fa6344132d
+      - req-259d9a74-2998-4e36-a693-3963aecbe843
       Date:
-      - Thu, 25 Oct 2018 18:22:33 GMT
+      - Thu, 01 Nov 2018 18:30:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:33 GMT
+  recorded_at: Thu, 01 Nov 2018 18:30:54 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-keypairs?all_tenants=True&limit=1000
@@ -4594,7 +4594,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d76a653d8e4441508612294af96ce283
+      - a7e72dfbdd7849359bde7e944e5fa25a
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4607,9 +4607,9 @@ http_interactions:
       Content-Length:
       - '1611'
       X-Compute-Request-Id:
-      - req-981e0bc4-e50f-49fb-9343-b772aa45f64a
+      - req-bb68af00-bc50-4349-962b-5b4936eb64c8
       Date:
-      - Thu, 25 Oct 2018 18:22:33 GMT
+      - Thu, 01 Nov 2018 18:30:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKQyhM0ECmYmB8mI4vfeTEaY90skgHYgA/5apgT+cHhKzZX59Go+LGfb98dOCYEjnV3XKdO5dy7MrSdI5QSvGJmJIQPsH4WZNpRNuEhHzcHS1fEPe9zMceRlLafkTeUKhUGMIi1gOmBRdyZtz6fJw37AK6ioM4+16IhXjNVLV09jHn2PsUjh2RsGX5TzA3eHivptzINBD8eMBkyQwS2uejY42FlIg9qBpa8KEMgyo4KLvd/99kw9wLg1D9Y5+3OxA/J6hLfjSBv7Vd7Xvwd4ZmDlkU5+yH88b2ZOte8MyfAnlVA4v8bMdSsAf1e5NvUuZsoZC8goZCHjXmTDSI+yen
@@ -4619,7 +4619,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:33 GMT
+  recorded_at: Thu, 01 Nov 2018 18:30:54 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-keypairs?all_tenants=True&limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -4634,7 +4634,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d76a653d8e4441508612294af96ce283
+      - a7e72dfbdd7849359bde7e944e5fa25a
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4647,9 +4647,9 @@ http_interactions:
       Content-Length:
       - '1611'
       X-Compute-Request-Id:
-      - req-82e924f8-39ce-4163-8ad9-1ad8e11d0438
+      - req-0b679783-ed8c-43d0-9e19-14a442df0500
       Date:
-      - Thu, 25 Oct 2018 18:22:33 GMT
+      - Thu, 01 Nov 2018 18:30:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKQyhM0ECmYmB8mI4vfeTEaY90skgHYgA/5apgT+cHhKzZX59Go+LGfb98dOCYEjnV3XKdO5dy7MrSdI5QSvGJmJIQPsH4WZNpRNuEhHzcHS1fEPe9zMceRlLafkTeUKhUGMIi1gOmBRdyZtz6fJw37AK6ioM4+16IhXjNVLV09jHn2PsUjh2RsGX5TzA3eHivptzINBD8eMBkyQwS2uejY42FlIg9qBpa8KEMgyo4KLvd/99kw9wLg1D9Y5+3OxA/J6hLfjSBv7Vd7Xvwd4ZmDlkU5+yH88b2ZOte8MyfAnlVA4v8bMdSsAf1e5NvUuZsoZC8goZCHjXmTDSI+yen
@@ -4659,7 +4659,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:33 GMT
+  recorded_at: Thu, 01 Nov 2018 18:30:54 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -4677,15 +4677,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:22:33 GMT
+      - Thu, 01 Nov 2018 18:30:54 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 8d4b3cc8453b4c95b188a5fafe710698
+      - '084a89bdc7d64e0e9810be483538dd78'
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-a6415c29-797e-4cab-8680-8332581c0e43
+      - req-34d27336-3921-4216-9db7-f28408133da5
       Content-Length:
       - '7278'
       Connection:
@@ -4697,7 +4697,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:22:33.931345Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:30:54.893037Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -4776,10 +4776,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["QeX_jqdmTYuLYftFlwB3Ug"],
-        "issued_at": "2018-10-25T18:22:33.931365Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["ck7H6WB2TnipF8dTVFEyvQ"],
+        "issued_at": "2018-11-01T18:30:54.893058Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:33 GMT
+  recorded_at: Thu, 01 Nov 2018 18:30:54 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/0098405163cd4c9dbb42c2cb43eb6fd3/stacks?limit=1000&show_nested=true
@@ -4794,7 +4794,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8d4b3cc8453b4c95b188a5fafe710698
+      - '084a89bdc7d64e0e9810be483538dd78'
   response:
     status:
       code: 200
@@ -4805,14 +4805,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-8296632f-56b8-486a-a43a-daf08cd00961
+      - req-85ffc035-2701-469e-a5f7-fa5ac4d6cc8c
       Date:
-      - Thu, 25 Oct 2018 18:22:34 GMT
+      - Thu, 01 Nov 2018 18:30:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:34 GMT
+  recorded_at: Thu, 01 Nov 2018 18:30:55 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -4830,15 +4830,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:22:34 GMT
+      - Thu, 01 Nov 2018 18:30:55 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - fd18cf0716cf493d9b3fb7d979dd4703
+      - bebf8f14f24f4af58fea91889165bbe3
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-cbf10c39-4036-4052-84ba-c2f0e582de54
+      - req-326ceb22-996d-408e-8560-9720c45dd6d3
       Content-Length:
       - '7278'
       Connection:
@@ -4850,7 +4850,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:22:34.382680Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:30:55.237041Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -4929,10 +4929,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["mfXO-KZuRkyfPxKUYyvmVg"],
-        "issued_at": "2018-10-25T18:22:34.382701Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["23uQH6sxSm-N4-iPvMtXsQ"],
+        "issued_at": "2018-11-01T18:30:55.237063Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:34 GMT
+  recorded_at: Thu, 01 Nov 2018 18:30:55 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/28db8f69ba9e4305b7fad82da4c86e74/stacks?limit=1000&show_nested=true
@@ -4947,7 +4947,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fd18cf0716cf493d9b3fb7d979dd4703
+      - bebf8f14f24f4af58fea91889165bbe3
   response:
     status:
       code: 200
@@ -4958,14 +4958,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-afa9590b-b171-49b2-b099-c7fda43ec7da
+      - req-f6fcf475-fba7-46e5-9b3b-b7445d670e1b
       Date:
-      - Thu, 25 Oct 2018 18:22:34 GMT
+      - Thu, 01 Nov 2018 18:30:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:34 GMT
+  recorded_at: Thu, 01 Nov 2018 18:30:55 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -4983,15 +4983,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:22:34 GMT
+      - Thu, 01 Nov 2018 18:30:55 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - c062937adb0840a79341ccb1379d179a
+      - 2be788ef303246cbaf40b143433f7b9b
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-75cb29eb-ebb4-4fd0-84e2-219eb2be491e
+      - req-cb97df2b-ef17-4463-a3a4-321a104faddf
       Content-Length:
       - '7264'
       Connection:
@@ -5003,7 +5003,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:22:34.727508Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:30:55.965910Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -5082,10 +5082,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["UmP_QVFlTGaV8aYj2U3mYQ"],
-        "issued_at": "2018-10-25T18:22:34.727529Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["BjKaFZPZTKua4h9D35VqLg"],
+        "issued_at": "2018-11-01T18:30:55.965932Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:34 GMT
+  recorded_at: Thu, 01 Nov 2018 18:30:55 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks?limit=1000&show_nested=true
@@ -5100,7 +5100,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c062937adb0840a79341ccb1379d179a
+      - 2be788ef303246cbaf40b143433f7b9b
   response:
     status:
       code: 200
@@ -5111,9 +5111,9 @@ http_interactions:
       Content-Length:
       - '2559'
       X-Openstack-Request-Id:
-      - req-0ae81d2f-eb8e-4287-aa94-361c2a153210
+      - req-793d3fc3-9b2c-48b2-9520-b63c01f7459b
       Date:
-      - Thu, 25 Oct 2018 18:22:34 GMT
+      - Thu, 01 Nov 2018 18:30:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": [{"description": "Heat WordPress template to support F20,
@@ -5147,7 +5147,7 @@ http_interactions:
         "rel": "self"}], "updated_time": null, "stack_owner": null, "stack_status":
         "CREATE_COMPLETE", "id": "7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:34 GMT
+  recorded_at: Thu, 01 Nov 2018 18:30:56 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks?limit=1000&marker=7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0&show_nested=true
@@ -5162,7 +5162,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c062937adb0840a79341ccb1379d179a
+      - 2be788ef303246cbaf40b143433f7b9b
   response:
     status:
       code: 200
@@ -5173,14 +5173,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-9e144d8f-95f2-44d3-8520-d7549b481145
+      - req-bbfa81eb-636a-4ed1-8fdf-493c9c6bc73b
       Date:
-      - Thu, 25 Oct 2018 18:22:35 GMT
+      - Thu, 01 Nov 2018 18:30:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:35 GMT
+  recorded_at: Thu, 01 Nov 2018 18:30:56 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -5198,15 +5198,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:22:35 GMT
+      - Thu, 01 Nov 2018 18:30:56 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 59ebe0cb67004dff95508d37289fa923
+      - 31a66ee081514b189361f0238b2ec7db
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-df2f5772-f3e0-4b63-ba8a-b63aafe1d705
+      - req-41a133ad-8b15-4da4-ad29-a52b0d021e6b
       Content-Length:
       - '7278'
       Connection:
@@ -5218,7 +5218,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:22:35.208685Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:30:56.487946Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -5297,10 +5297,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["hs9ZlmGTSbC6skik1BcuTA"],
-        "issued_at": "2018-10-25T18:22:35.208706Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Mos6-0HdSFyCD8zgwrEIcg"],
+        "issued_at": "2018-11-01T18:30:56.487972Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:35 GMT
+  recorded_at: Thu, 01 Nov 2018 18:30:56 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/52c452d7763a4295950527948232a3e5/stacks?limit=1000&show_nested=true
@@ -5315,7 +5315,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 59ebe0cb67004dff95508d37289fa923
+      - 31a66ee081514b189361f0238b2ec7db
   response:
     status:
       code: 200
@@ -5326,14 +5326,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-ebb4c259-9df9-4217-bb21-2af040f61e30
+      - req-ff57d823-f974-48e2-b132-cd6e60c05ba6
       Date:
-      - Thu, 25 Oct 2018 18:22:35 GMT
+      - Thu, 01 Nov 2018 18:30:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:35 GMT
+  recorded_at: Thu, 01 Nov 2018 18:30:56 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/88ae57d444fd485ab2dfddd5a2615d52/stacks?limit=1000&show_nested=true
@@ -5348,7 +5348,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1ca552d7955a475cb4e5ad6ab71b445a
+      - 525f9444b6b94752a1d1f510957407a6
   response:
     status:
       code: 200
@@ -5359,14 +5359,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-971e4d47-22b6-41c5-a7dc-3c82785e0902
+      - req-37c9ef14-93ce-440d-bcf5-f51393e0f5aa
       Date:
-      - Thu, 25 Oct 2018 18:22:35 GMT
+      - Thu, 01 Nov 2018 18:30:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:35 GMT
+  recorded_at: Thu, 01 Nov 2018 18:30:56 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -5384,15 +5384,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:22:35 GMT
+      - Thu, 01 Nov 2018 18:30:56 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - d22ab4befc924627a86a313bd78347f0
+      - 0da32ba864d04c63a9ba930f8c8ae885
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-3346a57e-8749-42f5-9535-d002de340cb2
+      - req-04e2724c-b69f-4ff1-90dc-bebf4ead46a5
       Content-Length:
       - '7265'
       Connection:
@@ -5404,7 +5404,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:22:35.654168Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:30:56.943291Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -5483,10 +5483,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["d4qqBQOLQw--TTsl6KeurQ"],
-        "issued_at": "2018-10-25T18:22:35.654191Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["iYKFz61jS4WqtCKSLQPYlQ"],
+        "issued_at": "2018-11-01T18:30:56.943311Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:35 GMT
+  recorded_at: Thu, 01 Nov 2018 18:30:56 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/d09cbe26295d47ff848ea73c74264e23/stacks?limit=1000&show_nested=true
@@ -5501,7 +5501,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d22ab4befc924627a86a313bd78347f0
+      - 0da32ba864d04c63a9ba930f8c8ae885
   response:
     status:
       code: 200
@@ -5512,14 +5512,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-48d5f5ac-6223-4fa2-b411-29fc761916f1
+      - req-4fd87608-169d-498d-a9f4-37b4bfd39c1e
       Date:
-      - Thu, 25 Oct 2018 18:22:35 GMT
+      - Thu, 01 Nov 2018 18:30:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:35 GMT
+  recorded_at: Thu, 01 Nov 2018 18:30:57 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -5537,15 +5537,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:22:35 GMT
+      - Thu, 01 Nov 2018 18:30:57 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 220c3a2ae4384cd7a229e27c914e3593
+      - 3dc4f4e749e74bc586bceed49b6de446
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-17a49c25-270a-4ee3-95cf-51e2420772cb
+      - req-d33ce5f0-bf9b-4146-828f-ce0e5a701cee
       Content-Length:
       - '7278'
       Connection:
@@ -5557,7 +5557,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:22:35.980734Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:30:57.274065Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -5636,10 +5636,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Sgp8hJg5RByQoxTlhUgMWQ"],
-        "issued_at": "2018-10-25T18:22:35.980755Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["x3Lkr99MQtid4sYYgALWwA"],
+        "issued_at": "2018-11-01T18:30:57.274086Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:36 GMT
+  recorded_at: Thu, 01 Nov 2018 18:30:57 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/ef2a3405d1ef4dfd9a3616993ef46a4d/stacks?limit=1000&show_nested=true
@@ -5654,7 +5654,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 220c3a2ae4384cd7a229e27c914e3593
+      - 3dc4f4e749e74bc586bceed49b6de446
   response:
     status:
       code: 200
@@ -5665,14 +5665,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-61b322b5-c907-46be-8197-e011233f5b6d
+      - req-d064665c-7921-4bd0-92e2-eaf1820d8d9e
       Date:
-      - Thu, 25 Oct 2018 18:22:36 GMT
+      - Thu, 01 Nov 2018 18:30:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:36 GMT
+  recorded_at: Thu, 01 Nov 2018 18:30:57 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack3/00c5dc04-2c94-48d2-8031-db08934e9a44
@@ -5687,7 +5687,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c062937adb0840a79341ccb1379d179a
+      - 2be788ef303246cbaf40b143433f7b9b
   response:
     status:
       code: 200
@@ -5698,9 +5698,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-8649f54d-86a9-4dbf-aca6-26197365df44
+      - req-139b6bbd-260f-4d1a-891f-3fd4e2afe5a6
       Date:
-      - Thu, 25 Oct 2018 18:22:37 GMT
+      - Thu, 01 Nov 2018 18:30:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -5727,7 +5727,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:37 GMT
+  recorded_at: Thu, 01 Nov 2018 18:30:57 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack2/d6eba2a2-7b0d-4213-afbb-69c8f6dddd8d
@@ -5742,7 +5742,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c062937adb0840a79341ccb1379d179a
+      - 2be788ef303246cbaf40b143433f7b9b
   response:
     status:
       code: 200
@@ -5753,9 +5753,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-e9711200-b5e3-4e55-90cf-59c23b2d761f
+      - req-c0fa5485-512c-4bd1-be73-a8c55c5904ae
       Date:
-      - Thu, 25 Oct 2018 18:22:38 GMT
+      - Thu, 01 Nov 2018 18:30:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -5782,7 +5782,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:38 GMT
+  recorded_at: Thu, 01 Nov 2018 18:30:58 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack1/7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0
@@ -5797,7 +5797,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c062937adb0840a79341ccb1379d179a
+      - 2be788ef303246cbaf40b143433f7b9b
   response:
     status:
       code: 200
@@ -5808,9 +5808,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-8bad15cc-eceb-47fd-9d38-74026241ae56
+      - req-841d6c16-108f-43ca-a8fc-c160455bf761
       Date:
-      - Thu, 25 Oct 2018 18:22:38 GMT
+      - Thu, 01 Nov 2018 18:30:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -5837,7 +5837,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:38 GMT
+  recorded_at: Thu, 01 Nov 2018 18:30:58 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack3/00c5dc04-2c94-48d2-8031-db08934e9a44/resources
@@ -5852,7 +5852,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c062937adb0840a79341ccb1379d179a
+      - 2be788ef303246cbaf40b143433f7b9b
   response:
     status:
       code: 200
@@ -5863,9 +5863,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-735de1bb-7559-484e-ac76-3fc583806c0d
+      - req-4ce0aa8c-51b7-48ff-ae2f-8026be4930e0
       Date:
-      - Thu, 25 Oct 2018 18:22:38 GMT
+      - Thu, 01 Nov 2018 18:30:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -5877,7 +5877,7 @@ http_interactions:
         changed", "physical_resource_id": "40989f26-9c38-4f72-b739-afccb44397cf",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:38 GMT
+  recorded_at: Thu, 01 Nov 2018 18:30:58 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack3/00c5dc04-2c94-48d2-8031-db08934e9a44/template
@@ -5892,7 +5892,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c062937adb0840a79341ccb1379d179a
+      - 2be788ef303246cbaf40b143433f7b9b
   response:
     status:
       code: 200
@@ -5903,9 +5903,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-293a3ed3-0cb5-40af-84bd-7a52dc9304ff
+      - req-0344115e-18e9-4377-bfbc-be3d9467d666
       Date:
-      - Thu, 25 Oct 2018 18:22:38 GMT
+      - Thu, 01 Nov 2018 18:30:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -5961,7 +5961,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:38 GMT
+  recorded_at: Thu, 01 Nov 2018 18:30:58 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack2/d6eba2a2-7b0d-4213-afbb-69c8f6dddd8d/resources
@@ -5976,7 +5976,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c062937adb0840a79341ccb1379d179a
+      - 2be788ef303246cbaf40b143433f7b9b
   response:
     status:
       code: 200
@@ -5987,9 +5987,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-4aadbe6d-8d7e-4c05-86f6-3aa219ebac8f
+      - req-9574f5e1-d38b-4837-8f39-048556ce9f63
       Date:
-      - Thu, 25 Oct 2018 18:22:39 GMT
+      - Thu, 01 Nov 2018 18:30:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -6001,7 +6001,7 @@ http_interactions:
         changed", "physical_resource_id": "ad4f7eb0-9122-41a6-a0f7-55c1d4ca5e02",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:39 GMT
+  recorded_at: Thu, 01 Nov 2018 18:30:58 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack2/d6eba2a2-7b0d-4213-afbb-69c8f6dddd8d/template
@@ -6016,7 +6016,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c062937adb0840a79341ccb1379d179a
+      - 2be788ef303246cbaf40b143433f7b9b
   response:
     status:
       code: 200
@@ -6027,9 +6027,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-8c7e6fdf-48c8-427a-82d1-6ccdcc51c852
+      - req-b6f1975b-4620-4f8a-96cd-71ddaede7244
       Date:
-      - Thu, 25 Oct 2018 18:22:39 GMT
+      - Thu, 01 Nov 2018 18:30:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -6085,7 +6085,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:39 GMT
+  recorded_at: Thu, 01 Nov 2018 18:30:58 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack1/7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0/resources
@@ -6100,7 +6100,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c062937adb0840a79341ccb1379d179a
+      - 2be788ef303246cbaf40b143433f7b9b
   response:
     status:
       code: 200
@@ -6111,9 +6111,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-1dc901c7-a24f-4eea-8aea-021270424702
+      - req-a36bd732-3774-4417-8267-8bd638300537
       Date:
-      - Thu, 25 Oct 2018 18:22:39 GMT
+      - Thu, 01 Nov 2018 18:30:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -6125,7 +6125,7 @@ http_interactions:
         changed", "physical_resource_id": "8022b967-813a-4e3b-8ff4-7c036957a8a0",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:39 GMT
+  recorded_at: Thu, 01 Nov 2018 18:30:58 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack1/7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0/template
@@ -6140,7 +6140,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c062937adb0840a79341ccb1379d179a
+      - 2be788ef303246cbaf40b143433f7b9b
   response:
     status:
       code: 200
@@ -6151,9 +6151,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-fc8bae3a-9134-4c7e-a38d-b4aa5ea06af6
+      - req-72995e8f-7f06-4b04-a713-bd63ba44cbaf
       Date:
-      - Thu, 25 Oct 2018 18:22:39 GMT
+      - Thu, 01 Nov 2018 18:30:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -6209,7 +6209,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:39 GMT
+  recorded_at: Thu, 01 Nov 2018 18:30:59 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images?all_tenants=True&limit=1000
@@ -6224,7 +6224,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 36b6f29c59bf47458d04bf115e27e853
+      - 7cafec443b2443c5bfde5bcda2370a8d
   response:
     status:
       code: 200
@@ -6235,14 +6235,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-1d48d881-36a4-4fcd-8967-c659ab7d80d6
+      - req-d50e4e21-713c-4b52-b19d-6efc7aa81c49
       Date:
-      - Thu, 25 Oct 2018 18:22:39 GMT
+      - Thu, 01 Nov 2018 18:30:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000&all_tenants=True"}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:39 GMT
+  recorded_at: Thu, 01 Nov 2018 18:30:59 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images
@@ -6257,7 +6257,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 36b6f29c59bf47458d04bf115e27e853
+      - 7cafec443b2443c5bfde5bcda2370a8d
   response:
     status:
       code: 200
@@ -6268,9 +6268,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-86f389ee-0210-4bb5-a36a-4c7859be456e
+      - req-3f016d3d-45e7-4954-8c37-f57d1ed305b6
       Date:
-      - Thu, 25 Oct 2018 18:22:39 GMT
+      - Thu, 01 Nov 2018 18:30:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -6312,7 +6312,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images"}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:39 GMT
+  recorded_at: Thu, 01 Nov 2018 18:30:59 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images/f17ed5a2-4e34-4140-a634-0d56b2e564b5/members
@@ -6327,7 +6327,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 36b6f29c59bf47458d04bf115e27e853
+      - 7cafec443b2443c5bfde5bcda2370a8d
   response:
     status:
       code: 200
@@ -6338,14 +6338,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-d94b9c32-1956-4f45-b618-76f364f6a0a2
+      - req-1c3f7bd1-01ad-46b7-a276-816742375182
       Date:
-      - Thu, 25 Oct 2018 18:22:39 GMT
+      - Thu, 01 Nov 2018 18:30:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"members": [], "schema": "/v2/schemas/members"}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:39 GMT
+  recorded_at: Thu, 01 Nov 2018 18:30:59 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images/afa19b9e-6375-431a-9ef0-07723a338c64/members
@@ -6360,7 +6360,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 36b6f29c59bf47458d04bf115e27e853
+      - 7cafec443b2443c5bfde5bcda2370a8d
   response:
     status:
       code: 200
@@ -6371,14 +6371,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-a6ff63f2-a677-4d68-94a2-ed335cdaa9f4
+      - req-6df9156b-993e-4e7c-9881-4551cecc6e97
       Date:
-      - Thu, 25 Oct 2018 18:22:39 GMT
+      - Thu, 01 Nov 2018 18:30:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"members": [], "schema": "/v2/schemas/members"}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:39 GMT
+  recorded_at: Thu, 01 Nov 2018 18:30:59 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images/f5a1950f-a8e8-4485-9e51-a49ee40ae42e/members
@@ -6393,7 +6393,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 36b6f29c59bf47458d04bf115e27e853
+      - 7cafec443b2443c5bfde5bcda2370a8d
   response:
     status:
       code: 200
@@ -6404,14 +6404,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-b379ab04-cfe3-42be-9d56-25af41360d35
+      - req-b0bdb285-025e-46b8-b27e-8a25a90c7cee
       Date:
-      - Thu, 25 Oct 2018 18:22:39 GMT
+      - Thu, 01 Nov 2018 18:30:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"members": [], "schema": "/v2/schemas/members"}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:39 GMT
+  recorded_at: Thu, 01 Nov 2018 18:30:59 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images/b672acdb-654b-41d7-963c-44a0349bd285/members
@@ -6426,7 +6426,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 36b6f29c59bf47458d04bf115e27e853
+      - 7cafec443b2443c5bfde5bcda2370a8d
   response:
     status:
       code: 200
@@ -6437,14 +6437,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-24e5adf9-d73b-4f34-96ab-983b815c83ca
+      - req-3b546dbc-7b1f-40db-812f-1179340ef637
       Date:
-      - Thu, 25 Oct 2018 18:22:40 GMT
+      - Thu, 01 Nov 2018 18:30:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"members": [], "schema": "/v2/schemas/members"}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:40 GMT
+  recorded_at: Thu, 01 Nov 2018 18:30:59 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?all_tenants=True&limit=1000
@@ -6459,7 +6459,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d76a653d8e4441508612294af96ce283
+      - a7e72dfbdd7849359bde7e944e5fa25a
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6472,9 +6472,9 @@ http_interactions:
       Content-Length:
       - '3998'
       X-Compute-Request-Id:
-      - req-bbd74793-ca60-4208-ab06-34f2de4ff372
+      - req-1a7a9b8a-528b-4a1b-8b91-087bdd3aa8d8
       Date:
-      - Thu, 25 Oct 2018 18:22:40 GMT
+      - Thu, 01 Nov 2018 18:31:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?all_tenants=True&limit=1000&marker=43f23d3a-fe8d-4bbb-9d23-fe1c437c7813",
@@ -6520,7 +6520,7 @@ http_interactions:
         [], "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:40 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:00 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?all_tenants=True&limit=1000&marker=43f23d3a-fe8d-4bbb-9d23-fe1c437c7813
@@ -6535,7 +6535,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d76a653d8e4441508612294af96ce283
+      - a7e72dfbdd7849359bde7e944e5fa25a
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6548,9 +6548,9 @@ http_interactions:
       Content-Length:
       - '4062'
       X-Compute-Request-Id:
-      - req-b5340773-833b-46ba-9ab0-1525d218db31
+      - req-5d118c24-13fc-4a22-abac-41ed4f72f582
       Date:
-      - Thu, 25 Oct 2018 18:22:40 GMT
+      - Thu, 01 Nov 2018 18:31:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?all_tenants=True&limit=1000&marker=5d121f19-3e04-4743-8ed7-c5dfaa6ef71f",
@@ -6596,7 +6596,7 @@ http_interactions:
         [], "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 3, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:40 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:00 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?all_tenants=True&limit=1000&marker=5d121f19-3e04-4743-8ed7-c5dfaa6ef71f
@@ -6611,7 +6611,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d76a653d8e4441508612294af96ce283
+      - a7e72dfbdd7849359bde7e944e5fa25a
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6624,9 +6624,9 @@ http_interactions:
       Content-Length:
       - '4144'
       X-Compute-Request-Id:
-      - req-168c184f-c2e7-498c-8ebf-0c1fe77147e9
+      - req-26087ae3-aa68-4952-adbb-36d48ac05d4d
       Date:
-      - Thu, 25 Oct 2018 18:22:40 GMT
+      - Thu, 01 Nov 2018 18:31:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?all_tenants=True&limit=1000&marker=7edb7855-d974-4e45-8ad2-88491541ab91",
@@ -6674,7 +6674,7 @@ http_interactions:
         "", "progress": 0, "OS-EXT-STS:power_state": 1, "config_drive": "", "metadata":
         {}}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:40 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:00 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?all_tenants=True&limit=1000&marker=7edb7855-d974-4e45-8ad2-88491541ab91
@@ -6689,7 +6689,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d76a653d8e4441508612294af96ce283
+      - a7e72dfbdd7849359bde7e944e5fa25a
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6702,9 +6702,9 @@ http_interactions:
       Content-Length:
       - '3813'
       X-Compute-Request-Id:
-      - req-afbacc6f-1f0a-44a9-9e3d-b09d00b9ff03
+      - req-cff9695a-8e14-4f69-b75b-5dd0b4f36cfa
       Date:
-      - Thu, 25 Oct 2018 18:22:41 GMT
+      - Thu, 01 Nov 2018 18:31:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?all_tenants=True&limit=1000&marker=ad4f7eb0-9122-41a6-a0f7-55c1d4ca5e02",
@@ -6746,7 +6746,7 @@ http_interactions:
         "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:41 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:00 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?all_tenants=True&limit=1000&marker=ad4f7eb0-9122-41a6-a0f7-55c1d4ca5e02
@@ -6761,7 +6761,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d76a653d8e4441508612294af96ce283
+      - a7e72dfbdd7849359bde7e944e5fa25a
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6774,9 +6774,9 @@ http_interactions:
       Content-Length:
       - '1816'
       X-Compute-Request-Id:
-      - req-6dc77e40-b2af-4a0f-95ed-22a8a8b708fd
+      - req-ab63d18e-3bde-470b-ac98-f7fe918300b0
       Date:
-      - Thu, 25 Oct 2018 18:22:41 GMT
+      - Thu, 01 Nov 2018 18:31:01 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": [{"status": "SHUTOFF", "updated": "2017-05-22T16:01:49Z",
@@ -6799,7 +6799,7 @@ http_interactions:
         "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:41 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:01 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-floating-ips
@@ -6814,7 +6814,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d76a653d8e4441508612294af96ce283
+      - a7e72dfbdd7849359bde7e944e5fa25a
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6827,14 +6827,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-2ebae9cc-635b-441e-8e2b-0fbe4689fe98
+      - req-c82bff20-6739-4f29-86c7-d44790c2f535
       Date:
-      - Thu, 25 Oct 2018 18:22:41 GMT
+      - Thu, 01 Nov 2018 18:31:01 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:41 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:01 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-floating-ips
@@ -6849,7 +6849,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d76a653d8e4441508612294af96ce283
+      - a7e72dfbdd7849359bde7e944e5fa25a
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6862,14 +6862,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-13e0877a-836c-48fd-9154-c9cde202f1ae
+      - req-6e29b476-4f78-42e5-925b-355a8a417181
       Date:
-      - Thu, 25 Oct 2018 18:22:41 GMT
+      - Thu, 01 Nov 2018 18:31:01 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:41 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:01 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-floating-ips
@@ -6884,7 +6884,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d76a653d8e4441508612294af96ce283
+      - a7e72dfbdd7849359bde7e944e5fa25a
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6897,14 +6897,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-1ab76fee-f7a3-4000-bcf7-7bf4907a2f09
+      - req-214197bc-d35d-4f5a-bc64-e270a987c464
       Date:
-      - Thu, 25 Oct 2018 18:22:41 GMT
+      - Thu, 01 Nov 2018 18:31:01 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:41 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:01 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-floating-ips
@@ -6919,7 +6919,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d76a653d8e4441508612294af96ce283
+      - a7e72dfbdd7849359bde7e944e5fa25a
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6932,14 +6932,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-7b48047e-ac74-4090-a57a-296c3145cf3f
+      - req-5f2fadcb-f80f-4333-b581-500003905b99
       Date:
-      - Thu, 25 Oct 2018 18:22:41 GMT
+      - Thu, 01 Nov 2018 18:31:01 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:41 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:01 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-floating-ips
@@ -6954,7 +6954,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d76a653d8e4441508612294af96ce283
+      - a7e72dfbdd7849359bde7e944e5fa25a
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6967,14 +6967,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-49e2489d-562b-4532-9549-7e633bb366ff
+      - req-3c8308a6-798d-471f-b976-0f4e7a5d8a56
       Date:
-      - Thu, 25 Oct 2018 18:22:42 GMT
+      - Thu, 01 Nov 2018 18:31:01 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:42 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:01 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-floating-ips
@@ -6989,7 +6989,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d76a653d8e4441508612294af96ce283
+      - a7e72dfbdd7849359bde7e944e5fa25a
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -7002,14 +7002,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-d2bf32f1-df1f-494a-9350-074bfbc69640
+      - req-716b3fca-431d-42f5-9010-fc57acae4534
       Date:
-      - Thu, 25 Oct 2018 18:22:42 GMT
+      - Thu, 01 Nov 2018 18:31:01 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:42 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:02 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-floating-ips
@@ -7024,7 +7024,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d76a653d8e4441508612294af96ce283
+      - a7e72dfbdd7849359bde7e944e5fa25a
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -7037,14 +7037,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-30c71f63-fc9b-4847-88e4-1ac6aaa5dbde
+      - req-b9abcb61-c3e3-4cc6-9b2d-5b5ce86e958a
       Date:
-      - Thu, 25 Oct 2018 18:22:42 GMT
+      - Thu, 01 Nov 2018 18:31:02 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:42 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:02 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-floating-ips
@@ -7059,7 +7059,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d76a653d8e4441508612294af96ce283
+      - a7e72dfbdd7849359bde7e944e5fa25a
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -7072,14 +7072,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-f3282bfb-65d0-488e-bfe1-b8fc4b1eb663
+      - req-0f367442-afff-4a5c-9383-01cb69132dd2
       Date:
-      - Thu, 25 Oct 2018 18:22:42 GMT
+      - Thu, 01 Nov 2018 18:31:02 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:42 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:02 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-floating-ips
@@ -7094,7 +7094,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d76a653d8e4441508612294af96ce283
+      - a7e72dfbdd7849359bde7e944e5fa25a
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -7107,14 +7107,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-67c2212d-e033-4703-a6b1-10d13443982b
+      - req-4976660f-19d5-4012-857d-a2ae6cdafb20
       Date:
-      - Thu, 25 Oct 2018 18:22:42 GMT
+      - Thu, 01 Nov 2018 18:31:02 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:42 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:02 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-services?all_tenants=True&limit=1000
@@ -7129,7 +7129,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d76a653d8e4441508612294af96ce283
+      - a7e72dfbdd7849359bde7e944e5fa25a
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -7142,26 +7142,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-295971be-734a-45d2-8af7-bec2f3b6c2c5
+      - req-391dae30-ead7-49a6-86dd-02b3a3e1e113
       Date:
-      - Thu, 25 Oct 2018 18:22:42 GMT
+      - Thu, 01 Nov 2018 18:31:02 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-10-25T18:22:34.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-11-01T18:30:53.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-10-25T18:22:40.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-11-01T18:30:55.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-10-25T18:22:33.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-11-01T18:31:01.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 5, "updated_at":
-        "2018-10-25T18:22:35.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-11-01T18:30:53.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-10-25T18:22:36.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-11-01T18:30:54.000000"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:42 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:02 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-services?all_tenants=True&limit=1000&marker=6
@@ -7176,7 +7176,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d76a653d8e4441508612294af96ce283
+      - a7e72dfbdd7849359bde7e944e5fa25a
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -7189,26 +7189,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-23de3684-1b06-4dbf-9f05-782390fa968b
+      - req-1e19e1c8-986c-4a4d-8226-4af6bdc66bef
       Date:
-      - Thu, 25 Oct 2018 18:22:42 GMT
+      - Thu, 01 Nov 2018 18:31:02 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-10-25T18:22:34.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-11-01T18:30:53.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-10-25T18:22:40.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-11-01T18:30:55.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-10-25T18:22:33.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-11-01T18:31:01.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 5, "updated_at":
-        "2018-10-25T18:22:35.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-11-01T18:30:53.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-10-25T18:22:36.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-11-01T18:30:54.000000"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:42 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:02 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -7226,15 +7226,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:22:44 GMT
+      - Thu, 01 Nov 2018 18:31:07 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 7e427e3c954e418e9b1f03635c863990
+      - 0af1e83d96e3472c8f68b8c09ce8dc8b
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-3c6f648f-5378-47c0-864c-ef87e88ef87d
+      - req-a707ce9a-2597-4428-95ae-e881eb8781c4
       Content-Length:
       - '7311'
       Connection:
@@ -7246,7 +7246,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-10-25T19:22:44.168940Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-11-01T19:31:07.400041Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -7325,10 +7325,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["kZPczLYAQGGlV-8rf-rwfA"],
-        "issued_at": "2018-10-25T18:22:44.168971Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["9iSmLi91RVaMv54sOlu0tQ"],
+        "issued_at": "2018-11-01T18:31:07.400061Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:44 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:07 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -7346,15 +7346,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:22:44 GMT
+      - Thu, 01 Nov 2018 18:31:07 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - d2027c3ea4e64c3a8a1fa2d1362f1fa7
+      - 1cca3c198be045b18c72c82fea92b24c
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-485353f1-279b-4e99-a557-f98abf5bf73e
+      - req-9ee6a835-c5ea-4f75-9718-00559a10c38d
       Content-Length:
       - '7311'
       Connection:
@@ -7366,7 +7366,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-10-25T19:22:44.375877Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-11-01T19:31:07.610555Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -7445,10 +7445,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["DZ4ryE8rQTyT7aSTpii6fQ"],
-        "issued_at": "2018-10-25T18:22:44.375897Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["gfEG_5F3QXG59avnF5a74w"],
+        "issued_at": "2018-11-01T18:31:07.610575Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:44 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:07 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000
@@ -7463,7 +7463,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d2027c3ea4e64c3a8a1fa2d1362f1fa7
+      - 1cca3c198be045b18c72c82fea92b24c
   response:
     status:
       code: 200
@@ -7474,9 +7474,9 @@ http_interactions:
       Content-Length:
       - '2751'
       X-Openstack-Request-Id:
-      - req-b86409c7-4243-4537-919f-a24ef1db27c2
+      - req-17175238-31c0-40ef-b30c-c85d6fa934a6
       Date:
-      - Thu, 25 Oct 2018 18:22:44 GMT
+      - Thu, 01 Nov 2018 18:31:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=2e57d382-aeb2-4107-85cd-9dbde325f8f7",
@@ -7511,7 +7511,7 @@ http_interactions:
         null, "port_range_min": null, "id": "7e354503-9d45-4cc4-a742-4ff9501ba396",
         "security_group_id": "2e57d382-aeb2-4107-85cd-9dbde325f8f7"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:44 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:07 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=2e57d382-aeb2-4107-85cd-9dbde325f8f7
@@ -7526,7 +7526,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d2027c3ea4e64c3a8a1fa2d1362f1fa7
+      - 1cca3c198be045b18c72c82fea92b24c
   response:
     status:
       code: 200
@@ -7537,9 +7537,9 @@ http_interactions:
       Content-Length:
       - '3418'
       X-Openstack-Request-Id:
-      - req-214e3439-ed85-4443-b7f0-0af6e18a32eb
+      - req-b8dc5e0c-6c21-463a-b4a5-c951d230cf5e
       Date:
-      - Thu, 25 Oct 2018 18:22:44 GMT
+      - Thu, 01 Nov 2018 18:31:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=42bcab35-fe98-49f3-ba0e-705a2737b81d",
@@ -7582,7 +7582,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "f87c3733-0682-46d9-8df1-05f1207541d1",
         "security_group_id": "42bcab35-fe98-49f3-ba0e-705a2737b81d"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:44 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:07 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=42bcab35-fe98-49f3-ba0e-705a2737b81d
@@ -7597,7 +7597,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d2027c3ea4e64c3a8a1fa2d1362f1fa7
+      - 1cca3c198be045b18c72c82fea92b24c
   response:
     status:
       code: 200
@@ -7608,9 +7608,9 @@ http_interactions:
       Content-Length:
       - '3418'
       X-Openstack-Request-Id:
-      - req-bc978f8a-0c5b-4df7-8112-5699721a1dd8
+      - req-ee58873e-1a0b-4412-b181-1af977afec46
       Date:
-      - Thu, 25 Oct 2018 18:22:44 GMT
+      - Thu, 01 Nov 2018 18:31:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=7250f04f-facd-4731-b072-f346b1cc7a80",
@@ -7653,7 +7653,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "d0ee1562-3ff7-4ad5-b29f-8dd350ed221f",
         "security_group_id": "7250f04f-facd-4731-b072-f346b1cc7a80"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:44 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:08 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=7250f04f-facd-4731-b072-f346b1cc7a80
@@ -7668,7 +7668,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d2027c3ea4e64c3a8a1fa2d1362f1fa7
+      - 1cca3c198be045b18c72c82fea92b24c
   response:
     status:
       code: 200
@@ -7679,9 +7679,9 @@ http_interactions:
       Content-Length:
       - '8771'
       X-Openstack-Request-Id:
-      - req-3553e3f2-405f-4960-aec4-4239beceee6b
+      - req-ca6078b9-3ce4-4f3c-8558-97a1fa26b817
       Date:
-      - Thu, 25 Oct 2018 18:22:44 GMT
+      - Thu, 01 Nov 2018 18:31:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d",
@@ -7788,7 +7788,7 @@ http_interactions:
         "port_range_max": 65535, "port_range_min": 1, "id": "e483857b-5eb5-4cb0-94d6-b431a2f0cb10",
         "security_group_id": "8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:45 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:08 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d
@@ -7803,7 +7803,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d2027c3ea4e64c3a8a1fa2d1362f1fa7
+      - 1cca3c198be045b18c72c82fea92b24c
   response:
     status:
       code: 200
@@ -7814,9 +7814,9 @@ http_interactions:
       Content-Length:
       - '3418'
       X-Openstack-Request-Id:
-      - req-7ac8998c-c9b4-4289-b694-cea032244755
+      - req-eed27b94-40ba-4cc2-b282-7c73a298215a
       Date:
-      - Thu, 25 Oct 2018 18:22:45 GMT
+      - Thu, 01 Nov 2018 18:31:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=bab65d2f-4717-47eb-bfb2-95100b254563",
@@ -7858,7 +7858,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "e1aa03c0-0758-42ca-b030-a3d62800e578",
         "security_group_id": "bab65d2f-4717-47eb-bfb2-95100b254563"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:45 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:08 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=bab65d2f-4717-47eb-bfb2-95100b254563
@@ -7873,7 +7873,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d2027c3ea4e64c3a8a1fa2d1362f1fa7
+      - 1cca3c198be045b18c72c82fea92b24c
   response:
     status:
       code: 200
@@ -7884,15 +7884,15 @@ http_interactions:
       Content-Length:
       - '173'
       X-Openstack-Request-Id:
-      - req-fb279582-9673-4d38-88bc-92c54753388d
+      - req-4f7cba3c-f522-4872-b521-c5b8c1283b2e
       Date:
-      - Thu, 25 Oct 2018 18:22:45 GMT
+      - Thu, 01 Nov 2018 18:31:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&page_reverse=True",
         "rel": "previous"}], "security_groups": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:45 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:08 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/networks
@@ -7907,7 +7907,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d2027c3ea4e64c3a8a1fa2d1362f1fa7
+      - 1cca3c198be045b18c72c82fea92b24c
   response:
     status:
       code: 200
@@ -7918,27 +7918,12 @@ http_interactions:
       Content-Length:
       - '5330'
       X-Openstack-Request-Id:
-      - req-21f7e40a-a85e-4d74-a152-483b1ddcf37d
+      - req-7283bb87-4247-4cca-af40-95b64c3c563f
       Date:
-      - Thu, 25 Oct 2018 18:22:45 GMT
+      - Thu, 01 Nov 2018 18:31:08 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"networks": [{"status": "ACTIVE", "subnets": ["978d38ec-4845-45ce-b3e3-89e7c9d9109b",
-        "9801267c-cd57-437a-a852-b46640cb4332"], "name": "EmsRefreshSpec-IsolatedNetworkPrivate_2",
-        "provider:physical_network": null, "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
-        "vxlan", "id": "483c08c7-96b0-4e08-9db7-96d5650974ac", "provider:segmentation_id":
-        36}, {"status": "ACTIVE", "subnets": ["e96c89d2-810a-4cdb-a19b-93072db5dd20"],
-        "name": "EmsRefreshSpec-NetworkPrivate_3", "provider:physical_network": null,
-        "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
-        0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
-        "id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571", "provider:segmentation_id":
-        99}, {"status": "ACTIVE", "subnets": ["e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d"],
-        "name": "EmsRefreshSpec-NetworkPrivate_20", "provider:physical_network": null,
-        "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
-        0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
-        "id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "provider:segmentation_id":
-        31}, {"status": "ACTIVE", "subnets": ["53450d1a-8ecc-43aa-a641-95db25b6be2e"],
+      string: '{"networks": [{"status": "ACTIVE", "subnets": ["53450d1a-8ecc-43aa-a641-95db25b6be2e"],
         "name": "EmsRefreshSpec-NetworkPublic_40", "provider:physical_network": "public_net_4",
         "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
         0, "router:external": true, "shared": false, "provider:network_type": "flat",
@@ -7978,19 +7963,34 @@ http_interactions:
         "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
         0, "router:external": true, "shared": false, "provider:network_type": "flat",
         "id": "c66145df-4d9d-4898-9e35-12a102b66346", "provider:segmentation_id":
-        null}, {"status": "ACTIVE", "subnets": ["76d851f4-9cd9-49ca-93ac-bcc7b3c8153a"],
+        null}, {"status": "ACTIVE", "subnets": ["9801267c-cd57-437a-a852-b46640cb4332",
+        "978d38ec-4845-45ce-b3e3-89e7c9d9109b"], "name": "EmsRefreshSpec-IsolatedNetworkPrivate_2",
+        "provider:physical_network": null, "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
+        "vxlan", "id": "483c08c7-96b0-4e08-9db7-96d5650974ac", "provider:segmentation_id":
+        36}, {"status": "ACTIVE", "subnets": ["76d851f4-9cd9-49ca-93ac-bcc7b3c8153a"],
         "name": "EmsRefreshSpec-NetworkPublic_20", "provider:physical_network": "public_net_2",
         "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
         0, "router:external": true, "shared": false, "provider:network_type": "flat",
         "id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "provider:segmentation_id":
-        null}, {"status": "ACTIVE", "subnets": ["f4c17602-9618-4604-b3c9-9e4801d094d3",
-        "24c83610-eab6-4f68-99dd-ab22a638b4a0"], "name": "EmsRefreshSpec-NetworkPrivate",
+        null}, {"status": "ACTIVE", "subnets": ["e96c89d2-810a-4cdb-a19b-93072db5dd20"],
+        "name": "EmsRefreshSpec-NetworkPrivate_3", "provider:physical_network": null,
+        "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
+        0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
+        "id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571", "provider:segmentation_id":
+        99}, {"status": "ACTIVE", "subnets": ["e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d"],
+        "name": "EmsRefreshSpec-NetworkPrivate_20", "provider:physical_network": null,
+        "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
+        0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
+        "id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "provider:segmentation_id":
+        31}, {"status": "ACTIVE", "subnets": ["24c83610-eab6-4f68-99dd-ab22a638b4a0",
+        "f4c17602-9618-4604-b3c9-9e4801d094d3"], "name": "EmsRefreshSpec-NetworkPrivate",
         "provider:physical_network": null, "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
         "vxlan", "id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "provider:segmentation_id":
         11}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:45 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:08 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/subnets?all_tenants=True&limit=1000
@@ -8005,7 +8005,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d2027c3ea4e64c3a8a1fa2d1362f1fa7
+      - 1cca3c198be045b18c72c82fea92b24c
   response:
     status:
       code: 200
@@ -8016,74 +8016,28 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-01abb499-1074-453b-b3a5-8308b9b3b21c
+      - req-b97de6ca-f918-460a-93ef-95fc6dfc709a
       Date:
-      - Thu, 25 Oct 2018 18:22:45 GMT
+      - Thu, 01 Nov 2018 18:31:08 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
-        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "9801267c-cd57-437a-a852-b46640cb4332",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
-        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.20.0/24", "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21",
-        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.51.2",
-        "end": "192.168.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.51.0/24", "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
-        true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
-        "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
         "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
         "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
         [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
         "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp": false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49",
+        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e",
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.18.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2",
-        "end": "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
+        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
         false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
@@ -8097,6 +8051,12 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
         [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
         "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.8",
+        "end": "192.168.3.10"}, {"start": "192.168.3.2", "end": "192.168.3.6"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
         "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
@@ -8108,62 +8068,6 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
         "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:45 GMT
-- request:
-    method: get
-    uri: http://10.8.99.206:9696/v2.0/subnets?all_tenants=True&limit=1000&marker=24c83610-eab6-4f68-99dd-ab22a638b4a0
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - d2027c3ea4e64c3a8a1fa2d1362f1fa7
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-2f1a30b0-f369-45bc-8758-a6c5dc02e7f1
-      Date:
-      - Thu, 25 Oct 2018 18:22:45 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.2", "end": "192.168.3.6"}, {"start":
-        "192.168.3.8", "end": "192.168.3.10"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
         "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
@@ -8205,7 +8109,51 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
         "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.8", "end": "192.168.0.8"},
+        {"start": "192.168.0.3", "end": "192.168.0.5"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 01 Nov 2018 18:31:08 GMT
+- request:
+    method: get
+    uri: http://10.8.99.206:9696/v2.0/subnets?all_tenants=True&limit=1000&marker=f4c17602-9618-4604-b3c9-9e4801d094d3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 1cca3c198be045b18c72c82fea92b24c
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-5dd8862e-4966-4646-925c-b651439e9b5a
+      Date:
+      - Thu, 01 Nov 2018 18:31:08 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
         "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
@@ -8235,25 +8183,78 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
         [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
         "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.8",
+        "end": "192.168.3.10"}, {"start": "192.168.3.2", "end": "192.168.3.6"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
         "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
         "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
+        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
+        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.8", "end": "192.168.0.8"},
+        {"start": "192.168.0.3", "end": "192.168.0.5"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
         null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}]}'
+        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:45 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:08 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/routers?all_tenants=True&limit=1000
@@ -8268,7 +8269,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d2027c3ea4e64c3a8a1fa2d1362f1fa7
+      - 1cca3c198be045b18c72c82fea92b24c
   response:
     status:
       code: 200
@@ -8279,9 +8280,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-efe445a8-b7eb-477d-81fa-002fc18dadbc
+      - req-c51bf5f0-d459-48b6-908d-cc3c9969018c
       Date:
-      - Thu, 25 Oct 2018 18:22:45 GMT
+      - Thu, 01 Nov 2018 18:31:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -8313,7 +8314,7 @@ http_interactions:
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:45 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:08 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/routers?all_tenants=True&limit=1000&marker=e49f1a18-9fd8-4130-9e9f-f13b5190f9fd
@@ -8328,7 +8329,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d2027c3ea4e64c3a8a1fa2d1362f1fa7
+      - 1cca3c198be045b18c72c82fea92b24c
   response:
     status:
       code: 200
@@ -8339,9 +8340,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-3bee337d-1a21-477a-950e-65fd05bf5167
+      - req-2eb4a251-6db1-4500-87b9-13bb7b9fb71d
       Date:
-      - Thu, 25 Oct 2018 18:22:45 GMT
+      - Thu, 01 Nov 2018 18:31:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -8373,7 +8374,7 @@ http_interactions:
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:45 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:09 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/ports?all_tenants=True&limit=1000
@@ -8388,7 +8389,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d2027c3ea4e64c3a8a1fa2d1362f1fa7
+      - 1cca3c198be045b18c72c82fea92b24c
   response:
     status:
       code: 200
@@ -8399,9 +8400,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-0f50908d-be0f-48de-8248-ffe334de22fc
+      - req-0594bca3-15d2-4b1c-890b-69b0a3ab8610
       Date:
-      - Thu, 25 Oct 2018 18:22:46 GMT
+      - Thu, 01 Nov 2018 18:31:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -8804,7 +8805,7 @@ http_interactions:
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:46 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:09 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/ports?all_tenants=True&limit=1000&marker=fb9152f8-5f19-4171-9b8e-f1e594c24d64
@@ -8819,7 +8820,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d2027c3ea4e64c3a8a1fa2d1362f1fa7
+      - 1cca3c198be045b18c72c82fea92b24c
   response:
     status:
       code: 200
@@ -8830,9 +8831,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-b619d89e-f4d4-4be4-b015-f440d7e1605b
+      - req-78f0e88e-67c1-4c5f-a250-0f2254adc504
       Date:
-      - Thu, 25 Oct 2018 18:22:46 GMT
+      - Thu, 01 Nov 2018 18:31:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -9235,7 +9236,7 @@ http_interactions:
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:46 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:09 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/floatingips?all_tenants=True&limit=1000
@@ -9250,7 +9251,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d2027c3ea4e64c3a8a1fa2d1362f1fa7
+      - 1cca3c198be045b18c72c82fea92b24c
   response:
     status:
       code: 200
@@ -9261,9 +9262,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-97cfd14e-1514-435b-add1-6e7ebcf2598b
+      - req-116e1b5a-840b-48e4-8c70-5fda6a0a2fa2
       Date:
-      - Thu, 25 Oct 2018 18:22:46 GMT
+      - Thu, 01 Nov 2018 18:31:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
@@ -9305,7 +9306,7 @@ http_interactions:
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:46 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:09 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/floatingips?all_tenants=True&limit=1000&marker=e5a4a7fd-b2c7-4a38-b725-a666d4f90f60
@@ -9320,7 +9321,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d2027c3ea4e64c3a8a1fa2d1362f1fa7
+      - 1cca3c198be045b18c72c82fea92b24c
   response:
     status:
       code: 200
@@ -9331,9 +9332,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-7d853ebc-e23c-4641-bef3-322b82e56bdc
+      - req-2141af69-00c9-4ffb-af37-3412439e7326
       Date:
-      - Thu, 25 Oct 2018 18:22:46 GMT
+      - Thu, 01 Nov 2018 18:31:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
@@ -9375,7 +9376,7 @@ http_interactions:
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:46 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:09 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -9393,15 +9394,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:22:47 GMT
+      - Thu, 01 Nov 2018 18:31:11 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 03f6b128b4a046bb9c4242031c6e6dc6
+      - a262b28bb4f04f2dbd532fe293fd6da5
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-520b7328-50dd-4185-8bd4-f4039021b20c
+      - req-895186d4-072d-416f-b647-81ef606b3ee3
       Content-Length:
       - '7311'
       Connection:
@@ -9413,7 +9414,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-10-25T19:22:47.288504Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-11-01T19:31:11.178198Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -9492,10 +9493,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["kHFyS_glScuRaFS8YSufjw"],
-        "issued_at": "2018-10-25T18:22:47.288524Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["r2HSEc4CSVC6BohULZ-C5g"],
+        "issued_at": "2018-11-01T18:31:11.178219Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:47 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:11 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -9513,15 +9514,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:22:47 GMT
+      - Thu, 01 Nov 2018 18:31:11 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - c5a7911dde30482ab43ddb64b6f8e000
+      - b8d5c2ca31c44c84bee1eef274366d54
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-1017d03a-94ec-41d2-93b8-e405bc7ff5a0
+      - req-4e6eee3d-6e77-4c34-adcd-58647eebc669
       Content-Length:
       - '7311'
       Connection:
@@ -9533,7 +9534,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-10-25T19:22:47.485294Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-11-01T19:31:11.385634Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -9612,10 +9613,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["snFA1v0PRyufudMw9nMuFg"],
-        "issued_at": "2018-10-25T18:22:47.485315Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["cnstaJdTQqmGuoOBKfiqUA"],
+        "issued_at": "2018-11-01T18:31:11.385654Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:47 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:11 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -9633,15 +9634,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:22:47 GMT
+      - Thu, 01 Nov 2018 18:31:11 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 967dc97408fb4a2b9a0248a76834af41
+      - 781874a7f43a49bfbcc0a3fe4fbd159c
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-972ec8ae-b44e-4b2b-a907-6dbdfcb1329e
+      - req-b764b4d9-e046-48e2-91e0-a94e51e639ef
       Content-Length:
       - '297'
       Connection:
@@ -9650,12 +9651,12 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"token": {"methods": ["password"], "expires_at": "2018-10-25T19:22:47.652002Z",
+      string: '{"token": {"methods": ["password"], "expires_at": "2018-11-01T19:31:11.566546Z",
         "extras": {}, "user": {"domain": {"id": "default", "name": "Default"}, "id":
-        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["w3OBZCXMT0aK3CzDkdAmQQ"],
-        "issued_at": "2018-10-25T18:22:47.652023Z"}}'
+        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["0v0hz09PSRqdVqTzrfhbQQ"],
+        "issued_at": "2018-11-01T18:31:11.566565Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:47 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:11 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects?domain_id=default
@@ -9670,20 +9671,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 967dc97408fb4a2b9a0248a76834af41
+      - 781874a7f43a49bfbcc0a3fe4fbd159c
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:22:47 GMT
+      - Thu, 01 Nov 2018 18:31:11 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-bea0eb7c-b551-4bb2-9887-f2f868219b6f
+      - req-03b1a772-7128-47fe-8ebc-cddb4968592f
       Content-Length:
       - '2475'
       Connection:
@@ -9716,7 +9717,7 @@ http_interactions:
         "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
         "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:47 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:11 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -9734,15 +9735,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:22:47 GMT
+      - Thu, 01 Nov 2018 18:31:11 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 465b88062e7e45ac97db3ce8f1fd56b0
+      - 63af1107c1e540b39ea9a20962e6f7da
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-69f68b5c-c24c-4686-9dfb-2dbe055bc923
+      - req-f0962b3b-0595-4ca3-a9dd-9b16e00334d6
       Content-Length:
       - '7278'
       Connection:
@@ -9754,7 +9755,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:22:47.977968Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:31:11.922116Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -9833,10 +9834,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["zyLpNmFBRH-xkOjeL7rS5Q"],
-        "issued_at": "2018-10-25T18:22:47.977993Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["qqo3mKpRQvmqRoAIN4Epvw"],
+        "issued_at": "2018-11-01T18:31:11.922137Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:48 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:11 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -9854,15 +9855,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:22:48 GMT
+      - Thu, 01 Nov 2018 18:31:12 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 1a1919b2284041f782d71ebf4e46d3b7
+      - 1e93c252b11f4197a88215ab1a323806
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-ce3049d3-85c1-4dec-9a16-35f652b4fbee
+      - req-9df692a0-2463-422e-b2bf-fb8072906fa4
       Content-Length:
       - '7278'
       Connection:
@@ -9874,7 +9875,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:22:48.179186Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:31:12.137397Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -9953,10 +9954,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["_YXRyAgYShWzIKAPS1HEfA"],
-        "issued_at": "2018-10-25T18:22:48.179207Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["gjTidmy0SAiuCMy1_scWYA"],
+        "issued_at": "2018-11-01T18:31:12.137423Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:48 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:12 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -9974,15 +9975,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:22:48 GMT
+      - Thu, 01 Nov 2018 18:31:12 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 45b78f07fe8a4b50a16c301e23622ce7
+      - 826f94c7314b4fec9a550f0f0fa5108d
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-a6b7d563-f1f6-4b8c-9c4b-f7d8481c2fc1
+      - req-91ebc090-fdea-4bd7-b1ca-b12cf32083bc
       Content-Length:
       - '7264'
       Connection:
@@ -9994,7 +9995,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:22:48.379124Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:31:12.348648Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -10073,10 +10074,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["3e4SJxTsTG6jOQlGELb9UA"],
-        "issued_at": "2018-10-25T18:22:48.379144Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["-F398eUgQte7dXxSlmooqQ"],
+        "issued_at": "2018-11-01T18:31:12.348668Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:48 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:12 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -10094,15 +10095,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:22:48 GMT
+      - Thu, 01 Nov 2018 18:31:12 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - ee2616ba7dfd4c34a8b21fb0b65fd743
+      - f477a2e1793c4b029e00345c3e9ea4cd
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-20721b7a-088e-499e-bfe8-c11f707c8251
+      - req-38d78749-92ef-4615-b72b-56c6fb1f4b70
       Content-Length:
       - '7278'
       Connection:
@@ -10114,7 +10115,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:22:48.576585Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:31:12.563987Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -10193,10 +10194,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["KCKVLGn1RIiCSjKg-ypAlQ"],
-        "issued_at": "2018-10-25T18:22:48.576605Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["gmzB4sgPQxWuwm2l208qBQ"],
+        "issued_at": "2018-11-01T18:31:12.564010Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:48 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:12 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -10214,15 +10215,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:22:48 GMT
+      - Thu, 01 Nov 2018 18:31:12 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - d73f94041c1647ee8a965906d3cef602
+      - bbe6990136fd4ddab871a97eb4160a4d
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-700c0b05-04f5-446e-9461-8d235129cc57
+      - req-ce241493-5bb5-4659-bae4-564db8d309b5
       Content-Length:
       - '7265'
       Connection:
@@ -10234,7 +10235,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:22:48.772997Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:31:12.770643Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -10313,10 +10314,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["nHdYH0_MTiKD6Ds4EyrbGw"],
-        "issued_at": "2018-10-25T18:22:48.773016Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["JpA58w-oSlmK2i_hkPlrCA"],
+        "issued_at": "2018-11-01T18:31:12.770663Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:48 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:12 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -10334,15 +10335,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:22:48 GMT
+      - Thu, 01 Nov 2018 18:31:12 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - d572af06df1e4835819c400fb4158997
+      - ad1718f830254f4bb915cec16e23facb
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-cf486589-439a-4ea7-833b-7b6ff5619b60
+      - req-ffef7123-1604-48e5-8279-6b8656b8f309
       Content-Length:
       - '7278'
       Connection:
@@ -10354,7 +10355,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:22:48.995980Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:31:13.004826Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -10433,10 +10434,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["pUOd6e8uTT6pArpZwHaJWQ"],
-        "issued_at": "2018-10-25T18:22:48.996006Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["GvKW5pOWQ2O6_kj2ILmImQ"],
+        "issued_at": "2018-11-01T18:31:13.004845Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:49 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:13 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -10454,15 +10455,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:22:49 GMT
+      - Thu, 01 Nov 2018 18:31:13 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - b3f59ad033b1499ca257cd30eca7708c
+      - e80a7b4cb2e04b7bb5d74cfd0625fb80
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-bfd534a6-ee9c-47ee-a6fd-0a5699abbd2e
+      - req-b81c0ac4-40b1-41b9-bed8-0c8337b46492
       Content-Length:
       - '7278'
       Connection:
@@ -10474,7 +10475,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:22:49.211228Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:31:13.218326Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -10553,10 +10554,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["hnBSrRqiQ5qUhJra33bYVg"],
-        "issued_at": "2018-10-25T18:22:49.211248Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["EhjurTdUQe-ENXQgN-Chhg"],
+        "issued_at": "2018-11-01T18:31:13.218344Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:49 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:13 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/volumes/detail?limit=1000
@@ -10571,27 +10572,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b3f59ad033b1499ca257cd30eca7708c
+      - e80a7b4cb2e04b7bb5d74cfd0625fb80
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-bbf52ee9-e3f3-40a0-b8fa-4779070085e5
+      - req-0eca2690-8c90-484c-8374-fbd47a3aa2d5
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-bbf52ee9-e3f3-40a0-b8fa-4779070085e5
+      - req-0eca2690-8c90-484c-8374-fbd47a3aa2d5
       Date:
-      - Thu, 25 Oct 2018 18:22:49 GMT
+      - Thu, 01 Nov 2018 18:31:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:49 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:13 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -10609,15 +10610,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:22:49 GMT
+      - Thu, 01 Nov 2018 18:31:13 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 9b2757c7af3b48b0b61126ed274f796f
+      - bf9918219b594a82b357f4f5d1373aaa
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-f674b7ea-72d6-4ba0-9c63-a5f7a2695b6b
+      - req-77ac2a5f-51d6-45b3-b4fe-e278eeb72158
       Content-Length:
       - '7278'
       Connection:
@@ -10629,7 +10630,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:22:49.556129Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:31:13.591141Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -10708,10 +10709,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["nrl6mFhPROOK38pacmUWZA"],
-        "issued_at": "2018-10-25T18:22:49.556151Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["H-4KOoIGQLK7Cb8gmQ3pwg"],
+        "issued_at": "2018-11-01T18:31:13.591162Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:49 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:13 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/volumes/detail?limit=1000
@@ -10726,27 +10727,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9b2757c7af3b48b0b61126ed274f796f
+      - bf9918219b594a82b357f4f5d1373aaa
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-85ac093b-d94e-47a1-9f2d-6b11b50dfae0
+      - req-2ee66aa9-7b67-4b84-8f70-16843861a76e
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-85ac093b-d94e-47a1-9f2d-6b11b50dfae0
+      - req-2ee66aa9-7b67-4b84-8f70-16843861a76e
       Date:
-      - Thu, 25 Oct 2018 18:22:49 GMT
+      - Thu, 01 Nov 2018 18:31:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:49 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:13 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -10764,15 +10765,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:22:49 GMT
+      - Thu, 01 Nov 2018 18:31:13 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - f544b491a1014192a262c6bc53a569ba
+      - 72f23c087a2742758d2600b68776dc7a
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-4bec1ec0-522a-4641-9703-872d86d496b6
+      - req-093c48fd-bf1a-430e-a493-4b577c535443
       Content-Length:
       - '7264'
       Connection:
@@ -10784,7 +10785,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:22:49.896090Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:31:13.956572Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -10863,10 +10864,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["sBrgA12-RnmCGUYQOZgSAw"],
-        "issued_at": "2018-10-25T18:22:49.896109Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["1DHYV3UYR4mN3bKyNgmSwQ"],
+        "issued_at": "2018-11-01T18:31:13.956593Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:49 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:13 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000
@@ -10881,22 +10882,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f544b491a1014192a262c6bc53a569ba
+      - 72f23c087a2742758d2600b68776dc7a
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-16f219a1-c67a-47c1-8773-056a2aa4bdc7
+      - req-3921fcfc-c1cf-426d-b8e8-d6f36a42e529
       Content-Type:
       - application/json
       Content-Length:
       - '2706'
       X-Openstack-Request-Id:
-      - req-16f219a1-c67a-47c1-8773-056a2aa4bdc7
+      - req-3921fcfc-c1cf-426d-b8e8-d6f36a42e529
       Date:
-      - Thu, 25 Oct 2018 18:22:50 GMT
+      - Thu, 01 Nov 2018 18:31:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=f46458aa-309d-4f47-b996-a39db065030a",
@@ -10929,7 +10930,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-4", "bootable": "true", "created_at":
         "2016-08-19T08:37:45.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:50 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:14 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=f46458aa-309d-4f47-b996-a39db065030a
@@ -10944,22 +10945,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f544b491a1014192a262c6bc53a569ba
+      - 72f23c087a2742758d2600b68776dc7a
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-0e1d144d-4a25-4cff-9786-1fb9cf1f2179
+      - req-091dd63b-4228-4750-b87f-9a142f5c149d
       Content-Type:
       - application/json
       Content-Length:
       - '3284'
       X-Openstack-Request-Id:
-      - req-0e1d144d-4a25-4cff-9786-1fb9cf1f2179
+      - req-091dd63b-4228-4750-b87f-9a142f5c149d
       Date:
-      - Thu, 25 Oct 2018 18:22:50 GMT
+      - Thu, 01 Nov 2018 18:31:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=476a0c89-4322-42aa-b7ce-3ac21be55af7",
@@ -11000,7 +11001,7 @@ http_interactions:
         "name": "EmsRefreshSpec-Volume-2", "bootable": "false", "created_at": "2016-08-19T08:37:33.000000",
         "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:50 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:14 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=476a0c89-4322-42aa-b7ce-3ac21be55af7
@@ -11015,22 +11016,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f544b491a1014192a262c6bc53a569ba
+      - 72f23c087a2742758d2600b68776dc7a
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-a55a8ee2-21ce-4522-98b6-7fc115a0189a
+      - req-ed6d81cd-2214-408a-bd20-7523cd289665
       Content-Type:
       - application/json
       Content-Length:
       - '2753'
       X-Openstack-Request-Id:
-      - req-a55a8ee2-21ce-4522-98b6-7fc115a0189a
+      - req-ed6d81cd-2214-408a-bd20-7523cd289665
       Date:
-      - Thu, 25 Oct 2018 18:22:50 GMT
+      - Thu, 01 Nov 2018 18:31:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=8791e24f-874d-4f1e-99ec-75fdb9d48ca5",
@@ -11064,7 +11065,7 @@ http_interactions:
         "bootable": "false", "created_at": "2016-08-19T08:37:05.000000", "volume_type":
         "iscsi"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:50 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:14 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=8791e24f-874d-4f1e-99ec-75fdb9d48ca5
@@ -11079,27 +11080,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f544b491a1014192a262c6bc53a569ba
+      - 72f23c087a2742758d2600b68776dc7a
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-08066e46-ea32-4c67-9cef-d2451e4730c9
+      - req-4f4531eb-484b-4d42-a18c-9618a7ad9fca
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-08066e46-ea32-4c67-9cef-d2451e4730c9
+      - req-4f4531eb-484b-4d42-a18c-9618a7ad9fca
       Date:
-      - Thu, 25 Oct 2018 18:22:50 GMT
+      - Thu, 01 Nov 2018 18:31:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:50 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:15 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -11117,15 +11118,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:22:50 GMT
+      - Thu, 01 Nov 2018 18:31:15 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 2889cfd6299d41e2be5a0bd461c6ac1a
+      - 1abb7480ccc54fea9e82aa2e89ac5ce1
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-96ad0403-ca2a-4f96-986d-66ee7785645a
+      - req-43d31fa6-277a-407d-8aa4-4d2662a4dcda
       Content-Length:
       - '7278'
       Connection:
@@ -11137,7 +11138,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:22:51.032595Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:31:15.914406Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -11216,10 +11217,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["vEswN6jBQXW97FhPFT-Ymg"],
-        "issued_at": "2018-10-25T18:22:51.032621Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["3rjYXHFsTJGaGLEGU7t1sQ"],
+        "issued_at": "2018-11-01T18:31:15.914428Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:51 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:15 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/volumes/detail?limit=1000
@@ -11234,27 +11235,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2889cfd6299d41e2be5a0bd461c6ac1a
+      - 1abb7480ccc54fea9e82aa2e89ac5ce1
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-7fd5d6af-c6e3-4687-8d1b-1a6e3865a122
+      - req-89a9a66e-525f-4c3e-bcc8-a0c77161086d
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-7fd5d6af-c6e3-4687-8d1b-1a6e3865a122
+      - req-89a9a66e-525f-4c3e-bcc8-a0c77161086d
       Date:
-      - Thu, 25 Oct 2018 18:22:51 GMT
+      - Thu, 01 Nov 2018 18:31:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:51 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:16 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/volumes/detail?limit=1000
@@ -11269,27 +11270,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c5a7911dde30482ab43ddb64b6f8e000
+      - b8d5c2ca31c44c84bee1eef274366d54
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-46e999da-b2e1-4d4e-861c-9000d339274a
+      - req-fa47ce37-9789-477e-9209-310215a5222e
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-46e999da-b2e1-4d4e-861c-9000d339274a
+      - req-fa47ce37-9789-477e-9209-310215a5222e
       Date:
-      - Thu, 25 Oct 2018 18:22:51 GMT
+      - Thu, 01 Nov 2018 18:31:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:51 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:16 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -11307,15 +11308,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:22:51 GMT
+      - Thu, 01 Nov 2018 18:31:16 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - ced41b29d94b44dcb6859d2130e9d670
+      - 3411179f4704436bb1e1646bf5726d99
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-5d3721f4-1d46-49e4-8b8b-7a789f847c88
+      - req-8112b7e2-388f-4601-aa4b-6a0faf0ec18f
       Content-Length:
       - '7265'
       Connection:
@@ -11327,7 +11328,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:22:51.514362Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:31:16.500108Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -11406,10 +11407,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["dd83ET2OQFKa0vh1BdN-Pw"],
-        "issued_at": "2018-10-25T18:22:51.514382Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["KqZN65lEQ8CQEx7IVAUNxw"],
+        "issued_at": "2018-11-01T18:31:16.500131Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:51 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:16 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/volumes/detail?limit=1000
@@ -11424,27 +11425,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ced41b29d94b44dcb6859d2130e9d670
+      - 3411179f4704436bb1e1646bf5726d99
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-e8a393b5-5654-4070-af5b-850a808ca1b7
+      - req-874dff0c-c08c-4704-bb5c-80d2e3d2904e
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-e8a393b5-5654-4070-af5b-850a808ca1b7
+      - req-874dff0c-c08c-4704-bb5c-80d2e3d2904e
       Date:
-      - Thu, 25 Oct 2018 18:22:51 GMT
+      - Thu, 01 Nov 2018 18:31:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:51 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:16 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -11462,15 +11463,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:22:51 GMT
+      - Thu, 01 Nov 2018 18:31:16 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 72517ec57a154677b723f279cd7d153f
+      - 7d5b8d98cbe74be793c51a590b3ac9e3
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-ed352e31-8364-40db-b535-26cab79d496a
+      - req-f5130582-e181-483f-aa12-89885ae9cfba
       Content-Length:
       - '7278'
       Connection:
@@ -11482,7 +11483,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:22:51.859656Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:31:16.867315Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -11561,10 +11562,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["8hZz9owzQOmgigpFajr7fw"],
-        "issued_at": "2018-10-25T18:22:51.859689Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["6ktfIKO4QheRyqL9uGxwzg"],
+        "issued_at": "2018-11-01T18:31:16.867336Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:51 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:16 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/volumes/detail?limit=1000
@@ -11579,27 +11580,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 72517ec57a154677b723f279cd7d153f
+      - 7d5b8d98cbe74be793c51a590b3ac9e3
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-e75f8f73-ee79-44a3-8a07-ad3779121c6f
+      - req-40be503e-a95c-4d58-8954-c1cb9f1f029b
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-e75f8f73-ee79-44a3-8a07-ad3779121c6f
+      - req-40be503e-a95c-4d58-8954-c1cb9f1f029b
       Date:
-      - Thu, 25 Oct 2018 18:22:52 GMT
+      - Thu, 01 Nov 2018 18:31:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:52 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:17 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/snapshots/detail
@@ -11614,27 +11615,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b3f59ad033b1499ca257cd30eca7708c
+      - e80a7b4cb2e04b7bb5d74cfd0625fb80
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-d9ee535d-f727-4501-ba11-2348ddc2c85c
+      - req-8d5c4196-cff4-4d07-b67e-422ffebb0aeb
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-d9ee535d-f727-4501-ba11-2348ddc2c85c
+      - req-8d5c4196-cff4-4d07-b67e-422ffebb0aeb
       Date:
-      - Thu, 25 Oct 2018 18:22:52 GMT
+      - Thu, 01 Nov 2018 18:31:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:52 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:17 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/snapshots/detail?limit=1000
@@ -11649,27 +11650,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b3f59ad033b1499ca257cd30eca7708c
+      - e80a7b4cb2e04b7bb5d74cfd0625fb80
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-f86cf1d9-e94c-4244-a40c-9272ad23fc6e
+      - req-2bf916a3-7569-4eef-93e2-a82efe31ff58
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-f86cf1d9-e94c-4244-a40c-9272ad23fc6e
+      - req-2bf916a3-7569-4eef-93e2-a82efe31ff58
       Date:
-      - Thu, 25 Oct 2018 18:22:52 GMT
+      - Thu, 01 Nov 2018 18:31:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:52 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:17 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/snapshots/detail
@@ -11684,27 +11685,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9b2757c7af3b48b0b61126ed274f796f
+      - bf9918219b594a82b357f4f5d1373aaa
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-ae3623bc-7fb7-41ae-8595-84e7522d52f5
+      - req-aef9fc75-7095-4524-a3c2-6403e6c1834c
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-ae3623bc-7fb7-41ae-8595-84e7522d52f5
+      - req-aef9fc75-7095-4524-a3c2-6403e6c1834c
       Date:
-      - Thu, 25 Oct 2018 18:22:52 GMT
+      - Thu, 01 Nov 2018 18:31:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:52 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:17 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/snapshots/detail?limit=1000
@@ -11719,27 +11720,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9b2757c7af3b48b0b61126ed274f796f
+      - bf9918219b594a82b357f4f5d1373aaa
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-aa2e7a5e-f05d-488d-9688-f77c5b25b076
+      - req-a11493ac-fbf6-4454-afdd-7b02413f3cf3
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-aa2e7a5e-f05d-488d-9688-f77c5b25b076
+      - req-a11493ac-fbf6-4454-afdd-7b02413f3cf3
       Date:
-      - Thu, 25 Oct 2018 18:22:52 GMT
+      - Thu, 01 Nov 2018 18:31:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:52 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:17 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/snapshots/detail
@@ -11754,22 +11755,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f544b491a1014192a262c6bc53a569ba
+      - 72f23c087a2742758d2600b68776dc7a
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-816e7604-d411-4c2a-8f89-fa3e2094dd48
+      - req-af6e6a06-c21e-470e-853c-d2acc43e7b59
       Content-Type:
       - application/json
       Content-Length:
       - '1053'
       X-Openstack-Request-Id:
-      - req-816e7604-d411-4c2a-8f89-fa3e2094dd48
+      - req-af6e6a06-c21e-470e-853c-d2acc43e7b59
       Date:
-      - Thu, 25 Oct 2018 18:22:52 GMT
+      - Thu, 01 Nov 2018 18:31:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/snapshots/detail?marker=c44d3eb3-31fe-46ed-bfae-707920be171d",
@@ -11784,7 +11785,7 @@ http_interactions:
         "created_at": "2016-08-19T08:37:24.000000", "size": 1, "id": "c44d3eb3-31fe-46ed-bfae-707920be171d",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:52 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:17 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/snapshots/detail?limit=1000
@@ -11799,22 +11800,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f544b491a1014192a262c6bc53a569ba
+      - 72f23c087a2742758d2600b68776dc7a
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-f1449d23-b94b-4c09-a0a8-b32a27a67e64
+      - req-154b70c9-611f-4b62-9ef2-ab931705931c
       Content-Type:
       - application/json
       Content-Length:
       - '1064'
       X-Openstack-Request-Id:
-      - req-f1449d23-b94b-4c09-a0a8-b32a27a67e64
+      - req-154b70c9-611f-4b62-9ef2-ab931705931c
       Date:
-      - Thu, 25 Oct 2018 18:22:52 GMT
+      - Thu, 01 Nov 2018 18:31:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/snapshots/detail?limit=1000&marker=c44d3eb3-31fe-46ed-bfae-707920be171d",
@@ -11829,7 +11830,7 @@ http_interactions:
         "created_at": "2016-08-19T08:37:24.000000", "size": 1, "id": "c44d3eb3-31fe-46ed-bfae-707920be171d",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:52 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:17 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/snapshots/detail
@@ -11844,27 +11845,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2889cfd6299d41e2be5a0bd461c6ac1a
+      - 1abb7480ccc54fea9e82aa2e89ac5ce1
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-f65b1b28-edd1-4b42-990e-1077bd3f1091
+      - req-755f6f9c-4712-4e7d-978f-5933b954b479
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-f65b1b28-edd1-4b42-990e-1077bd3f1091
+      - req-755f6f9c-4712-4e7d-978f-5933b954b479
       Date:
-      - Thu, 25 Oct 2018 18:22:52 GMT
+      - Thu, 01 Nov 2018 18:31:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:52 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:17 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/snapshots/detail?limit=1000
@@ -11879,27 +11880,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2889cfd6299d41e2be5a0bd461c6ac1a
+      - 1abb7480ccc54fea9e82aa2e89ac5ce1
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-af2be1b9-108f-47aa-aba0-1ba56b7460bb
+      - req-dd59ae61-6ca1-41e0-ba0e-c80612fe0893
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-af2be1b9-108f-47aa-aba0-1ba56b7460bb
+      - req-dd59ae61-6ca1-41e0-ba0e-c80612fe0893
       Date:
-      - Thu, 25 Oct 2018 18:22:52 GMT
+      - Thu, 01 Nov 2018 18:31:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:52 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:17 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/snapshots/detail
@@ -11914,27 +11915,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c5a7911dde30482ab43ddb64b6f8e000
+      - b8d5c2ca31c44c84bee1eef274366d54
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-27f05967-c17b-456a-a787-a15018a7d98d
+      - req-8369684c-d219-4293-8fbc-ea4587cf6e2f
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-27f05967-c17b-456a-a787-a15018a7d98d
+      - req-8369684c-d219-4293-8fbc-ea4587cf6e2f
       Date:
-      - Thu, 25 Oct 2018 18:22:52 GMT
+      - Thu, 01 Nov 2018 18:31:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:52 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:18 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/snapshots/detail?limit=1000
@@ -11949,27 +11950,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c5a7911dde30482ab43ddb64b6f8e000
+      - b8d5c2ca31c44c84bee1eef274366d54
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-9c680337-326f-4b17-a7c8-bfee90b61782
+      - req-508b4695-374a-46c2-964c-974eaf82fbfd
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-9c680337-326f-4b17-a7c8-bfee90b61782
+      - req-508b4695-374a-46c2-964c-974eaf82fbfd
       Date:
-      - Thu, 25 Oct 2018 18:22:53 GMT
+      - Thu, 01 Nov 2018 18:31:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:53 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:19 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/snapshots/detail
@@ -11984,27 +11985,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ced41b29d94b44dcb6859d2130e9d670
+      - 3411179f4704436bb1e1646bf5726d99
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-2e7c698d-7596-408c-a785-e3513d984705
+      - req-36f2b19a-dd64-4d7f-9144-234d03991970
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-2e7c698d-7596-408c-a785-e3513d984705
+      - req-36f2b19a-dd64-4d7f-9144-234d03991970
       Date:
-      - Thu, 25 Oct 2018 18:22:53 GMT
+      - Thu, 01 Nov 2018 18:31:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:53 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:19 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/snapshots/detail?limit=1000
@@ -12019,27 +12020,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ced41b29d94b44dcb6859d2130e9d670
+      - 3411179f4704436bb1e1646bf5726d99
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-8310c7c9-67b6-403e-b954-f5897d270666
+      - req-1ec73ae2-fdf3-49fa-997c-dbf73e7c1401
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-8310c7c9-67b6-403e-b954-f5897d270666
+      - req-1ec73ae2-fdf3-49fa-997c-dbf73e7c1401
       Date:
-      - Thu, 25 Oct 2018 18:22:53 GMT
+      - Thu, 01 Nov 2018 18:31:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:53 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:19 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/snapshots/detail
@@ -12054,27 +12055,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 72517ec57a154677b723f279cd7d153f
+      - 7d5b8d98cbe74be793c51a590b3ac9e3
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-598af5ae-d7fc-4320-865b-5eadab967f8a
+      - req-57a11629-9a16-4ae8-bd5e-d7f8d5f4d062
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-598af5ae-d7fc-4320-865b-5eadab967f8a
+      - req-57a11629-9a16-4ae8-bd5e-d7f8d5f4d062
       Date:
-      - Thu, 25 Oct 2018 18:22:53 GMT
+      - Thu, 01 Nov 2018 18:31:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:53 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:19 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/snapshots/detail?limit=1000
@@ -12089,27 +12090,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 72517ec57a154677b723f279cd7d153f
+      - 7d5b8d98cbe74be793c51a590b3ac9e3
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-a972ec25-00d3-4c60-be48-af7cb1d7c6b9
+      - req-60c2c3ae-2128-4db3-93e7-c046cf3370e8
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-a972ec25-00d3-4c60-be48-af7cb1d7c6b9
+      - req-60c2c3ae-2128-4db3-93e7-c046cf3370e8
       Date:
-      - Thu, 25 Oct 2018 18:22:53 GMT
+      - Thu, 01 Nov 2018 18:31:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:53 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:19 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/backups/detail
@@ -12124,27 +12125,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b3f59ad033b1499ca257cd30eca7708c
+      - e80a7b4cb2e04b7bb5d74cfd0625fb80
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-054ebe52-4165-474a-be41-1dc4908bd809
+      - req-9e1d269f-f933-4de0-bb32-6815b9c79f00
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-054ebe52-4165-474a-be41-1dc4908bd809
+      - req-9e1d269f-f933-4de0-bb32-6815b9c79f00
       Date:
-      - Thu, 25 Oct 2018 18:22:53 GMT
+      - Thu, 01 Nov 2018 18:31:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:53 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:19 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/backups/detail?limit=1000
@@ -12159,27 +12160,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b3f59ad033b1499ca257cd30eca7708c
+      - e80a7b4cb2e04b7bb5d74cfd0625fb80
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-15a57c2a-db94-4a5e-b9af-a312c48578c2
+      - req-e35da29e-de58-4b1d-b527-e27200ed0ef1
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-15a57c2a-db94-4a5e-b9af-a312c48578c2
+      - req-e35da29e-de58-4b1d-b527-e27200ed0ef1
       Date:
-      - Thu, 25 Oct 2018 18:22:53 GMT
+      - Thu, 01 Nov 2018 18:31:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:53 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:19 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/backups/detail
@@ -12194,27 +12195,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9b2757c7af3b48b0b61126ed274f796f
+      - bf9918219b594a82b357f4f5d1373aaa
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-04359ef7-4fd1-4092-a608-6a81d97250f8
+      - req-9d1ebe5b-11a0-43ae-9496-ce87d43deafd
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-04359ef7-4fd1-4092-a608-6a81d97250f8
+      - req-9d1ebe5b-11a0-43ae-9496-ce87d43deafd
       Date:
-      - Thu, 25 Oct 2018 18:22:53 GMT
+      - Thu, 01 Nov 2018 18:31:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:53 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:20 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/backups/detail?limit=1000
@@ -12229,27 +12230,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9b2757c7af3b48b0b61126ed274f796f
+      - bf9918219b594a82b357f4f5d1373aaa
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-bb8b69ba-afea-4bd6-934d-8578c631a5f0
+      - req-d580c37d-0d63-43b9-b2da-aa50c22bbddb
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-bb8b69ba-afea-4bd6-934d-8578c631a5f0
+      - req-d580c37d-0d63-43b9-b2da-aa50c22bbddb
       Date:
-      - Thu, 25 Oct 2018 18:22:53 GMT
+      - Thu, 01 Nov 2018 18:31:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:53 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:20 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/backups/detail
@@ -12264,27 +12265,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f544b491a1014192a262c6bc53a569ba
+      - 72f23c087a2742758d2600b68776dc7a
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-5dca3e7c-4266-49e8-9ef3-411316f8dc05
+      - req-78d883bd-3033-4764-96e4-3d80da2b1663
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-5dca3e7c-4266-49e8-9ef3-411316f8dc05
+      - req-78d883bd-3033-4764-96e4-3d80da2b1663
       Date:
-      - Thu, 25 Oct 2018 18:22:53 GMT
+      - Thu, 01 Nov 2018 18:31:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:53 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:20 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/backups/detail?limit=1000
@@ -12299,27 +12300,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f544b491a1014192a262c6bc53a569ba
+      - 72f23c087a2742758d2600b68776dc7a
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-71ad6868-08fb-484c-b268-cfaa9a94997e
+      - req-cd515b32-072c-4340-8355-208260ae3a6d
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-71ad6868-08fb-484c-b268-cfaa9a94997e
+      - req-cd515b32-072c-4340-8355-208260ae3a6d
       Date:
-      - Thu, 25 Oct 2018 18:22:54 GMT
+      - Thu, 01 Nov 2018 18:31:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:54 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:20 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/backups/detail
@@ -12334,27 +12335,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2889cfd6299d41e2be5a0bd461c6ac1a
+      - 1abb7480ccc54fea9e82aa2e89ac5ce1
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-c2f60501-3850-47ce-9d43-f086bf719a64
+      - req-9b45a2f5-8932-4068-877c-faf49736f4ac
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-c2f60501-3850-47ce-9d43-f086bf719a64
+      - req-9b45a2f5-8932-4068-877c-faf49736f4ac
       Date:
-      - Thu, 25 Oct 2018 18:22:54 GMT
+      - Thu, 01 Nov 2018 18:31:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:54 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:20 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/backups/detail?limit=1000
@@ -12369,27 +12370,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2889cfd6299d41e2be5a0bd461c6ac1a
+      - 1abb7480ccc54fea9e82aa2e89ac5ce1
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-a97828c8-ebc2-4a0c-8516-03af1c44f82f
+      - req-033421ee-03ba-4bd5-99ca-c7bb8af56fc5
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-a97828c8-ebc2-4a0c-8516-03af1c44f82f
+      - req-033421ee-03ba-4bd5-99ca-c7bb8af56fc5
       Date:
-      - Thu, 25 Oct 2018 18:22:54 GMT
+      - Thu, 01 Nov 2018 18:31:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:54 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:20 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/backups/detail
@@ -12404,27 +12405,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c5a7911dde30482ab43ddb64b6f8e000
+      - b8d5c2ca31c44c84bee1eef274366d54
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-8cbaed5a-d06c-4b4b-957d-0ebdab8aa964
+      - req-9bb80eda-472f-4e46-af6a-83d6809302ec
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-8cbaed5a-d06c-4b4b-957d-0ebdab8aa964
+      - req-9bb80eda-472f-4e46-af6a-83d6809302ec
       Date:
-      - Thu, 25 Oct 2018 18:22:54 GMT
+      - Thu, 01 Nov 2018 18:31:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:54 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:20 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/backups/detail?limit=1000
@@ -12439,27 +12440,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c5a7911dde30482ab43ddb64b6f8e000
+      - b8d5c2ca31c44c84bee1eef274366d54
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-f5c1da76-c9ab-43dc-8bac-3b9e9a0824d8
+      - req-2d81272a-08c3-48c0-9442-1a1c10f70aba
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-f5c1da76-c9ab-43dc-8bac-3b9e9a0824d8
+      - req-2d81272a-08c3-48c0-9442-1a1c10f70aba
       Date:
-      - Thu, 25 Oct 2018 18:22:54 GMT
+      - Thu, 01 Nov 2018 18:31:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:54 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:21 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/backups/detail
@@ -12474,27 +12475,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ced41b29d94b44dcb6859d2130e9d670
+      - 3411179f4704436bb1e1646bf5726d99
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-a5229314-8a6e-4afe-9f02-0ad46e5a7832
+      - req-e6f4b6dc-83f3-47a9-9a48-489285bbfd2d
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-a5229314-8a6e-4afe-9f02-0ad46e5a7832
+      - req-e6f4b6dc-83f3-47a9-9a48-489285bbfd2d
       Date:
-      - Thu, 25 Oct 2018 18:22:54 GMT
+      - Thu, 01 Nov 2018 18:31:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:54 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:21 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/backups/detail?limit=1000
@@ -12509,27 +12510,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ced41b29d94b44dcb6859d2130e9d670
+      - 3411179f4704436bb1e1646bf5726d99
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-b34bcb44-4c77-401a-a164-e28d86706e74
+      - req-bb399d72-fea4-4826-b35d-bb48cd363aec
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-b34bcb44-4c77-401a-a164-e28d86706e74
+      - req-bb399d72-fea4-4826-b35d-bb48cd363aec
       Date:
-      - Thu, 25 Oct 2018 18:22:54 GMT
+      - Thu, 01 Nov 2018 18:31:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:54 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:21 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/backups/detail
@@ -12544,27 +12545,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 72517ec57a154677b723f279cd7d153f
+      - 7d5b8d98cbe74be793c51a590b3ac9e3
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-5e3973a6-f825-436f-8b89-0261a4ec1cf4
+      - req-4cc1e406-009f-4600-9804-b61a029a5374
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-5e3973a6-f825-436f-8b89-0261a4ec1cf4
+      - req-4cc1e406-009f-4600-9804-b61a029a5374
       Date:
-      - Thu, 25 Oct 2018 18:22:54 GMT
+      - Thu, 01 Nov 2018 18:31:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:54 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:21 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/backups/detail?limit=1000
@@ -12579,27 +12580,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 72517ec57a154677b723f279cd7d153f
+      - 7d5b8d98cbe74be793c51a590b3ac9e3
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-76c960db-357d-41ee-ba63-03350577de50
+      - req-5c1fbfa3-2688-4ee1-9c1e-9147ed9b071b
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-76c960db-357d-41ee-ba63-03350577de50
+      - req-5c1fbfa3-2688-4ee1-9c1e-9147ed9b071b
       Date:
-      - Thu, 25 Oct 2018 18:22:54 GMT
+      - Thu, 01 Nov 2018 18:31:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:54 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:21 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/types?limit=1000
@@ -12614,22 +12615,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b3f59ad033b1499ca257cd30eca7708c
+      - e80a7b4cb2e04b7bb5d74cfd0625fb80
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-816e90c0-d8f9-4d7f-907c-1b74425a7476
+      - req-2a8fdf31-59b3-43b7-a65f-b8853a5a313c
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-816e90c0-d8f9-4d7f-907c-1b74425a7476
+      - req-2a8fdf31-59b3-43b7-a65f-b8853a5a313c
       Date:
-      - Thu, 25 Oct 2018 18:22:54 GMT
+      - Thu, 01 Nov 2018 18:31:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -12641,7 +12642,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:54 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:21 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/types?limit=1000&marker=b953db40-aeea-4a55-9bd9-c08dcafd6f7e
@@ -12656,22 +12657,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b3f59ad033b1499ca257cd30eca7708c
+      - e80a7b4cb2e04b7bb5d74cfd0625fb80
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-18422950-cad2-476e-90a8-f95a32687fb0
+      - req-135962a9-50f6-4004-b4e8-ffcea026d211
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-18422950-cad2-476e-90a8-f95a32687fb0
+      - req-135962a9-50f6-4004-b4e8-ffcea026d211
       Date:
-      - Thu, 25 Oct 2018 18:22:54 GMT
+      - Thu, 01 Nov 2018 18:31:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -12683,7 +12684,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:55 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:21 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/types?limit=1000
@@ -12698,22 +12699,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9b2757c7af3b48b0b61126ed274f796f
+      - bf9918219b594a82b357f4f5d1373aaa
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-1936253c-7004-4cfd-abd7-697eeac493c9
+      - req-59cee2a5-86f4-4752-9c9e-814b6835f621
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-1936253c-7004-4cfd-abd7-697eeac493c9
+      - req-59cee2a5-86f4-4752-9c9e-814b6835f621
       Date:
-      - Thu, 25 Oct 2018 18:22:55 GMT
+      - Thu, 01 Nov 2018 18:31:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -12725,7 +12726,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:55 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:21 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/types?limit=1000&marker=b953db40-aeea-4a55-9bd9-c08dcafd6f7e
@@ -12740,22 +12741,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9b2757c7af3b48b0b61126ed274f796f
+      - bf9918219b594a82b357f4f5d1373aaa
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-5f82276e-4a89-442c-8b7e-a75e42e24356
+      - req-03afe697-6f19-451b-b3ed-be03aad5fc4a
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-5f82276e-4a89-442c-8b7e-a75e42e24356
+      - req-03afe697-6f19-451b-b3ed-be03aad5fc4a
       Date:
-      - Thu, 25 Oct 2018 18:22:55 GMT
+      - Thu, 01 Nov 2018 18:31:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -12767,7 +12768,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:55 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:21 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/types?limit=1000
@@ -12782,22 +12783,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f544b491a1014192a262c6bc53a569ba
+      - 72f23c087a2742758d2600b68776dc7a
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-a7072438-842e-4581-af84-e89ef23eb197
+      - req-460fcea8-6daa-441e-8d82-6ad03078eb18
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-a7072438-842e-4581-af84-e89ef23eb197
+      - req-460fcea8-6daa-441e-8d82-6ad03078eb18
       Date:
-      - Thu, 25 Oct 2018 18:22:55 GMT
+      - Thu, 01 Nov 2018 18:31:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -12809,7 +12810,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:55 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:21 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/types?limit=1000&marker=b953db40-aeea-4a55-9bd9-c08dcafd6f7e
@@ -12824,22 +12825,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f544b491a1014192a262c6bc53a569ba
+      - 72f23c087a2742758d2600b68776dc7a
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-2fc757c1-2b42-48c6-acb8-4fe456a5133f
+      - req-9914dac3-6fd2-4b25-b555-9ef87ba7effa
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-2fc757c1-2b42-48c6-acb8-4fe456a5133f
+      - req-9914dac3-6fd2-4b25-b555-9ef87ba7effa
       Date:
-      - Thu, 25 Oct 2018 18:22:55 GMT
+      - Thu, 01 Nov 2018 18:31:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -12851,7 +12852,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:55 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:22 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/types?limit=1000
@@ -12866,22 +12867,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2889cfd6299d41e2be5a0bd461c6ac1a
+      - 1abb7480ccc54fea9e82aa2e89ac5ce1
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-b5574609-7afc-4ae1-bf21-53b46080f7cf
+      - req-ede1a1e6-8762-448e-89d5-1110557a58f4
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-b5574609-7afc-4ae1-bf21-53b46080f7cf
+      - req-ede1a1e6-8762-448e-89d5-1110557a58f4
       Date:
-      - Thu, 25 Oct 2018 18:22:55 GMT
+      - Thu, 01 Nov 2018 18:31:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -12893,7 +12894,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:55 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:22 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/types?limit=1000&marker=b953db40-aeea-4a55-9bd9-c08dcafd6f7e
@@ -12908,22 +12909,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2889cfd6299d41e2be5a0bd461c6ac1a
+      - 1abb7480ccc54fea9e82aa2e89ac5ce1
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-c9173df7-c958-45c5-8a54-8303c6f236f3
+      - req-2f598fff-36dc-4bcb-a50f-895bfb6f3418
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-c9173df7-c958-45c5-8a54-8303c6f236f3
+      - req-2f598fff-36dc-4bcb-a50f-895bfb6f3418
       Date:
-      - Thu, 25 Oct 2018 18:22:55 GMT
+      - Thu, 01 Nov 2018 18:31:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -12935,7 +12936,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:55 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:22 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/types?limit=1000
@@ -12950,22 +12951,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c5a7911dde30482ab43ddb64b6f8e000
+      - b8d5c2ca31c44c84bee1eef274366d54
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-18084c93-db11-47a7-852a-0c2ed4aadc88
+      - req-13b6fa9d-98a7-42ec-bb30-aac7375c1afa
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-18084c93-db11-47a7-852a-0c2ed4aadc88
+      - req-13b6fa9d-98a7-42ec-bb30-aac7375c1afa
       Date:
-      - Thu, 25 Oct 2018 18:22:55 GMT
+      - Thu, 01 Nov 2018 18:31:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -12977,7 +12978,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:55 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:22 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/types?limit=1000&marker=b953db40-aeea-4a55-9bd9-c08dcafd6f7e
@@ -12992,22 +12993,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c5a7911dde30482ab43ddb64b6f8e000
+      - b8d5c2ca31c44c84bee1eef274366d54
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-8ed1608f-e232-45b9-a37e-b3a8ddd27fd3
+      - req-04cc7d29-e3c6-439d-a484-2927c9e8d755
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-8ed1608f-e232-45b9-a37e-b3a8ddd27fd3
+      - req-04cc7d29-e3c6-439d-a484-2927c9e8d755
       Date:
-      - Thu, 25 Oct 2018 18:22:55 GMT
+      - Thu, 01 Nov 2018 18:31:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -13019,7 +13020,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:55 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:22 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/types?limit=1000
@@ -13034,22 +13035,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ced41b29d94b44dcb6859d2130e9d670
+      - 3411179f4704436bb1e1646bf5726d99
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-a5040719-aab1-4ad4-ab7c-2eb203d7b6d1
+      - req-28a29bd2-f2b4-462d-96da-3aee06729113
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-a5040719-aab1-4ad4-ab7c-2eb203d7b6d1
+      - req-28a29bd2-f2b4-462d-96da-3aee06729113
       Date:
-      - Thu, 25 Oct 2018 18:22:55 GMT
+      - Thu, 01 Nov 2018 18:31:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -13061,7 +13062,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:55 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:22 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/types?limit=1000&marker=b953db40-aeea-4a55-9bd9-c08dcafd6f7e
@@ -13076,22 +13077,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ced41b29d94b44dcb6859d2130e9d670
+      - 3411179f4704436bb1e1646bf5726d99
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-cbc9f36e-4f99-4f00-b1d8-7236d4889bc3
+      - req-9e6f9634-ca11-456f-b6b0-97a87c53ddaa
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-cbc9f36e-4f99-4f00-b1d8-7236d4889bc3
+      - req-9e6f9634-ca11-456f-b6b0-97a87c53ddaa
       Date:
-      - Thu, 25 Oct 2018 18:22:55 GMT
+      - Thu, 01 Nov 2018 18:31:25 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -13103,7 +13104,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:55 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:25 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/types?limit=1000
@@ -13118,22 +13119,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 72517ec57a154677b723f279cd7d153f
+      - 7d5b8d98cbe74be793c51a590b3ac9e3
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-4e02fac8-a802-408a-a10e-437e7451bc94
+      - req-117890fe-139e-4bed-b715-98bb1a7cf136
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-4e02fac8-a802-408a-a10e-437e7451bc94
+      - req-117890fe-139e-4bed-b715-98bb1a7cf136
       Date:
-      - Thu, 25 Oct 2018 18:22:56 GMT
+      - Thu, 01 Nov 2018 18:31:25 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -13145,7 +13146,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:56 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:25 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/types?limit=1000&marker=b953db40-aeea-4a55-9bd9-c08dcafd6f7e
@@ -13160,22 +13161,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 72517ec57a154677b723f279cd7d153f
+      - 7d5b8d98cbe74be793c51a590b3ac9e3
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-b806bd11-afe6-4cc1-b78b-eb40707ccd95
+      - req-f4df8bec-65f6-4a3d-9b96-859128eb7d3d
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-b806bd11-afe6-4cc1-b78b-eb40707ccd95
+      - req-f4df8bec-65f6-4a3d-9b96-859128eb7d3d
       Date:
-      - Thu, 25 Oct 2018 18:22:56 GMT
+      - Thu, 01 Nov 2018 18:31:25 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -13187,7 +13188,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:56 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:25 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -13205,15 +13206,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:22:56 GMT
+      - Thu, 01 Nov 2018 18:31:26 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 9fec64dec3094533812ad026184d2127
+      - 7f6326b60cdd4cc48b3b875179dd4431
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-5eec544c-d7b6-45dd-ab4c-214131e734f4
+      - req-ef56017b-1fff-4539-96ed-942b4be9cf83
       Content-Length:
       - '7311'
       Connection:
@@ -13225,7 +13226,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-10-25T19:22:56.434356Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-11-01T19:31:26.313398Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -13304,10 +13305,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["c9wrYX3nTwaTkm1UDZQJPw"],
-        "issued_at": "2018-10-25T18:22:56.434376Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["FIscPTpFSCK6_IuaIPgceA"],
+        "issued_at": "2018-11-01T18:31:26.313419Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:56 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:26 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -13325,15 +13326,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:22:56 GMT
+      - Thu, 01 Nov 2018 18:31:27 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 8753591aa21d464f8bf26dec4d6ad7b4
+      - c9d27448fdea4d73a07e9a2d0d8eccf8
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-7d569647-922a-45f7-bc23-7e52ce677efe
+      - req-1af52b39-3c6a-481b-bc7d-0d249e513543
       Content-Length:
       - '7311'
       Connection:
@@ -13345,7 +13346,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-10-25T19:22:56.636581Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-11-01T19:31:27.573004Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -13424,10 +13425,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["p-gr-ErYRs67eBQlHptWtQ"],
-        "issued_at": "2018-10-25T18:22:56.636601Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["VmIthRVrSS64Y0UW7k8zsA"],
+        "issued_at": "2018-11-01T18:31:27.573026Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:56 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:27 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -13445,15 +13446,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:22:56 GMT
+      - Thu, 01 Nov 2018 18:31:27 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 5d9d62919631472ab8419291fb156431
+      - d718e0726a5e415197200bd981f81a8a
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-e554a2d5-7d97-443e-b928-3715a8e184b7
+      - req-7adb10d0-9f3f-43d8-8d65-8575a10e5289
       Content-Length:
       - '297'
       Connection:
@@ -13462,12 +13463,12 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"token": {"methods": ["password"], "expires_at": "2018-10-25T19:22:56.803574Z",
+      string: '{"token": {"methods": ["password"], "expires_at": "2018-11-01T19:31:27.770470Z",
         "extras": {}, "user": {"domain": {"id": "default", "name": "Default"}, "id":
-        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["R0CngDPcTdCx-ui87Xg1cA"],
-        "issued_at": "2018-10-25T18:22:56.803593Z"}}'
+        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["91YxgeWqRz-SQAdWPVUoqw"],
+        "issued_at": "2018-11-01T18:31:27.770490Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:56 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:27 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects?domain_id=default
@@ -13482,20 +13483,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5d9d62919631472ab8419291fb156431
+      - d718e0726a5e415197200bd981f81a8a
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:22:56 GMT
+      - Thu, 01 Nov 2018 18:31:27 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-03b641db-9937-485d-847c-b2cb3e52c204
+      - req-62de4c88-eadb-4356-9fbc-eb5f295b82e1
       Content-Length:
       - '2475'
       Connection:
@@ -13528,7 +13529,7 @@ http_interactions:
         "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
         "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:56 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:28 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -13546,15 +13547,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:22:57 GMT
+      - Thu, 01 Nov 2018 18:31:28 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 5ad7119b280d4cbe9869665cfdd969c0
+      - 26a3220b3f2449419ab35a23b45174c3
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-678fdb5f-2022-4896-bd07-133cac3e81bf
+      - req-15d732e6-9027-4a59-9ea2-15a60bf96db8
       Content-Length:
       - '7278'
       Connection:
@@ -13566,7 +13567,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:22:57.157321Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:31:28.189211Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -13645,10 +13646,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["zmcZ35kbRimBHpuszweQRA"],
-        "issued_at": "2018-10-25T18:22:57.157353Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["KSKaYGH4TxGsXvHNEXeJfA"],
+        "issued_at": "2018-11-01T18:31:28.189236Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:57 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:28 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -13666,15 +13667,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:22:57 GMT
+      - Thu, 01 Nov 2018 18:31:28 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 9c52ab11bae24c4e88515ecaa9d7daa9
+      - 381edc81c1a04bbd8985e0de8e29e08c
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-a6c27b63-adca-495a-99db-bc7d7e300668
+      - req-98827101-573d-49db-bfc6-f94d6e03df37
       Content-Length:
       - '7278'
       Connection:
@@ -13686,7 +13687,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:22:57.353975Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:31:28.416498Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -13765,10 +13766,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["hW4t4AHiT5aSQYIGelTGaQ"],
-        "issued_at": "2018-10-25T18:22:57.353994Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["C72soSCSQS-AVTsiwr2uIg"],
+        "issued_at": "2018-11-01T18:31:28.416521Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:57 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:28 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -13786,15 +13787,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:22:57 GMT
+      - Thu, 01 Nov 2018 18:31:28 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 01be84e64e7c434091102c6f9d011834
+      - 48b79f79a7984d68a2554982477e456e
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-2f72e19d-0d96-4f28-beaa-9fa65a2766b7
+      - req-dd8d16ba-45c2-4358-93b4-b2b67c40860c
       Content-Length:
       - '7264'
       Connection:
@@ -13806,7 +13807,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:22:57.559778Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:31:28.622483Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -13885,10 +13886,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["q6ON5LSdT7Cb1QtHkAR2yg"],
-        "issued_at": "2018-10-25T18:22:57.559805Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["yv-rb9LpTK-KWRo8CVsQaA"],
+        "issued_at": "2018-11-01T18:31:28.622504Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:57 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:28 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -13906,15 +13907,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:22:57 GMT
+      - Thu, 01 Nov 2018 18:31:28 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 221948b62e004fcb8326ec1e953a0875
+      - f220c35bcd0a4c6492deb015c4ebf59d
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-98a0b1bc-7850-431b-a518-77424211956a
+      - req-1d917033-db53-4d7a-94e9-c5f036f9bc44
       Content-Length:
       - '7278'
       Connection:
@@ -13926,7 +13927,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:22:57.759346Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:31:28.837576Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -14005,10 +14006,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["wGkc3tP8Sq-yPwKhVYUhtg"],
-        "issued_at": "2018-10-25T18:22:57.759368Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["gQA27gEDRZO0rZPB7n8PMw"],
+        "issued_at": "2018-11-01T18:31:28.837597Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:57 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:28 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -14026,15 +14027,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:22:57 GMT
+      - Thu, 01 Nov 2018 18:31:28 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - aa5a7e64e1fd473db87f61d9a63df358
+      - '062448e0e6b14de8af91e795182dcc6c'
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-6c857173-1e83-45f4-be9c-69b0bd800660
+      - req-c5a5b972-03e2-46e7-9861-1f7fc4979513
       Content-Length:
       - '7265'
       Connection:
@@ -14046,7 +14047,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:22:57.961204Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:31:29.042150Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -14125,10 +14126,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["tmEvn6z1QIyo149BKHjypQ"],
-        "issued_at": "2018-10-25T18:22:57.961224Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["944xS7uRRzC6AGhKK0rz_A"],
+        "issued_at": "2018-11-01T18:31:29.042171Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:57 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:29 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -14146,15 +14147,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:22:58 GMT
+      - Thu, 01 Nov 2018 18:31:29 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 2c4cd69bc15a4397b1c9908ffb1be77a
+      - 7767695f12e743598a5547d380ab2639
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-adeb4795-c00f-4bbf-b7f6-6422d6cf7501
+      - req-8e828342-d8f9-40d4-bb34-0d2d97ab8d3a
       Content-Length:
       - '7278'
       Connection:
@@ -14166,7 +14167,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:22:58.163184Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:31:29.246048Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -14245,10 +14246,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["vxV5x-iXQ_qyTNUMuhPAFQ"],
-        "issued_at": "2018-10-25T18:22:58.163217Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["13idtzK0SOKwdOC4vs5eNA"],
+        "issued_at": "2018-11-01T18:31:29.246068Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:58 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:29 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -14266,15 +14267,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:22:58 GMT
+      - Thu, 01 Nov 2018 18:31:29 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 0aff51ea3c644efb91e7a1d4d3c594fc
+      - 633f2c35683247c2b23ee7f4746a95fd
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-43babebe-1874-4456-ad25-e595ac7ee178
+      - req-d1209e10-f325-448f-ac44-b2d9a34aeb9d
       Content-Length:
       - '7278'
       Connection:
@@ -14286,7 +14287,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:22:58.380274Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:31:29.458005Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -14365,10 +14366,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["LQKzM7DZT9y4ynxd3TONZg"],
-        "issued_at": "2018-10-25T18:22:58.380299Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["XunNkAEaTCaWzHFzfAqSCQ"],
+        "issued_at": "2018-11-01T18:31:29.458026Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:58 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:29 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_0098405163cd4c9dbb42c2cb43eb6fd3/?format=json&limit=1000
@@ -14383,7 +14384,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0aff51ea3c644efb91e7a1d4d3c594fc
+      - 633f2c35683247c2b23ee7f4746a95fd
   response:
     status:
       code: 200
@@ -14396,22 +14397,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1540491778.56614'
+      - '1541097089.59074'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1540491778.56614'
+      - '1541097089.59074'
       X-Trans-Id:
-      - txdbe9a7a196cd40cf963d4-005bd20a02
+      - tx6d6401ed45684c5da0ecb-005bdb4681
       Date:
-      - Thu, 25 Oct 2018 18:22:58 GMT
+      - Thu, 01 Nov 2018 18:31:29 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:58 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:29 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -14429,15 +14430,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:22:58 GMT
+      - Thu, 01 Nov 2018 18:31:30 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - db2e095c867948fe88fe38f82772dbb9
+      - 8b8b0d7d899d4bf19294987108d31847
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-e9c8f9df-a9de-4b05-a1e0-9563ce66c763
+      - req-21461137-42ea-4a0c-86aa-94e71e00f6ca
       Content-Length:
       - '7278'
       Connection:
@@ -14449,7 +14450,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:22:58.756619Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:31:30.078861Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -14528,10 +14529,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["u3VUD9kVSgetvHwMY5D9uA"],
-        "issued_at": "2018-10-25T18:22:58.756639Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["cTBZ1o7oTDS6NEpu_K2evw"],
+        "issued_at": "2018-11-01T18:31:30.078883Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:58 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:30 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_28db8f69ba9e4305b7fad82da4c86e74/?format=json&limit=1000
@@ -14546,7 +14547,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - db2e095c867948fe88fe38f82772dbb9
+      - 8b8b0d7d899d4bf19294987108d31847
   response:
     status:
       code: 200
@@ -14559,22 +14560,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1540491778.88714'
+      - '1541097090.21661'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1540491778.88714'
+      - '1541097090.21661'
       X-Trans-Id:
-      - txda6adbdbb38e42879c0f0-005bd20a02
+      - tx8673ce1deae245f2a3e39-005bdb4682
       Date:
-      - Thu, 25 Oct 2018 18:22:58 GMT
+      - Thu, 01 Nov 2018 18:31:30 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:58 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:30 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -14592,15 +14593,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:22:59 GMT
+      - Thu, 01 Nov 2018 18:31:30 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - f91c54f710b64497b08ce8b25d0bf03f
+      - '0241922db65f48839831da121cf59c38'
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-e61e79d8-b6f5-4fea-90f8-9ac66a213d40
+      - req-63a1689a-7427-4163-ac42-7d099caf7d85
       Content-Length:
       - '7264'
       Connection:
@@ -14612,7 +14613,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:22:59.081223Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:31:30.440091Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -14691,10 +14692,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["4sklUnGtQ6KTboghUCpQVw"],
-        "issued_at": "2018-10-25T18:22:59.081245Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["S2r8BjrbRpijtT-yjLCUxA"],
+        "issued_at": "2018-11-01T18:31:30.440118Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:59 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:30 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_4637c33fee924ebea81f8d209e452c91/?format=json&limit=1000
@@ -14709,7 +14710,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f91c54f710b64497b08ce8b25d0bf03f
+      - '0241922db65f48839831da121cf59c38'
   response:
     status:
       code: 200
@@ -14738,15 +14739,15 @@ http_interactions:
       X-Account-Project-Domain-Id:
       - default
       X-Trans-Id:
-      - tx5f1a6323600f4b1599e98-005bd20a03
+      - tx6d64c79b2c4e4960a633e-005bdb4682
       Date:
-      - Thu, 25 Oct 2018 18:22:59 GMT
+      - Thu, 01 Nov 2018 18:31:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '[{"count": 3, "bytes": 33, "name": "dir_1"}, {"count": 0, "bytes":
         0, "name": "dir_2"}, {"count": 0, "bytes": 0, "name": "dir_3"}]'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:59 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:30 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_4637c33fee924ebea81f8d209e452c91/?format=json&limit=1000&marker=dir_3
@@ -14761,7 +14762,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f91c54f710b64497b08ce8b25d0bf03f
+      - '0241922db65f48839831da121cf59c38'
   response:
     status:
       code: 200
@@ -14790,14 +14791,14 @@ http_interactions:
       X-Account-Project-Domain-Id:
       - default
       X-Trans-Id:
-      - tx50243ffefbc6466280609-005bd20a03
+      - txb65044bbc0b04a0ca28c9-005bdb4682
       Date:
-      - Thu, 25 Oct 2018 18:22:59 GMT
+      - Thu, 01 Nov 2018 18:31:30 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:59 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:30 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -14815,15 +14816,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:22:59 GMT
+      - Thu, 01 Nov 2018 18:31:30 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 0cec305458214e1cb01ddb815933ba74
+      - 3148f8f838e74725be128a035579a007
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-1b6828a6-ce3d-4a12-ac28-21841ca887b4
+      - req-c923066d-f678-48b3-90fa-7da616aa47c4
       Content-Length:
       - '7278'
       Connection:
@@ -14835,7 +14836,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:22:59.551141Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:31:30.884943Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -14914,10 +14915,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["qVjbBujfQTO_S3ve-MfYyA"],
-        "issued_at": "2018-10-25T18:22:59.551166Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["e0Rg76EJTbajsh04SJfU7w"],
+        "issued_at": "2018-11-01T18:31:30.884964Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:59 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:30 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_52c452d7763a4295950527948232a3e5/?format=json&limit=1000
@@ -14932,7 +14933,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0cec305458214e1cb01ddb815933ba74
+      - 3148f8f838e74725be128a035579a007
   response:
     status:
       code: 200
@@ -14945,22 +14946,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1540491779.68125'
+      - '1541097091.01978'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1540491779.68125'
+      - '1541097091.01978'
       X-Trans-Id:
-      - txca1ffcbf7d8146f9a2675-005bd20a03
+      - txba06b35c5dee4d07a8692-005bdb4682
       Date:
-      - Thu, 25 Oct 2018 18:22:59 GMT
+      - Thu, 01 Nov 2018 18:31:31 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:59 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:31 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_88ae57d444fd485ab2dfddd5a2615d52/?format=json&limit=1000
@@ -14975,7 +14976,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8753591aa21d464f8bf26dec4d6ad7b4
+      - c9d27448fdea4d73a07e9a2d0d8eccf8
   response:
     status:
       code: 200
@@ -14988,22 +14989,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1540491779.79574'
+      - '1541097091.13784'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1540491779.79574'
+      - '1541097091.13784'
       X-Trans-Id:
-      - tx6bc28a73bc024d1c85470-005bd20a03
+      - txad465a4586624162b1ec9-005bdb4683
       Date:
-      - Thu, 25 Oct 2018 18:22:59 GMT
+      - Thu, 01 Nov 2018 18:31:31 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:22:59 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:31 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -15021,15 +15022,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:22:59 GMT
+      - Thu, 01 Nov 2018 18:31:31 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - b01d690c2c364a60a223c556fc7c1375
+      - 2c7f88ace1514ecfa5b32f5b75812ba3
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-77cfbcb7-c478-4105-a587-3a8494f934c0
+      - req-671c6e8a-8a42-446d-aafc-75207860ef60
       Content-Length:
       - '7265'
       Connection:
@@ -15041,7 +15042,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:22:59.987729Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:31:31.341109Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -15120,10 +15121,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["N9g17dVjSWKASSrS-hNfkg"],
-        "issued_at": "2018-10-25T18:22:59.987751Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["L3Q3EwuHSZeuZ3wTJ7q06w"],
+        "issued_at": "2018-11-01T18:31:31.341130Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:00 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:31 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_d09cbe26295d47ff848ea73c74264e23/?format=json&limit=1000
@@ -15138,7 +15139,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b01d690c2c364a60a223c556fc7c1375
+      - 2c7f88ace1514ecfa5b32f5b75812ba3
   response:
     status:
       code: 200
@@ -15151,22 +15152,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1540491780.11591'
+      - '1541097091.47872'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1540491780.11591'
+      - '1541097091.47872'
       X-Trans-Id:
-      - tx05482d307b264fc792b27-005bd20a04
+      - tx4319e7401ba84df489f83-005bdb4683
       Date:
-      - Thu, 25 Oct 2018 18:23:00 GMT
+      - Thu, 01 Nov 2018 18:31:31 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:00 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:31 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -15184,15 +15185,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:23:00 GMT
+      - Thu, 01 Nov 2018 18:31:31 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - cd7bdf8051dc490882c15f14fc077c0c
+      - 9a4dc08f56754d879aa0c9da4664ed3c
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-561d37df-3514-4261-a5a1-386382c0d068
+      - req-383cbc84-31a4-4b74-a6a6-3135a651febf
       Content-Length:
       - '7278'
       Connection:
@@ -15204,7 +15205,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-10-25T19:23:00.311000Z", "project": {"domain": {"id":
+        "expires_at": "2018-11-01T19:31:31.679557Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -15283,10 +15284,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["eGZ9JVJoQPebeJqhDiOhDg"],
-        "issued_at": "2018-10-25T18:23:00.311025Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["hAFUjMEDTouE2O6uydWvAw"],
+        "issued_at": "2018-11-01T18:31:31.679577Z"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:00 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:31 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_ef2a3405d1ef4dfd9a3616993ef46a4d/?format=json&limit=1000
@@ -15301,7 +15302,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cd7bdf8051dc490882c15f14fc077c0c
+      - 9a4dc08f56754d879aa0c9da4664ed3c
   response:
     status:
       code: 200
@@ -15314,22 +15315,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1540491780.44213'
+      - '1541097091.81627'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1540491780.44213'
+      - '1541097091.81627'
       X-Trans-Id:
-      - tx5bc79494fda44cb993e13-005bd20a04
+      - txa832144976f247cb966a2-005bdb4683
       Date:
-      - Thu, 25 Oct 2018 18:23:00 GMT
+      - Thu, 01 Nov 2018 18:31:31 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:00 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:31 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_4637c33fee924ebea81f8d209e452c91/dir_1?format=json
@@ -15344,7 +15345,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f91c54f710b64497b08ce8b25d0bf03f
+      - '0241922db65f48839831da121cf59c38'
   response:
     status:
       code: 200
@@ -15365,9 +15366,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - tx8fe2a5e7b9124b359f914-005bd20a04
+      - tx855558b39384471d8f748-005bdb4683
       Date:
-      - Thu, 25 Oct 2018 18:23:00 GMT
+      - Thu, 01 Nov 2018 18:31:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '[{"hash": "61257bf228e2f6802a196c9a460d19a8", "last_modified": "2016-08-19T08:37:59.564460",
@@ -15377,7 +15378,7 @@ http_interactions:
         {"hash": "1727a9b61bddf85bbe7a5710c9f45691", "last_modified": "2016-08-19T08:38:00.995870",
         "bytes": 11, "name": "file_3", "content_type": "application/octet-stream"}]'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:00 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:31 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_4637c33fee924ebea81f8d209e452c91/dir_2?format=json
@@ -15392,7 +15393,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f91c54f710b64497b08ce8b25d0bf03f
+      - '0241922db65f48839831da121cf59c38'
   response:
     status:
       code: 200
@@ -15413,14 +15414,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - tx9cd65f3c289e4054acdba-005bd20a04
+      - txa259e98974134475998b1-005bdb4684
       Date:
-      - Thu, 25 Oct 2018 18:23:00 GMT
+      - Thu, 01 Nov 2018 18:31:32 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:00 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:32 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_4637c33fee924ebea81f8d209e452c91/dir_3?format=json
@@ -15435,7 +15436,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f91c54f710b64497b08ce8b25d0bf03f
+      - '0241922db65f48839831da121cf59c38'
   response:
     status:
       code: 200
@@ -15456,12 +15457,12 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - tx15cc09f77e78469687a3b-005bd20a04
+      - txd7f3780b3d0a4cb3adda3-005bdb4684
       Date:
-      - Thu, 25 Oct 2018 18:23:00 GMT
+      - Thu, 01 Nov 2018 18:31:32 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:23:00 GMT
+  recorded_at: Thu, 01 Nov 2018 18:31:32 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_legacy_fast_refresh.yml
+++ b/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_legacy_fast_refresh.yml
@@ -17,13 +17,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:18:50 GMT
+      - Thu, 01 Nov 2018 18:33:53 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-4a999528-d230-4d85-99ec-9c33765eb315
+      - req-5ba3cf9f-b42a-41d7-bafb-d84908e4556f
       Content-Length:
       - '4170'
       Connection:
@@ -32,10 +32,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:18:51.008906", "expires":
-        "2018-10-25T19:18:50Z", "id": "f62a708414a54311af58f113b00a65b3", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:33:53.633567", "expires":
+        "2018-11-01T19:33:53Z", "id": "b4299fc1651d47448bc035fd737e5923", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["H76FoWlETAOPiIzXSeJDxQ"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["nTnuGJHdTYSEeEUpqPSzHQ"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -80,7 +80,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:18:51 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:53 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -95,7 +95,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f62a708414a54311af58f113b00a65b3
+      - b4299fc1651d47448bc035fd737e5923
   response:
     status:
       code: 200
@@ -106,7 +106,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Thu, 25 Oct 2018 18:18:51 GMT
+      - Thu, 01 Nov 2018 18:33:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -115,7 +115,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:18:51 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:53 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -133,13 +133,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:18:51 GMT
+      - Thu, 01 Nov 2018 18:33:53 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-779d8a9a-2eba-4478-a2ee-080e8a407e2a
+      - req-e7042b56-9035-43fb-927c-88157fff7b32
       Content-Length:
       - '4170'
       Connection:
@@ -148,10 +148,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:18:51.628044", "expires":
-        "2018-10-25T19:18:51Z", "id": "f64906fa09424f9684c8339b5679811b", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:33:53.919241", "expires":
+        "2018-11-01T19:33:53Z", "id": "2acc73ecea0c4f9a98439fb237740321", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["Xc1xS6reRBKwGWX89ot3vQ"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["kgDb9wd5S7G-WRvUiNSsgQ"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -196,7 +196,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:18:51 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:53 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -214,13 +214,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:18:51 GMT
+      - Thu, 01 Nov 2018 18:33:54 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-105cceba-3a2b-4a98-a950-baa10f67bebc
+      - req-e1d15537-0901-44b6-b397-006e639e3031
       Content-Length:
       - '4170'
       Connection:
@@ -229,10 +229,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:18:51.827692", "expires":
-        "2018-10-25T19:18:51Z", "id": "b7b81a82496443559c43d00a3463ae10", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:33:54.114818", "expires":
+        "2018-11-01T19:33:54Z", "id": "a4e97c15088244ad9697621e1262dbd7", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["RLkeTXCGQZSPfSnU-XixvA"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["lkq7mepFSKSHeoOrUtONMg"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -277,7 +277,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:18:51 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:54 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -295,13 +295,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:18:51 GMT
+      - Thu, 01 Nov 2018 18:33:54 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-d55f148c-61de-4657-9049-feb19959b8f3
+      - req-c166e0da-e67e-45ba-8ac7-91dae9106a65
       Content-Length:
       - '4170'
       Connection:
@@ -310,10 +310,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:18:52.046951", "expires":
-        "2018-10-25T19:18:52Z", "id": "3e98b31fe83541bca8af8b6614b5c870", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:33:54.308947", "expires":
+        "2018-11-01T19:33:54Z", "id": "3997ad1a62de48219cc50bf6c7deba46", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["rzaxB68SRfyZZyUAmbhnqA"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["fAAWYGPnTxS7SOFH_bYfEg"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -358,7 +358,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:18:52 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:54 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -376,13 +376,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:18:52 GMT
+      - Thu, 01 Nov 2018 18:33:54 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-02ac5d35-592f-4ed2-9682-32e228038e49
+      - req-f2dea1fd-1b9d-49cf-a86c-51ba01eb0a6c
       Content-Length:
       - '4170'
       Connection:
@@ -391,10 +391,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:18:52.404729", "expires":
-        "2018-10-25T19:18:52Z", "id": "2387293e47d04a44a2b29e7b10b4cac8", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:33:54.508583", "expires":
+        "2018-11-01T19:33:54Z", "id": "5d25e5e98cc14e10a656a3b498b50552", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["sewJfXQPRhmmrBQ7P3lJnw"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["TeVh3hnBRC6pUDoEKv_NpA"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -439,7 +439,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:18:52 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:54 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -457,13 +457,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:18:52 GMT
+      - Thu, 01 Nov 2018 18:33:54 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-281ea2ac-7963-484b-a274-84bfe91b5aa9
+      - req-9f471a23-7148-438d-874e-faff3e3a8459
       Content-Length:
       - '4170'
       Connection:
@@ -472,10 +472,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:18:52.636814", "expires":
-        "2018-10-25T19:18:52Z", "id": "3cdf759937994bfda9cb8180d582cefc", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:33:54.700675", "expires":
+        "2018-11-01T19:33:54Z", "id": "1ae4ff44e18f42b68b90454160103f72", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["iBKKdzOJRWqcgpy8Wrzt0Q"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["dugfs4E7Qpm0V4mChgw9XQ"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -520,7 +520,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:18:52 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:54 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -538,13 +538,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:18:52 GMT
+      - Thu, 01 Nov 2018 18:33:54 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-b6eb48fd-38ea-44fb-b436-dc4cbbd41bf9
+      - req-97caa12c-28ac-46e8-a759-0fe2c181e6b7
       Content-Length:
       - '4170'
       Connection:
@@ -553,10 +553,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:18:52.882045", "expires":
-        "2018-10-25T19:18:52Z", "id": "fc93cfea992141b2b3f33861e00ccc11", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:33:54.974697", "expires":
+        "2018-11-01T19:33:54Z", "id": "eb3e041dddc34b4d8dfb7d2f3828d213", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["-wUPuMa4Q9iabw8zqAjcRw"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["VdJ4ir4KT7WrR5SLlBPwDA"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -601,7 +601,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:18:52 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:55 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -619,13 +619,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:18:53 GMT
+      - Thu, 01 Nov 2018 18:33:55 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-01ccd17d-bbdb-4d5d-9023-c57b468eaea6
+      - req-35bc9bdb-1062-4a36-9b89-e6ddd749eefe
       Content-Length:
       - '4170'
       Connection:
@@ -634,10 +634,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:18:53.142221", "expires":
-        "2018-10-25T19:18:53Z", "id": "41cc0054e6014e34adc973534935eeed", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:33:55.167409", "expires":
+        "2018-11-01T19:33:55Z", "id": "9ab033b55ab84bbba2a56ebbd53b6176", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["yY6U2Pp4SEueGzMkZFvPEw"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["dbcgAuJuRqm6oQ6iMMlb-Q"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -682,7 +682,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:18:53 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:55 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -700,13 +700,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:18:53 GMT
+      - Thu, 01 Nov 2018 18:33:55 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-f144ca7a-a5f3-402b-afb3-99ee82d36058
+      - req-8a74cb04-969c-4af2-a7ce-f845e8d3b6bb
       Content-Length:
       - '370'
       Connection:
@@ -715,13 +715,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:18:53.308760", "expires":
-        "2018-10-25T19:18:53Z", "id": "08cae195023c487a9f9fa2010670f8a4", "audit_ids":
-        ["2SPTj15CRsiYYRfr0KSALg"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:33:55.328992", "expires":
+        "2018-11-01T19:33:55Z", "id": "ea0f15a0ddbf44968a5919f3b5a54fa9", "audit_ids":
+        ["YoEAAABkQLutl2Zwj1Nx-Q"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:18:53 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:55 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -736,20 +736,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '08cae195023c487a9f9fa2010670f8a4'
+      - ea0f15a0ddbf44968a5919f3b5a54fa9
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:18:53 GMT
+      - Thu, 01 Nov 2018 18:33:55 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-a09db42a-8512-4026-b80a-337c6178c17f
+      - req-0b8b1f8e-285c-44c8-949f-df126be5e94a
       Content-Length:
       - '500'
       Connection:
@@ -766,7 +766,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:18:53 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:55 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -784,13 +784,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:18:53 GMT
+      - Thu, 01 Nov 2018 18:33:55 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-7a7acff4-5414-40ee-9a3f-7d218c690456
+      - req-cbe30766-566f-4d3b-9337-872d27fe49cd
       Content-Length:
       - '4117'
       Connection:
@@ -799,10 +799,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:18:53.630615", "expires":
-        "2018-10-25T19:18:53Z", "id": "81cabbfb9d39459299262bf35b482ead", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:33:55.663549", "expires":
+        "2018-11-01T19:33:55Z", "id": "80ae4c20defb4555a2c2f93ba0868ae7", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["EYGqaRmLTt-rI04qstOlQw"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["Jy-Oc3qnQDaBdE6eI6jDRA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -846,7 +846,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:18:53 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:55 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -861,7 +861,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 81cabbfb9d39459299262bf35b482ead
+      - 80ae4c20defb4555a2c2f93ba0868ae7
   response:
     status:
       code: 200
@@ -872,7 +872,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Thu, 25 Oct 2018 18:18:53 GMT
+      - Thu, 01 Nov 2018 18:33:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -881,7 +881,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:18:53 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:55 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -899,13 +899,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:18:53 GMT
+      - Thu, 01 Nov 2018 18:33:55 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-565569f3-cfe4-4df2-8c3b-00ddf2d03c80
+      - req-51659fec-961a-43c3-a1bd-13e839834176
       Content-Length:
       - '4131'
       Connection:
@@ -914,10 +914,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:18:53.895536", "expires":
-        "2018-10-25T19:18:53Z", "id": "a3aa2cad4b4c4dada157d26b2e68a4a4", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:33:55.960531", "expires":
+        "2018-11-01T19:33:55Z", "id": "636114ed1f7146b48139a354a06af293", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["gXR0n8QbR1afOMu_YZGeTg"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["FdldmdBsQ2yVFjVca0Srog"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -961,7 +961,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:18:53 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:55 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -976,7 +976,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a3aa2cad4b4c4dada157d26b2e68a4a4
+      - 636114ed1f7146b48139a354a06af293
   response:
     status:
       code: 200
@@ -987,7 +987,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Thu, 25 Oct 2018 18:18:53 GMT
+      - Thu, 01 Nov 2018 18:33:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -996,7 +996,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:18:54 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:56 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1014,13 +1014,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:18:54 GMT
+      - Thu, 01 Nov 2018 18:33:56 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-0362ea23-c315-47db-a630-6ea75a0161e7
+      - req-7cb50cf1-42cf-44fe-8ff6-d2a8c8e6c4fe
       Content-Length:
       - '4118'
       Connection:
@@ -1029,10 +1029,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:18:54.157571", "expires":
-        "2018-10-25T19:18:54Z", "id": "b6200c7d10824ffb97f5892f251eb64b", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:33:56.230478", "expires":
+        "2018-11-01T19:33:56Z", "id": "bd7b214781b64600b060b2c58ddff8ba", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["3fFFy93yScWfhmZad_2jYw"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["ZZBTXzRcRcq55QLZbbRjbA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -1076,7 +1076,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:18:54 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:56 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -1091,7 +1091,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b6200c7d10824ffb97f5892f251eb64b
+      - bd7b214781b64600b060b2c58ddff8ba
   response:
     status:
       code: 200
@@ -1102,7 +1102,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Thu, 25 Oct 2018 18:18:54 GMT
+      - Thu, 01 Nov 2018 18:33:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -1111,7 +1111,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:18:54 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:56 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000
@@ -1126,7 +1126,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f62a708414a54311af58f113b00a65b3
+      - b4299fc1651d47448bc035fd737e5923
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1139,9 +1139,9 @@ http_interactions:
       Content-Length:
       - '1010'
       X-Compute-Request-Id:
-      - req-a0241c5c-06c1-40ff-afbe-7b36eb240bef
+      - req-7b128632-162b-4557-a1eb-c2a1009a84d7
       Date:
-      - Thu, 25 Oct 2018 18:18:54 GMT
+      - Thu, 01 Nov 2018 18:33:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.tiny", "links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/1",
@@ -1155,7 +1155,7 @@ http_interactions:
         0, "disk": 20, "id": "2"}], "flavors_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=2",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:18:54 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:56 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=2
@@ -1170,7 +1170,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f62a708414a54311af58f113b00a65b3
+      - b4299fc1651d47448bc035fd737e5923
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1183,9 +1183,9 @@ http_interactions:
       Content-Length:
       - '1014'
       X-Compute-Request-Id:
-      - req-e7cb45fe-4feb-4035-80df-08351c43ecac
+      - req-6ed3a879-e18b-4b87-beb0-874171b3b8aa
       Date:
-      - Thu, 25 Oct 2018 18:18:54 GMT
+      - Thu, 01 Nov 2018 18:33:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.medium", "links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/3",
@@ -1199,7 +1199,7 @@ http_interactions:
         0, "disk": 80, "id": "4"}], "flavors_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=4",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:18:54 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:56 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=4
@@ -1214,7 +1214,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f62a708414a54311af58f113b00a65b3
+      - b4299fc1651d47448bc035fd737e5923
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1227,9 +1227,9 @@ http_interactions:
       Content-Length:
       - '1026'
       X-Compute-Request-Id:
-      - req-38160db3-12eb-4ab8-b333-9742f58644c9
+      - req-637c19a9-85ce-4d94-9fce-8fddbf5c50db
       Date:
-      - Thu, 25 Oct 2018 18:18:54 GMT
+      - Thu, 01 Nov 2018 18:33:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.xlarge", "links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/5",
@@ -1244,7 +1244,7 @@ http_interactions:
         1, "disk": 1, "id": "6"}], "flavors_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=6",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:18:54 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:57 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=6
@@ -1259,7 +1259,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f62a708414a54311af58f113b00a65b3
+      - b4299fc1651d47448bc035fd737e5923
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1272,9 +1272,9 @@ http_interactions:
       Content-Length:
       - '448'
       X-Compute-Request-Id:
-      - req-ade3117c-9ec4-4b7a-82ba-3a66cfad3f62
+      - req-5f349246-7857-4171-9d3d-048c8f71e9ac
       Date:
-      - Thu, 25 Oct 2018 18:18:54 GMT
+      - Thu, 01 Nov 2018 18:33:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.ems_refresh_spec_private", "links": [{"href":
@@ -1284,7 +1284,7 @@ http_interactions:
         8, "swap": "", "os-flavor-access:is_public": false, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         0, "disk": 160, "id": "7"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:18:54 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:57 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/7/os-flavor-access
@@ -1299,7 +1299,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f62a708414a54311af58f113b00a65b3
+      - b4299fc1651d47448bc035fd737e5923
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1312,15 +1312,15 @@ http_interactions:
       Content-Length:
       - '88'
       X-Compute-Request-Id:
-      - req-1b84f8c9-4784-4f28-8acf-16be83d66aa8
+      - req-5e7c5dc8-0205-478f-9d88-2d08c4099008
       Date:
-      - Thu, 25 Oct 2018 18:18:54 GMT
+      - Thu, 01 Nov 2018 18:33:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavor_access": [{"tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "flavor_id": "7"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:18:54 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:57 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-availability-zone
@@ -1335,7 +1335,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f62a708414a54311af58f113b00a65b3
+      - b4299fc1651d47448bc035fd737e5923
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1348,15 +1348,15 @@ http_interactions:
       Content-Length:
       - '97'
       X-Compute-Request-Id:
-      - req-8c9baae5-ff3d-4968-b14d-ee50bb1b7c3e
+      - req-7f4d0ee1-1704-4941-a6c8-76552a525783
       Date:
-      - Thu, 25 Oct 2018 18:18:55 GMT
+      - Thu, 01 Nov 2018 18:33:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"availabilityZoneInfo": [{"zoneState": {"available": true}, "hosts":
         null, "zoneName": "nova"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:18:55 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:57 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-availability-zone.json
@@ -1371,28 +1371,28 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2387293e47d04a44a2b29e7b10b4cac8
+      - 5d25e5e98cc14e10a656a3b498b50552
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-74cafb47-185e-4901-aa20-9fc35e61243a
+      - req-8516c56d-cf8d-4749-80ef-6aa2093371d6
       Content-Type:
       - application/json
       Content-Length:
       - '82'
       X-Openstack-Request-Id:
-      - req-74cafb47-185e-4901-aa20-9fc35e61243a
+      - req-8516c56d-cf8d-4749-80ef-6aa2093371d6
       Date:
-      - Thu, 25 Oct 2018 18:18:55 GMT
+      - Thu, 01 Nov 2018 18:33:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"availabilityZoneInfo": [{"zoneState": {"available": true}, "zoneName":
         "nova"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:18:55 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:57 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-aggregates
@@ -1407,7 +1407,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f62a708414a54311af58f113b00a65b3
+      - b4299fc1651d47448bc035fd737e5923
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1420,14 +1420,14 @@ http_interactions:
       Content-Length:
       - '18'
       X-Compute-Request-Id:
-      - req-dc876100-d665-4101-a6e4-518fecb705bf
+      - req-b64f0206-c5a0-4cdf-911b-3b9455f92ffb
       Date:
-      - Thu, 25 Oct 2018 18:18:55 GMT
+      - Thu, 01 Nov 2018 18:33:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"aggregates": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:18:55 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:57 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a//os-quota-sets/69f8f7205ade4aa59084c32c83e60b5a
@@ -1442,7 +1442,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 81cabbfb9d39459299262bf35b482ead
+      - 80ae4c20defb4555a2c2f93ba0868ae7
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1455,9 +1455,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-87232b66-a844-4948-adab-f04e3b9ee9e5
+      - req-9126eb39-7d6f-45cd-9be9-e6faef87ebf8
       Date:
-      - Thu, 25 Oct 2018 18:18:55 GMT
+      - Thu, 01 Nov 2018 18:33:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -1466,7 +1466,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:18:55 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:57 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8//os-quota-sets/b458a5c25c3749758f4c0661940b3ba8
@@ -1481,7 +1481,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a3aa2cad4b4c4dada157d26b2e68a4a4
+      - 636114ed1f7146b48139a354a06af293
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1494,9 +1494,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-da8434ad-f4b8-4f8e-a879-ef03d0eb439c
+      - req-a1aa7729-f769-4784-a66b-02847fb301f7
       Date:
-      - Thu, 25 Oct 2018 18:18:55 GMT
+      - Thu, 01 Nov 2018 18:33:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -1505,7 +1505,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:18:55 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:57 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a//os-quota-sets/e54e5c3c19e34720b05661f2ea1ea00a
@@ -1520,7 +1520,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f62a708414a54311af58f113b00a65b3
+      - b4299fc1651d47448bc035fd737e5923
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1533,9 +1533,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-8308d2bf-aecb-4e18-8bbb-875d29ed8697
+      - req-a69904a2-411b-4cc7-aba8-68232365cbb4
       Date:
-      - Thu, 25 Oct 2018 18:18:55 GMT
+      - Thu, 01 Nov 2018 18:33:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -1544,7 +1544,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:18:55 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:58 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608//os-quota-sets/e8f744b1fc6a487681d35fb275252608
@@ -1559,7 +1559,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b6200c7d10824ffb97f5892f251eb64b
+      - bd7b214781b64600b060b2c58ddff8ba
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1572,9 +1572,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-df7a012c-34ba-422e-a454-4f1840bc7d5d
+      - req-6576671d-2320-4828-8b07-d0c011555dcc
       Date:
-      - Thu, 25 Oct 2018 18:18:55 GMT
+      - Thu, 01 Nov 2018 18:33:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -1583,7 +1583,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:18:55 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:58 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1601,13 +1601,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:18:56 GMT
+      - Thu, 01 Nov 2018 18:33:58 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-5c3acd7c-86b3-4cad-9082-a7be8a76590b
+      - req-eb572320-359f-49f8-9be5-67d452f26677
       Content-Length:
       - '4117'
       Connection:
@@ -1616,10 +1616,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:18:56.129245", "expires":
-        "2018-10-25T19:18:56Z", "id": "d79950dccdbb40b088d24456211d5c31", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:33:58.397789", "expires":
+        "2018-11-01T19:33:58Z", "id": "1ab955f2b9494942b18827fca768227d", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["sNbRbcLMSNOUXGFbZ-Ka9g"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["TJng83dGQj2xLCLu99rYlA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -1663,7 +1663,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:18:56 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:58 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a//os-quota-sets/69f8f7205ade4aa59084c32c83e60b5a
@@ -1678,22 +1678,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d79950dccdbb40b088d24456211d5c31
+      - 1ab955f2b9494942b18827fca768227d
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-95767645-ad4a-4741-a87e-b8c53b8c416c
+      - req-e5d4f5f6-524c-414a-a1e2-951dd2e7e300
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-95767645-ad4a-4741-a87e-b8c53b8c416c
+      - req-e5d4f5f6-524c-414a-a1e2-951dd2e7e300
       Date:
-      - Thu, 25 Oct 2018 18:18:56 GMT
+      - Thu, 01 Nov 2018 18:33:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -1703,7 +1703,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "69f8f7205ade4aa59084c32c83e60b5a"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:18:56 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:58 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1721,13 +1721,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:18:56 GMT
+      - Thu, 01 Nov 2018 18:33:58 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-e3512c73-9e40-43b7-bc52-57a3e5d59f40
+      - req-feae855f-5d42-4f8b-a7a6-73e54d5c22dc
       Content-Length:
       - '4131'
       Connection:
@@ -1736,10 +1736,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:18:56.667355", "expires":
-        "2018-10-25T19:18:56Z", "id": "0bdb892631cb42f8a6a6ec00bdc0100d", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:33:58.875792", "expires":
+        "2018-11-01T19:33:58Z", "id": "bb470980ec384fbea2ab0cc3f6e0a535", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["g6y45KcTQPCAvq7s5XNIUQ"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["EBB8e1cLTJqDLFzRQ6EL0g"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -1783,7 +1783,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:18:56 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:58 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8//os-quota-sets/b458a5c25c3749758f4c0661940b3ba8
@@ -1798,22 +1798,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0bdb892631cb42f8a6a6ec00bdc0100d
+      - bb470980ec384fbea2ab0cc3f6e0a535
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-58985d19-3c42-41c1-bb25-7954c387b271
+      - req-139c1ba6-37e2-4970-b247-8b31c71f1c8f
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-58985d19-3c42-41c1-bb25-7954c387b271
+      - req-139c1ba6-37e2-4970-b247-8b31c71f1c8f
       Date:
-      - Thu, 25 Oct 2018 18:18:56 GMT
+      - Thu, 01 Nov 2018 18:33:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -1823,7 +1823,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "b458a5c25c3749758f4c0661940b3ba8"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:18:56 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:59 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a//os-quota-sets/e54e5c3c19e34720b05661f2ea1ea00a
@@ -1838,22 +1838,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2387293e47d04a44a2b29e7b10b4cac8
+      - 5d25e5e98cc14e10a656a3b498b50552
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-c424bf5a-9aca-4000-8b1c-18dd67617c42
+      - req-949dd9c2-ea66-41a7-bcc9-cdbae7266f8b
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-c424bf5a-9aca-4000-8b1c-18dd67617c42
+      - req-949dd9c2-ea66-41a7-bcc9-cdbae7266f8b
       Date:
-      - Thu, 25 Oct 2018 18:18:57 GMT
+      - Thu, 01 Nov 2018 18:33:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -1863,7 +1863,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "e54e5c3c19e34720b05661f2ea1ea00a"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:18:57 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:59 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1881,13 +1881,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:18:57 GMT
+      - Thu, 01 Nov 2018 18:33:59 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-24ba7a78-5bdb-453f-a5ea-78eb3ebb2c31
+      - req-44aedb22-66a5-456a-b9f7-f1794cc311bf
       Content-Length:
       - '4118'
       Connection:
@@ -1896,10 +1896,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:18:57.433110", "expires":
-        "2018-10-25T19:18:57Z", "id": "b919c7177b5841619f68b9d68d9cc60b", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:33:59.615654", "expires":
+        "2018-11-01T19:33:59Z", "id": "519493eb524347289ed961e547322a66", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["tRjbQ7lpT8Ko7KeeW-fdjQ"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["6RLnwBpaTHqhqq5V2mWfIg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -1943,7 +1943,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:18:57 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:59 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608//os-quota-sets/e8f744b1fc6a487681d35fb275252608
@@ -1958,22 +1958,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b919c7177b5841619f68b9d68d9cc60b
+      - 519493eb524347289ed961e547322a66
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-eb5cb851-0fc2-42a5-98d6-ae0775462080
+      - req-11153aeb-ba50-4f23-9fb0-00b0591697e7
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-eb5cb851-0fc2-42a5-98d6-ae0775462080
+      - req-11153aeb-ba50-4f23-9fb0-00b0591697e7
       Date:
-      - Thu, 25 Oct 2018 18:18:57 GMT
+      - Thu, 01 Nov 2018 18:33:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -1983,7 +1983,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "e8f744b1fc6a487681d35fb275252608"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:18:57 GMT
+  recorded_at: Thu, 01 Nov 2018 18:33:59 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -2001,13 +2001,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:18:57 GMT
+      - Thu, 01 Nov 2018 18:34:00 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-66681052-b98d-4fdb-a2bc-82359dd77a50
+      - req-ae5e3d1f-84a0-4368-9cd0-5b059331e8a1
       Content-Length:
       - '4117'
       Connection:
@@ -2016,10 +2016,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:18:57.943009", "expires":
-        "2018-10-25T19:18:57Z", "id": "89288df0524c42c69c60a6bfc0a2b08f", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:34:00.116298", "expires":
+        "2018-11-01T19:34:00Z", "id": "880f0882f32a4ad2bbba36972c49d3e0", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["lFRaEEeDT7GIWrNK_-zMKQ"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["txdmCiKwR8ehq8bZOLn-ww"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -2063,7 +2063,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:18:57 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:00 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0//quotas/69f8f7205ade4aa59084c32c83e60b5a
@@ -2078,7 +2078,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 89288df0524c42c69c60a6bfc0a2b08f
+      - 880f0882f32a4ad2bbba36972c49d3e0
   response:
     status:
       code: 200
@@ -2089,16 +2089,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-fc5141d6-2445-473e-98e7-a14aada82c7d
+      - req-dd623e2c-e80b-4a01-bbb4-22d895c31c15
       Date:
-      - Thu, 25 Oct 2018 18:18:58 GMT
+      - Thu, 01 Nov 2018 18:34:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 20, "network": 20, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:18:58 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:00 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -2116,13 +2116,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:18:58 GMT
+      - Thu, 01 Nov 2018 18:34:00 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-58d25be9-d982-4b53-922c-027b859afa39
+      - req-754cacfa-d516-4c09-be6e-073a4ee7f4f5
       Content-Length:
       - '4131'
       Connection:
@@ -2131,10 +2131,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:18:58.286540", "expires":
-        "2018-10-25T19:18:58Z", "id": "305c55d30176468db6351df9a06f3d58", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:34:00.477616", "expires":
+        "2018-11-01T19:34:00Z", "id": "b57992f3df73424b871e32a305855a9a", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["rJ45XlIySoK6ozI93OF1ZQ"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["jeb03MDYR0OMuSH_7Obdbg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -2178,7 +2178,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:18:58 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:00 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0//quotas/b458a5c25c3749758f4c0661940b3ba8
@@ -2193,7 +2193,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 305c55d30176468db6351df9a06f3d58
+      - b57992f3df73424b871e32a305855a9a
   response:
     status:
       code: 200
@@ -2204,16 +2204,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-d7917210-8298-435b-8e26-b4b1fcc3fd85
+      - req-abe80a13-565a-42b3-bfd2-409680b0f29b
       Date:
-      - Thu, 25 Oct 2018 18:18:58 GMT
+      - Thu, 01 Nov 2018 18:34:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:18:58 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:00 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0//quotas/e54e5c3c19e34720b05661f2ea1ea00a
@@ -2228,7 +2228,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f64906fa09424f9684c8339b5679811b
+      - 2acc73ecea0c4f9a98439fb237740321
   response:
     status:
       code: 200
@@ -2239,16 +2239,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-db482807-a6d4-46e5-82d7-c0e156de970b
+      - req-93e35033-ee2e-4a9a-adbc-657e362018c4
       Date:
-      - Thu, 25 Oct 2018 18:18:58 GMT
+      - Thu, 01 Nov 2018 18:34:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:18:58 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:00 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -2266,13 +2266,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:18:58 GMT
+      - Thu, 01 Nov 2018 18:34:00 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-3972d38c-3d18-4617-912c-10f8063c5f2a
+      - req-0d18cddb-4a81-4beb-b51a-153c09f840b4
       Content-Length:
       - '4118'
       Connection:
@@ -2281,10 +2281,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:18:58.771792", "expires":
-        "2018-10-25T19:18:58Z", "id": "dabe09b463674b8ea69d79e4a80a585b", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:34:00.981715", "expires":
+        "2018-11-01T19:34:00Z", "id": "bcbf12ea89334de0acb67c47bbbfa62e", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["O-kxLbUJR7-RbHPB98Xlmw"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["Clf4CGDtQEGo-XZvdww7Xw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -2328,7 +2328,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:18:58 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:01 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0//quotas/e8f744b1fc6a487681d35fb275252608
@@ -2343,7 +2343,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - dabe09b463674b8ea69d79e4a80a585b
+      - bcbf12ea89334de0acb67c47bbbfa62e
   response:
     status:
       code: 200
@@ -2354,16 +2354,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-30495f74-037d-4ab9-ae93-611baa0e5325
+      - req-4372db07-ab8b-4a04-a930-f4e3bc5b3a3e
       Date:
-      - Thu, 25 Oct 2018 18:18:58 GMT
+      - Thu, 01 Nov 2018 18:34:01 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:18:58 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:01 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-keypairs?all_tenants=True&limit=1000
@@ -2378,7 +2378,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f62a708414a54311af58f113b00a65b3
+      - b4299fc1651d47448bc035fd737e5923
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2391,9 +2391,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-1a781dbe-c875-4487-a0d4-570575a82520
+      - req-474bd19e-e9a6-4ae5-ad97-8f3d0d0f064e
       Date:
-      - Thu, 25 Oct 2018 18:18:59 GMT
+      - Thu, 01 Nov 2018 18:34:01 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -2403,7 +2403,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:18:59 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:01 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-keypairs?all_tenants=True&limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -2418,7 +2418,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f62a708414a54311af58f113b00a65b3
+      - b4299fc1651d47448bc035fd737e5923
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2431,9 +2431,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-9a67cba7-4ea6-43d6-95b5-c54f6a9d00b4
+      - req-f974c636-9916-4555-b6bd-d6cc8266c4ae
       Date:
-      - Thu, 25 Oct 2018 18:18:59 GMT
+      - Thu, 01 Nov 2018 18:34:01 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -2443,7 +2443,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:18:59 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:01 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -2461,13 +2461,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:18:59 GMT
+      - Thu, 01 Nov 2018 18:34:01 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-1c6aac61-d822-4ca3-9c8f-455c6bf4b7c4
+      - req-7be9fd1b-2121-4919-b377-b8dab5b38c2a
       Content-Length:
       - '4117'
       Connection:
@@ -2476,10 +2476,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:18:59.283699", "expires":
-        "2018-10-25T19:18:59Z", "id": "ad05b33062d14277b1b734bda51bb04c", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:34:01.542158", "expires":
+        "2018-11-01T19:34:01Z", "id": "3bf952e738204540938b18f4d88b08f3", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["a1xfKqK9RQ2lNwbhnlbmiw"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["KtSZr67OT5e7atRgRERB9Q"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -2523,7 +2523,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:18:59 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:01 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks?limit=1000&show_nested=true
@@ -2538,7 +2538,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ad05b33062d14277b1b734bda51bb04c
+      - 3bf952e738204540938b18f4d88b08f3
   response:
     status:
       code: 200
@@ -2549,9 +2549,9 @@ http_interactions:
       Content-Length:
       - '2559'
       X-Openstack-Request-Id:
-      - req-8ca8ba70-6e7d-4c4d-9c80-cd57e33e97ad
+      - req-57771662-92a0-451f-bf2a-326d28be9e1a
       Date:
-      - Thu, 25 Oct 2018 18:18:59 GMT
+      - Thu, 01 Nov 2018 18:34:01 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": [{"description": "Heat WordPress template to support F20,
@@ -2585,7 +2585,7 @@ http_interactions:
         "rel": "self"}], "updated_time": null, "stack_owner": null, "stack_status":
         "CREATE_COMPLETE", "id": "091e1e54-e01c-4ec5-a0ab-b00bee4d425c"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:18:59 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:01 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks?limit=1000&marker=091e1e54-e01c-4ec5-a0ab-b00bee4d425c&show_nested=true
@@ -2600,7 +2600,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ad05b33062d14277b1b734bda51bb04c
+      - 3bf952e738204540938b18f4d88b08f3
   response:
     status:
       code: 200
@@ -2611,14 +2611,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-e7213109-0dbc-4639-b518-f82d22dc5e57
+      - req-e40f8032-a5f5-4346-850d-28bf2ad5ac5e
       Date:
-      - Thu, 25 Oct 2018 18:18:59 GMT
+      - Thu, 01 Nov 2018 18:34:01 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:18:59 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:01 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -2636,13 +2636,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:18:59 GMT
+      - Thu, 01 Nov 2018 18:34:01 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-856d0b8b-7e2b-4f67-a87a-25bdb71d7d08
+      - req-d0d1388f-9b0e-4fcb-9963-e9422487d3ef
       Content-Length:
       - '4131'
       Connection:
@@ -2651,10 +2651,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:19:00.022642", "expires":
-        "2018-10-25T19:19:00Z", "id": "1d9dedec55c54f7b85f751d72819d9b5", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:34:02.049601", "expires":
+        "2018-11-01T19:34:02Z", "id": "b07d38593a7444808eaa690efb0a51b4", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["dZpHJ-pYTta6n5oPWKN6yg"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["xO0Aj9EBSZezLCIlwa8hGQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -2698,7 +2698,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:00 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:02 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/b458a5c25c3749758f4c0661940b3ba8/stacks?limit=1000&show_nested=true
@@ -2713,7 +2713,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1d9dedec55c54f7b85f751d72819d9b5
+      - b07d38593a7444808eaa690efb0a51b4
   response:
     status:
       code: 200
@@ -2724,14 +2724,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-e03f822b-6e42-462f-a3db-5f749a988c75
+      - req-5c24fd83-e491-4264-8397-ea2e55db64df
       Date:
-      - Thu, 25 Oct 2018 18:19:00 GMT
+      - Thu, 01 Nov 2018 18:34:02 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:00 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:02 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/e54e5c3c19e34720b05661f2ea1ea00a/stacks?limit=1000&show_nested=true
@@ -2746,7 +2746,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 41cc0054e6014e34adc973534935eeed
+      - 9ab033b55ab84bbba2a56ebbd53b6176
   response:
     status:
       code: 200
@@ -2757,14 +2757,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-bf4e84ff-f8b9-4e05-9e26-f453eeee9120
+      - req-016a8482-20b0-4c43-8bfd-43bf52e4a7bc
       Date:
-      - Thu, 25 Oct 2018 18:19:00 GMT
+      - Thu, 01 Nov 2018 18:34:02 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:00 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:02 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -2782,13 +2782,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:19:00 GMT
+      - Thu, 01 Nov 2018 18:34:02 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-bcc1daba-85e2-4a55-85ad-6671f0ae8f2a
+      - req-3837130f-c3b2-43f1-be87-5ff391de9c3a
       Content-Length:
       - '4118'
       Connection:
@@ -2797,10 +2797,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:19:00.527083", "expires":
-        "2018-10-25T19:19:00Z", "id": "986cd1ac45764494bada48ed6d6365ce", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:34:02.829044", "expires":
+        "2018-11-01T19:34:02Z", "id": "8fb372f916114ab1bb1420cb1b657cfd", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["s7WZ2QJkSmSbC97zRZuA0g"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["kT-RC5vQRmKXHZ88Foz4yQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -2844,7 +2844,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:00 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:02 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/e8f744b1fc6a487681d35fb275252608/stacks?limit=1000&show_nested=true
@@ -2859,7 +2859,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 986cd1ac45764494bada48ed6d6365ce
+      - 8fb372f916114ab1bb1420cb1b657cfd
   response:
     status:
       code: 200
@@ -2870,14 +2870,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-6c90ecb0-e9a8-4b98-9edf-d9ea741b8008
+      - req-7a954516-240f-4c1b-a311-416bf061e2aa
       Date:
-      - Thu, 25 Oct 2018 18:19:00 GMT
+      - Thu, 01 Nov 2018 18:34:02 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:00 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:03 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack3/45d2af82-eff9-4483-a1f0-f19c44d96146
@@ -2892,7 +2892,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ad05b33062d14277b1b734bda51bb04c
+      - 3bf952e738204540938b18f4d88b08f3
   response:
     status:
       code: 200
@@ -2903,9 +2903,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-aef0a694-1976-4b67-a414-ad9eef819672
+      - req-111de0e5-dc77-4b7d-b13d-71b996179e65
       Date:
-      - Thu, 25 Oct 2018 18:19:04 GMT
+      - Thu, 01 Nov 2018 18:34:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -2932,7 +2932,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:04 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:03 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack2/4cf24b12-29fc-4529-a8ed-6b079dea7c17
@@ -2947,7 +2947,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ad05b33062d14277b1b734bda51bb04c
+      - 3bf952e738204540938b18f4d88b08f3
   response:
     status:
       code: 200
@@ -2958,9 +2958,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-f05448f4-f56a-4326-966f-61b1efa42d14
+      - req-bc56444b-d181-4b11-93a1-24ff1432376a
       Date:
-      - Thu, 25 Oct 2018 18:19:05 GMT
+      - Thu, 01 Nov 2018 18:34:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -2987,7 +2987,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:05 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:03 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c
@@ -3002,7 +3002,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ad05b33062d14277b1b734bda51bb04c
+      - 3bf952e738204540938b18f4d88b08f3
   response:
     status:
       code: 200
@@ -3013,9 +3013,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-71d3ae1e-a486-49f1-9427-def1139d42e9
+      - req-18d3f9e4-4fbb-4ad5-a61e-1ffacfd80a11
       Date:
-      - Thu, 25 Oct 2018 18:19:05 GMT
+      - Thu, 01 Nov 2018 18:34:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -3042,7 +3042,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:05 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:03 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack3/45d2af82-eff9-4483-a1f0-f19c44d96146/resources
@@ -3057,7 +3057,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ad05b33062d14277b1b734bda51bb04c
+      - 3bf952e738204540938b18f4d88b08f3
   response:
     status:
       code: 200
@@ -3068,9 +3068,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-c9ce327b-4750-4e96-bf82-59b4d3c7b2d2
+      - req-22c2d6e2-9bf5-4a6d-aa5a-f5c4f4548833
       Date:
-      - Thu, 25 Oct 2018 18:19:05 GMT
+      - Thu, 01 Nov 2018 18:34:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -3082,7 +3082,7 @@ http_interactions:
         changed", "physical_resource_id": "aa5907f3-8209-4dd0-b3ef-600431d85bac",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:05 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:04 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack3/45d2af82-eff9-4483-a1f0-f19c44d96146/template
@@ -3097,7 +3097,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ad05b33062d14277b1b734bda51bb04c
+      - 3bf952e738204540938b18f4d88b08f3
   response:
     status:
       code: 200
@@ -3108,9 +3108,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-1fa91373-8a5e-4626-aea1-4b05b60fe5c7
+      - req-4d906c02-148b-4428-96c4-b6ee91e5f284
       Date:
-      - Thu, 25 Oct 2018 18:19:05 GMT
+      - Thu, 01 Nov 2018 18:34:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -3166,7 +3166,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:05 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:04 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack2/4cf24b12-29fc-4529-a8ed-6b079dea7c17/resources
@@ -3181,7 +3181,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ad05b33062d14277b1b734bda51bb04c
+      - 3bf952e738204540938b18f4d88b08f3
   response:
     status:
       code: 200
@@ -3192,9 +3192,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-2329554c-3993-4dab-9300-1ad1fd8567bb
+      - req-e9fb0769-ee33-4cc1-b1db-35e64245837b
       Date:
-      - Thu, 25 Oct 2018 18:19:05 GMT
+      - Thu, 01 Nov 2018 18:34:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -3206,7 +3206,7 @@ http_interactions:
         changed", "physical_resource_id": "219a737c-b4ad-430d-944a-a92a4834b12d",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:05 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:04 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack2/4cf24b12-29fc-4529-a8ed-6b079dea7c17/template
@@ -3221,7 +3221,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ad05b33062d14277b1b734bda51bb04c
+      - 3bf952e738204540938b18f4d88b08f3
   response:
     status:
       code: 200
@@ -3232,9 +3232,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-7fdf7269-726e-473a-bee4-b35e43fcbd2b
+      - req-628f3253-109e-4a29-91d1-1f725d39a050
       Date:
-      - Thu, 25 Oct 2018 18:19:06 GMT
+      - Thu, 01 Nov 2018 18:34:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -3290,7 +3290,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:06 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:04 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c/resources
@@ -3305,7 +3305,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ad05b33062d14277b1b734bda51bb04c
+      - 3bf952e738204540938b18f4d88b08f3
   response:
     status:
       code: 200
@@ -3316,9 +3316,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-6a88dc32-cd6a-438a-a5f4-4b43cc02b414
+      - req-e7cdbefd-9a6e-4034-bfbc-d86c3f46974d
       Date:
-      - Thu, 25 Oct 2018 18:19:06 GMT
+      - Thu, 01 Nov 2018 18:34:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -3330,7 +3330,7 @@ http_interactions:
         changed", "physical_resource_id": "b686353f-0da0-48bf-bc35-8ea411a67dfd",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:06 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:04 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c/template
@@ -3345,7 +3345,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ad05b33062d14277b1b734bda51bb04c
+      - 3bf952e738204540938b18f4d88b08f3
   response:
     status:
       code: 200
@@ -3356,9 +3356,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-ffdb289e-56c9-4bab-9890-81a828ac7818
+      - req-3f3bd2c5-0ce2-4d30-9b26-0221a248d5ac
       Date:
-      - Thu, 25 Oct 2018 18:19:06 GMT
+      - Thu, 01 Nov 2018 18:34:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -3414,7 +3414,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:06 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:04 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images?all_tenants=True&limit=1000
@@ -3429,7 +3429,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3e98b31fe83541bca8af8b6614b5c870
+      - 3997ad1a62de48219cc50bf6c7deba46
   response:
     status:
       code: 200
@@ -3440,14 +3440,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-34ddfa53-5ea7-4079-8b8b-151b467d855a
+      - req-5811fae6-5028-43dc-803d-9ce49097764d
       Date:
-      - Thu, 25 Oct 2018 18:19:06 GMT
+      - Thu, 01 Nov 2018 18:34:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000&all_tenants=True"}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:06 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:04 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images
@@ -3462,7 +3462,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3e98b31fe83541bca8af8b6614b5c870
+      - 3997ad1a62de48219cc50bf6c7deba46
   response:
     status:
       code: 200
@@ -3473,9 +3473,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-d7c889f4-ad57-4a22-ac35-c9975d3bdd00
+      - req-5472164c-d064-4be8-be63-b2bf628e3f6a
       Date:
-      - Thu, 25 Oct 2018 18:19:06 GMT
+      - Thu, 01 Nov 2018 18:34:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -3517,7 +3517,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images"}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:06 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:05 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images/78ab353a-8b32-4cb9-b00b-60a70bacae08/members
@@ -3532,7 +3532,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3e98b31fe83541bca8af8b6614b5c870
+      - 3997ad1a62de48219cc50bf6c7deba46
   response:
     status:
       code: 200
@@ -3543,14 +3543,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-c5522874-3898-40c4-ab88-ba319179be80
+      - req-17556a4b-1095-494a-a7cd-efd33c782fb0
       Date:
-      - Thu, 25 Oct 2018 18:19:06 GMT
+      - Thu, 01 Nov 2018 18:34:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"members": [], "schema": "/v2/schemas/members"}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:06 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:05 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images/c9e7d983-c1a3-45f5-be89-3cfa4d7d9c0f/members
@@ -3565,7 +3565,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3e98b31fe83541bca8af8b6614b5c870
+      - 3997ad1a62de48219cc50bf6c7deba46
   response:
     status:
       code: 200
@@ -3576,14 +3576,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-c6450e73-fca2-4596-9bd9-d0b60d39331f
+      - req-0277b1a8-837a-4ded-b4e7-dd8800fb2c60
       Date:
-      - Thu, 25 Oct 2018 18:19:06 GMT
+      - Thu, 01 Nov 2018 18:34:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"members": [], "schema": "/v2/schemas/members"}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:06 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:05 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images/2f6b4eb7-8fc2-4439-9dc2-560d7457c706/members
@@ -3598,7 +3598,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3e98b31fe83541bca8af8b6614b5c870
+      - 3997ad1a62de48219cc50bf6c7deba46
   response:
     status:
       code: 200
@@ -3609,14 +3609,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-fb845266-a7b7-4cd5-abdd-76acf7dfe5e4
+      - req-008efdf1-6e4b-4c38-b67c-41fc17aef7a8
       Date:
-      - Thu, 25 Oct 2018 18:19:07 GMT
+      - Thu, 01 Nov 2018 18:34:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"members": [], "schema": "/v2/schemas/members"}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:07 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:05 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images/bb799f70-5e02-461b-8324-17ee88259c7b/members
@@ -3631,7 +3631,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3e98b31fe83541bca8af8b6614b5c870
+      - 3997ad1a62de48219cc50bf6c7deba46
   response:
     status:
       code: 200
@@ -3642,14 +3642,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-74f75013-841f-4a11-b05e-af82a639fab2
+      - req-6c7a5320-8f42-4639-9773-b3680748d9ff
       Date:
-      - Thu, 25 Oct 2018 18:19:07 GMT
+      - Thu, 01 Nov 2018 18:34:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"members": [], "schema": "/v2/schemas/members"}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:07 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:05 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?all_tenants=True&limit=1000
@@ -3664,7 +3664,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f62a708414a54311af58f113b00a65b3
+      - b4299fc1651d47448bc035fd737e5923
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3677,9 +3677,9 @@ http_interactions:
       Content-Length:
       - '3998'
       X-Compute-Request-Id:
-      - req-a3f06196-2d3b-421c-84a3-d70f2bf390c4
+      - req-adf3479e-2026-46b8-82ef-8dd4ec46c773
       Date:
-      - Thu, 25 Oct 2018 18:19:07 GMT
+      - Thu, 01 Nov 2018 18:34:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?all_tenants=True&limit=1000&marker=96fef14f-5338-4d58-8b89-58b627b27b9b",
@@ -3725,7 +3725,7 @@ http_interactions:
         [], "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:07 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:05 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?all_tenants=True&limit=1000&marker=96fef14f-5338-4d58-8b89-58b627b27b9b
@@ -3740,7 +3740,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f62a708414a54311af58f113b00a65b3
+      - b4299fc1651d47448bc035fd737e5923
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3753,9 +3753,9 @@ http_interactions:
       Content-Length:
       - '4062'
       X-Compute-Request-Id:
-      - req-e86a854e-82de-4135-86cb-c1bfc50935b6
+      - req-e51aee61-f1a5-4f4b-815d-b1f5bcd86f5a
       Date:
-      - Thu, 25 Oct 2018 18:19:07 GMT
+      - Thu, 01 Nov 2018 18:34:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?all_tenants=True&limit=1000&marker=ca1fc357-ee31-45e9-a38d-98723d6c8876",
@@ -3801,7 +3801,7 @@ http_interactions:
         [], "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 3, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:07 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:06 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?all_tenants=True&limit=1000&marker=ca1fc357-ee31-45e9-a38d-98723d6c8876
@@ -3816,7 +3816,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f62a708414a54311af58f113b00a65b3
+      - b4299fc1651d47448bc035fd737e5923
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3829,9 +3829,9 @@ http_interactions:
       Content-Length:
       - '4144'
       X-Compute-Request-Id:
-      - req-a8937341-973f-470d-beb4-7bf14aed684d
+      - req-265f5a71-3cba-4856-bbe9-dd723ef44a59
       Date:
-      - Thu, 25 Oct 2018 18:19:08 GMT
+      - Thu, 01 Nov 2018 18:34:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?all_tenants=True&limit=1000&marker=ca4f3a16-bae3-4407-83e9-f77b28af0f2b",
@@ -3879,7 +3879,7 @@ http_interactions:
         "", "progress": 0, "OS-EXT-STS:power_state": 1, "config_drive": "", "metadata":
         {}}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:08 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:06 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?all_tenants=True&limit=1000&marker=ca4f3a16-bae3-4407-83e9-f77b28af0f2b
@@ -3894,7 +3894,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f62a708414a54311af58f113b00a65b3
+      - b4299fc1651d47448bc035fd737e5923
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3907,9 +3907,9 @@ http_interactions:
       Content-Length:
       - '3813'
       X-Compute-Request-Id:
-      - req-bdb9221b-4eb4-43a1-a47e-11de85bbf37b
+      - req-61bc28dc-805f-4746-955c-305b4bc4f0c8
       Date:
-      - Thu, 25 Oct 2018 18:19:08 GMT
+      - Thu, 01 Nov 2018 18:34:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?all_tenants=True&limit=1000&marker=aa5907f3-8209-4dd0-b3ef-600431d85bac",
@@ -3951,7 +3951,7 @@ http_interactions:
         "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:08 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:06 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?all_tenants=True&limit=1000&marker=aa5907f3-8209-4dd0-b3ef-600431d85bac
@@ -3966,7 +3966,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f62a708414a54311af58f113b00a65b3
+      - b4299fc1651d47448bc035fd737e5923
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3979,9 +3979,9 @@ http_interactions:
       Content-Length:
       - '1816'
       X-Compute-Request-Id:
-      - req-d07d6bf7-1ae7-434a-ae22-fb06571ddd7c
+      - req-ab020f81-7a47-4131-b07f-ef6ffa7d61fa
       Date:
-      - Thu, 25 Oct 2018 18:19:08 GMT
+      - Thu, 01 Nov 2018 18:34:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": [{"status": "SHUTOFF", "updated": "2018-01-17T14:49:17Z",
@@ -4004,7 +4004,7 @@ http_interactions:
         "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:08 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:06 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-floating-ips
@@ -4019,7 +4019,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f62a708414a54311af58f113b00a65b3
+      - b4299fc1651d47448bc035fd737e5923
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4032,14 +4032,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-49422070-a15c-447d-b42e-d41557006108
+      - req-3620c4d4-4306-4830-9c1c-954c4a5a2f01
       Date:
-      - Thu, 25 Oct 2018 18:19:08 GMT
+      - Thu, 01 Nov 2018 18:34:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:08 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:06 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-floating-ips
@@ -4054,7 +4054,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f62a708414a54311af58f113b00a65b3
+      - b4299fc1651d47448bc035fd737e5923
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4067,14 +4067,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-c24b19df-83c0-4324-bee1-2d95e00c54cd
+      - req-6097716b-2e3d-499b-9848-b5bd202e7e0f
       Date:
-      - Thu, 25 Oct 2018 18:19:08 GMT
+      - Thu, 01 Nov 2018 18:34:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:08 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:07 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-floating-ips
@@ -4089,7 +4089,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f62a708414a54311af58f113b00a65b3
+      - b4299fc1651d47448bc035fd737e5923
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4102,14 +4102,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-763a0d76-584d-401b-8fc8-12ae62f60338
+      - req-01b14b0a-8df0-4d25-9537-97e69bb851e7
       Date:
-      - Thu, 25 Oct 2018 18:19:08 GMT
+      - Thu, 01 Nov 2018 18:34:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:08 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:07 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-floating-ips
@@ -4124,7 +4124,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f62a708414a54311af58f113b00a65b3
+      - b4299fc1651d47448bc035fd737e5923
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4137,14 +4137,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-7c1f09a6-45d8-4843-84c1-232fd7a5dac8
+      - req-76e5aafa-0782-49a4-a4d8-51c96e746d65
       Date:
-      - Thu, 25 Oct 2018 18:19:09 GMT
+      - Thu, 01 Nov 2018 18:34:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:09 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:07 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-floating-ips
@@ -4159,7 +4159,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f62a708414a54311af58f113b00a65b3
+      - b4299fc1651d47448bc035fd737e5923
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4172,14 +4172,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-f4abe089-11cf-4455-823a-868991f46244
+      - req-58755368-dc13-4c85-be14-218c04d2a6e2
       Date:
-      - Thu, 25 Oct 2018 18:19:09 GMT
+      - Thu, 01 Nov 2018 18:34:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:09 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:07 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-floating-ips
@@ -4194,7 +4194,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f62a708414a54311af58f113b00a65b3
+      - b4299fc1651d47448bc035fd737e5923
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4207,14 +4207,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-19b83fa1-0460-4ef9-831a-cbe519a23980
+      - req-15df2e08-68d8-4d4f-a691-6d43cedddede
       Date:
-      - Thu, 25 Oct 2018 18:19:09 GMT
+      - Thu, 01 Nov 2018 18:34:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:09 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:07 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-floating-ips
@@ -4229,7 +4229,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f62a708414a54311af58f113b00a65b3
+      - b4299fc1651d47448bc035fd737e5923
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4242,14 +4242,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-cccbd7d1-8aad-4a5e-b6e7-b193d3d2cdc3
+      - req-617072ab-4557-4589-9425-56a54a06279b
       Date:
-      - Thu, 25 Oct 2018 18:19:09 GMT
+      - Thu, 01 Nov 2018 18:34:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:09 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:07 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-floating-ips
@@ -4264,7 +4264,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f62a708414a54311af58f113b00a65b3
+      - b4299fc1651d47448bc035fd737e5923
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4277,14 +4277,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-c24a2d15-dea9-45ef-aea3-16223eb1e4c9
+      - req-3adf79f5-4188-4863-9daf-86bd273f725a
       Date:
-      - Thu, 25 Oct 2018 18:19:09 GMT
+      - Thu, 01 Nov 2018 18:34:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:09 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:08 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-floating-ips
@@ -4299,7 +4299,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f62a708414a54311af58f113b00a65b3
+      - b4299fc1651d47448bc035fd737e5923
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4312,14 +4312,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-0be873cf-cace-4c80-8bb1-bd39426503dc
+      - req-f3f3c694-d21a-420f-8720-e75cfe28af69
       Date:
-      - Thu, 25 Oct 2018 18:19:09 GMT
+      - Thu, 01 Nov 2018 18:34:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:09 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:08 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-services?all_tenants=True&limit=1000
@@ -4334,7 +4334,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f62a708414a54311af58f113b00a65b3
+      - b4299fc1651d47448bc035fd737e5923
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4347,26 +4347,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-eb864402-b553-4bbc-80d3-e68de5f6af0a
+      - req-98c55882-efa0-4da2-8d84-cca034704b26
       Date:
-      - Thu, 25 Oct 2018 18:19:09 GMT
+      - Thu, 01 Nov 2018 18:34:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-10-25T18:19:01.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-11-01T18:34:02.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-10-25T18:19:07.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-11-01T18:33:59.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-10-25T18:19:08.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-11-01T18:34:01.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2018-10-25T18:19:01.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-11-01T18:34:07.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-10-25T18:19:02.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-11-01T18:34:03.000000"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:09 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:08 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-services?all_tenants=True&limit=1000&marker=5
@@ -4381,7 +4381,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f62a708414a54311af58f113b00a65b3
+      - b4299fc1651d47448bc035fd737e5923
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4394,26 +4394,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-a8dbc978-0381-4e62-9adc-a0ed1493f377
+      - req-fe7ec297-5260-46d0-b384-dd80c259a252
       Date:
-      - Thu, 25 Oct 2018 18:19:10 GMT
+      - Thu, 01 Nov 2018 18:34:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-10-25T18:19:01.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-11-01T18:34:02.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-10-25T18:19:07.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-11-01T18:33:59.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-10-25T18:19:08.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-11-01T18:34:01.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2018-10-25T18:19:01.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-11-01T18:34:07.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-10-25T18:19:02.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-11-01T18:34:03.000000"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:10 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:08 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4431,13 +4431,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:19:13 GMT
+      - Thu, 01 Nov 2018 18:34:09 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-6fcb6106-aa2d-42d0-ba38-228041035ded
+      - req-550cec40-fdfa-456d-a331-91cf2dfa0972
       Content-Length:
       - '4170'
       Connection:
@@ -4446,10 +4446,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:19:13.863840", "expires":
-        "2018-10-25T19:19:13Z", "id": "8ff1417d9fae4c2b8097a444d32d6d99", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:34:09.571109", "expires":
+        "2018-11-01T19:34:09Z", "id": "5df34311daab479db154f0061e172beb", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["CUfWkRYKRrq1eG0UdJrdWw"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["mJfF9_7VTXW5SzmqgfKNLQ"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -4494,7 +4494,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:13 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:09 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4512,13 +4512,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:19:13 GMT
+      - Thu, 01 Nov 2018 18:34:09 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-02f8b569-d2ce-4cf4-b3c2-8793bf88fe47
+      - req-4ef13b9e-5d1c-4354-b0e9-876a3c698315
       Content-Length:
       - '4170'
       Connection:
@@ -4527,10 +4527,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:19:14.045538", "expires":
-        "2018-10-25T19:19:14Z", "id": "938d9094ae4848d5801b056a51988e42", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:34:09.764348", "expires":
+        "2018-11-01T19:34:09Z", "id": "ad5fb6f6e6604ff0b134abfb5db82b7c", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["YIyrpdp3Q820OyIt6sxwQQ"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["16lSKvcAR-qU20ITvHcWzA"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -4575,7 +4575,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:14 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:09 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?all_tenants=True&limit=1000
@@ -4590,7 +4590,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 938d9094ae4848d5801b056a51988e42
+      - ad5fb6f6e6604ff0b134abfb5db82b7c
   response:
     status:
       code: 200
@@ -4601,9 +4601,9 @@ http_interactions:
       Content-Length:
       - '3418'
       X-Openstack-Request-Id:
-      - req-a8940fe0-43e6-4ce8-a5e4-dc2c76e7b898
+      - req-a162054e-b11b-40ba-97f9-fce7710de6b0
       Date:
-      - Thu, 25 Oct 2018 18:19:14 GMT
+      - Thu, 01 Nov 2018 18:34:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef",
@@ -4645,7 +4645,7 @@ http_interactions:
         null, "port_range_min": null, "id": "ff24dfac-169a-4238-b78b-ed1536a0bf06",
         "security_group_id": "5b2b42a6-1271-4c4a-b062-8e8ba299acef"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:14 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:09 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef
@@ -4660,7 +4660,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 938d9094ae4848d5801b056a51988e42
+      - ad5fb6f6e6604ff0b134abfb5db82b7c
   response:
     status:
       code: 200
@@ -4671,9 +4671,9 @@ http_interactions:
       Content-Length:
       - '3418'
       X-Openstack-Request-Id:
-      - req-46bc1a84-2545-49e6-83ba-b0eb1293c37f
+      - req-15af7664-3c21-441b-8e4f-71cb3298bec7
       Date:
-      - Thu, 25 Oct 2018 18:19:14 GMT
+      - Thu, 01 Nov 2018 18:34:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab",
@@ -4716,7 +4716,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "c06c0e71-2c18-43a9-ace9-91242f0251e2",
         "security_group_id": "98bfc20c-a897-42c5-b33c-f0d8317667ab"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:14 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:10 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab
@@ -4731,7 +4731,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 938d9094ae4848d5801b056a51988e42
+      - ad5fb6f6e6604ff0b134abfb5db82b7c
   response:
     status:
       code: 200
@@ -4742,9 +4742,9 @@ http_interactions:
       Content-Length:
       - '2751'
       X-Openstack-Request-Id:
-      - req-d7d416ea-016c-496c-8ac5-6665fff0645c
+      - req-62a5ebf3-7e95-4146-b1b7-ac6d09f9b813
       Date:
-      - Thu, 25 Oct 2018 18:19:14 GMT
+      - Thu, 01 Nov 2018 18:34:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4",
@@ -4779,7 +4779,7 @@ http_interactions:
         null, "port_range_min": null, "id": "75924ebc-4758-4042-ad04-4ef3c9189098",
         "security_group_id": "e4836528-d0df-425e-a117-ae8ec6f356d4"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:14 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:10 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4
@@ -4794,7 +4794,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 938d9094ae4848d5801b056a51988e42
+      - ad5fb6f6e6604ff0b134abfb5db82b7c
   response:
     status:
       code: 200
@@ -4805,9 +4805,9 @@ http_interactions:
       Content-Length:
       - '7097'
       X-Openstack-Request-Id:
-      - req-0844c039-1f62-47c1-a48a-c56fd8f8af2f
+      - req-de69e31a-15bc-4cef-a962-7766c5d3b95b
       Date:
-      - Thu, 25 Oct 2018 18:19:14 GMT
+      - Thu, 01 Nov 2018 18:34:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=fd147cb7-7456-43d9-a01f-c06e21b4e6fb&page_reverse=True",
@@ -4894,7 +4894,7 @@ http_interactions:
         "port_range_max": 80, "port_range_min": 80, "id": "f79f0e32-b186-4778-952e-20827a60ef73",
         "security_group_id": "fd147cb7-7456-43d9-a01f-c06e21b4e6fb"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:14 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:10 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/networks
@@ -4909,7 +4909,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 938d9094ae4848d5801b056a51988e42
+      - ad5fb6f6e6604ff0b134abfb5db82b7c
   response:
     status:
       code: 200
@@ -4920,12 +4920,17 @@ http_interactions:
       Content-Length:
       - '5330'
       X-Openstack-Request-Id:
-      - req-777164df-e814-4aaa-babc-6c63c086357e
+      - req-edcf38d4-5200-41b5-afc1-940e81524b9e
       Date:
-      - Thu, 25 Oct 2018 18:19:14 GMT
+      - Thu, 01 Nov 2018 18:34:10 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"networks": [{"status": "ACTIVE", "subnets": ["2092b802-1034-4fb8-9c5e-1ec61d1e463f"],
+      string: '{"networks": [{"status": "ACTIVE", "subnets": ["33da95a6-bded-44d8-be36-6cc97f3d72bd"],
+        "name": "EmsRefreshSpec-NetworkPublic", "provider:physical_network": "public_net_0",
+        "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
+        0, "router:external": true, "shared": false, "provider:network_type": "flat",
+        "id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "provider:segmentation_id":
+        null}, {"status": "ACTIVE", "subnets": ["2092b802-1034-4fb8-9c5e-1ec61d1e463f"],
         "name": "EmsRefreshSpec-NetworkPrivate_20", "provider:physical_network": null,
         "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
         0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
@@ -4980,19 +4985,14 @@ http_interactions:
         "provider:physical_network": null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
         "vxlan", "id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "provider:segmentation_id":
-        79}, {"status": "ACTIVE", "subnets": ["33da95a6-bded-44d8-be36-6cc97f3d72bd"],
-        "name": "EmsRefreshSpec-NetworkPublic", "provider:physical_network": "public_net_0",
-        "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
-        0, "router:external": true, "shared": false, "provider:network_type": "flat",
-        "id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "provider:segmentation_id":
-        null}, {"status": "ACTIVE", "subnets": ["d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        79}, {"status": "ACTIVE", "subnets": ["d53802a5-f0f6-48ba-9207-dbd9b13acac3",
         "104c081f-97dd-42b7-8930-98abbd015c74"], "name": "EmsRefreshSpec-NetworkPrivate",
         "provider:physical_network": null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
         "vxlan", "id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "provider:segmentation_id":
         14}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:14 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:10 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?all_tenants=True&limit=1000
@@ -5007,7 +5007,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 938d9094ae4848d5801b056a51988e42
+      - ad5fb6f6e6604ff0b134abfb5db82b7c
   response:
     status:
       code: 200
@@ -5018,41 +5018,12 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-92e6d8c0-08b3-47d0-8f82-adc147300155
+      - req-871bbb72-55b1-4b19-851d-0cebf981d548
       Date:
-      - Thu, 25 Oct 2018 18:19:15 GMT
+      - Thu, 01 Nov 2018 18:34:10 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.50.4", "end": "192.168.50.4"}, {"start":
-        "192.168.50.2", "end": "192.168.50.2"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
         false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
@@ -5105,29 +5076,58 @@ http_interactions:
         "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
         "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
-        false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
-        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
         null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:15 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:10 GMT
 - request:
     method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?all_tenants=True&limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    uri: http://10.8.99.233:9696/v2.0/subnets?all_tenants=True&limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
     body:
       encoding: US-ASCII
       string: ''
@@ -5139,7 +5139,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 938d9094ae4848d5801b056a51988e42
+      - ad5fb6f6e6604ff0b134abfb5db82b7c
   response:
     status:
       code: 200
@@ -5150,9 +5150,9 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-a9484c18-b071-4458-ad15-5c7d35f3c08d
+      - req-d6faa19d-70b9-4d99-9fb7-5039858f464b
       Date:
-      - Thu, 25 Oct 2018 18:19:15 GMT
+      - Thu, 01 Nov 2018 18:34:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
@@ -5256,7 +5256,139 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:15 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:10 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?all_tenants=True&limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - ad5fb6f6e6604ff0b134abfb5db82b7c
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-55962b06-b635-4ffe-9c67-ea0ae82a9173
+      Date:
+      - Thu, 01 Nov 2018 18:34:10 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 01 Nov 2018 18:34:10 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?all_tenants=True&limit=1000
@@ -5271,7 +5403,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 938d9094ae4848d5801b056a51988e42
+      - ad5fb6f6e6604ff0b134abfb5db82b7c
   response:
     status:
       code: 200
@@ -5282,9 +5414,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-966b7d4d-ce8f-4171-87a8-cf2a859ae324
+      - req-b0350f2e-cbf4-434c-bd14-d8da81febee0
       Date:
-      - Thu, 25 Oct 2018 18:19:15 GMT
+      - Thu, 01 Nov 2018 18:34:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -5316,7 +5448,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:15 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:11 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?all_tenants=True&limit=1000&marker=a41c036a-c34e-454b-851d-5eefd03888cb
@@ -5331,7 +5463,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 938d9094ae4848d5801b056a51988e42
+      - ad5fb6f6e6604ff0b134abfb5db82b7c
   response:
     status:
       code: 200
@@ -5342,9 +5474,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-15d8820f-07f1-4507-a20a-aca49c814c29
+      - req-b582844d-ba3c-4e6d-93ee-f5b5eea67396
       Date:
-      - Thu, 25 Oct 2018 18:19:15 GMT
+      - Thu, 01 Nov 2018 18:34:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -5376,7 +5508,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:15 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:11 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?all_tenants=True&limit=1000
@@ -5391,7 +5523,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 938d9094ae4848d5801b056a51988e42
+      - ad5fb6f6e6604ff0b134abfb5db82b7c
   response:
     status:
       code: 200
@@ -5402,9 +5534,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-8c97a469-1ccb-4e1a-901e-f4ac59543ce4
+      - req-707193f2-6509-4d5a-b601-3b0126eb16c1
       Date:
-      - Thu, 25 Oct 2018 18:19:15 GMT
+      - Thu, 01 Nov 2018 18:34:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -5807,7 +5939,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:15 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:11 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?all_tenants=True&limit=1000&marker=dee8791c-23b3-4e65-846d-49aeaba18036
@@ -5822,7 +5954,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 938d9094ae4848d5801b056a51988e42
+      - ad5fb6f6e6604ff0b134abfb5db82b7c
   response:
     status:
       code: 200
@@ -5833,9 +5965,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-93bad4ca-722f-4ab5-94f1-84438c42b901
+      - req-40d7aaac-65d8-4f13-b487-437a1ce4751b
       Date:
-      - Thu, 25 Oct 2018 18:19:15 GMT
+      - Thu, 01 Nov 2018 18:34:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -6238,7 +6370,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:15 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:11 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?all_tenants=True&limit=1000
@@ -6253,7 +6385,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 938d9094ae4848d5801b056a51988e42
+      - ad5fb6f6e6604ff0b134abfb5db82b7c
   response:
     status:
       code: 200
@@ -6264,9 +6396,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-bfeefd34-6550-40bd-95ba-4b92a4201320
+      - req-bf8d14f3-3528-4332-bdfe-ed2b0f02fd99
       Date:
-      - Thu, 25 Oct 2018 18:19:15 GMT
+      - Thu, 01 Nov 2018 18:34:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -6308,7 +6440,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:16 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:11 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?all_tenants=True&limit=1000&marker=ee601a91-f6ac-4a46-a599-87cfd83094a3
@@ -6323,7 +6455,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 938d9094ae4848d5801b056a51988e42
+      - ad5fb6f6e6604ff0b134abfb5db82b7c
   response:
     status:
       code: 200
@@ -6334,9 +6466,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-59d9b34b-964a-4629-b7a3-c917a78345f2
+      - req-4fff7919-7272-42ca-90f8-6978faf9875c
       Date:
-      - Thu, 25 Oct 2018 18:19:16 GMT
+      - Thu, 01 Nov 2018 18:34:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -6378,7 +6510,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:16 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:11 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -6396,13 +6528,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:19:17 GMT
+      - Thu, 01 Nov 2018 18:34:12 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-e8eeaa7f-d904-4c0e-bc0e-073d5e70880f
+      - req-94453b4b-ac61-4f07-a69c-296f7f514171
       Content-Length:
       - '4170'
       Connection:
@@ -6411,10 +6543,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:19:17.079225", "expires":
-        "2018-10-25T19:19:17Z", "id": "b16fbb774bad4b029aa89f4c1530c489", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:34:12.613506", "expires":
+        "2018-11-01T19:34:12Z", "id": "07e4c27b45814b34a37aee1bab2855bc", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["fsYiZouMQVCKv2oiiHvH4A"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["87c8XsnBTpuISX8FYvcWpA"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -6459,7 +6591,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:17 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:12 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -6477,13 +6609,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:19:17 GMT
+      - Thu, 01 Nov 2018 18:34:12 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-888ba512-6aff-47ae-a0e8-2c3ce30eb0e3
+      - req-63b84c72-931f-4082-bbc1-8d8dc72dc387
       Content-Length:
       - '4170'
       Connection:
@@ -6492,10 +6624,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:19:17.260928", "expires":
-        "2018-10-25T19:19:17Z", "id": "0c915a4c21a14c29bc0780a74cd7f333", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:34:12.801817", "expires":
+        "2018-11-01T19:34:12Z", "id": "b1ddd24383d8407cba141667f81f917f", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["BWTvDg0CSK6rZ88pTiAzUg"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["KU303EyWSUKhJ3IkBWHhlg"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -6540,7 +6672,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:17 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:12 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -6558,13 +6690,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:19:17 GMT
+      - Thu, 01 Nov 2018 18:34:12 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-b57c2dd0-af66-4331-b91e-daea1d18380a
+      - req-d33551b5-95f1-4202-abec-a79006509205
       Content-Length:
       - '370'
       Connection:
@@ -6573,13 +6705,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:19:17.417951", "expires":
-        "2018-10-25T19:19:17Z", "id": "f3b57032e7ca47299d1f59f5b2e0cb84", "audit_ids":
-        ["0QqT4M-tT0mvqpN7S7XCzA"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:34:12.962650", "expires":
+        "2018-11-01T19:34:12Z", "id": "1fcb63da20fc41838829fa0ebd8fccca", "audit_ids":
+        ["0dbXrnl2T0efDCzg7K7SBw"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:17 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:12 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -6594,20 +6726,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f3b57032e7ca47299d1f59f5b2e0cb84
+      - 1fcb63da20fc41838829fa0ebd8fccca
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:19:17 GMT
+      - Thu, 01 Nov 2018 18:34:13 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-d022cf96-6def-447f-af94-aa0804b74c2f
+      - req-63410854-9b65-46df-853c-343b54e21874
       Content-Length:
       - '500'
       Connection:
@@ -6624,7 +6756,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:17 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:13 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -6642,13 +6774,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:19:17 GMT
+      - Thu, 01 Nov 2018 18:34:13 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-f83b9692-410d-4497-ab3b-344549a313d9
+      - req-920c0a10-ed6a-416d-8223-ecab0719d8a0
       Content-Length:
       - '4117'
       Connection:
@@ -6657,10 +6789,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:19:17.735511", "expires":
-        "2018-10-25T19:19:17Z", "id": "9fe70029b1524536843dfe618c521add", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:34:13.294088", "expires":
+        "2018-11-01T19:34:13Z", "id": "66223381566247d0a162d2ea05d55025", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["qzmRKyRuQEOUahJvSULqwg"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["RMi-F2u-S7mnF_5fWVhchw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -6704,7 +6836,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:17 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:13 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -6722,13 +6854,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:19:17 GMT
+      - Thu, 01 Nov 2018 18:34:13 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-665f9334-d9fc-4c02-84bf-c76dc46d29d4
+      - req-a4b8273a-7367-477d-bf2b-efc1c07b71dc
       Content-Length:
       - '4131'
       Connection:
@@ -6737,10 +6869,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:19:17.920433", "expires":
-        "2018-10-25T19:19:17Z", "id": "fa3b1b52050045b48209d179dd1c61d5", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:34:13.498659", "expires":
+        "2018-11-01T19:34:13Z", "id": "d171d0cf76604c3d98729967c15d2c7b", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["ENOLFigrT8KxNov6u3nLPQ"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["EbGpws06R9-7fOqJIjzeyA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -6784,7 +6916,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:17 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:13 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -6802,13 +6934,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:19:18 GMT
+      - Thu, 01 Nov 2018 18:34:13 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-89b5e35f-67d3-4b9d-af6e-0a7f720317ec
+      - req-aaaf3a30-58c3-4412-a245-9c3cc7e6ee13
       Content-Length:
       - '4118'
       Connection:
@@ -6817,10 +6949,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:19:18.100457", "expires":
-        "2018-10-25T19:19:18Z", "id": "6cfa00b90dd0447d9b628a39048f628d", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:34:13.684840", "expires":
+        "2018-11-01T19:34:13Z", "id": "948b04058e54420eb2069c2468554aaa", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["pndcZSBoQ2SGGRn4ScLlnQ"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["OdCLtzH_TASGu3GEt_VKew"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -6864,7 +6996,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:18 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:13 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -6882,13 +7014,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:19:18 GMT
+      - Thu, 01 Nov 2018 18:34:13 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-821d6330-51d0-410e-85b8-a6458bc4298d
+      - req-0efb8ced-b53c-4816-8aab-946adb72b7e2
       Content-Length:
       - '4117'
       Connection:
@@ -6897,10 +7029,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:19:18.281265", "expires":
-        "2018-10-25T19:19:18Z", "id": "40982ead58fa466cb1e3873689ad2d60", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:34:13.866266", "expires":
+        "2018-11-01T19:34:13Z", "id": "cc8b5dc0a72940d5b49046261050c882", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["MrJvFK97SvOdX_w26cGeLw"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["NZnNi7liRuiHwgwD_dK-9g"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -6944,7 +7076,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:18 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:13 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000
@@ -6959,22 +7091,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 40982ead58fa466cb1e3873689ad2d60
+      - cc8b5dc0a72940d5b49046261050c882
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-05b11e05-d7c1-432a-a208-d5ca4918df3c
+      - req-148a670e-0638-4630-b623-16236d1110f5
       Content-Type:
       - application/json
       Content-Length:
       - '2706'
       X-Openstack-Request-Id:
-      - req-05b11e05-d7c1-432a-a208-d5ca4918df3c
+      - req-148a670e-0638-4630-b623-16236d1110f5
       Date:
-      - Thu, 25 Oct 2018 18:19:18 GMT
+      - Thu, 01 Nov 2018 18:34:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=9bb99818-b339-4e31-b87f-e4181ec48acd",
@@ -7007,7 +7139,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-4", "bootable": "true", "created_at":
         "2016-11-11T13:49:53.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:18 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:14 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=9bb99818-b339-4e31-b87f-e4181ec48acd
@@ -7022,22 +7154,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 40982ead58fa466cb1e3873689ad2d60
+      - cc8b5dc0a72940d5b49046261050c882
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-bfd4f024-2f68-46db-8c75-8ba087832100
+      - req-42e3d5ad-432e-4003-97d6-2fe342ceaedb
       Content-Type:
       - application/json
       Content-Length:
       - '3284'
       X-Openstack-Request-Id:
-      - req-bfd4f024-2f68-46db-8c75-8ba087832100
+      - req-42e3d5ad-432e-4003-97d6-2fe342ceaedb
       Date:
-      - Thu, 25 Oct 2018 18:19:18 GMT
+      - Thu, 01 Nov 2018 18:34:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=2c774148-c11a-434c-aabb-7fa9c82c37ce",
@@ -7078,7 +7210,7 @@ http_interactions:
         "name": "EmsRefreshSpec-Volume-2", "bootable": "false", "created_at": "2016-11-11T13:49:43.000000",
         "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:18 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:14 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=2c774148-c11a-434c-aabb-7fa9c82c37ce
@@ -7093,22 +7225,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 40982ead58fa466cb1e3873689ad2d60
+      - cc8b5dc0a72940d5b49046261050c882
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-e3326ab7-f1d0-4492-9b49-b3cc47a4a451
+      - req-e891ba80-f4b4-4d06-819c-6df086b17ef4
       Content-Type:
       - application/json
       Content-Length:
       - '2753'
       X-Openstack-Request-Id:
-      - req-e3326ab7-f1d0-4492-9b49-b3cc47a4a451
+      - req-e891ba80-f4b4-4d06-819c-6df086b17ef4
       Date:
-      - Thu, 25 Oct 2018 18:19:18 GMT
+      - Thu, 01 Nov 2018 18:34:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=0a55c0d5-c780-4e7d-9d09-47f5520c7448",
@@ -7142,7 +7274,7 @@ http_interactions:
         "bootable": "false", "created_at": "2016-11-11T13:49:20.000000", "volume_type":
         "iscsi"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:18 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:14 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=0a55c0d5-c780-4e7d-9d09-47f5520c7448
@@ -7157,27 +7289,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 40982ead58fa466cb1e3873689ad2d60
+      - cc8b5dc0a72940d5b49046261050c882
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-e4e83ac3-e5dd-4fef-9c91-576dcb62321f
+      - req-5ec14e23-6d0e-4f3f-9408-2e193c523ed8
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-e4e83ac3-e5dd-4fef-9c91-576dcb62321f
+      - req-5ec14e23-6d0e-4f3f-9408-2e193c523ed8
       Date:
-      - Thu, 25 Oct 2018 18:19:18 GMT
+      - Thu, 01 Nov 2018 18:34:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:18 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:14 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -7195,13 +7327,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:19:19 GMT
+      - Thu, 01 Nov 2018 18:34:14 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-72d40d54-cea1-46cd-92f8-e7c3fcaece2b
+      - req-7ea37965-8b95-454b-9166-534cc5122aae
       Content-Length:
       - '4131'
       Connection:
@@ -7210,10 +7342,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:19:19.112121", "expires":
-        "2018-10-25T19:19:19Z", "id": "0fea1460976545c8957e7bf03da35442", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:34:14.848138", "expires":
+        "2018-11-01T19:34:14Z", "id": "cb0404d958e246358e0f97a1200874b6", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["ukAvOrZ9Qkafa2VwFq3bWw"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["uOeO8bwCSUKFMr_vsac9ww"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -7257,7 +7389,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:19 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:14 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/volumes/detail?limit=1000
@@ -7272,27 +7404,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0fea1460976545c8957e7bf03da35442
+      - cb0404d958e246358e0f97a1200874b6
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-e8598618-fac9-450c-b2d2-6b7e615dd307
+      - req-f3100e3e-4eac-457e-b903-b8af5e9aeb69
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-e8598618-fac9-450c-b2d2-6b7e615dd307
+      - req-f3100e3e-4eac-457e-b903-b8af5e9aeb69
       Date:
-      - Thu, 25 Oct 2018 18:19:19 GMT
+      - Thu, 01 Nov 2018 18:34:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:19 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:15 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/volumes/detail?limit=1000
@@ -7307,27 +7439,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0c915a4c21a14c29bc0780a74cd7f333
+      - b1ddd24383d8407cba141667f81f917f
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-b9e42986-5959-486a-8869-ee72d6755bb3
+      - req-3ce8e3a7-f3d0-4621-ab03-9c0441e66bb7
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-b9e42986-5959-486a-8869-ee72d6755bb3
+      - req-3ce8e3a7-f3d0-4621-ab03-9c0441e66bb7
       Date:
-      - Thu, 25 Oct 2018 18:19:19 GMT
+      - Thu, 01 Nov 2018 18:34:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:19 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:15 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -7345,13 +7477,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:19:19 GMT
+      - Thu, 01 Nov 2018 18:34:15 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-86a526cd-a31b-4ce3-a6e9-455f98fb9f55
+      - req-935f2181-fe1d-44d7-9361-202ae0aad007
       Content-Length:
       - '4118'
       Connection:
@@ -7360,10 +7492,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:19:19.644888", "expires":
-        "2018-10-25T19:19:19Z", "id": "a2cfe70e692a4658954edf9b9518d4d8", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:34:15.396166", "expires":
+        "2018-11-01T19:34:15Z", "id": "49562ef0069b4604bb7b4bb574e81674", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["ua4uLKT8RD-9ET_BJPFmag"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["bjyI7ZGbSLmt-p4BFrSD5w"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -7407,7 +7539,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:19 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:15 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/volumes/detail?limit=1000
@@ -7422,27 +7554,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a2cfe70e692a4658954edf9b9518d4d8
+      - 49562ef0069b4604bb7b4bb574e81674
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-535d5c87-e65b-473c-b612-be815a2f473e
+      - req-e4a5946d-46dd-4f25-b40b-c33db0a727d2
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-535d5c87-e65b-473c-b612-be815a2f473e
+      - req-e4a5946d-46dd-4f25-b40b-c33db0a727d2
       Date:
-      - Thu, 25 Oct 2018 18:19:19 GMT
+      - Thu, 01 Nov 2018 18:34:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:19 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:15 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail
@@ -7457,22 +7589,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 40982ead58fa466cb1e3873689ad2d60
+      - cc8b5dc0a72940d5b49046261050c882
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-3eab6cd2-1cf2-4be4-85f0-29669ce183dc
+      - req-42d442c2-336f-4a4e-84bb-efa772ecdbba
       Content-Type:
       - application/json
       Content-Length:
       - '1053'
       X-Openstack-Request-Id:
-      - req-3eab6cd2-1cf2-4be4-85f0-29669ce183dc
+      - req-42d442c2-336f-4a4e-84bb-efa772ecdbba
       Date:
-      - Thu, 25 Oct 2018 18:19:19 GMT
+      - Thu, 01 Nov 2018 18:34:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?marker=76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
@@ -7487,7 +7619,7 @@ http_interactions:
         "created_at": "2016-11-11T13:49:36.000000", "size": 1, "id": "76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:19 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:15 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?limit=1000
@@ -7502,22 +7634,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 40982ead58fa466cb1e3873689ad2d60
+      - cc8b5dc0a72940d5b49046261050c882
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-83eeeb64-e23d-424e-a01e-46c5946b0596
+      - req-6bedda78-a122-47c4-891e-9612613cf5f2
       Content-Type:
       - application/json
       Content-Length:
       - '1064'
       X-Openstack-Request-Id:
-      - req-83eeeb64-e23d-424e-a01e-46c5946b0596
+      - req-6bedda78-a122-47c4-891e-9612613cf5f2
       Date:
-      - Thu, 25 Oct 2018 18:19:20 GMT
+      - Thu, 01 Nov 2018 18:34:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?limit=1000&marker=76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
@@ -7532,7 +7664,7 @@ http_interactions:
         "created_at": "2016-11-11T13:49:36.000000", "size": 1, "id": "76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:20 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:15 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/snapshots/detail
@@ -7547,27 +7679,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0fea1460976545c8957e7bf03da35442
+      - cb0404d958e246358e0f97a1200874b6
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-2f7ed56b-282e-41e4-93c2-14dea999d5ac
+      - req-3927f76f-7189-484b-8160-2ec89c1ad506
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-2f7ed56b-282e-41e4-93c2-14dea999d5ac
+      - req-3927f76f-7189-484b-8160-2ec89c1ad506
       Date:
-      - Thu, 25 Oct 2018 18:19:20 GMT
+      - Thu, 01 Nov 2018 18:34:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:20 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:15 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/snapshots/detail?limit=1000
@@ -7582,27 +7714,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0fea1460976545c8957e7bf03da35442
+      - cb0404d958e246358e0f97a1200874b6
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-14e14a00-d3eb-414b-b962-fc1bec9dd09d
+      - req-60350325-100a-42a8-9f7d-6dbf8e5f057c
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-14e14a00-d3eb-414b-b962-fc1bec9dd09d
+      - req-60350325-100a-42a8-9f7d-6dbf8e5f057c
       Date:
-      - Thu, 25 Oct 2018 18:19:20 GMT
+      - Thu, 01 Nov 2018 18:34:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:20 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:16 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/snapshots/detail
@@ -7617,27 +7749,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0c915a4c21a14c29bc0780a74cd7f333
+      - b1ddd24383d8407cba141667f81f917f
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-f42f86db-dc15-4dd2-9382-8abb938543f8
+      - req-69a464ba-5016-4c25-8141-9e6e644e6ef5
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-f42f86db-dc15-4dd2-9382-8abb938543f8
+      - req-69a464ba-5016-4c25-8141-9e6e644e6ef5
       Date:
-      - Thu, 25 Oct 2018 18:19:20 GMT
+      - Thu, 01 Nov 2018 18:34:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:20 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:16 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/snapshots/detail?limit=1000
@@ -7652,27 +7784,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0c915a4c21a14c29bc0780a74cd7f333
+      - b1ddd24383d8407cba141667f81f917f
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-e8dade85-dec3-435f-9289-d921aacaa1b0
+      - req-e7bdf87e-7ae1-4165-8401-98829223c68f
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-e8dade85-dec3-435f-9289-d921aacaa1b0
+      - req-e7bdf87e-7ae1-4165-8401-98829223c68f
       Date:
-      - Thu, 25 Oct 2018 18:19:20 GMT
+      - Thu, 01 Nov 2018 18:34:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:20 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:16 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/snapshots/detail
@@ -7687,27 +7819,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a2cfe70e692a4658954edf9b9518d4d8
+      - 49562ef0069b4604bb7b4bb574e81674
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-da15657b-f7a6-4c41-b1cf-a62bf2b7f073
+      - req-0bef060d-48d5-47b2-a44d-cacf6f30ccdd
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-da15657b-f7a6-4c41-b1cf-a62bf2b7f073
+      - req-0bef060d-48d5-47b2-a44d-cacf6f30ccdd
       Date:
-      - Thu, 25 Oct 2018 18:19:20 GMT
+      - Thu, 01 Nov 2018 18:34:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:20 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:16 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/snapshots/detail?limit=1000
@@ -7722,27 +7854,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a2cfe70e692a4658954edf9b9518d4d8
+      - 49562ef0069b4604bb7b4bb574e81674
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-5f41a061-9695-4af4-87ff-de762a36db31
+      - req-2de71489-2b79-425d-ab07-6b0858797454
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-5f41a061-9695-4af4-87ff-de762a36db31
+      - req-2de71489-2b79-425d-ab07-6b0858797454
       Date:
-      - Thu, 25 Oct 2018 18:19:20 GMT
+      - Thu, 01 Nov 2018 18:34:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:20 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:16 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/backups/detail
@@ -7757,27 +7889,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 40982ead58fa466cb1e3873689ad2d60
+      - cc8b5dc0a72940d5b49046261050c882
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-2820c25e-b469-444c-a914-45e2a379b70a
+      - req-6f1a14e3-833c-4858-8516-414f82a7ed0d
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-2820c25e-b469-444c-a914-45e2a379b70a
+      - req-6f1a14e3-833c-4858-8516-414f82a7ed0d
       Date:
-      - Thu, 25 Oct 2018 18:19:20 GMT
+      - Thu, 01 Nov 2018 18:34:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:20 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:16 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/backups/detail?limit=1000
@@ -7792,27 +7924,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 40982ead58fa466cb1e3873689ad2d60
+      - cc8b5dc0a72940d5b49046261050c882
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-d4d3513b-f772-432e-bf2a-ed34c5865443
+      - req-2ed0df85-27a3-438d-bd25-c0b7e9c0e4da
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-d4d3513b-f772-432e-bf2a-ed34c5865443
+      - req-2ed0df85-27a3-438d-bd25-c0b7e9c0e4da
       Date:
-      - Thu, 25 Oct 2018 18:19:21 GMT
+      - Thu, 01 Nov 2018 18:34:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:21 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:16 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/backups/detail
@@ -7827,27 +7959,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0fea1460976545c8957e7bf03da35442
+      - cb0404d958e246358e0f97a1200874b6
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-e479b527-fa98-4a50-8f48-fdc2affe94b5
+      - req-3546ed4e-205a-4249-b5a7-71d53c8a9063
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-e479b527-fa98-4a50-8f48-fdc2affe94b5
+      - req-3546ed4e-205a-4249-b5a7-71d53c8a9063
       Date:
-      - Thu, 25 Oct 2018 18:19:21 GMT
+      - Thu, 01 Nov 2018 18:34:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:21 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:16 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/backups/detail?limit=1000
@@ -7862,27 +7994,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0fea1460976545c8957e7bf03da35442
+      - cb0404d958e246358e0f97a1200874b6
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-90f2f740-ad89-400b-8cbb-9ef353dd2933
+      - req-079ae678-681e-4b62-a95c-8aaa8d81bdef
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-90f2f740-ad89-400b-8cbb-9ef353dd2933
+      - req-079ae678-681e-4b62-a95c-8aaa8d81bdef
       Date:
-      - Thu, 25 Oct 2018 18:19:21 GMT
+      - Thu, 01 Nov 2018 18:34:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:21 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:16 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/backups/detail
@@ -7897,27 +8029,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0c915a4c21a14c29bc0780a74cd7f333
+      - b1ddd24383d8407cba141667f81f917f
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-8e536adb-08ea-4e5d-86ca-5a25bafe6343
+      - req-d015a3e1-678e-4bdd-ad88-1727862712b7
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-8e536adb-08ea-4e5d-86ca-5a25bafe6343
+      - req-d015a3e1-678e-4bdd-ad88-1727862712b7
       Date:
-      - Thu, 25 Oct 2018 18:19:21 GMT
+      - Thu, 01 Nov 2018 18:34:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:21 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:17 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/backups/detail?limit=1000
@@ -7932,27 +8064,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0c915a4c21a14c29bc0780a74cd7f333
+      - b1ddd24383d8407cba141667f81f917f
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-fafe6c49-39f6-4e19-814d-51cd98221ce2
+      - req-20e75f46-8726-4de6-b31b-45f83a0955b8
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-fafe6c49-39f6-4e19-814d-51cd98221ce2
+      - req-20e75f46-8726-4de6-b31b-45f83a0955b8
       Date:
-      - Thu, 25 Oct 2018 18:19:21 GMT
+      - Thu, 01 Nov 2018 18:34:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:21 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:17 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/backups/detail
@@ -7967,27 +8099,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a2cfe70e692a4658954edf9b9518d4d8
+      - 49562ef0069b4604bb7b4bb574e81674
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-87ae6054-2edc-4c01-8ac9-cdccecf6ffec
+      - req-929f0f28-d107-4844-9234-741a3f5077c3
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-87ae6054-2edc-4c01-8ac9-cdccecf6ffec
+      - req-929f0f28-d107-4844-9234-741a3f5077c3
       Date:
-      - Thu, 25 Oct 2018 18:19:21 GMT
+      - Thu, 01 Nov 2018 18:34:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:21 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:17 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/backups/detail?limit=1000
@@ -8002,27 +8134,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a2cfe70e692a4658954edf9b9518d4d8
+      - 49562ef0069b4604bb7b4bb574e81674
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-ffc062cf-c61b-4c0c-88e1-0b2d9d24a5f1
+      - req-7b9a83dc-f5f1-47a5-9dd0-7853202a4a68
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-ffc062cf-c61b-4c0c-88e1-0b2d9d24a5f1
+      - req-7b9a83dc-f5f1-47a5-9dd0-7853202a4a68
       Date:
-      - Thu, 25 Oct 2018 18:19:21 GMT
+      - Thu, 01 Nov 2018 18:34:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:21 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:17 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -8040,13 +8172,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:19:21 GMT
+      - Thu, 01 Nov 2018 18:34:17 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-d202bf0d-6cc1-405b-8665-5c45f1fd3930
+      - req-250ac247-15bf-4135-b2d6-354570ff4c1e
       Content-Length:
       - '4170'
       Connection:
@@ -8055,10 +8187,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:19:21.948797", "expires":
-        "2018-10-25T19:19:21Z", "id": "ace88c09b901442d8a238c9e1da8fbd5", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:34:17.579969", "expires":
+        "2018-11-01T19:34:17Z", "id": "170fab41072c486daaf63d22a8f23217", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["YA19BazjTsyLhYXdjjlp4w"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["X_u4QXRpSNqHSOLItzHdKg"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -8103,7 +8235,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:21 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:17 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -8121,13 +8253,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:19:22 GMT
+      - Thu, 01 Nov 2018 18:34:17 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-f92d91dd-76c4-4a0a-af37-ab05eaa50130
+      - req-328f836c-9ba8-4aa3-bcb5-9fefbb35cd37
       Content-Length:
       - '4170'
       Connection:
@@ -8136,10 +8268,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:19:22.138687", "expires":
-        "2018-10-25T19:19:22Z", "id": "f9c5ec6c049d40ad95fc640ccef28458", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:34:17.776099", "expires":
+        "2018-11-01T19:34:17Z", "id": "f22d980ea14145199b5baaa9f8ab8064", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["BnksuwcURbKAO24JHfwZmg"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["_z2cCRIGQHae08-D-hRFTQ"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -8184,7 +8316,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:22 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:17 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -8202,13 +8334,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:19:22 GMT
+      - Thu, 01 Nov 2018 18:34:17 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-9ddb1065-0762-4515-820f-2aed338b8453
+      - req-148d654f-c8f6-421d-9492-22b56df50f43
       Content-Length:
       - '370'
       Connection:
@@ -8217,13 +8349,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:19:22.287739", "expires":
-        "2018-10-25T19:19:22Z", "id": "9ab89ff04c4b4e439d0d45b6f48fd559", "audit_ids":
-        ["y0ZFo5Q7R2SxYgNnh5nLGw"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:34:17.934811", "expires":
+        "2018-11-01T19:34:17Z", "id": "f091c4cd92514460b98630b588d4ead0", "audit_ids":
+        ["cwiiy6l2Qqi2bKozftXpag"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:22 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:17 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -8238,20 +8370,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9ab89ff04c4b4e439d0d45b6f48fd559
+      - f091c4cd92514460b98630b588d4ead0
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:19:22 GMT
+      - Thu, 01 Nov 2018 18:34:18 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-4838ca62-cc4a-4bc1-b9d8-76d5b5541252
+      - req-f35c117a-8977-4922-930c-80a92020455b
       Content-Length:
       - '500'
       Connection:
@@ -8268,7 +8400,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:22 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:18 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -8286,13 +8418,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:19:22 GMT
+      - Thu, 01 Nov 2018 18:34:18 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-5d6d2b30-f46e-471a-97e5-65d26c84afec
+      - req-4fc11151-7261-4745-8fb2-b61d4aab4ee3
       Content-Length:
       - '4117'
       Connection:
@@ -8301,10 +8433,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:19:22.595187", "expires":
-        "2018-10-25T19:19:22Z", "id": "2f9f79962d44427aa9fff55a46f9d96c", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:34:18.293031", "expires":
+        "2018-11-01T19:34:18Z", "id": "2d1cbb498aa244eba56cd49abc9ac431", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["rVzzixL7TJSCt_s7VK-2uA"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["zQnPaiw9QWaYfwFI5G50iA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -8348,7 +8480,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:22 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:18 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -8366,13 +8498,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:19:22 GMT
+      - Thu, 01 Nov 2018 18:34:18 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-a3258868-a05d-4229-8f24-3b91ed1e8048
+      - req-79f0d4eb-7199-4803-a72f-8adb47b75996
       Content-Length:
       - '4131'
       Connection:
@@ -8381,10 +8513,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:19:22.779243", "expires":
-        "2018-10-25T19:19:22Z", "id": "6401f1e7ba614c0da37ec39cb11baa32", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:34:18.497941", "expires":
+        "2018-11-01T19:34:18Z", "id": "27036f54711b43899a55da76c3bcc335", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["5sfi2Y5FSUOJTlPE9DZY2A"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["Q7ATyR8MTimYFp_YGiZQ6g"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -8428,7 +8560,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:22 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:18 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -8446,13 +8578,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:19:22 GMT
+      - Thu, 01 Nov 2018 18:34:18 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-a0872ec6-a7e5-4965-8318-8e4068ff3b9a
+      - req-7a5fe81e-9a09-4fb4-9300-d0854a0144b7
       Content-Length:
       - '4118'
       Connection:
@@ -8461,10 +8593,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:19:22.953333", "expires":
-        "2018-10-25T19:19:22Z", "id": "70c23ed6878d4130b272591941fa3c33", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:34:18.694301", "expires":
+        "2018-11-01T19:34:18Z", "id": "62f0bdc6879740ee84e56bac41b917b4", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["e8QlBwPVT8SjI-UlVqgctQ"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["seEYEEnMT1O0SRn_snQRAw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -8508,7 +8640,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:22 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:18 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -8526,13 +8658,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:19:23 GMT
+      - Thu, 01 Nov 2018 18:34:18 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-a5e6be66-212c-4e99-9acf-ed161b1a4d6f
+      - req-c79b5087-9a47-4614-b0d0-b9beb495455e
       Content-Length:
       - '4117'
       Connection:
@@ -8541,10 +8673,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:19:23.171437", "expires":
-        "2018-10-25T19:19:23Z", "id": "24adb3bc0061469883245308ebcbf0c4", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:34:18.894462", "expires":
+        "2018-11-01T19:34:18Z", "id": "a9444c63ea9b4a029028b4d4496867ae", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["VN8ZnGCrRqa2N0n0o2syDg"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["k9k37M2YTYGhHXuU7jC-Tw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -8588,7 +8720,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:23 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:18 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/?format=json&limit=1000
@@ -8603,7 +8735,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 24adb3bc0061469883245308ebcbf0c4
+      - a9444c63ea9b4a029028b4d4496867ae
   response:
     status:
       code: 200
@@ -8632,15 +8764,15 @@ http_interactions:
       X-Account-Project-Domain-Id:
       - default
       X-Trans-Id:
-      - txcdac7f81b4d94733a02f0-005bd2092b
+      - tx15f75e4fa48a4d39af131-005bdb472a
       Date:
-      - Thu, 25 Oct 2018 18:19:23 GMT
+      - Thu, 01 Nov 2018 18:34:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '[{"count": 3, "bytes": 33, "name": "dir_1"}, {"count": 0, "bytes":
         0, "name": "dir_2"}, {"count": 0, "bytes": 0, "name": "dir_3"}]'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:23 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:19 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/?format=json&limit=1000&marker=dir_3
@@ -8655,7 +8787,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 24adb3bc0061469883245308ebcbf0c4
+      - a9444c63ea9b4a029028b4d4496867ae
   response:
     status:
       code: 200
@@ -8684,14 +8816,14 @@ http_interactions:
       X-Account-Project-Domain-Id:
       - default
       X-Trans-Id:
-      - tx0b9d9a05ed464d7cb6ace-005bd2092b
+      - tx14d9c87357b84a2abcbd3-005bdb472b
       Date:
-      - Thu, 25 Oct 2018 18:19:23 GMT
+      - Thu, 01 Nov 2018 18:34:19 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:23 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:19 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -8709,13 +8841,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:19:23 GMT
+      - Thu, 01 Nov 2018 18:34:19 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-419bda9a-999b-4bca-a384-fda74b8fa78f
+      - req-d36179ee-b29f-4cd8-9d95-87609127a11a
       Content-Length:
       - '4131'
       Connection:
@@ -8724,10 +8856,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:19:23.926507", "expires":
-        "2018-10-25T19:19:23Z", "id": "1eeb09515c31474a878fe6809df507bf", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:34:19.347473", "expires":
+        "2018-11-01T19:34:19Z", "id": "9f46a48fcf874781ac41fca27483855d", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["A_kcVhjlTXage4RS5bpiKg"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["CRNQjNb8SNiVRo-ncPfeRg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -8771,7 +8903,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:23 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:19 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_b458a5c25c3749758f4c0661940b3ba8/?format=json&limit=1000
@@ -8786,7 +8918,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1eeb09515c31474a878fe6809df507bf
+      - 9f46a48fcf874781ac41fca27483855d
   response:
     status:
       code: 200
@@ -8799,22 +8931,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1540491564.08763'
+      - '1541097259.56999'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1540491564.08763'
+      - '1541097259.56999'
       X-Trans-Id:
-      - tx69fda55216fa463c89a5e-005bd2092c
+      - tx17facbed43464d9eabbf7-005bdb472b
       Date:
-      - Thu, 25 Oct 2018 18:19:24 GMT
+      - Thu, 01 Nov 2018 18:34:19 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:24 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:19 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_e54e5c3c19e34720b05661f2ea1ea00a/?format=json&limit=1000
@@ -8829,7 +8961,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f9c5ec6c049d40ad95fc640ccef28458
+      - f22d980ea14145199b5baaa9f8ab8064
   response:
     status:
       code: 200
@@ -8842,22 +8974,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1540491564.27775'
+      - '1541097259.72647'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1540491564.27775'
+      - '1541097259.72647'
       X-Trans-Id:
-      - txfe8842f01c8c4817b4079-005bd2092c
+      - txcd80abdb167845c78fe60-005bdb472b
       Date:
-      - Thu, 25 Oct 2018 18:19:24 GMT
+      - Thu, 01 Nov 2018 18:34:19 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:24 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:19 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -8875,13 +9007,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:19:24 GMT
+      - Thu, 01 Nov 2018 18:34:19 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-647f8bd7-d61f-4e78-a965-e22661dec14f
+      - req-fcfac1a9-b6e0-4331-93f0-d1fa9de35c8d
       Content-Length:
       - '4118'
       Connection:
@@ -8890,10 +9022,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:19:24.459812", "expires":
-        "2018-10-25T19:19:24Z", "id": "bd00dfa075d2452fae454d05792b6086", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:34:19.915325", "expires":
+        "2018-11-01T19:34:19Z", "id": "8b2afa313e9147c898d0db51a50b4db2", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["ktQO7WIJQPanWgmJ_0e2rg"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["S950oVXxRByGHdckmFhEHg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -8937,7 +9069,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:24 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:19 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_e8f744b1fc6a487681d35fb275252608/?format=json&limit=1000
@@ -8952,7 +9084,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bd00dfa075d2452fae454d05792b6086
+      - 8b2afa313e9147c898d0db51a50b4db2
   response:
     status:
       code: 200
@@ -8965,22 +9097,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1540491564.62641'
+      - '1541097260.08604'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1540491564.62641'
+      - '1541097260.08604'
       X-Trans-Id:
-      - txa86fa8ab376a40c7a3358-005bd2092c
+      - tx0144adfbb16345dc891fb-005bdb472c
       Date:
-      - Thu, 25 Oct 2018 18:19:24 GMT
+      - Thu, 01 Nov 2018 18:34:20 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:24 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:20 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/dir_1?format=json
@@ -8995,7 +9127,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 24adb3bc0061469883245308ebcbf0c4
+      - a9444c63ea9b4a029028b4d4496867ae
   response:
     status:
       code: 200
@@ -9016,9 +9148,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - tx7490ff941a9d4560a3b56-005bd2092c
+      - tx9442a3e95aa64be0a4183-005bdb472c
       Date:
-      - Thu, 25 Oct 2018 18:19:24 GMT
+      - Thu, 01 Nov 2018 18:34:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '[{"hash": "61257bf228e2f6802a196c9a460d19a8", "last_modified": "2016-11-11T13:50:03.869630",
@@ -9028,7 +9160,7 @@ http_interactions:
         {"hash": "1727a9b61bddf85bbe7a5710c9f45691", "last_modified": "2016-11-11T13:50:04.495640",
         "bytes": 11, "name": "file_3", "content_type": "application/octet-stream"}]'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:24 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:20 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/dir_2?format=json
@@ -9043,7 +9175,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 24adb3bc0061469883245308ebcbf0c4
+      - a9444c63ea9b4a029028b4d4496867ae
   response:
     status:
       code: 200
@@ -9064,14 +9196,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - txd0d167e56c6f4fe9b1285-005bd2092c
+      - tx0c6d52963e7b40bbaafe8-005bdb472c
       Date:
-      - Thu, 25 Oct 2018 18:19:24 GMT
+      - Thu, 01 Nov 2018 18:34:20 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:24 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:20 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/dir_3?format=json
@@ -9086,7 +9218,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 24adb3bc0061469883245308ebcbf0c4
+      - a9444c63ea9b4a029028b4d4496867ae
   response:
     status:
       code: 200
@@ -9107,12 +9239,12 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - tx1d806a65bb404520954a3-005bd2092c
+      - txbd30548182654d97bedd5-005bdb472c
       Date:
-      - Thu, 25 Oct 2018 18:19:24 GMT
+      - Thu, 01 Nov 2018 18:34:20 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:19:24 GMT
+  recorded_at: Thu, 01 Nov 2018 18:34:20 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_network_targeted_refresh.yml
+++ b/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_network_targeted_refresh.yml
@@ -17,13 +17,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:20:39 GMT
+      - Thu, 01 Nov 2018 18:35:35 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-a6078d24-f23b-4f3a-a832-cd73fb92de30
+      - req-3a1ae553-4c6a-4259-87c8-d979c4c15d2d
       Content-Length:
       - '4170'
       Connection:
@@ -32,10 +32,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:20:39.616815", "expires":
-        "2018-10-25T19:20:39Z", "id": "4c1551e76ebe4d2ebb68a4467c6a441e", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:35:35.534246", "expires":
+        "2018-11-01T19:35:35Z", "id": "4ba9271ddd564698a97d2cab70319e8f", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["c_RCjpQhQe22Cii6yHF0ZQ"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["Fev6WDeqRwauPzCsmvrOCQ"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -80,7 +80,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:39 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:35 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -95,7 +95,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4c1551e76ebe4d2ebb68a4467c6a441e
+      - 4ba9271ddd564698a97d2cab70319e8f
   response:
     status:
       code: 200
@@ -106,7 +106,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Thu, 25 Oct 2018 18:20:39 GMT
+      - Thu, 01 Nov 2018 18:35:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -115,7 +115,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:39 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:35 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-availability-zone
@@ -130,7 +130,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4c1551e76ebe4d2ebb68a4467c6a441e
+      - 4ba9271ddd564698a97d2cab70319e8f
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -143,15 +143,15 @@ http_interactions:
       Content-Length:
       - '97'
       X-Compute-Request-Id:
-      - req-dc92a463-843b-4005-9e78-3027f87722ca
+      - req-687567e2-6660-4593-af93-eca140cfab99
       Date:
-      - Thu, 25 Oct 2018 18:20:39 GMT
+      - Thu, 01 Nov 2018 18:35:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"availabilityZoneInfo": [{"zoneState": {"available": true}, "hosts":
         null, "zoneName": "nova"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:39 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:35 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -169,13 +169,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:20:40 GMT
+      - Thu, 01 Nov 2018 18:35:35 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-fc80f17b-2b8b-4ba8-ba97-682b282b83a4
+      - req-2583d3f6-ab8c-41de-83ff-3f507208a853
       Content-Length:
       - '4170'
       Connection:
@@ -184,10 +184,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:20:40.060285", "expires":
-        "2018-10-25T19:20:40Z", "id": "e6d583ace24c48059fa12175ffd8d4a3", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:35:35.998753", "expires":
+        "2018-11-01T19:35:35Z", "id": "c7653c8ab31241bf96da749dff95b6e8", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["jJyhkdeqS8mve3EOmgyewQ"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["sYf4FBpVSja1gOUIC7CF2Q"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -232,7 +232,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:40 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:36 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-availability-zone.json
@@ -247,28 +247,28 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e6d583ace24c48059fa12175ffd8d4a3
+      - c7653c8ab31241bf96da749dff95b6e8
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-086819de-0848-40bd-8a12-c93e495a2dda
+      - req-5ffd6715-bbdc-40c4-9c11-8f3b076cccf7
       Content-Type:
       - application/json
       Content-Length:
       - '82'
       X-Openstack-Request-Id:
-      - req-086819de-0848-40bd-8a12-c93e495a2dda
+      - req-5ffd6715-bbdc-40c4-9c11-8f3b076cccf7
       Date:
-      - Thu, 25 Oct 2018 18:20:40 GMT
+      - Thu, 01 Nov 2018 18:35:36 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"availabilityZoneInfo": [{"zoneState": {"available": true}, "zoneName":
         "nova"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:40 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:36 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -286,13 +286,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:20:40 GMT
+      - Thu, 01 Nov 2018 18:35:36 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-ebdde89b-7d31-44c8-8609-3fe840085dd0
+      - req-ccebf2ed-d9c4-484f-b5f2-f29d08aa301f
       Content-Length:
       - '370'
       Connection:
@@ -301,13 +301,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:20:40.379965", "expires":
-        "2018-10-25T19:20:40Z", "id": "f4e24959442b4c4580e2b1404c6f6d7d", "audit_ids":
-        ["5w-FSRAeQMK5GzSiqQ4bVQ"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:35:36.390716", "expires":
+        "2018-11-01T19:35:36Z", "id": "6bf5a339ccbd4fdead431718c44105fc", "audit_ids":
+        ["nkQAda2FQ6eZDUgJcxHKEQ"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:40 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:36 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -322,20 +322,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f4e24959442b4c4580e2b1404c6f6d7d
+      - 6bf5a339ccbd4fdead431718c44105fc
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:20:40 GMT
+      - Thu, 01 Nov 2018 18:35:36 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-d1546fa6-cf49-4517-a8ba-e37f77bef341
+      - req-52d34c77-567c-4665-ad82-acb86eeb7cd7
       Content-Length:
       - '500'
       Connection:
@@ -352,7 +352,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:40 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:36 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -370,13 +370,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:20:40 GMT
+      - Thu, 01 Nov 2018 18:35:36 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-a5f0c89c-970d-4eed-929e-0524d1197c60
+      - req-fe595a14-2b55-4ad8-8400-7c1138e65195
       Content-Length:
       - '4117'
       Connection:
@@ -385,10 +385,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:20:40.693545", "expires":
-        "2018-10-25T19:20:40Z", "id": "38e245157a014262a3571406f0b30599", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:35:36.723441", "expires":
+        "2018-11-01T19:35:36Z", "id": "bccacccac2bb4171b9c93c6383860456", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["zt3Y8JpBR9u8TlNmc4vrKA"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["sOml9HduQFSyz-PcYKBavA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -432,7 +432,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:40 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:36 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -447,7 +447,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 38e245157a014262a3571406f0b30599
+      - bccacccac2bb4171b9c93c6383860456
   response:
     status:
       code: 200
@@ -458,7 +458,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Thu, 25 Oct 2018 18:20:40 GMT
+      - Thu, 01 Nov 2018 18:35:36 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -467,7 +467,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:40 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:36 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -485,13 +485,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:20:40 GMT
+      - Thu, 01 Nov 2018 18:35:36 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-bdadb8e8-2894-4553-afb4-8b448ee7d14c
+      - req-0b56c313-a798-4654-b918-c52b1c4edfae
       Content-Length:
       - '4131'
       Connection:
@@ -500,10 +500,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:20:40.961571", "expires":
-        "2018-10-25T19:20:40Z", "id": "d0617893a7d8498ca571b7000e867f85", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:35:37.020958", "expires":
+        "2018-11-01T19:35:37Z", "id": "f28d5b2bc14e48ecb1ee1e71851067f2", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["3iz_mngVQJ260OP4zAK5Cg"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["teEQSsy5SnyrpfZUKjd6uQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -547,7 +547,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:40 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:37 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -562,7 +562,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d0617893a7d8498ca571b7000e867f85
+      - f28d5b2bc14e48ecb1ee1e71851067f2
   response:
     status:
       code: 200
@@ -573,7 +573,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Thu, 25 Oct 2018 18:20:41 GMT
+      - Thu, 01 Nov 2018 18:35:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -582,7 +582,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:41 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:37 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -600,13 +600,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:20:41 GMT
+      - Thu, 01 Nov 2018 18:35:37 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-5a5f60ee-632c-4541-a716-de59745833ee
+      - req-8836fb17-5299-4195-aa39-362022c67420
       Content-Length:
       - '4118'
       Connection:
@@ -615,10 +615,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:20:41.258783", "expires":
-        "2018-10-25T19:20:41Z", "id": "e2862124e07c4ce98c3440bfb1f0310d", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:35:37.304722", "expires":
+        "2018-11-01T19:35:37Z", "id": "71ff79aa172a48579b1a6586527a9726", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["4JNZcvu4TPikgloEpvMyMQ"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["nogw-wEjQdCP5mSl5uA4MA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -662,7 +662,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:41 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:37 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -677,7 +677,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e2862124e07c4ce98c3440bfb1f0310d
+      - 71ff79aa172a48579b1a6586527a9726
   response:
     status:
       code: 200
@@ -688,7 +688,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Thu, 25 Oct 2018 18:20:41 GMT
+      - Thu, 01 Nov 2018 18:35:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -697,7 +697,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:41 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:37 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-services?limit=1000
@@ -712,7 +712,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 38e245157a014262a3571406f0b30599
+      - bccacccac2bb4171b9c93c6383860456
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -725,26 +725,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-a405b654-0224-4cbd-96be-a9b719f3d939
+      - req-899c46c0-788d-4cbd-a04b-d8804318ee48
       Date:
-      - Thu, 25 Oct 2018 18:20:41 GMT
+      - Thu, 01 Nov 2018 18:35:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-10-25T18:20:41.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-11-01T18:35:32.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-10-25T18:20:37.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-11-01T18:35:29.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-10-25T18:20:38.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-11-01T18:35:31.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2018-10-25T18:20:41.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-11-01T18:35:37.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-10-25T18:20:32.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-11-01T18:35:33.000000"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:41 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:37 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-services?limit=1000&marker=5
@@ -759,7 +759,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 38e245157a014262a3571406f0b30599
+      - bccacccac2bb4171b9c93c6383860456
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -772,26 +772,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-1f6fdc18-6603-4e00-806c-17ab5f87a7b3
+      - req-2fab8684-d03a-4ea0-ba10-8cbd555b1beb
       Date:
-      - Thu, 25 Oct 2018 18:20:41 GMT
+      - Thu, 01 Nov 2018 18:35:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-10-25T18:20:41.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-11-01T18:35:32.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-10-25T18:20:37.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-11-01T18:35:29.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-10-25T18:20:38.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-11-01T18:35:31.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2018-10-25T18:20:41.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-11-01T18:35:37.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-10-25T18:20:32.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-11-01T18:35:33.000000"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:41 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:38 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8/os-services?limit=1000
@@ -806,7 +806,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d0617893a7d8498ca571b7000e867f85
+      - f28d5b2bc14e48ecb1ee1e71851067f2
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -819,26 +819,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-9a3a2d8c-66f0-47ae-a8b1-f506d8472b70
+      - req-44189719-8a5d-477c-a6ec-d9c130fe71f1
       Date:
-      - Thu, 25 Oct 2018 18:20:41 GMT
+      - Thu, 01 Nov 2018 18:35:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-10-25T18:20:41.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-11-01T18:35:32.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-10-25T18:20:37.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-11-01T18:35:29.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-10-25T18:20:38.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-11-01T18:35:31.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2018-10-25T18:20:41.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-11-01T18:35:37.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-10-25T18:20:32.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-11-01T18:35:33.000000"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:41 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:38 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8/os-services?limit=1000&marker=5
@@ -853,7 +853,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d0617893a7d8498ca571b7000e867f85
+      - f28d5b2bc14e48ecb1ee1e71851067f2
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -866,26 +866,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-ec2670d2-72ef-4840-8c6f-199bc40ad181
+      - req-2753019c-3be6-4299-9109-925ce9324e7c
       Date:
-      - Thu, 25 Oct 2018 18:20:41 GMT
+      - Thu, 01 Nov 2018 18:35:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-10-25T18:20:41.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-11-01T18:35:32.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-10-25T18:20:37.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-11-01T18:35:29.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-10-25T18:20:38.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-11-01T18:35:31.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2018-10-25T18:20:41.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-11-01T18:35:37.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-10-25T18:20:32.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-11-01T18:35:33.000000"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:41 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:38 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-services?limit=1000
@@ -900,7 +900,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4c1551e76ebe4d2ebb68a4467c6a441e
+      - 4ba9271ddd564698a97d2cab70319e8f
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -913,26 +913,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-b5534d2f-7078-4535-ae06-c5ddf4ab4123
+      - req-a4850982-c91a-4d22-9414-9452d5b16558
       Date:
-      - Thu, 25 Oct 2018 18:20:42 GMT
+      - Thu, 01 Nov 2018 18:35:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-10-25T18:20:41.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-11-01T18:35:32.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-10-25T18:20:37.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-11-01T18:35:29.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-10-25T18:20:38.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-11-01T18:35:31.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2018-10-25T18:20:41.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-11-01T18:35:37.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-10-25T18:20:32.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-11-01T18:35:33.000000"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:42 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:38 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-services?limit=1000&marker=5
@@ -947,7 +947,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4c1551e76ebe4d2ebb68a4467c6a441e
+      - 4ba9271ddd564698a97d2cab70319e8f
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -960,26 +960,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-33bd0115-95c9-43ff-b0d7-97f5d7205e59
+      - req-663d735f-a523-4aab-806f-3934776527db
       Date:
-      - Thu, 25 Oct 2018 18:20:42 GMT
+      - Thu, 01 Nov 2018 18:35:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-10-25T18:20:41.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-11-01T18:35:32.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-10-25T18:20:37.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-11-01T18:35:29.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-10-25T18:20:38.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-11-01T18:35:31.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2018-10-25T18:20:41.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-11-01T18:35:37.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-10-25T18:20:42.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-11-01T18:35:33.000000"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:42 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:38 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608/os-services?limit=1000
@@ -994,7 +994,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e2862124e07c4ce98c3440bfb1f0310d
+      - 71ff79aa172a48579b1a6586527a9726
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1007,26 +1007,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-716468e1-4bf6-45f2-909c-bf3f0f10be95
+      - req-6e299e57-ae16-47cc-b872-24545e78ed40
       Date:
-      - Thu, 25 Oct 2018 18:20:42 GMT
+      - Thu, 01 Nov 2018 18:35:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-10-25T18:20:41.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-11-01T18:35:32.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-10-25T18:20:37.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-11-01T18:35:29.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-10-25T18:20:38.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-11-01T18:35:31.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2018-10-25T18:20:41.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-11-01T18:35:37.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-10-25T18:20:42.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-11-01T18:35:33.000000"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:42 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:38 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608/os-services?limit=1000&marker=5
@@ -1041,7 +1041,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e2862124e07c4ce98c3440bfb1f0310d
+      - 71ff79aa172a48579b1a6586527a9726
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1054,26 +1054,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-800d7a0e-cffc-4a12-980c-30389f5ba0fc
+      - req-2fbd2be7-89e4-4486-91d0-bb5094d73ae6
       Date:
-      - Thu, 25 Oct 2018 18:20:42 GMT
+      - Thu, 01 Nov 2018 18:35:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-10-25T18:20:41.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-11-01T18:35:32.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-10-25T18:20:37.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-11-01T18:35:29.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-10-25T18:20:38.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-11-01T18:35:31.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2018-10-25T18:20:41.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-11-01T18:35:37.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-10-25T18:20:42.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-11-01T18:35:33.000000"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:42 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:38 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000
@@ -1088,7 +1088,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4c1551e76ebe4d2ebb68a4467c6a441e
+      - 4ba9271ddd564698a97d2cab70319e8f
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1101,9 +1101,9 @@ http_interactions:
       Content-Length:
       - '1010'
       X-Compute-Request-Id:
-      - req-751f4761-82fd-4ec3-980a-af6df293b8d7
+      - req-b8769238-c8c7-4086-a4c8-82434802b301
       Date:
-      - Thu, 25 Oct 2018 18:20:42 GMT
+      - Thu, 01 Nov 2018 18:35:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.tiny", "links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/1",
@@ -1117,7 +1117,7 @@ http_interactions:
         0, "disk": 20, "id": "2"}], "flavors_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=2",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:42 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:38 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=2
@@ -1132,7 +1132,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4c1551e76ebe4d2ebb68a4467c6a441e
+      - 4ba9271ddd564698a97d2cab70319e8f
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1145,9 +1145,9 @@ http_interactions:
       Content-Length:
       - '1014'
       X-Compute-Request-Id:
-      - req-6f8d69a8-8abb-41c1-937b-f0dc89ba9f86
+      - req-2f16e061-7132-4068-808f-6ab93922995d
       Date:
-      - Thu, 25 Oct 2018 18:20:42 GMT
+      - Thu, 01 Nov 2018 18:35:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.medium", "links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/3",
@@ -1161,7 +1161,7 @@ http_interactions:
         0, "disk": 80, "id": "4"}], "flavors_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=4",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:42 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:39 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=4
@@ -1176,7 +1176,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4c1551e76ebe4d2ebb68a4467c6a441e
+      - 4ba9271ddd564698a97d2cab70319e8f
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1189,9 +1189,9 @@ http_interactions:
       Content-Length:
       - '1026'
       X-Compute-Request-Id:
-      - req-f0c6b070-8183-4265-bbfb-ee5b7393ca5a
+      - req-d1113a2b-4816-4842-bcb1-02ade0a1580e
       Date:
-      - Thu, 25 Oct 2018 18:20:42 GMT
+      - Thu, 01 Nov 2018 18:35:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.xlarge", "links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/5",
@@ -1206,7 +1206,7 @@ http_interactions:
         1, "disk": 1, "id": "6"}], "flavors_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=6",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:42 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:39 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=6
@@ -1221,7 +1221,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4c1551e76ebe4d2ebb68a4467c6a441e
+      - 4ba9271ddd564698a97d2cab70319e8f
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1234,9 +1234,9 @@ http_interactions:
       Content-Length:
       - '448'
       X-Compute-Request-Id:
-      - req-3195ded1-3348-4b2b-8ff9-13f7bef25c81
+      - req-5c8ee529-c306-4929-b478-7b7ccbad40f1
       Date:
-      - Thu, 25 Oct 2018 18:20:42 GMT
+      - Thu, 01 Nov 2018 18:35:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.ems_refresh_spec_private", "links": [{"href":
@@ -1246,7 +1246,7 @@ http_interactions:
         8, "swap": "", "os-flavor-access:is_public": false, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         0, "disk": 160, "id": "7"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:42 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:39 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/7/os-flavor-access
@@ -1261,7 +1261,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4c1551e76ebe4d2ebb68a4467c6a441e
+      - 4ba9271ddd564698a97d2cab70319e8f
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1274,15 +1274,15 @@ http_interactions:
       Content-Length:
       - '88'
       X-Compute-Request-Id:
-      - req-0a00bf85-9bde-47fc-b41b-8ff05e775a94
+      - req-4c0631d3-9ad0-4eb7-a5e6-83fafd91c1b0
       Date:
-      - Thu, 25 Oct 2018 18:20:42 GMT
+      - Thu, 01 Nov 2018 18:35:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavor_access": [{"tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "flavor_id": "7"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:42 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:39 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1300,13 +1300,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:20:43 GMT
+      - Thu, 01 Nov 2018 18:35:39 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-8320ecb3-e5f7-4d40-ad17-be17f40e9431
+      - req-3db0a178-a5b4-401b-8383-d27bd16e55ad
       Content-Length:
       - '4170'
       Connection:
@@ -1315,10 +1315,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:20:43.166487", "expires":
-        "2018-10-25T19:20:43Z", "id": "761970b1e1b94bd382b3b9d4f305c48c", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:35:39.579237", "expires":
+        "2018-11-01T19:35:39Z", "id": "20622d0063344c0bb55679f0b5eec756", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["YgswmtIIRIWS_CwI2C25Vg"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["AXofoM1DRKe2G6tGCAJHvA"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -1363,7 +1363,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:43 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:39 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1381,13 +1381,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:20:43 GMT
+      - Thu, 01 Nov 2018 18:35:39 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-70d52f5b-f6b5-435c-9ca3-a7232ed0ae75
+      - req-2536d0a8-4120-44d5-9668-ee05e93064af
       Content-Length:
       - '4117'
       Connection:
@@ -1396,10 +1396,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:20:43.346553", "expires":
-        "2018-10-25T19:20:43Z", "id": "a482c14795714eb6b1348bb17337bdd3", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:35:39.760352", "expires":
+        "2018-11-01T19:35:39Z", "id": "7976aa477f284906be9348070b0eb7ca", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["tes9EfGWSUSsY3e_x_iHAw"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["Hn-DNqllQf2nm5AsjfXIlQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -1443,7 +1443,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:43 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:39 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images?limit=1000
@@ -1458,7 +1458,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a482c14795714eb6b1348bb17337bdd3
+      - 7976aa477f284906be9348070b0eb7ca
   response:
     status:
       code: 200
@@ -1469,9 +1469,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-5f0a63b2-17ca-415f-8946-99c92d52edcf
+      - req-dbc61314-98fb-4443-8a9f-8aa3982c247c
       Date:
-      - Thu, 25 Oct 2018 18:20:43 GMT
+      - Thu, 01 Nov 2018 18:35:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -1513,7 +1513,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:43 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:39 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images?limit=1000&marker=bb799f70-5e02-461b-8324-17ee88259c7b
@@ -1528,7 +1528,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a482c14795714eb6b1348bb17337bdd3
+      - 7976aa477f284906be9348070b0eb7ca
   response:
     status:
       code: 200
@@ -1539,14 +1539,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-29d6742a-cd31-4f67-a447-1227c8d2155a
+      - req-379e9162-abb3-46b5-8e0d-9b8ee6e6b92a
       Date:
-      - Thu, 25 Oct 2018 18:20:43 GMT
+      - Thu, 01 Nov 2018 18:35:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:43 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:40 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1564,13 +1564,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:20:43 GMT
+      - Thu, 01 Nov 2018 18:35:40 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-71f8225b-5c97-4538-b923-abeceaa1ca60
+      - req-1a89777e-358a-44c2-b9f5-c5e09a8c033d
       Content-Length:
       - '4131'
       Connection:
@@ -1579,10 +1579,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:20:43.869528", "expires":
-        "2018-10-25T19:20:43Z", "id": "8b59bb3fd3074bb08cab3be212575494", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:35:40.244070", "expires":
+        "2018-11-01T19:35:40Z", "id": "1b35c5dedf834800ab928b55c3abc059", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["dlYa4D-NQmSqEcUgQJ3Yhw"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["M9n0N41rQMS-hsxOPhjSag"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -1626,7 +1626,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:43 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:40 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images?limit=1000
@@ -1641,7 +1641,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8b59bb3fd3074bb08cab3be212575494
+      - 1b35c5dedf834800ab928b55c3abc059
   response:
     status:
       code: 200
@@ -1652,9 +1652,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-964467ec-04e3-447c-b85c-1875fe76e546
+      - req-9e2a8a09-b20b-41c4-ab9e-05aad2617c37
       Date:
-      - Thu, 25 Oct 2018 18:20:44 GMT
+      - Thu, 01 Nov 2018 18:35:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -1696,7 +1696,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:44 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:40 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images?limit=1000&marker=bb799f70-5e02-461b-8324-17ee88259c7b
@@ -1711,7 +1711,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8b59bb3fd3074bb08cab3be212575494
+      - 1b35c5dedf834800ab928b55c3abc059
   response:
     status:
       code: 200
@@ -1722,14 +1722,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-78c36271-0a96-4408-9e67-1dd4314ff205
+      - req-bbe2e57a-c21d-49d0-86e1-3a4b033b9dfc
       Date:
-      - Thu, 25 Oct 2018 18:20:44 GMT
+      - Thu, 01 Nov 2018 18:35:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:44 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:40 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images?limit=1000
@@ -1744,7 +1744,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 761970b1e1b94bd382b3b9d4f305c48c
+      - 20622d0063344c0bb55679f0b5eec756
   response:
     status:
       code: 200
@@ -1755,9 +1755,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-ada0814e-8922-4267-991a-51efa46d5558
+      - req-d8ba98c2-a447-47ba-b24b-480c605b439f
       Date:
-      - Thu, 25 Oct 2018 18:20:44 GMT
+      - Thu, 01 Nov 2018 18:35:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -1799,7 +1799,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:44 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:40 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images?limit=1000&marker=bb799f70-5e02-461b-8324-17ee88259c7b
@@ -1814,7 +1814,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 761970b1e1b94bd382b3b9d4f305c48c
+      - 20622d0063344c0bb55679f0b5eec756
   response:
     status:
       code: 200
@@ -1825,14 +1825,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-9f083946-a615-4e90-b641-6e74b17a7823
+      - req-d2d4d2a4-64e7-4258-8e14-3bf747668c58
       Date:
-      - Thu, 25 Oct 2018 18:20:44 GMT
+      - Thu, 01 Nov 2018 18:35:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:44 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:41 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1850,13 +1850,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:20:44 GMT
+      - Thu, 01 Nov 2018 18:35:41 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-d093f3b4-a061-4a8d-9c8f-195822b45ec5
+      - req-e826860a-3ece-43aa-8b89-2d59120bf94f
       Content-Length:
       - '4118'
       Connection:
@@ -1865,10 +1865,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:20:44.689804", "expires":
-        "2018-10-25T19:20:44Z", "id": "836448ddfc794d1f85e4ccae2a599b58", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:35:41.263687", "expires":
+        "2018-11-01T19:35:41Z", "id": "5b3ff7b1772c43fbbdd51f3f99fb76fd", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["Zt5Xk3GZQGSXBs0T4vJUrg"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["-UQ4fY5pTyCQl8iFEHCtKg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -1912,7 +1912,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:44 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:41 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images?limit=1000
@@ -1927,7 +1927,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 836448ddfc794d1f85e4ccae2a599b58
+      - 5b3ff7b1772c43fbbdd51f3f99fb76fd
   response:
     status:
       code: 200
@@ -1938,9 +1938,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-76b7a141-40f2-49b5-a24f-08860de76c10
+      - req-3a59be2a-5609-4031-ad7d-32fe70d0620d
       Date:
-      - Thu, 25 Oct 2018 18:20:44 GMT
+      - Thu, 01 Nov 2018 18:35:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -1982,7 +1982,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:44 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:41 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images?limit=1000&marker=bb799f70-5e02-461b-8324-17ee88259c7b
@@ -1997,7 +1997,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 836448ddfc794d1f85e4ccae2a599b58
+      - 5b3ff7b1772c43fbbdd51f3f99fb76fd
   response:
     status:
       code: 200
@@ -2008,14 +2008,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-d019ae49-8157-4c22-b8f8-6bffd3d341a1
+      - req-7fffdb8f-7068-4b16-9c19-9a50205f78b2
       Date:
-      - Thu, 25 Oct 2018 18:20:44 GMT
+      - Thu, 01 Nov 2018 18:35:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:45 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:41 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-keypairs?limit=1000
@@ -2030,7 +2030,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 38e245157a014262a3571406f0b30599
+      - bccacccac2bb4171b9c93c6383860456
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2043,9 +2043,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-3942c581-c4a3-4142-b49a-93749ce0d08c
+      - req-e7b0b6a6-27e7-4a10-bd44-495c51e6ed97
       Date:
-      - Thu, 25 Oct 2018 18:20:45 GMT
+      - Thu, 01 Nov 2018 18:35:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -2055,7 +2055,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:45 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:41 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -2070,7 +2070,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 38e245157a014262a3571406f0b30599
+      - bccacccac2bb4171b9c93c6383860456
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2083,9 +2083,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-a1d0620f-a9b7-4a0e-85e4-342f1cbac66a
+      - req-fe51f69a-875c-4341-806f-2c95f28b8f37
       Date:
-      - Thu, 25 Oct 2018 18:20:45 GMT
+      - Thu, 01 Nov 2018 18:35:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -2095,7 +2095,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:45 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:41 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8/os-keypairs?limit=1000
@@ -2110,7 +2110,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d0617893a7d8498ca571b7000e867f85
+      - f28d5b2bc14e48ecb1ee1e71851067f2
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2123,9 +2123,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-bb0f8366-983c-45aa-ac71-7eb0413e06a6
+      - req-246d90d0-757b-4698-9fcb-8b4d70951540
       Date:
-      - Thu, 25 Oct 2018 18:20:45 GMT
+      - Thu, 01 Nov 2018 18:35:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -2135,7 +2135,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:45 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:41 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -2150,7 +2150,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d0617893a7d8498ca571b7000e867f85
+      - f28d5b2bc14e48ecb1ee1e71851067f2
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2163,9 +2163,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-1c56d56d-8c53-455f-bd36-8d90c4832572
+      - req-45ab1253-6478-435f-8175-fb38f7b37efc
       Date:
-      - Thu, 25 Oct 2018 18:20:45 GMT
+      - Thu, 01 Nov 2018 18:35:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -2175,7 +2175,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:45 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:42 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-keypairs?limit=1000
@@ -2190,7 +2190,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4c1551e76ebe4d2ebb68a4467c6a441e
+      - 4ba9271ddd564698a97d2cab70319e8f
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2203,9 +2203,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-38e5bd5b-b1ed-42ad-9e74-fe46252becd4
+      - req-4c0fa21e-e751-4a21-b66a-d7b10aeca3bd
       Date:
-      - Thu, 25 Oct 2018 18:20:45 GMT
+      - Thu, 01 Nov 2018 18:35:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -2215,7 +2215,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:45 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:42 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -2230,7 +2230,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4c1551e76ebe4d2ebb68a4467c6a441e
+      - 4ba9271ddd564698a97d2cab70319e8f
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2243,9 +2243,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-23f50c78-9f26-47a5-905c-ee313f59b712
+      - req-8e88d09f-61d1-4907-b57a-da7e1cdad2f4
       Date:
-      - Thu, 25 Oct 2018 18:20:45 GMT
+      - Thu, 01 Nov 2018 18:35:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -2255,7 +2255,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:45 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:42 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608/os-keypairs?limit=1000
@@ -2270,7 +2270,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e2862124e07c4ce98c3440bfb1f0310d
+      - 71ff79aa172a48579b1a6586527a9726
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2283,9 +2283,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-56dc769a-232c-4a18-a174-95cf7ed8ffe8
+      - req-0745b0c2-a485-4c16-808e-a0cf9d9ca460
       Date:
-      - Thu, 25 Oct 2018 18:20:45 GMT
+      - Thu, 01 Nov 2018 18:35:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -2295,7 +2295,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:45 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:42 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -2310,7 +2310,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e2862124e07c4ce98c3440bfb1f0310d
+      - 71ff79aa172a48579b1a6586527a9726
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2323,9 +2323,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-33859d00-94e8-4a9b-94cf-4b4e156f4630
+      - req-76f5468d-f356-40a1-a0ac-268131f22b75
       Date:
-      - Thu, 25 Oct 2018 18:20:45 GMT
+      - Thu, 01 Nov 2018 18:35:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -2335,7 +2335,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:45 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:42 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -2353,13 +2353,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:20:45 GMT
+      - Thu, 01 Nov 2018 18:35:42 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-4023cf04-937b-4e0f-a438-7445f325940e
+      - req-989ce91e-d350-42c0-a4b4-19f05d3882e8
       Content-Length:
       - '4170'
       Connection:
@@ -2368,10 +2368,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:20:45.944623", "expires":
-        "2018-10-25T19:20:45Z", "id": "68e224b3cf4c4579a0d95c373fabab5b", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:35:42.685979", "expires":
+        "2018-11-01T19:35:42Z", "id": "c86233821167480b8404824756f8fe79", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["Yc_2hGRNRaOhMSoVc56tEg"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["pZ7AC6u1QgSnNT2fscLnpQ"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -2416,7 +2416,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:45 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:42 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -2434,13 +2434,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:20:46 GMT
+      - Thu, 01 Nov 2018 18:35:42 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-2a25e6b0-bac2-48b0-a2ce-3cb1d0d619d0
+      - req-996ec45f-3ce3-4dbc-ac05-d1c785d7ea22
       Content-Length:
       - '4117'
       Connection:
@@ -2449,10 +2449,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:20:46.127739", "expires":
-        "2018-10-25T19:20:46Z", "id": "14b86404e1d5474d8aad1f054ba61dfd", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:35:42.884878", "expires":
+        "2018-11-01T19:35:42Z", "id": "a92a8c461a3e49e79dbdccf69ea8200d", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["f_7VV6DvTOuEnj1fKUjDIA"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["lbPMEN8MRnOdOf16wy3NyA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -2496,7 +2496,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:46 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:42 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks?limit=1000&show_nested=true
@@ -2511,7 +2511,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 14b86404e1d5474d8aad1f054ba61dfd
+      - a92a8c461a3e49e79dbdccf69ea8200d
   response:
     status:
       code: 200
@@ -2522,9 +2522,9 @@ http_interactions:
       Content-Length:
       - '2559'
       X-Openstack-Request-Id:
-      - req-2f9394cb-a937-48db-95a7-33addb04ed78
+      - req-22debc0a-9c7f-462e-92f3-1086c9e8ef3d
       Date:
-      - Thu, 25 Oct 2018 18:20:46 GMT
+      - Thu, 01 Nov 2018 18:35:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": [{"description": "Heat WordPress template to support F20,
@@ -2558,7 +2558,7 @@ http_interactions:
         "rel": "self"}], "updated_time": null, "stack_owner": null, "stack_status":
         "CREATE_COMPLETE", "id": "091e1e54-e01c-4ec5-a0ab-b00bee4d425c"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:46 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:43 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks?limit=1000&marker=091e1e54-e01c-4ec5-a0ab-b00bee4d425c&show_nested=true
@@ -2573,7 +2573,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 14b86404e1d5474d8aad1f054ba61dfd
+      - a92a8c461a3e49e79dbdccf69ea8200d
   response:
     status:
       code: 200
@@ -2584,14 +2584,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-4c56dbbb-88c6-4404-b418-5e4f4375a419
+      - req-5ba922c7-daa4-49ee-99d4-ab546627935d
       Date:
-      - Thu, 25 Oct 2018 18:20:46 GMT
+      - Thu, 01 Nov 2018 18:35:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:46 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:43 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -2609,13 +2609,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:20:46 GMT
+      - Thu, 01 Nov 2018 18:35:43 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-d7a54c3c-7d6b-4084-8f8b-ee84c48df763
+      - req-f1d3e3d9-c5ab-4926-8c34-2629a0b25f3c
       Content-Length:
       - '4131'
       Connection:
@@ -2624,10 +2624,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:20:46.615933", "expires":
-        "2018-10-25T19:20:46Z", "id": "084c8c5b651e47b38a9a81d4f1234784", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:35:43.384231", "expires":
+        "2018-11-01T19:35:43Z", "id": "f1cbdf75b4ff464d8ddd007aab6eb8cf", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["t24shibaSI2K1dOQ3ESnew"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["t0dJcMLQSu-ExD9Vw80uxA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -2671,7 +2671,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:46 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:43 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/b458a5c25c3749758f4c0661940b3ba8/stacks?limit=1000&show_nested=true
@@ -2686,7 +2686,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '084c8c5b651e47b38a9a81d4f1234784'
+      - f1cbdf75b4ff464d8ddd007aab6eb8cf
   response:
     status:
       code: 200
@@ -2697,14 +2697,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-b7fbe078-abc8-4389-ae4b-45616327dd5e
+      - req-5ee68d85-fb01-411d-a49e-d670649a5910
       Date:
-      - Thu, 25 Oct 2018 18:20:46 GMT
+      - Thu, 01 Nov 2018 18:35:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:46 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:43 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/e54e5c3c19e34720b05661f2ea1ea00a/stacks?limit=1000&show_nested=true
@@ -2719,7 +2719,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 68e224b3cf4c4579a0d95c373fabab5b
+      - c86233821167480b8404824756f8fe79
   response:
     status:
       code: 200
@@ -2730,14 +2730,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-1aa9b693-d0b5-4859-8765-36cc9396c55f
+      - req-bd590f8a-910d-40a9-814d-10d0ce27cce7
       Date:
-      - Thu, 25 Oct 2018 18:20:46 GMT
+      - Thu, 01 Nov 2018 18:35:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:46 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:43 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -2755,13 +2755,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:20:47 GMT
+      - Thu, 01 Nov 2018 18:35:43 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-eda47782-974f-4030-9c3d-2387f65ac215
+      - req-c3961c2a-c393-4182-a395-f89d6c70e6d4
       Content-Length:
       - '4118'
       Connection:
@@ -2770,10 +2770,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:20:47.145404", "expires":
-        "2018-10-25T19:20:47Z", "id": "0803a104f96b48e195e7bc575f0edfe8", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:35:43.908396", "expires":
+        "2018-11-01T19:35:43Z", "id": "0bc59dd5a99b404498c602ed122cb784", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["089H9Og3QqCD_8goh8actg"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["q4G_FQCnSeuw_kOSEYkPvw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -2817,7 +2817,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:47 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:43 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/e8f744b1fc6a487681d35fb275252608/stacks?limit=1000&show_nested=true
@@ -2832,7 +2832,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '0803a104f96b48e195e7bc575f0edfe8'
+      - 0bc59dd5a99b404498c602ed122cb784
   response:
     status:
       code: 200
@@ -2843,14 +2843,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-3719f207-9a43-432e-9b11-8fa07664b0ab
+      - req-56ef9689-86b1-409f-ab9e-fe5f3ddad6a1
       Date:
-      - Thu, 25 Oct 2018 18:20:47 GMT
+      - Thu, 01 Nov 2018 18:35:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:47 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:44 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack3/45d2af82-eff9-4483-a1f0-f19c44d96146
@@ -2865,7 +2865,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 14b86404e1d5474d8aad1f054ba61dfd
+      - a92a8c461a3e49e79dbdccf69ea8200d
   response:
     status:
       code: 200
@@ -2876,9 +2876,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-bc0ddddb-d0b9-48a2-a709-84f1091670b9
+      - req-c285e5b7-f70b-4127-ba06-9a55d8051875
       Date:
-      - Thu, 25 Oct 2018 18:20:47 GMT
+      - Thu, 01 Nov 2018 18:35:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -2905,7 +2905,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:47 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:44 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack2/4cf24b12-29fc-4529-a8ed-6b079dea7c17
@@ -2920,7 +2920,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 14b86404e1d5474d8aad1f054ba61dfd
+      - a92a8c461a3e49e79dbdccf69ea8200d
   response:
     status:
       code: 200
@@ -2931,9 +2931,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-d907a2bf-5026-46db-8654-ea6bf42968a8
+      - req-d1fcce7b-0d98-4a56-b991-2d62c784e1f0
       Date:
-      - Thu, 25 Oct 2018 18:20:48 GMT
+      - Thu, 01 Nov 2018 18:35:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -2960,7 +2960,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:48 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:44 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c
@@ -2975,7 +2975,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 14b86404e1d5474d8aad1f054ba61dfd
+      - a92a8c461a3e49e79dbdccf69ea8200d
   response:
     status:
       code: 200
@@ -2986,9 +2986,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-a7f5cb2e-7184-4b07-b557-fb85b6bc3338
+      - req-82c00564-2be4-47c6-a5d4-c8d0fcfb6b0d
       Date:
-      - Thu, 25 Oct 2018 18:20:48 GMT
+      - Thu, 01 Nov 2018 18:35:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -3015,7 +3015,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:48 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:45 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack3/45d2af82-eff9-4483-a1f0-f19c44d96146/template
@@ -3030,7 +3030,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 14b86404e1d5474d8aad1f054ba61dfd
+      - a92a8c461a3e49e79dbdccf69ea8200d
   response:
     status:
       code: 200
@@ -3041,9 +3041,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-893b4957-1d75-4a0e-9689-831cc30fa1e3
+      - req-f055b215-2231-4b81-a3db-6dde226ac480
       Date:
-      - Thu, 25 Oct 2018 18:20:48 GMT
+      - Thu, 01 Nov 2018 18:35:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -3099,7 +3099,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:48 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:45 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack3/45d2af82-eff9-4483-a1f0-f19c44d96146/resources
@@ -3114,7 +3114,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 14b86404e1d5474d8aad1f054ba61dfd
+      - a92a8c461a3e49e79dbdccf69ea8200d
   response:
     status:
       code: 200
@@ -3125,9 +3125,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-9b843e66-16c2-4947-a74d-e32dbd3840ad
+      - req-1194d413-33d2-4cbe-8619-92b8d05d4405
       Date:
-      - Thu, 25 Oct 2018 18:20:48 GMT
+      - Thu, 01 Nov 2018 18:35:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -3139,7 +3139,7 @@ http_interactions:
         changed", "physical_resource_id": "aa5907f3-8209-4dd0-b3ef-600431d85bac",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:48 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:45 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/detail?limit=1000
@@ -3154,7 +3154,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 38e245157a014262a3571406f0b30599
+      - bccacccac2bb4171b9c93c6383860456
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3167,9 +3167,9 @@ http_interactions:
       Content-Length:
       - '3981'
       X-Compute-Request-Id:
-      - req-98bd6cb5-f0c9-4e35-aae4-d8cb7db3371c
+      - req-fb4a61fe-c823-43e8-8fc2-d331352b3a2b
       Date:
-      - Thu, 25 Oct 2018 18:20:48 GMT
+      - Thu, 01 Nov 2018 18:35:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/detail?limit=1000&marker=96fef14f-5338-4d58-8b89-58b627b27b9b",
@@ -3215,7 +3215,7 @@ http_interactions:
         [], "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:48 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:45 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/detail?limit=1000&marker=96fef14f-5338-4d58-8b89-58b627b27b9b
@@ -3230,7 +3230,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 38e245157a014262a3571406f0b30599
+      - bccacccac2bb4171b9c93c6383860456
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3243,9 +3243,9 @@ http_interactions:
       Content-Length:
       - '4045'
       X-Compute-Request-Id:
-      - req-a76e47ee-accc-4957-a4e0-bedd5b56db9a
+      - req-37396383-f708-4422-9f56-d69313372f76
       Date:
-      - Thu, 25 Oct 2018 18:20:49 GMT
+      - Thu, 01 Nov 2018 18:35:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/detail?limit=1000&marker=ca1fc357-ee31-45e9-a38d-98723d6c8876",
@@ -3291,7 +3291,7 @@ http_interactions:
         [], "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 3, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:49 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:45 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/detail?limit=1000&marker=ca1fc357-ee31-45e9-a38d-98723d6c8876
@@ -3306,7 +3306,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 38e245157a014262a3571406f0b30599
+      - bccacccac2bb4171b9c93c6383860456
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3319,9 +3319,9 @@ http_interactions:
       Content-Length:
       - '4127'
       X-Compute-Request-Id:
-      - req-cebef3f8-62fc-4e48-95d8-91796653e454
+      - req-d75c573f-4cfb-4fb2-8211-c919553bab2d
       Date:
-      - Thu, 25 Oct 2018 18:20:49 GMT
+      - Thu, 01 Nov 2018 18:35:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/detail?limit=1000&marker=ca4f3a16-bae3-4407-83e9-f77b28af0f2b",
@@ -3369,7 +3369,7 @@ http_interactions:
         "", "progress": 0, "OS-EXT-STS:power_state": 1, "config_drive": "", "metadata":
         {}}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:49 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:46 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/detail?limit=1000&marker=ca4f3a16-bae3-4407-83e9-f77b28af0f2b
@@ -3384,7 +3384,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 38e245157a014262a3571406f0b30599
+      - bccacccac2bb4171b9c93c6383860456
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3397,9 +3397,9 @@ http_interactions:
       Content-Length:
       - '3796'
       X-Compute-Request-Id:
-      - req-dbeac794-f5fb-4e57-badb-3ace99063e0d
+      - req-21a1151b-1889-4902-9567-3d4da170aab6
       Date:
-      - Thu, 25 Oct 2018 18:20:49 GMT
+      - Thu, 01 Nov 2018 18:35:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/detail?limit=1000&marker=aa5907f3-8209-4dd0-b3ef-600431d85bac",
@@ -3441,7 +3441,7 @@ http_interactions:
         "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:49 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:46 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/detail?limit=1000&marker=aa5907f3-8209-4dd0-b3ef-600431d85bac
@@ -3456,7 +3456,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 38e245157a014262a3571406f0b30599
+      - bccacccac2bb4171b9c93c6383860456
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3469,9 +3469,9 @@ http_interactions:
       Content-Length:
       - '1816'
       X-Compute-Request-Id:
-      - req-829723aa-5ac5-4e87-ac2d-274489e2a07d
+      - req-c7a916eb-3c63-4b44-b076-32b4f852f8cb
       Date:
-      - Thu, 25 Oct 2018 18:20:49 GMT
+      - Thu, 01 Nov 2018 18:35:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": [{"status": "SHUTOFF", "updated": "2018-01-17T14:49:17Z",
@@ -3494,7 +3494,7 @@ http_interactions:
         "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:49 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:46 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8/servers/detail?limit=1000
@@ -3509,7 +3509,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d0617893a7d8498ca571b7000e867f85
+      - f28d5b2bc14e48ecb1ee1e71851067f2
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3522,14 +3522,14 @@ http_interactions:
       Content-Length:
       - '15'
       X-Compute-Request-Id:
-      - req-89f1c284-1eb8-49c4-ae61-7202a7b21c49
+      - req-4dabd35b-d6eb-47f0-8bd7-9c1afae9967e
       Date:
-      - Thu, 25 Oct 2018 18:20:50 GMT
+      - Thu, 01 Nov 2018 18:35:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:50 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:46 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?limit=1000
@@ -3544,7 +3544,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4c1551e76ebe4d2ebb68a4467c6a441e
+      - 4ba9271ddd564698a97d2cab70319e8f
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3557,14 +3557,14 @@ http_interactions:
       Content-Length:
       - '15'
       X-Compute-Request-Id:
-      - req-7457678c-962a-4e38-8b70-a7840a09a083
+      - req-7213d83d-fa0e-4dd4-ae2d-d008db1663ff
       Date:
-      - Thu, 25 Oct 2018 18:20:50 GMT
+      - Thu, 01 Nov 2018 18:35:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:50 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:47 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608/servers/detail?limit=1000
@@ -3579,7 +3579,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e2862124e07c4ce98c3440bfb1f0310d
+      - 71ff79aa172a48579b1a6586527a9726
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3592,14 +3592,14 @@ http_interactions:
       Content-Length:
       - '15'
       X-Compute-Request-Id:
-      - req-4dd8c614-5821-42a3-8bd3-ff545b428773
+      - req-497123de-bf71-4b13-9e5b-9f361852ca77
       Date:
-      - Thu, 25 Oct 2018 18:20:50 GMT
+      - Thu, 01 Nov 2018 18:35:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:50 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:47 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack2/4cf24b12-29fc-4529-a8ed-6b079dea7c17/template
@@ -3614,7 +3614,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 14b86404e1d5474d8aad1f054ba61dfd
+      - a92a8c461a3e49e79dbdccf69ea8200d
   response:
     status:
       code: 200
@@ -3625,9 +3625,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-ef2bdb2b-c584-4321-aab2-cdcce8cdf0ee
+      - req-e387cf72-9bfd-4e91-9230-59e7c9bbd3a4
       Date:
-      - Thu, 25 Oct 2018 18:20:50 GMT
+      - Thu, 01 Nov 2018 18:35:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -3683,7 +3683,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:51 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:47 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack2/4cf24b12-29fc-4529-a8ed-6b079dea7c17/resources
@@ -3698,7 +3698,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 14b86404e1d5474d8aad1f054ba61dfd
+      - a92a8c461a3e49e79dbdccf69ea8200d
   response:
     status:
       code: 200
@@ -3709,9 +3709,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-45480488-8dfc-44f8-9a74-814c84b467ae
+      - req-29ce0085-6829-4ffb-843e-78212b1f43c2
       Date:
-      - Thu, 25 Oct 2018 18:20:51 GMT
+      - Thu, 01 Nov 2018 18:35:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -3723,7 +3723,7 @@ http_interactions:
         changed", "physical_resource_id": "219a737c-b4ad-430d-944a-a92a4834b12d",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:51 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:47 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c/template
@@ -3738,7 +3738,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 14b86404e1d5474d8aad1f054ba61dfd
+      - a92a8c461a3e49e79dbdccf69ea8200d
   response:
     status:
       code: 200
@@ -3749,9 +3749,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-40614a3f-873a-45f0-8062-06a519fdd0ce
+      - req-de036b7c-698e-4b18-9b8c-6d8b1cda798b
       Date:
-      - Thu, 25 Oct 2018 18:20:51 GMT
+      - Thu, 01 Nov 2018 18:35:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -3807,7 +3807,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:51 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:47 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c/resources
@@ -3822,7 +3822,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 14b86404e1d5474d8aad1f054ba61dfd
+      - a92a8c461a3e49e79dbdccf69ea8200d
   response:
     status:
       code: 200
@@ -3833,9 +3833,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-7ad6a91d-9280-4854-9267-522f4e67b4cd
+      - req-7e0eccad-a08d-42af-892e-5fcd5b68c26a
       Date:
-      - Thu, 25 Oct 2018 18:20:51 GMT
+      - Thu, 01 Nov 2018 18:35:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -3847,7 +3847,7 @@ http_interactions:
         changed", "physical_resource_id": "b686353f-0da0-48bf-bc35-8ea411a67dfd",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:51 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:47 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a//os-quota-sets/69f8f7205ade4aa59084c32c83e60b5a
@@ -3862,7 +3862,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 38e245157a014262a3571406f0b30599
+      - bccacccac2bb4171b9c93c6383860456
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3875,9 +3875,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-942a07eb-a506-41d9-9215-94466a07b449
+      - req-7a051020-dd26-4866-a646-b2bd072a8010
       Date:
-      - Thu, 25 Oct 2018 18:20:51 GMT
+      - Thu, 01 Nov 2018 18:35:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -3886,7 +3886,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:51 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:47 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8//os-quota-sets/b458a5c25c3749758f4c0661940b3ba8
@@ -3901,7 +3901,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d0617893a7d8498ca571b7000e867f85
+      - f28d5b2bc14e48ecb1ee1e71851067f2
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3914,9 +3914,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-cbc24310-035e-4ba4-887b-355ed854ba7a
+      - req-ef873a55-3d8d-451d-9fff-0a472718b5fc
       Date:
-      - Thu, 25 Oct 2018 18:20:51 GMT
+      - Thu, 01 Nov 2018 18:35:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -3925,7 +3925,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:51 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:47 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a//os-quota-sets/e54e5c3c19e34720b05661f2ea1ea00a
@@ -3940,7 +3940,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4c1551e76ebe4d2ebb68a4467c6a441e
+      - 4ba9271ddd564698a97d2cab70319e8f
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3953,9 +3953,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-fa2dee29-da8b-45fe-a703-1d88cf235743
+      - req-d348b10c-e6b3-4db1-9045-e9df2e4cb119
       Date:
-      - Thu, 25 Oct 2018 18:20:51 GMT
+      - Thu, 01 Nov 2018 18:35:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -3964,7 +3964,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:51 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:48 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608//os-quota-sets/e8f744b1fc6a487681d35fb275252608
@@ -3979,7 +3979,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e2862124e07c4ce98c3440bfb1f0310d
+      - 71ff79aa172a48579b1a6586527a9726
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3992,9 +3992,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-c77a4b44-4113-48c9-b3ac-29878d79966d
+      - req-5495a8f1-5292-422b-b425-70e058fb25c2
       Date:
-      - Thu, 25 Oct 2018 18:20:51 GMT
+      - Thu, 01 Nov 2018 18:35:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -4003,7 +4003,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:51 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:48 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4021,13 +4021,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:20:51 GMT
+      - Thu, 01 Nov 2018 18:35:48 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-c1fa9909-3b72-4ced-83dc-395798b7162e
+      - req-a86c5c6e-2aea-479e-b8d8-4a1201a63b34
       Content-Length:
       - '4117'
       Connection:
@@ -4036,10 +4036,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:20:51.926966", "expires":
-        "2018-10-25T19:20:51Z", "id": "6c97ee060d61417eaeffaac7986bfdaa", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:35:48.320605", "expires":
+        "2018-11-01T19:35:48Z", "id": "0d390fc182bd49ce8a70a34aa026bcf4", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["v2ll89LBR4WNw0OTw-i0gg"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["_axSOSXNTdyIdJ9tPSlz-g"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -4083,7 +4083,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:51 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:48 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a//os-quota-sets/69f8f7205ade4aa59084c32c83e60b5a
@@ -4098,22 +4098,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6c97ee060d61417eaeffaac7986bfdaa
+      - 0d390fc182bd49ce8a70a34aa026bcf4
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-38a1cc38-24bd-4e9d-8387-a91fe875c17a
+      - req-14d86f09-eaf0-458a-93de-24e5df78309d
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-38a1cc38-24bd-4e9d-8387-a91fe875c17a
+      - req-14d86f09-eaf0-458a-93de-24e5df78309d
       Date:
-      - Thu, 25 Oct 2018 18:20:52 GMT
+      - Thu, 01 Nov 2018 18:35:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -4123,7 +4123,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "69f8f7205ade4aa59084c32c83e60b5a"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:52 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:48 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4141,13 +4141,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:20:52 GMT
+      - Thu, 01 Nov 2018 18:35:48 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-06b3e9da-5b09-4e81-b143-d90942a45abc
+      - req-a5bfc5d8-a13f-4dbd-8ba1-235d393bbc6d
       Content-Length:
       - '4131'
       Connection:
@@ -4156,10 +4156,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:20:52.472851", "expires":
-        "2018-10-25T19:20:52Z", "id": "0461dcd5f0b34aa997bbcda22fbb5a80", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:35:48.820171", "expires":
+        "2018-11-01T19:35:48Z", "id": "76113b0e77334b4abd5a2df65c3517e0", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["gqULNIuBRg-TAHeoNYspVA"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["Q5NJVop7REacIVhK1hafPQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -4203,7 +4203,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:52 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:48 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8//os-quota-sets/b458a5c25c3749758f4c0661940b3ba8
@@ -4218,22 +4218,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0461dcd5f0b34aa997bbcda22fbb5a80
+      - 76113b0e77334b4abd5a2df65c3517e0
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-b770eaca-867b-4e8a-8336-52a62926f75d
+      - req-d24b369c-503f-4e1f-b144-972f6178e366
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-b770eaca-867b-4e8a-8336-52a62926f75d
+      - req-d24b369c-503f-4e1f-b144-972f6178e366
       Date:
-      - Thu, 25 Oct 2018 18:20:52 GMT
+      - Thu, 01 Nov 2018 18:35:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -4243,7 +4243,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "b458a5c25c3749758f4c0661940b3ba8"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:52 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:49 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a//os-quota-sets/e54e5c3c19e34720b05661f2ea1ea00a
@@ -4258,22 +4258,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e6d583ace24c48059fa12175ffd8d4a3
+      - c7653c8ab31241bf96da749dff95b6e8
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-4cfb2bf3-fce6-4724-b166-280c94b93584
+      - req-80e7135e-9aa6-4775-b8a5-228e0bec581e
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-4cfb2bf3-fce6-4724-b166-280c94b93584
+      - req-80e7135e-9aa6-4775-b8a5-228e0bec581e
       Date:
-      - Thu, 25 Oct 2018 18:20:53 GMT
+      - Thu, 01 Nov 2018 18:35:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -4283,7 +4283,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "e54e5c3c19e34720b05661f2ea1ea00a"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:53 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:49 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4301,13 +4301,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:20:53 GMT
+      - Thu, 01 Nov 2018 18:35:49 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-0c6a0de9-7cf9-4530-9f64-ee43ca09b39b
+      - req-9853dbf4-f09b-4122-9ef8-b996e71385d5
       Content-Length:
       - '4118'
       Connection:
@@ -4316,10 +4316,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:20:53.276740", "expires":
-        "2018-10-25T19:20:53Z", "id": "a89aa27f3db74247af98b4664ce2b7a3", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:35:49.951029", "expires":
+        "2018-11-01T19:35:49Z", "id": "d50cfb54867b40f6a84d7aa9f0562fea", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["ny3xvqQcQI2m7XnsOQD8qg"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["LH_1KAH9SuywRO3baf_WDA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -4363,7 +4363,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:53 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:49 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608//os-quota-sets/e8f744b1fc6a487681d35fb275252608
@@ -4378,22 +4378,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a89aa27f3db74247af98b4664ce2b7a3
+      - d50cfb54867b40f6a84d7aa9f0562fea
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-61ba532b-652c-4a6e-957e-256777bcbee6
+      - req-844da220-8585-4f82-ba85-4463594c3119
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-61ba532b-652c-4a6e-957e-256777bcbee6
+      - req-844da220-8585-4f82-ba85-4463594c3119
       Date:
-      - Thu, 25 Oct 2018 18:20:53 GMT
+      - Thu, 01 Nov 2018 18:35:50 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -4403,7 +4403,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "e8f744b1fc6a487681d35fb275252608"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:53 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:50 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4421,13 +4421,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:20:53 GMT
+      - Thu, 01 Nov 2018 18:35:50 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-1d35d3f5-e014-4699-8cad-85c4fd4f0391
+      - req-694a7ca7-d244-4a57-99e4-723cdbf3b404
       Content-Length:
       - '4170'
       Connection:
@@ -4436,10 +4436,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:20:53.765450", "expires":
-        "2018-10-25T19:20:53Z", "id": "1cd59edbcf224e6db6ef06e72bc7d90f", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:35:50.468983", "expires":
+        "2018-11-01T19:35:50Z", "id": "63656ee4958c4f0880a963dd3df5dc87", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["EkyKkqshTXy1ZKQ303eUjw"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["TVQp4ZcJQ5mEi2gijb6xZQ"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -4484,7 +4484,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:53 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:50 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4502,13 +4502,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:20:53 GMT
+      - Thu, 01 Nov 2018 18:35:50 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-dc337adf-7448-4fe1-b3e7-dc6cf1f0f85c
+      - req-5c9a30ea-739a-4525-94ba-a066d9df9e54
       Content-Length:
       - '4117'
       Connection:
@@ -4517,10 +4517,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:20:53.944175", "expires":
-        "2018-10-25T19:20:53Z", "id": "aef0c103e73b4b7e8e3cb8fefcfb3b94", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:35:50.649484", "expires":
+        "2018-11-01T19:35:50Z", "id": "9f190cd0c6b548318b10b08174b7622d", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["oT2ZON5ZRjeXoEEwGaY47A"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["SwZceg_fTdWI931hlQl3vA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -4564,7 +4564,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:53 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:50 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0//quotas/69f8f7205ade4aa59084c32c83e60b5a
@@ -4579,7 +4579,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - aef0c103e73b4b7e8e3cb8fefcfb3b94
+      - 9f190cd0c6b548318b10b08174b7622d
   response:
     status:
       code: 200
@@ -4590,16 +4590,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-0554a250-852d-4c9a-a3e9-0d1404cf7195
+      - req-4c77fb4d-c1ad-4b54-8612-89fcf53145b3
       Date:
-      - Thu, 25 Oct 2018 18:20:54 GMT
+      - Thu, 01 Nov 2018 18:35:50 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 20, "network": 20, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:54 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:50 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4617,13 +4617,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:20:54 GMT
+      - Thu, 01 Nov 2018 18:35:50 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-34a2b2c7-9b08-4988-aa2b-4907e59a29b5
+      - req-d5b6dc98-f4be-46cd-b67c-be1e9fd4dc0a
       Content-Length:
       - '4131'
       Connection:
@@ -4632,10 +4632,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:20:54.275660", "expires":
-        "2018-10-25T19:20:54Z", "id": "fe0510d9d93f4ffdb2389d1acb3f1325", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:35:51.001273", "expires":
+        "2018-11-01T19:35:50Z", "id": "5b85947db8fe4f1fba27ef99068eb04f", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["Oojl4J5bSXGu1ZWZ8Huugw"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["C_S_X9I5SmmsMzO35yOz6Q"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -4679,7 +4679,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:54 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:51 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0//quotas/b458a5c25c3749758f4c0661940b3ba8
@@ -4694,7 +4694,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fe0510d9d93f4ffdb2389d1acb3f1325
+      - 5b85947db8fe4f1fba27ef99068eb04f
   response:
     status:
       code: 200
@@ -4705,16 +4705,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-542a7c32-763b-4dd8-9277-43a40883ab4b
+      - req-d30e5daa-95f1-43dc-b4d2-3180cd39f459
       Date:
-      - Thu, 25 Oct 2018 18:20:54 GMT
+      - Thu, 01 Nov 2018 18:35:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:54 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:51 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0//quotas/e54e5c3c19e34720b05661f2ea1ea00a
@@ -4729,7 +4729,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1cd59edbcf224e6db6ef06e72bc7d90f
+      - 63656ee4958c4f0880a963dd3df5dc87
   response:
     status:
       code: 200
@@ -4740,16 +4740,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-4a4805f0-912d-4904-b535-8938cb8c1317
+      - req-213c7447-b997-4348-88bc-b4632176ddd4
       Date:
-      - Thu, 25 Oct 2018 18:20:54 GMT
+      - Thu, 01 Nov 2018 18:35:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:54 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:51 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4767,13 +4767,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:20:54 GMT
+      - Thu, 01 Nov 2018 18:35:51 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-f35baea6-569e-400c-ab8f-2f215c55c63c
+      - req-7ae773cb-b743-4ae1-895b-3a93faa96a41
       Content-Length:
       - '4118'
       Connection:
@@ -4782,10 +4782,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:20:54.737450", "expires":
-        "2018-10-25T19:20:54Z", "id": "43c0d89129c1435a914bf45c29d2710d", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:35:51.488718", "expires":
+        "2018-11-01T19:35:51Z", "id": "cf0e9ebfafdc4b1eb2bcb173674892d9", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["0Ko_xVT_QCSQ3m1YHFNKRQ"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["th7kIsmFROqCtb7Oa82Nng"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -4829,7 +4829,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:54 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:51 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0//quotas/e8f744b1fc6a487681d35fb275252608
@@ -4844,7 +4844,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 43c0d89129c1435a914bf45c29d2710d
+      - cf0e9ebfafdc4b1eb2bcb173674892d9
   response:
     status:
       code: 200
@@ -4855,16 +4855,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-c2f04c80-9a2a-45b9-9b56-729c3d96d81a
+      - req-0307f212-fb8f-4dd9-a57e-fa5bba18ea82
       Date:
-      - Thu, 25 Oct 2018 18:20:54 GMT
+      - Thu, 01 Nov 2018 18:35:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:54 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:51 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-floating-ips
@@ -4879,7 +4879,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 38e245157a014262a3571406f0b30599
+      - bccacccac2bb4171b9c93c6383860456
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4892,9 +4892,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-a61dfaec-9cfe-4e95-8530-4443446685d7
+      - req-1925a36b-802c-42c3-90aa-72712da04e1c
       Date:
-      - Thu, 25 Oct 2018 18:20:55 GMT
+      - Thu, 01 Nov 2018 18:35:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": null, "ip": "172.16.17.13", "fixed_ip":
@@ -4917,7 +4917,7 @@ http_interactions:
         "ip": "172.16.17.6", "fixed_ip": "192.168.1.4", "id": "ee601a91-f6ac-4a46-a599-87cfd83094a3",
         "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:55 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:51 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-floating-ips
@@ -4932,7 +4932,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 38e245157a014262a3571406f0b30599
+      - bccacccac2bb4171b9c93c6383860456
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4945,9 +4945,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-2eb3c777-27cb-484d-8ef3-03a7eaedf59c
+      - req-7dc0992c-c6c5-4862-8d2c-66cceef38880
       Date:
-      - Thu, 25 Oct 2018 18:20:55 GMT
+      - Thu, 01 Nov 2018 18:35:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": null, "ip": "172.16.17.13", "fixed_ip":
@@ -4970,7 +4970,7 @@ http_interactions:
         "ip": "172.16.17.6", "fixed_ip": "192.168.1.4", "id": "ee601a91-f6ac-4a46-a599-87cfd83094a3",
         "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:55 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:52 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-floating-ips
@@ -4985,7 +4985,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 38e245157a014262a3571406f0b30599
+      - bccacccac2bb4171b9c93c6383860456
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4998,9 +4998,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-4912a67a-ce50-4512-ab06-23aaa1cfc073
+      - req-3b55fb1d-c2ee-4ae1-b57f-bc89039a129f
       Date:
-      - Thu, 25 Oct 2018 18:20:55 GMT
+      - Thu, 01 Nov 2018 18:35:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": null, "ip": "172.16.17.13", "fixed_ip":
@@ -5023,7 +5023,7 @@ http_interactions:
         "ip": "172.16.17.6", "fixed_ip": "192.168.1.4", "id": "ee601a91-f6ac-4a46-a599-87cfd83094a3",
         "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:55 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:52 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-floating-ips
@@ -5038,7 +5038,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 38e245157a014262a3571406f0b30599
+      - bccacccac2bb4171b9c93c6383860456
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5051,9 +5051,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-cdda5475-52a5-4dbe-ac79-4dd09f9e9424
+      - req-69b1ac8c-465b-4bd6-a1df-7c5021b393b0
       Date:
-      - Thu, 25 Oct 2018 18:20:55 GMT
+      - Thu, 01 Nov 2018 18:35:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": null, "ip": "172.16.17.13", "fixed_ip":
@@ -5076,7 +5076,7 @@ http_interactions:
         "ip": "172.16.17.6", "fixed_ip": "192.168.1.4", "id": "ee601a91-f6ac-4a46-a599-87cfd83094a3",
         "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:55 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:52 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-floating-ips
@@ -5091,7 +5091,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 38e245157a014262a3571406f0b30599
+      - bccacccac2bb4171b9c93c6383860456
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5104,9 +5104,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-51d81f0a-5b3f-4f4f-94fd-7387d2cf6277
+      - req-6867618c-4823-4695-bb3e-393822e1c0eb
       Date:
-      - Thu, 25 Oct 2018 18:20:55 GMT
+      - Thu, 01 Nov 2018 18:35:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": null, "ip": "172.16.17.13", "fixed_ip":
@@ -5129,7 +5129,7 @@ http_interactions:
         "ip": "172.16.17.6", "fixed_ip": "192.168.1.4", "id": "ee601a91-f6ac-4a46-a599-87cfd83094a3",
         "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:55 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:52 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/4bb36934-fd61-4a19-ab9d-28fbbda0c7f0/os-volume_attachments
@@ -5144,7 +5144,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 38e245157a014262a3571406f0b30599
+      - bccacccac2bb4171b9c93c6383860456
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5157,15 +5157,15 @@ http_interactions:
       Content-Length:
       - '197'
       X-Compute-Request-Id:
-      - req-8c179ab4-d403-4c8c-9ca1-cd561d8f8021
+      - req-102202fb-c90a-49a9-b8aa-0fe04f80803c
       Date:
-      - Thu, 25 Oct 2018 18:20:55 GMT
+      - Thu, 01 Nov 2018 18:35:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumeAttachments": [{"device": "/dev/vda", "serverId": "4bb36934-fd61-4a19-ab9d-28fbbda0c7f0",
         "id": "b124469d-a857-4b39-abe9-d0e63985f834", "volumeId": "b124469d-a857-4b39-abe9-d0e63985f834"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:55 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:52 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-floating-ips
@@ -5180,7 +5180,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 38e245157a014262a3571406f0b30599
+      - bccacccac2bb4171b9c93c6383860456
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5193,9 +5193,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-057d283c-0781-4ae2-be04-f5358b966a91
+      - req-20fa5108-a149-4e77-bb49-e14e82b76601
       Date:
-      - Thu, 25 Oct 2018 18:20:56 GMT
+      - Thu, 01 Nov 2018 18:35:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": null, "ip": "172.16.17.13", "fixed_ip":
@@ -5218,7 +5218,7 @@ http_interactions:
         "ip": "172.16.17.6", "fixed_ip": "192.168.1.4", "id": "ee601a91-f6ac-4a46-a599-87cfd83094a3",
         "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:56 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:53 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/ca4f3a16-bae3-4407-83e9-f77b28af0f2b/os-volume_attachments
@@ -5233,7 +5233,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 38e245157a014262a3571406f0b30599
+      - bccacccac2bb4171b9c93c6383860456
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5246,15 +5246,15 @@ http_interactions:
       Content-Length:
       - '197'
       X-Compute-Request-Id:
-      - req-2f1dce31-e998-44ab-bab6-2711f5709bb4
+      - req-2e432402-a641-4140-b785-b3245a3356df
       Date:
-      - Thu, 25 Oct 2018 18:20:56 GMT
+      - Thu, 01 Nov 2018 18:35:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumeAttachments": [{"device": "/dev/vdd", "serverId": "ca4f3a16-bae3-4407-83e9-f77b28af0f2b",
         "id": "0a55c0d5-c780-4e7d-9d09-47f5520c7448", "volumeId": "0a55c0d5-c780-4e7d-9d09-47f5520c7448"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:56 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:53 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-floating-ips
@@ -5269,7 +5269,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 38e245157a014262a3571406f0b30599
+      - bccacccac2bb4171b9c93c6383860456
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5282,9 +5282,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-803d6b85-509a-49fa-b679-39bf5a1f8e82
+      - req-c659d65f-f491-4799-9013-24ade8f4b1e6
       Date:
-      - Thu, 25 Oct 2018 18:20:56 GMT
+      - Thu, 01 Nov 2018 18:35:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": null, "ip": "172.16.17.13", "fixed_ip":
@@ -5307,7 +5307,7 @@ http_interactions:
         "ip": "172.16.17.6", "fixed_ip": "192.168.1.4", "id": "ee601a91-f6ac-4a46-a599-87cfd83094a3",
         "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:56 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:53 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-floating-ips
@@ -5322,7 +5322,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 38e245157a014262a3571406f0b30599
+      - bccacccac2bb4171b9c93c6383860456
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5335,9 +5335,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-3f70b5e7-d8ea-42c8-a595-e8aefbbd447f
+      - req-ed332d78-8767-4ec4-9097-737f662868e9
       Date:
-      - Thu, 25 Oct 2018 18:20:56 GMT
+      - Thu, 01 Nov 2018 18:35:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": null, "ip": "172.16.17.13", "fixed_ip":
@@ -5360,7 +5360,7 @@ http_interactions:
         "ip": "172.16.17.6", "fixed_ip": "192.168.1.4", "id": "ee601a91-f6ac-4a46-a599-87cfd83094a3",
         "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:56 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:53 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-floating-ips
@@ -5375,7 +5375,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 38e245157a014262a3571406f0b30599
+      - bccacccac2bb4171b9c93c6383860456
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5388,9 +5388,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-ee371727-1782-4a55-9dce-f169da9ac894
+      - req-88500676-04dc-4672-a674-76bbb026c761
       Date:
-      - Thu, 25 Oct 2018 18:20:56 GMT
+      - Thu, 01 Nov 2018 18:35:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": null, "ip": "172.16.17.13", "fixed_ip":
@@ -5413,7 +5413,7 @@ http_interactions:
         "ip": "172.16.17.6", "fixed_ip": "192.168.1.4", "id": "ee601a91-f6ac-4a46-a599-87cfd83094a3",
         "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:56 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:53 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -5431,13 +5431,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:20:56 GMT
+      - Thu, 01 Nov 2018 18:35:53 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-b3ded2d0-65b9-41d3-b292-454a8c6577cf
+      - req-b6fba6ab-deb8-4a7e-871d-2c745fc3ff35
       Content-Length:
       - '4170'
       Connection:
@@ -5446,10 +5446,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:20:57.004762", "expires":
-        "2018-10-25T19:20:56Z", "id": "24367b3416f048c3af1d2ce7993f2925", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:35:53.913994", "expires":
+        "2018-11-01T19:35:53Z", "id": "6482a64556744e21b6fb7bd21568b9aa", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["Z_C-5laSRKSOa_fpeKFdmA"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["9ScCvEsGTn2KdJtJW_tBww"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -5494,7 +5494,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:57 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:53 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -5512,13 +5512,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:20:57 GMT
+      - Thu, 01 Nov 2018 18:35:54 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-ba117b66-ae11-46c9-96b0-409bd09c6a94
+      - req-8d4cc67e-2ba8-4837-a950-06ca707b1f39
       Content-Length:
       - '4170'
       Connection:
@@ -5527,10 +5527,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:20:57.190575", "expires":
-        "2018-10-25T19:20:57Z", "id": "602fe3a88f1743a5a77e883eaa2a88ad", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:35:54.115293", "expires":
+        "2018-11-01T19:35:54Z", "id": "905852466e9e43ddb8e660966c246d22", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["oBj8Mje_TQ-jg_6pV0dIAA"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["mD8vqaNDQiuu1OMT1-ox8g"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -5575,7 +5575,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:57 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:54 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-aggregates
@@ -5590,7 +5590,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4c1551e76ebe4d2ebb68a4467c6a441e
+      - 4ba9271ddd564698a97d2cab70319e8f
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5603,14 +5603,14 @@ http_interactions:
       Content-Length:
       - '18'
       X-Compute-Request-Id:
-      - req-2c80cc52-8f09-4cc5-96c1-7bcfea6c4a83
+      - req-b596ba00-9aa9-4eab-9ef6-b75b96a31d83
       Date:
-      - Thu, 25 Oct 2018 18:20:57 GMT
+      - Thu, 01 Nov 2018 18:35:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"aggregates": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:57 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:54 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&status=available
@@ -5625,22 +5625,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6c97ee060d61417eaeffaac7986bfdaa
+      - 0d390fc182bd49ce8a70a34aa026bcf4
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-1119ad52-a5ba-41e9-a117-dccfa6b990d0
+      - req-69fdefef-64d9-4ce5-8f34-62c199b4270a
       Content-Type:
       - application/json
       Content-Length:
       - '2723'
       X-Openstack-Request-Id:
-      - req-1119ad52-a5ba-41e9-a117-dccfa6b990d0
+      - req-69fdefef-64d9-4ce5-8f34-62c199b4270a
       Date:
-      - Thu, 25 Oct 2018 18:20:57 GMT
+      - Thu, 01 Nov 2018 18:35:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&status=available&marker=9bb99818-b339-4e31-b87f-e4181ec48acd",
@@ -5673,7 +5673,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-4", "bootable": "true", "created_at":
         "2016-11-11T13:49:53.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:57 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:54 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=9bb99818-b339-4e31-b87f-e4181ec48acd&status=available
@@ -5688,22 +5688,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6c97ee060d61417eaeffaac7986bfdaa
+      - 0d390fc182bd49ce8a70a34aa026bcf4
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-e5357eac-fc3c-4759-a61f-653b6217e3d9
+      - req-28ad935c-56c8-4e2f-813f-bf87bd38f458
       Content-Type:
       - application/json
       Content-Length:
       - '1180'
       X-Openstack-Request-Id:
-      - req-e5357eac-fc3c-4759-a61f-653b6217e3d9
+      - req-28ad935c-56c8-4e2f-813f-bf87bd38f458
       Date:
-      - Thu, 25 Oct 2018 18:20:57 GMT
+      - Thu, 01 Nov 2018 18:35:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": [{"migration_status": null, "attachments": [], "links":
@@ -5720,7 +5720,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-FromSnapshot", "bootable": "false", "created_at":
         "2016-11-11T13:49:26.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:57 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:54 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/volumes/detail?limit=1000&status=available
@@ -5735,27 +5735,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0461dcd5f0b34aa997bbcda22fbb5a80
+      - 76113b0e77334b4abd5a2df65c3517e0
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-7d4b53eb-3ba3-4a27-b68c-5691d580ac7a
+      - req-d59a6125-d06a-4ed3-97d1-b34d8e46d731
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-7d4b53eb-3ba3-4a27-b68c-5691d580ac7a
+      - req-d59a6125-d06a-4ed3-97d1-b34d8e46d731
       Date:
-      - Thu, 25 Oct 2018 18:20:57 GMT
+      - Thu, 01 Nov 2018 18:35:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:57 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:54 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/volumes/detail?limit=1000&status=available
@@ -5770,27 +5770,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e6d583ace24c48059fa12175ffd8d4a3
+      - c7653c8ab31241bf96da749dff95b6e8
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-7b8f7376-0c7a-4574-9c82-85d6d09f6b21
+      - req-51e8abfa-4745-499e-ae83-11408107b397
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-7b8f7376-0c7a-4574-9c82-85d6d09f6b21
+      - req-51e8abfa-4745-499e-ae83-11408107b397
       Date:
-      - Thu, 25 Oct 2018 18:20:57 GMT
+      - Thu, 01 Nov 2018 18:35:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:57 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:54 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/volumes/detail?limit=1000&status=available
@@ -5805,27 +5805,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a89aa27f3db74247af98b4664ce2b7a3
+      - d50cfb54867b40f6a84d7aa9f0562fea
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-195b270e-8c9b-47a4-b552-730ef2c83f37
+      - req-0ce354e7-d8fa-49bc-ab5e-7ef1df6c5e7a
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-195b270e-8c9b-47a4-b552-730ef2c83f37
+      - req-0ce354e7-d8fa-49bc-ab5e-7ef1df6c5e7a
       Date:
-      - Thu, 25 Oct 2018 18:20:57 GMT
+      - Thu, 01 Nov 2018 18:35:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:57 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:55 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail
@@ -5840,22 +5840,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6c97ee060d61417eaeffaac7986bfdaa
+      - 0d390fc182bd49ce8a70a34aa026bcf4
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-8adb1d8e-5693-4c56-97fe-1c302c4db1a9
+      - req-edd5a976-fc3e-490b-b6fb-e0b8f1ae15e8
       Content-Type:
       - application/json
       Content-Length:
       - '1053'
       X-Openstack-Request-Id:
-      - req-8adb1d8e-5693-4c56-97fe-1c302c4db1a9
+      - req-edd5a976-fc3e-490b-b6fb-e0b8f1ae15e8
       Date:
-      - Thu, 25 Oct 2018 18:20:58 GMT
+      - Thu, 01 Nov 2018 18:35:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?marker=76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
@@ -5870,7 +5870,7 @@ http_interactions:
         "created_at": "2016-11-11T13:49:36.000000", "size": 1, "id": "76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:58 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:55 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?limit=1000&status=available
@@ -5885,22 +5885,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6c97ee060d61417eaeffaac7986bfdaa
+      - 0d390fc182bd49ce8a70a34aa026bcf4
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-e8e03fec-0a0c-4a43-afca-235d09cc2faa
+      - req-806c6a7b-138f-436c-9334-5ce281a7236e
       Content-Type:
       - application/json
       Content-Length:
       - '1081'
       X-Openstack-Request-Id:
-      - req-e8e03fec-0a0c-4a43-afca-235d09cc2faa
+      - req-806c6a7b-138f-436c-9334-5ce281a7236e
       Date:
-      - Thu, 25 Oct 2018 18:20:59 GMT
+      - Thu, 01 Nov 2018 18:35:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?limit=1000&status=available&marker=76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
@@ -5915,7 +5915,7 @@ http_interactions:
         "created_at": "2016-11-11T13:49:36.000000", "size": 1, "id": "76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:59 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:55 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/snapshots/detail
@@ -5930,27 +5930,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0461dcd5f0b34aa997bbcda22fbb5a80
+      - 76113b0e77334b4abd5a2df65c3517e0
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-0517c64b-5ba4-4f2e-a065-604cc0b69abd
+      - req-8634ab6b-533a-4127-9c14-b71b6d88708c
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-0517c64b-5ba4-4f2e-a065-604cc0b69abd
+      - req-8634ab6b-533a-4127-9c14-b71b6d88708c
       Date:
-      - Thu, 25 Oct 2018 18:20:59 GMT
+      - Thu, 01 Nov 2018 18:35:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:59 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:55 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/snapshots/detail?limit=1000&status=available
@@ -5965,27 +5965,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0461dcd5f0b34aa997bbcda22fbb5a80
+      - 76113b0e77334b4abd5a2df65c3517e0
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-93423ba5-bac2-4633-803f-ea982fd88920
+      - req-6c97ac78-42b1-4159-82c2-a1d3b2b5885b
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-93423ba5-bac2-4633-803f-ea982fd88920
+      - req-6c97ac78-42b1-4159-82c2-a1d3b2b5885b
       Date:
-      - Thu, 25 Oct 2018 18:20:59 GMT
+      - Thu, 01 Nov 2018 18:35:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:59 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:55 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/snapshots/detail
@@ -6000,27 +6000,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e6d583ace24c48059fa12175ffd8d4a3
+      - c7653c8ab31241bf96da749dff95b6e8
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-7fd65027-3084-4b9b-9091-95d82a619b8b
+      - req-777433ac-ce26-4cae-874e-459e726ef7b0
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-7fd65027-3084-4b9b-9091-95d82a619b8b
+      - req-777433ac-ce26-4cae-874e-459e726ef7b0
       Date:
-      - Thu, 25 Oct 2018 18:20:59 GMT
+      - Thu, 01 Nov 2018 18:35:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:59 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:55 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/snapshots/detail?limit=1000&status=available
@@ -6035,27 +6035,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e6d583ace24c48059fa12175ffd8d4a3
+      - c7653c8ab31241bf96da749dff95b6e8
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-033f4be7-6a80-47de-8fb4-57187475d60c
+      - req-e5d92387-c2d4-4927-9350-bfa8ca869ed9
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-033f4be7-6a80-47de-8fb4-57187475d60c
+      - req-e5d92387-c2d4-4927-9350-bfa8ca869ed9
       Date:
-      - Thu, 25 Oct 2018 18:20:59 GMT
+      - Thu, 01 Nov 2018 18:35:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:59 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:55 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/snapshots/detail
@@ -6070,27 +6070,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a89aa27f3db74247af98b4664ce2b7a3
+      - d50cfb54867b40f6a84d7aa9f0562fea
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-9a02b611-460c-405b-9cc3-8e9a509667cb
+      - req-75b25b17-fd94-4630-a16a-6fa05bdf5e10
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-9a02b611-460c-405b-9cc3-8e9a509667cb
+      - req-75b25b17-fd94-4630-a16a-6fa05bdf5e10
       Date:
-      - Thu, 25 Oct 2018 18:20:59 GMT
+      - Thu, 01 Nov 2018 18:35:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:59 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:55 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/snapshots/detail?limit=1000&status=available
@@ -6105,27 +6105,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a89aa27f3db74247af98b4664ce2b7a3
+      - d50cfb54867b40f6a84d7aa9f0562fea
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-b2f3afa3-50f3-44f1-abcc-e823cb13495a
+      - req-b1b2ade3-cc00-4187-94cf-c85abb0b2785
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-b2f3afa3-50f3-44f1-abcc-e823cb13495a
+      - req-b1b2ade3-cc00-4187-94cf-c85abb0b2785
       Date:
-      - Thu, 25 Oct 2018 18:20:59 GMT
+      - Thu, 01 Nov 2018 18:35:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:59 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:55 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000
@@ -6140,22 +6140,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6c97ee060d61417eaeffaac7986bfdaa
+      - 0d390fc182bd49ce8a70a34aa026bcf4
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-092a92ad-dcf4-447e-91b4-aff4442ada77
+      - req-d92c9289-1310-499f-9992-a38fb7220c72
       Content-Type:
       - application/json
       Content-Length:
       - '2706'
       X-Openstack-Request-Id:
-      - req-092a92ad-dcf4-447e-91b4-aff4442ada77
+      - req-d92c9289-1310-499f-9992-a38fb7220c72
       Date:
-      - Thu, 25 Oct 2018 18:20:59 GMT
+      - Thu, 01 Nov 2018 18:35:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=9bb99818-b339-4e31-b87f-e4181ec48acd",
@@ -6188,7 +6188,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-4", "bootable": "true", "created_at":
         "2016-11-11T13:49:53.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:59 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:56 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=9bb99818-b339-4e31-b87f-e4181ec48acd
@@ -6203,22 +6203,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6c97ee060d61417eaeffaac7986bfdaa
+      - 0d390fc182bd49ce8a70a34aa026bcf4
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-420fc9c2-ed95-43c0-b687-7cad7f182db8
+      - req-cbd0ad24-e772-432e-b160-09a7cebe40d6
       Content-Type:
       - application/json
       Content-Length:
       - '3284'
       X-Openstack-Request-Id:
-      - req-420fc9c2-ed95-43c0-b687-7cad7f182db8
+      - req-cbd0ad24-e772-432e-b160-09a7cebe40d6
       Date:
-      - Thu, 25 Oct 2018 18:21:00 GMT
+      - Thu, 01 Nov 2018 18:35:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=2c774148-c11a-434c-aabb-7fa9c82c37ce",
@@ -6259,7 +6259,7 @@ http_interactions:
         "name": "EmsRefreshSpec-Volume-2", "bootable": "false", "created_at": "2016-11-11T13:49:43.000000",
         "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:00 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:56 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=2c774148-c11a-434c-aabb-7fa9c82c37ce
@@ -6274,22 +6274,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6c97ee060d61417eaeffaac7986bfdaa
+      - 0d390fc182bd49ce8a70a34aa026bcf4
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-0f74ca1e-b7cf-4d04-8bd7-b0da0b46a58e
+      - req-415a32c7-870d-4736-aa00-468933d69191
       Content-Type:
       - application/json
       Content-Length:
       - '2753'
       X-Openstack-Request-Id:
-      - req-0f74ca1e-b7cf-4d04-8bd7-b0da0b46a58e
+      - req-415a32c7-870d-4736-aa00-468933d69191
       Date:
-      - Thu, 25 Oct 2018 18:21:00 GMT
+      - Thu, 01 Nov 2018 18:35:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=0a55c0d5-c780-4e7d-9d09-47f5520c7448",
@@ -6323,7 +6323,7 @@ http_interactions:
         "bootable": "false", "created_at": "2016-11-11T13:49:20.000000", "volume_type":
         "iscsi"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:00 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:56 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=0a55c0d5-c780-4e7d-9d09-47f5520c7448
@@ -6338,27 +6338,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6c97ee060d61417eaeffaac7986bfdaa
+      - 0d390fc182bd49ce8a70a34aa026bcf4
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-556b7e33-9471-44a9-a8b6-05dc2c99948e
+      - req-3515beac-f92b-4da9-a292-b1b31da898d3
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-556b7e33-9471-44a9-a8b6-05dc2c99948e
+      - req-3515beac-f92b-4da9-a292-b1b31da898d3
       Date:
-      - Thu, 25 Oct 2018 18:21:00 GMT
+      - Thu, 01 Nov 2018 18:35:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:00 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:56 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/volumes/detail?limit=1000
@@ -6373,27 +6373,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0461dcd5f0b34aa997bbcda22fbb5a80
+      - 76113b0e77334b4abd5a2df65c3517e0
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-5e3cbefe-a147-4326-af88-a4f124c51ebd
+      - req-f32ccd67-e200-4a86-b8ac-a540d01e639d
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-5e3cbefe-a147-4326-af88-a4f124c51ebd
+      - req-f32ccd67-e200-4a86-b8ac-a540d01e639d
       Date:
-      - Thu, 25 Oct 2018 18:21:00 GMT
+      - Thu, 01 Nov 2018 18:35:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:00 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:56 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/volumes/detail?limit=1000
@@ -6408,27 +6408,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e6d583ace24c48059fa12175ffd8d4a3
+      - c7653c8ab31241bf96da749dff95b6e8
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-005bd2eb-7fdb-4f6e-977c-c17d7fbe81a6
+      - req-c3823a51-0cdd-4bc1-b192-54c8b1e6f0f2
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-005bd2eb-7fdb-4f6e-977c-c17d7fbe81a6
+      - req-c3823a51-0cdd-4bc1-b192-54c8b1e6f0f2
       Date:
-      - Thu, 25 Oct 2018 18:21:00 GMT
+      - Thu, 01 Nov 2018 18:35:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:00 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:56 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/volumes/detail?limit=1000
@@ -6443,27 +6443,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a89aa27f3db74247af98b4664ce2b7a3
+      - d50cfb54867b40f6a84d7aa9f0562fea
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-b829ffb7-01c1-40fd-8c0e-2f384dac0b88
+      - req-59d4f2d4-1af2-46cb-bd6a-5ea72feea427
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-b829ffb7-01c1-40fd-8c0e-2f384dac0b88
+      - req-59d4f2d4-1af2-46cb-bd6a-5ea72feea427
       Date:
-      - Thu, 25 Oct 2018 18:21:00 GMT
+      - Thu, 01 Nov 2018 18:35:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:00 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:57 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -6481,13 +6481,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:21:01 GMT
+      - Thu, 01 Nov 2018 18:35:58 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-b54db0d7-ea26-47a1-9793-1c4545ecee00
+      - req-c7253400-258d-4222-86b5-5f4e579b65cc
       Content-Length:
       - '4170'
       Connection:
@@ -6496,10 +6496,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:01.777914", "expires":
-        "2018-10-25T19:21:01Z", "id": "aa02163d31384f00a5cfcae5b2be4e82", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:35:58.174649", "expires":
+        "2018-11-01T19:35:58Z", "id": "803617e412df4d25a6bf9f4214c0e27c", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["mv6jh9n5S_yTAMKAzbfCrA"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["S_1U68uYQsmCb_qnhz2HsA"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -6544,7 +6544,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:01 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:58 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -6562,13 +6562,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:21:01 GMT
+      - Thu, 01 Nov 2018 18:35:58 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-b203f4e5-f696-4d14-9bc9-d6a1fbd0db20
+      - req-535fa74f-8946-43b3-843a-8d29b6c7f148
       Content-Length:
       - '4170'
       Connection:
@@ -6577,10 +6577,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:01.960457", "expires":
-        "2018-10-25T19:21:01Z", "id": "760b2203b4a84c07b1aed9c8c673ab9f", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:35:58.384329", "expires":
+        "2018-11-01T19:35:58Z", "id": "402a9ca6fb904cd3bd12280339f0cc32", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["Kl53PP8FRgCVqm4MIzw_oQ"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["UAkkbiu0R6CST0cgoChJMQ"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -6625,7 +6625,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:01 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:58 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/networks
@@ -6640,7 +6640,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 760b2203b4a84c07b1aed9c8c673ab9f
+      - 402a9ca6fb904cd3bd12280339f0cc32
   response:
     status:
       code: 200
@@ -6651,12 +6651,22 @@ http_interactions:
       Content-Length:
       - '5330'
       X-Openstack-Request-Id:
-      - req-d12da784-0dc0-41e1-8e1d-555bef9a94eb
+      - req-fbcaf389-feb0-4cfb-8433-d672c1a2d255
       Date:
-      - Thu, 25 Oct 2018 18:21:02 GMT
+      - Thu, 01 Nov 2018 18:35:58 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"networks": [{"status": "ACTIVE", "subnets": ["82ca5926-43cb-4312-a23f-727d5c0f5bae"],
+      string: '{"networks": [{"status": "ACTIVE", "subnets": ["2092b802-1034-4fb8-9c5e-1ec61d1e463f"],
+        "name": "EmsRefreshSpec-NetworkPrivate_20", "provider:physical_network": null,
+        "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
+        0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
+        "id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "provider:segmentation_id":
+        98}, {"status": "ACTIVE", "subnets": ["826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
+        "edfcb49b-e917-4897-b8ae-859ef3dae2de"], "name": "EmsRefreshSpec-IsolatedNetworkPrivate_2",
+        "provider:physical_network": null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
+        "vxlan", "id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "provider:segmentation_id":
+        57}, {"status": "ACTIVE", "subnets": ["82ca5926-43cb-4312-a23f-727d5c0f5bae"],
         "name": "EmsRefreshSpec-NetworkPrivate_3", "provider:physical_network": null,
         "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
         0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
@@ -6701,29 +6711,19 @@ http_interactions:
         "provider:physical_network": null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
         "vxlan", "id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "provider:segmentation_id":
-        79}, {"status": "ACTIVE", "subnets": ["edfcb49b-e917-4897-b8ae-859ef3dae2de",
-        "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4"], "name": "EmsRefreshSpec-IsolatedNetworkPrivate_2",
-        "provider:physical_network": null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
-        "vxlan", "id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "provider:segmentation_id":
-        57}, {"status": "ACTIVE", "subnets": ["33da95a6-bded-44d8-be36-6cc97f3d72bd"],
+        79}, {"status": "ACTIVE", "subnets": ["33da95a6-bded-44d8-be36-6cc97f3d72bd"],
         "name": "EmsRefreshSpec-NetworkPublic", "provider:physical_network": "public_net_0",
         "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
         0, "router:external": true, "shared": false, "provider:network_type": "flat",
         "id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "provider:segmentation_id":
-        null}, {"status": "ACTIVE", "subnets": ["2092b802-1034-4fb8-9c5e-1ec61d1e463f"],
-        "name": "EmsRefreshSpec-NetworkPrivate_20", "provider:physical_network": null,
-        "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
-        0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
-        "id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "provider:segmentation_id":
-        98}, {"status": "ACTIVE", "subnets": ["d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        null}, {"status": "ACTIVE", "subnets": ["d53802a5-f0f6-48ba-9207-dbd9b13acac3",
         "104c081f-97dd-42b7-8930-98abbd015c74"], "name": "EmsRefreshSpec-NetworkPrivate",
         "provider:physical_network": null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
         "vxlan", "id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "provider:segmentation_id":
         14}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:02 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:58 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -6741,13 +6741,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:21:02 GMT
+      - Thu, 01 Nov 2018 18:35:58 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-20cf0b49-a84a-4d3e-a34b-037cc9de08af
+      - req-e8f26c51-a169-40de-bd8f-42a67b6a26f7
       Content-Length:
       - '4170'
       Connection:
@@ -6756,10 +6756,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:02.317749", "expires":
-        "2018-10-25T19:21:02Z", "id": "906152fa897540e1a577b2dec4caeb6a", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:35:58.760748", "expires":
+        "2018-11-01T19:35:58Z", "id": "70d98b499dfd43a099e669fde2bfc979", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["4ql_v5W9RlSDFNpJcfBeIQ"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["CDzBZSK7RbmiIRaCmehYuA"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -6804,7 +6804,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:02 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:58 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -6822,13 +6822,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:21:02 GMT
+      - Thu, 01 Nov 2018 18:35:58 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-0227d6a6-be8c-4b10-80bc-74cff0ea2174
+      - req-75695ccb-dec8-4c36-8f44-3e1f2d73e098
       Content-Length:
       - '370'
       Connection:
@@ -6837,13 +6837,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:02.482782", "expires":
-        "2018-10-25T19:21:02Z", "id": "cfc25793645f4f40973c055c612ee7c7", "audit_ids":
-        ["C-1Mdb_TSgqXsOKrf51BmQ"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:35:58.924138", "expires":
+        "2018-11-01T19:35:58Z", "id": "134931eef4b94f959655bc5a19584a75", "audit_ids":
+        ["YxIfovsCQyOMJLO8VfL8Mg"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:02 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:58 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -6858,20 +6858,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cfc25793645f4f40973c055c612ee7c7
+      - 134931eef4b94f959655bc5a19584a75
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:21:02 GMT
+      - Thu, 01 Nov 2018 18:35:59 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-66906f65-d5a1-42e0-8659-9f424bdc1f67
+      - req-131bd355-a230-4c8f-b635-cdc26bc6fe26
       Content-Length:
       - '500'
       Connection:
@@ -6888,7 +6888,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:02 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:59 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -6906,13 +6906,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:21:02 GMT
+      - Thu, 01 Nov 2018 18:35:59 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-bb9d28ff-8d71-4b70-8716-b7d28a25875c
+      - req-3a6d058b-a24f-413c-b4de-c850742e1b6f
       Content-Length:
       - '4117'
       Connection:
@@ -6921,10 +6921,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:03.002361", "expires":
-        "2018-10-25T19:21:02Z", "id": "64d3e01064674a56a2ff83cc5d9a0315", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:35:59.305371", "expires":
+        "2018-11-01T19:35:59Z", "id": "ca33088d6a3842558c765edfb5c238f1", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["yfKh8ZtlSauCticgOD1oJA"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["knkaI2q5TFil_tuu87YEvg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -6968,7 +6968,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:03 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:59 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -6986,13 +6986,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:21:03 GMT
+      - Thu, 01 Nov 2018 18:35:59 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-f029302e-30a4-4a2f-88f4-b60f78cec738
+      - req-d5a8b0f8-af62-42be-9e9e-6aba3ef7fe46
       Content-Length:
       - '4131'
       Connection:
@@ -7001,10 +7001,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:03.197449", "expires":
-        "2018-10-25T19:21:03Z", "id": "85a54f2fa16244caa1ff2a5ee04da6f9", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:35:59.482940", "expires":
+        "2018-11-01T19:35:59Z", "id": "6472a0824e1b4d7fbee5c58fe10e977a", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["EjN4kOf_Su2ZPqpPz8Y7eg"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["jSSEVx9-SeWtY3UpElXsLw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -7048,7 +7048,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:03 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:59 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -7066,13 +7066,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:21:03 GMT
+      - Thu, 01 Nov 2018 18:35:59 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-dd8f41aa-8a8b-4231-a4e8-f2bf34013005
+      - req-1fdc0317-3beb-4aa9-8833-31aaa34e23b9
       Content-Length:
       - '4118'
       Connection:
@@ -7081,10 +7081,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:03.373012", "expires":
-        "2018-10-25T19:21:03Z", "id": "57a58fced9bf48f7be7836ecb3803b5e", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:35:59.666126", "expires":
+        "2018-11-01T19:35:59Z", "id": "ebd7d7e2786547499a8354bd5741db9b", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["fboWBeyOTYKHG-F48CDLHA"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["bPF9Y_k0RXCOpLRbWDjRUg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -7128,7 +7128,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:03 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:59 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -7146,13 +7146,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:21:03 GMT
+      - Thu, 01 Nov 2018 18:35:59 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-2edeb47b-ea85-48d9-978b-21462ffc0df8
+      - req-879a181e-e6e5-4f40-beb4-e8f184d1e50f
       Content-Length:
       - '4117'
       Connection:
@@ -7161,10 +7161,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:03.551855", "expires":
-        "2018-10-25T19:21:03Z", "id": "72f762964a4f48e58e61d8bde21c3461", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:35:59.854693", "expires":
+        "2018-11-01T19:35:59Z", "id": "7786205be853421cb329a1dfe5e85b94", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["tdJXD7X7S5S5iU3_FSU4CA"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["jo03IDX7QS-YTddzDGAlxw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -7208,7 +7208,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:03 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:59 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks?limit=1000&show_nested=true
@@ -7223,7 +7223,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 72f762964a4f48e58e61d8bde21c3461
+      - 7786205be853421cb329a1dfe5e85b94
   response:
     status:
       code: 200
@@ -7234,9 +7234,9 @@ http_interactions:
       Content-Length:
       - '2559'
       X-Openstack-Request-Id:
-      - req-dbcc393a-a5eb-47a0-9bb6-d836aa77f8d0
+      - req-632b0839-eeb5-4cc8-b78d-572617534b96
       Date:
-      - Thu, 25 Oct 2018 18:21:03 GMT
+      - Thu, 01 Nov 2018 18:36:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": [{"description": "Heat WordPress template to support F20,
@@ -7270,7 +7270,7 @@ http_interactions:
         "rel": "self"}], "updated_time": null, "stack_owner": null, "stack_status":
         "CREATE_COMPLETE", "id": "091e1e54-e01c-4ec5-a0ab-b00bee4d425c"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:03 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:00 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks?limit=1000&marker=091e1e54-e01c-4ec5-a0ab-b00bee4d425c&show_nested=true
@@ -7285,7 +7285,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 72f762964a4f48e58e61d8bde21c3461
+      - 7786205be853421cb329a1dfe5e85b94
   response:
     status:
       code: 200
@@ -7296,14 +7296,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-168c528d-d45b-4626-9e69-ba29a8e54ebe
+      - req-c6d256e4-2dbd-4fbb-b9d8-c1ec507a35e6
       Date:
-      - Thu, 25 Oct 2018 18:21:03 GMT
+      - Thu, 01 Nov 2018 18:36:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:03 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:00 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -7321,13 +7321,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:21:03 GMT
+      - Thu, 01 Nov 2018 18:36:00 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-27b77bcc-1e6b-4317-aa83-5e33cbc569b1
+      - req-873e8120-73fc-4b2f-bb84-85f033ca7833
       Content-Length:
       - '4131'
       Connection:
@@ -7336,10 +7336,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:04.045522", "expires":
-        "2018-10-25T19:21:04Z", "id": "ebc687d2d34c412484f25ee22aca813c", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:36:00.349870", "expires":
+        "2018-11-01T19:36:00Z", "id": "251a1b7dd0164c5e959b197fc9599aa6", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["e8pOM7VSREettFAPxmR4GA"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["P-kipkibQrCPVbTJ9g7mFg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -7383,7 +7383,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:04 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:00 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/b458a5c25c3749758f4c0661940b3ba8/stacks?limit=1000&show_nested=true
@@ -7398,7 +7398,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ebc687d2d34c412484f25ee22aca813c
+      - 251a1b7dd0164c5e959b197fc9599aa6
   response:
     status:
       code: 200
@@ -7409,14 +7409,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-775af8d8-26cf-4631-a990-85590f9b885c
+      - req-16876943-3524-4972-91c6-46f28f4464b4
       Date:
-      - Thu, 25 Oct 2018 18:21:04 GMT
+      - Thu, 01 Nov 2018 18:36:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:04 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:00 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/e54e5c3c19e34720b05661f2ea1ea00a/stacks?limit=1000&show_nested=true
@@ -7431,7 +7431,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 906152fa897540e1a577b2dec4caeb6a
+      - 70d98b499dfd43a099e669fde2bfc979
   response:
     status:
       code: 200
@@ -7442,14 +7442,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-58f83f79-09c3-49fa-9d83-38814235d864
+      - req-b63fbaf0-50cd-4b1e-9011-91d9cfc7aecd
       Date:
-      - Thu, 25 Oct 2018 18:21:04 GMT
+      - Thu, 01 Nov 2018 18:36:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:04 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:00 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -7467,13 +7467,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:21:04 GMT
+      - Thu, 01 Nov 2018 18:36:00 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-d354c6b4-365c-4c7d-ae12-128bb6c328f5
+      - req-97f0b3a0-0e9d-41db-8239-6683b253d23c
       Content-Length:
       - '4118'
       Connection:
@@ -7482,10 +7482,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:04.542551", "expires":
-        "2018-10-25T19:21:04Z", "id": "a010a59213e74a079412c85ea8139299", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:36:00.860643", "expires":
+        "2018-11-01T19:36:00Z", "id": "9de3ae8b192246d0b70be6daecaf5a88", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["m2-cPrhlS_WmOq6pMlIB3w"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["H9O8_5aYQpCHn0Gt1MV3GQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -7529,7 +7529,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:04 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:00 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/e8f744b1fc6a487681d35fb275252608/stacks?limit=1000&show_nested=true
@@ -7544,7 +7544,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a010a59213e74a079412c85ea8139299
+      - 9de3ae8b192246d0b70be6daecaf5a88
   response:
     status:
       code: 200
@@ -7555,14 +7555,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-ba1f3f5d-29a8-49c0-bbf0-66a3c72410e5
+      - req-d61b4159-0466-4d5f-962b-8f30151d4d82
       Date:
-      - Thu, 25 Oct 2018 18:21:04 GMT
+      - Thu, 01 Nov 2018 18:36:01 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:04 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:01 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack3/45d2af82-eff9-4483-a1f0-f19c44d96146
@@ -7577,7 +7577,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 72f762964a4f48e58e61d8bde21c3461
+      - 7786205be853421cb329a1dfe5e85b94
   response:
     status:
       code: 200
@@ -7588,9 +7588,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-bf02f9c4-99e8-4e4c-9cae-79b730e8760a
+      - req-0b22fb7a-559e-4d3b-8892-0ddcf415e0af
       Date:
-      - Thu, 25 Oct 2018 18:21:05 GMT
+      - Thu, 01 Nov 2018 18:36:01 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -7617,7 +7617,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:05 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:01 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack2/4cf24b12-29fc-4529-a8ed-6b079dea7c17
@@ -7632,7 +7632,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 72f762964a4f48e58e61d8bde21c3461
+      - 7786205be853421cb329a1dfe5e85b94
   response:
     status:
       code: 200
@@ -7643,9 +7643,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-57015872-eb16-44de-8884-9400de3ecbca
+      - req-cc7b2aba-3bb9-4224-9414-a3365b203450
       Date:
-      - Thu, 25 Oct 2018 18:21:05 GMT
+      - Thu, 01 Nov 2018 18:36:01 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -7672,7 +7672,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:05 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:01 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c
@@ -7687,7 +7687,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 72f762964a4f48e58e61d8bde21c3461
+      - 7786205be853421cb329a1dfe5e85b94
   response:
     status:
       code: 200
@@ -7698,9 +7698,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-d427be5a-21b8-435e-b0bd-1719d1d73236
+      - req-a84bc6da-b312-482d-ab0e-0f0f148459cc
       Date:
-      - Thu, 25 Oct 2018 18:21:05 GMT
+      - Thu, 01 Nov 2018 18:36:01 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -7727,7 +7727,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:05 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:01 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack3/45d2af82-eff9-4483-a1f0-f19c44d96146/resources
@@ -7742,7 +7742,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 72f762964a4f48e58e61d8bde21c3461
+      - 7786205be853421cb329a1dfe5e85b94
   response:
     status:
       code: 200
@@ -7753,9 +7753,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-6733f83e-d7f9-47cd-86c2-7a73270c6b0f
+      - req-12f1b508-a6bc-4987-8ec3-3a71a5a6eb3e
       Date:
-      - Thu, 25 Oct 2018 18:21:06 GMT
+      - Thu, 01 Nov 2018 18:36:02 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -7767,7 +7767,7 @@ http_interactions:
         changed", "physical_resource_id": "aa5907f3-8209-4dd0-b3ef-600431d85bac",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:06 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:02 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack2/4cf24b12-29fc-4529-a8ed-6b079dea7c17/resources
@@ -7782,7 +7782,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 72f762964a4f48e58e61d8bde21c3461
+      - 7786205be853421cb329a1dfe5e85b94
   response:
     status:
       code: 200
@@ -7793,9 +7793,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-5616446a-d646-49d2-b02e-2e3bbcd38688
+      - req-3caa7679-8e20-491e-b4e5-eef5d8659758
       Date:
-      - Thu, 25 Oct 2018 18:21:06 GMT
+      - Thu, 01 Nov 2018 18:36:02 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -7807,7 +7807,7 @@ http_interactions:
         changed", "physical_resource_id": "219a737c-b4ad-430d-944a-a92a4834b12d",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:06 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:02 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c/resources
@@ -7822,7 +7822,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 72f762964a4f48e58e61d8bde21c3461
+      - 7786205be853421cb329a1dfe5e85b94
   response:
     status:
       code: 200
@@ -7833,9 +7833,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-d399e03c-5ff6-43cb-a946-3205410a950a
+      - req-a95e4f63-56aa-4760-9598-ba952675b997
       Date:
-      - Thu, 25 Oct 2018 18:21:06 GMT
+      - Thu, 01 Nov 2018 18:36:02 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -7847,7 +7847,7 @@ http_interactions:
         changed", "physical_resource_id": "b686353f-0da0-48bf-bc35-8ea411a67dfd",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:06 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:02 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -7865,13 +7865,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:21:06 GMT
+      - Thu, 01 Nov 2018 18:36:02 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-77420475-3fb4-41f5-80a7-063e16a7d496
+      - req-ec80d0ae-5feb-4470-a0d2-2962919112f2
       Content-Length:
       - '4117'
       Connection:
@@ -7880,10 +7880,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:06.521939", "expires":
-        "2018-10-25T19:21:06Z", "id": "9cf592f4239141e4b04496837db81aa1", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:36:02.538197", "expires":
+        "2018-11-01T19:36:02Z", "id": "1fb6cdabc96d485eab51a006963c1507", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["KGaGScEdToGuXuGzaJurKA"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["BVltbD4dTUe5A_omLsNJMw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -7927,7 +7927,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:06 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:02 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -7942,7 +7942,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9cf592f4239141e4b04496837db81aa1
+      - 1fb6cdabc96d485eab51a006963c1507
   response:
     status:
       code: 200
@@ -7953,17 +7953,167 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-3b2a987c-5cc0-427f-9b42-a31d1d045e4f
+      - req-f71e9db2-b3a6-44e5-a237-1505ead5ea05
       Date:
-      - Thu, 25 Oct 2018 18:21:06 GMT
+      - Thu, 01 Nov 2018 18:36:02 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.50.4", "end": "192.168.50.4"}, {"start":
-        "192.168.50.2", "end": "192.168.50.2"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 01 Nov 2018 18:36:02 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 1fb6cdabc96d485eab51a006963c1507
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-6f30bb6c-f55c-4e9a-9943-68f9b2a97b7d
+      Date:
+      - Thu, 01 Nov 2018 18:36:02 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2",
+        "end": "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
         true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
@@ -8028,24 +8178,6 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
         "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
-        false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
-        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
@@ -8059,7 +8191,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:06 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:02 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
@@ -8074,7 +8206,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9cf592f4239141e4b04496837db81aa1
+      - 1fb6cdabc96d485eab51a006963c1507
   response:
     status:
       code: 200
@@ -8085,45 +8217,51 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-923c35ce-e33a-4919-8231-5b3c81d5c5ff
+      - req-55f92581-b50e-4b96-b257-7fb177acd4ee
       Date:
-      - Thu, 25 Oct 2018 18:21:06 GMT
+      - Thu, 01 Nov 2018 18:36:03 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
-        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2",
+        "end": "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
         "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
         "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
         "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.4",
-        "end": "192.168.50.4"}, {"start": "192.168.50.2", "end": "192.168.50.2"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
-        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.20.0/24", "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
-        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
         false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
@@ -8172,12 +8310,6 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
         "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
@@ -8191,7 +8323,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:06 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:03 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -8209,13 +8341,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:21:07 GMT
+      - Thu, 01 Nov 2018 18:36:03 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-7cd7c3c3-1738-41d1-873a-42743337a72d
+      - req-736ee9c0-9c1f-456c-9750-105c6531de9a
       Content-Length:
       - '4131'
       Connection:
@@ -8224,10 +8356,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:07.121681", "expires":
-        "2018-10-25T19:21:07Z", "id": "dbfb886069a446f4b6195c8b336e80d1", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:36:03.323722", "expires":
+        "2018-11-01T19:36:03Z", "id": "7c4dc3f00fcc48fcafc57a21d0fe61b5", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["HtWfFsqLR6C757-BOBFlBA"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["KNFxC4erTbOrJWhWTIhtWg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -8271,7 +8403,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:07 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:03 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -8286,7 +8418,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - dbfb886069a446f4b6195c8b336e80d1
+      - 7c4dc3f00fcc48fcafc57a21d0fe61b5
   response:
     status:
       code: 200
@@ -8297,9 +8429,9 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-6fc8045b-d2c1-4863-8136-ba928671fe64
+      - req-2c85c6ce-c1c5-4150-9604-f21ccc710019
       Date:
-      - Thu, 25 Oct 2018 18:21:07 GMT
+      - Thu, 01 Nov 2018 18:36:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
@@ -8403,7 +8535,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:07 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:03 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
@@ -8418,7 +8550,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - dbfb886069a446f4b6195c8b336e80d1
+      - 7c4dc3f00fcc48fcafc57a21d0fe61b5
   response:
     status:
       code: 200
@@ -8429,41 +8561,12 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-0823f650-ce80-4267-9cc6-3148cd8473b1
+      - req-9d792cdf-668b-470e-a486-a1ba1646df51
       Date:
-      - Thu, 25 Oct 2018 18:21:07 GMT
+      - Thu, 01 Nov 2018 18:36:06 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.50.4", "end": "192.168.50.4"}, {"start":
-        "192.168.50.2", "end": "192.168.50.2"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
         false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
@@ -8516,29 +8619,58 @@ http_interactions:
         "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
         "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
-        false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
-        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
         null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:07 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:06 GMT
 - request:
     method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
     body:
       encoding: US-ASCII
       string: ''
@@ -8550,7 +8682,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 760b2203b4a84c07b1aed9c8c673ab9f
+      - 7c4dc3f00fcc48fcafc57a21d0fe61b5
   response:
     status:
       code: 200
@@ -8561,9 +8693,9 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-a9429755-a611-49c3-9837-ba2b87fe7b0b
+      - req-a47a53b3-63f4-4e80-a40f-74f96a28c345
       Date:
-      - Thu, 25 Oct 2018 18:21:07 GMT
+      - Thu, 01 Nov 2018 18:36:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
@@ -8667,7 +8799,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:07 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:07 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
@@ -8682,7 +8814,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 760b2203b4a84c07b1aed9c8c673ab9f
+      - 7c4dc3f00fcc48fcafc57a21d0fe61b5
   response:
     status:
       code: 200
@@ -8693,17 +8825,35 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-a408488a-b099-468b-b0c2-9beb524e6f93
+      - req-f14997b7-8e38-4a83-ad29-ca3da79af5d7
       Date:
-      - Thu, 25 Oct 2018 18:21:07 GMT
+      - Thu, 01 Nov 2018 18:36:07 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.50.4", "end": "192.168.50.4"}, {"start":
-        "192.168.50.2", "end": "192.168.50.2"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2",
+        "end": "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
         true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
@@ -8768,24 +8918,6 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
         "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
-        false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
-        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
@@ -8799,7 +8931,535 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:07 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:07 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 402a9ca6fb904cd3bd12280339f0cc32
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-d370538b-3ae0-4090-af3b-954cd42321e1
+      Date:
+      - Thu, 01 Nov 2018 18:36:07 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2",
+        "end": "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 01 Nov 2018 18:36:07 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 402a9ca6fb904cd3bd12280339f0cc32
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-e80062d5-662e-47d1-901f-a4fdc2c94cf8
+      Date:
+      - Thu, 01 Nov 2018 18:36:07 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 01 Nov 2018 18:36:07 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 402a9ca6fb904cd3bd12280339f0cc32
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-87ce488a-0b5f-4201-b153-e433762a872a
+      Date:
+      - Thu, 01 Nov 2018 18:36:07 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2",
+        "end": "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 01 Nov 2018 18:36:07 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 402a9ca6fb904cd3bd12280339f0cc32
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-1a2a1f53-6330-4d28-a0c6-65ce224310e3
+      Date:
+      - Thu, 01 Nov 2018 18:36:07 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2",
+        "end": "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 01 Nov 2018 18:36:07 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -8817,13 +9477,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:21:07 GMT
+      - Thu, 01 Nov 2018 18:36:08 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-9219bb59-b914-4021-8e8c-f2c4b8515370
+      - req-230e9c7c-21c9-4aef-905c-5dbd00c9447e
       Content-Length:
       - '4118'
       Connection:
@@ -8832,10 +9492,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:08.034464", "expires":
-        "2018-10-25T19:21:08Z", "id": "62bde9868b734c38b919ebbf540a06f6", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:36:08.115609", "expires":
+        "2018-11-01T19:36:08Z", "id": "44cc1bab3e0e417982bdb110ea4cf40f", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["Pmn4h71VRKmgfcfC-DtfIA"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["syQvaZviT5qJiCBxx4o7hQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -8879,7 +9539,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:08 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:08 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -8894,7 +9554,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 62bde9868b734c38b919ebbf540a06f6
+      - 44cc1bab3e0e417982bdb110ea4cf40f
   response:
     status:
       code: 200
@@ -8905,9 +9565,9 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-a0bbe52d-03e3-4c7b-9902-2515e6843f83
+      - req-46229c29-8084-43a8-8fc8-9ef9db3a905d
       Date:
-      - Thu, 25 Oct 2018 18:21:08 GMT
+      - Thu, 01 Nov 2018 18:36:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
@@ -9011,7 +9671,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:08 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:08 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
@@ -9026,7 +9686,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 62bde9868b734c38b919ebbf540a06f6
+      - 44cc1bab3e0e417982bdb110ea4cf40f
   response:
     status:
       code: 200
@@ -9037,17 +9697,167 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-f5c07280-c691-4e65-9617-8b49a51beac8
+      - req-3a78d8e8-cf9e-418a-b188-fa9086a505d5
       Date:
-      - Thu, 25 Oct 2018 18:21:08 GMT
+      - Thu, 01 Nov 2018 18:36:08 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.50.4", "end": "192.168.50.4"}, {"start":
-        "192.168.50.2", "end": "192.168.50.2"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 01 Nov 2018 18:36:08 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 44cc1bab3e0e417982bdb110ea4cf40f
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-d64eff14-b49b-47a6-bb6d-8126b5131c2a
+      Date:
+      - Thu, 01 Nov 2018 18:36:08 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2",
+        "end": "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
         true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
@@ -9112,24 +9922,6 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
         "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
-        false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
-        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
@@ -9143,7 +9935,139 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:08 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:08 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 44cc1bab3e0e417982bdb110ea4cf40f
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-7b89bc3d-5b4a-4db3-8b78-c858a58b1b8c
+      Date:
+      - Thu, 01 Nov 2018 18:36:08 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2",
+        "end": "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 01 Nov 2018 18:36:08 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?limit=1000
@@ -9158,7 +10082,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9cf592f4239141e4b04496837db81aa1
+      - 1fb6cdabc96d485eab51a006963c1507
   response:
     status:
       code: 200
@@ -9169,9 +10093,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-69496a14-8c4c-4b59-82cb-e37353c03095
+      - req-581cb2a8-71b2-44fc-b2c8-2a799a325c03
       Date:
-      - Thu, 25 Oct 2018 18:21:08 GMT
+      - Thu, 01 Nov 2018 18:36:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -9213,7 +10137,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:08 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:09 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?limit=1000&marker=ee601a91-f6ac-4a46-a599-87cfd83094a3
@@ -9228,7 +10152,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9cf592f4239141e4b04496837db81aa1
+      - 1fb6cdabc96d485eab51a006963c1507
   response:
     status:
       code: 200
@@ -9239,9 +10163,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-6b66f5ff-3575-4be3-86c8-819cb299f47e
+      - req-475d61ca-62fe-4c93-9c91-e51b05b70e04
       Date:
-      - Thu, 25 Oct 2018 18:21:08 GMT
+      - Thu, 01 Nov 2018 18:36:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -9283,7 +10207,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:08 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:09 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?limit=1000
@@ -9298,7 +10222,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - dbfb886069a446f4b6195c8b336e80d1
+      - 7c4dc3f00fcc48fcafc57a21d0fe61b5
   response:
     status:
       code: 200
@@ -9309,9 +10233,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-eb2ff672-4e06-4e15-8523-b829a8201957
+      - req-db3105c1-e6ac-4d63-896a-05a654e3f69b
       Date:
-      - Thu, 25 Oct 2018 18:21:08 GMT
+      - Thu, 01 Nov 2018 18:36:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -9353,7 +10277,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:08 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:09 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?limit=1000&marker=ee601a91-f6ac-4a46-a599-87cfd83094a3
@@ -9368,7 +10292,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - dbfb886069a446f4b6195c8b336e80d1
+      - 7c4dc3f00fcc48fcafc57a21d0fe61b5
   response:
     status:
       code: 200
@@ -9379,9 +10303,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-6ee227a9-4856-44da-a751-29340b4bcd17
+      - req-96192752-fee3-4282-a01d-edf7d2ba9fd7
       Date:
-      - Thu, 25 Oct 2018 18:21:08 GMT
+      - Thu, 01 Nov 2018 18:36:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -9423,7 +10347,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:08 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:09 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?limit=1000
@@ -9438,7 +10362,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 760b2203b4a84c07b1aed9c8c673ab9f
+      - 402a9ca6fb904cd3bd12280339f0cc32
   response:
     status:
       code: 200
@@ -9449,9 +10373,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-f325517e-9d16-4b97-aa2a-e1dc53bc91fd
+      - req-85551f10-ed00-42b2-939d-a29489fa6a95
       Date:
-      - Thu, 25 Oct 2018 18:21:08 GMT
+      - Thu, 01 Nov 2018 18:36:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -9493,7 +10417,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:08 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:09 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?limit=1000&marker=ee601a91-f6ac-4a46-a599-87cfd83094a3
@@ -9508,7 +10432,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 760b2203b4a84c07b1aed9c8c673ab9f
+      - 402a9ca6fb904cd3bd12280339f0cc32
   response:
     status:
       code: 200
@@ -9519,9 +10443,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-e5e88dea-b217-4f09-884f-4b28d8404fd4
+      - req-b387e972-c67e-4efd-9ad6-f8f221dead1a
       Date:
-      - Thu, 25 Oct 2018 18:21:08 GMT
+      - Thu, 01 Nov 2018 18:36:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -9563,7 +10487,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:09 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:09 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?limit=1000
@@ -9578,7 +10502,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 62bde9868b734c38b919ebbf540a06f6
+      - 44cc1bab3e0e417982bdb110ea4cf40f
   response:
     status:
       code: 200
@@ -9589,9 +10513,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-8cb7a449-15be-4c83-a85e-50e224c172a8
+      - req-80d15cd2-0604-4614-b5b2-7131efd17713
       Date:
-      - Thu, 25 Oct 2018 18:21:09 GMT
+      - Thu, 01 Nov 2018 18:36:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -9633,7 +10557,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:09 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:09 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?limit=1000&marker=ee601a91-f6ac-4a46-a599-87cfd83094a3
@@ -9648,7 +10572,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 62bde9868b734c38b919ebbf540a06f6
+      - 44cc1bab3e0e417982bdb110ea4cf40f
   response:
     status:
       code: 200
@@ -9659,9 +10583,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-130f5e79-0173-42a9-86a5-04ead7cac951
+      - req-e703caef-6e63-4431-9b8a-90604317e189
       Date:
-      - Thu, 25 Oct 2018 18:21:09 GMT
+      - Thu, 01 Nov 2018 18:36:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -9703,7 +10627,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:09 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:09 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?limit=1000
@@ -9718,7 +10642,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9cf592f4239141e4b04496837db81aa1
+      - 1fb6cdabc96d485eab51a006963c1507
   response:
     status:
       code: 200
@@ -9729,9 +10653,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-f13652d8-6cac-4333-9fcf-8ef9adc206e3
+      - req-db662413-d7d0-4e30-894e-8c79ca499352
       Date:
-      - Thu, 25 Oct 2018 18:21:09 GMT
+      - Thu, 01 Nov 2018 18:36:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -10134,7 +11058,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:09 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:09 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?limit=1000&marker=dee8791c-23b3-4e65-846d-49aeaba18036
@@ -10149,7 +11073,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9cf592f4239141e4b04496837db81aa1
+      - 1fb6cdabc96d485eab51a006963c1507
   response:
     status:
       code: 200
@@ -10160,9 +11084,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-89e86738-fc3c-402e-9dfb-bfa850035a81
+      - req-2f693581-cde2-4737-a328-8fbc58a4dece
       Date:
-      - Thu, 25 Oct 2018 18:21:09 GMT
+      - Thu, 01 Nov 2018 18:36:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -10565,7 +11489,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:09 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:10 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?limit=1000
@@ -10580,7 +11504,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - dbfb886069a446f4b6195c8b336e80d1
+      - 7c4dc3f00fcc48fcafc57a21d0fe61b5
   response:
     status:
       code: 200
@@ -10591,9 +11515,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-01f62995-f07e-4ad6-b303-c0cf044e01fd
+      - req-cfd1acac-b5ed-40dc-ac7a-4d051845be22
       Date:
-      - Thu, 25 Oct 2018 18:21:09 GMT
+      - Thu, 01 Nov 2018 18:36:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -10996,7 +11920,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:09 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:10 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?limit=1000&marker=dee8791c-23b3-4e65-846d-49aeaba18036
@@ -11011,7 +11935,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - dbfb886069a446f4b6195c8b336e80d1
+      - 7c4dc3f00fcc48fcafc57a21d0fe61b5
   response:
     status:
       code: 200
@@ -11022,9 +11946,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-264d7f70-0555-4740-85a8-287cbe246170
+      - req-daafa69a-9f5f-480f-bf9d-8f33e4e02a42
       Date:
-      - Thu, 25 Oct 2018 18:21:09 GMT
+      - Thu, 01 Nov 2018 18:36:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -11427,7 +12351,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:09 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:10 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?limit=1000
@@ -11442,7 +12366,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 760b2203b4a84c07b1aed9c8c673ab9f
+      - 402a9ca6fb904cd3bd12280339f0cc32
   response:
     status:
       code: 200
@@ -11453,9 +12377,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-de9ab0cf-0805-4738-8b47-f318fa458e10
+      - req-21b400d0-3108-42c3-92c8-e560499d0436
       Date:
-      - Thu, 25 Oct 2018 18:21:10 GMT
+      - Thu, 01 Nov 2018 18:36:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -11858,7 +12782,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:10 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:10 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?limit=1000&marker=dee8791c-23b3-4e65-846d-49aeaba18036
@@ -11873,7 +12797,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 760b2203b4a84c07b1aed9c8c673ab9f
+      - 402a9ca6fb904cd3bd12280339f0cc32
   response:
     status:
       code: 200
@@ -11884,9 +12808,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-6d2ca450-c14d-4d68-af8f-91d03d81e420
+      - req-9078e475-75b7-4fca-8059-ffdb98d85722
       Date:
-      - Thu, 25 Oct 2018 18:21:10 GMT
+      - Thu, 01 Nov 2018 18:36:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -12289,7 +13213,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:10 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:10 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?limit=1000
@@ -12304,7 +13228,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 62bde9868b734c38b919ebbf540a06f6
+      - 44cc1bab3e0e417982bdb110ea4cf40f
   response:
     status:
       code: 200
@@ -12315,9 +13239,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-fcf82ddf-e35a-47a4-8afe-d355a51f7090
+      - req-9d4b4214-6b9c-431e-a317-520010c9db86
       Date:
-      - Thu, 25 Oct 2018 18:21:10 GMT
+      - Thu, 01 Nov 2018 18:36:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -12720,7 +13644,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:10 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:11 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?limit=1000&marker=dee8791c-23b3-4e65-846d-49aeaba18036
@@ -12735,7 +13659,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 62bde9868b734c38b919ebbf540a06f6
+      - 44cc1bab3e0e417982bdb110ea4cf40f
   response:
     status:
       code: 200
@@ -12746,9 +13670,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-101feee1-4574-41b3-b02e-589491ef9778
+      - req-3b4a0129-e9d0-4613-a512-774519d51f5d
       Date:
-      - Thu, 25 Oct 2018 18:21:10 GMT
+      - Thu, 01 Nov 2018 18:36:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -13151,7 +14075,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:10 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:11 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?limit=1000
@@ -13166,7 +14090,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9cf592f4239141e4b04496837db81aa1
+      - 1fb6cdabc96d485eab51a006963c1507
   response:
     status:
       code: 200
@@ -13177,9 +14101,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-5f0cc14e-b65e-4991-983a-baba175ea8f1
+      - req-d8f60284-edb0-4134-9bfa-da1282e63e3a
       Date:
-      - Thu, 25 Oct 2018 18:21:10 GMT
+      - Thu, 01 Nov 2018 18:36:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -13211,7 +14135,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:10 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:11 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?limit=1000&marker=a41c036a-c34e-454b-851d-5eefd03888cb
@@ -13226,7 +14150,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9cf592f4239141e4b04496837db81aa1
+      - 1fb6cdabc96d485eab51a006963c1507
   response:
     status:
       code: 200
@@ -13237,9 +14161,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-f83f3dd0-48f6-441a-bf2b-ed1590dc2a0d
+      - req-9a8ad270-af9f-41d0-ab50-6280174b284d
       Date:
-      - Thu, 25 Oct 2018 18:21:10 GMT
+      - Thu, 01 Nov 2018 18:36:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -13271,7 +14195,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:10 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:11 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?limit=1000
@@ -13286,7 +14210,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - dbfb886069a446f4b6195c8b336e80d1
+      - 7c4dc3f00fcc48fcafc57a21d0fe61b5
   response:
     status:
       code: 200
@@ -13297,9 +14221,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-deba776c-df4a-447c-91a0-a1d6d322c10b
+      - req-4cbc3836-333e-4a2b-8c2a-60ff35f779b0
       Date:
-      - Thu, 25 Oct 2018 18:21:11 GMT
+      - Thu, 01 Nov 2018 18:36:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -13331,7 +14255,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:11 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:11 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?limit=1000&marker=a41c036a-c34e-454b-851d-5eefd03888cb
@@ -13346,7 +14270,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - dbfb886069a446f4b6195c8b336e80d1
+      - 7c4dc3f00fcc48fcafc57a21d0fe61b5
   response:
     status:
       code: 200
@@ -13357,9 +14281,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-91d761df-e059-44c2-bca2-633cd62e9409
+      - req-250ea5b3-958c-47d9-92b7-ea0e0444c9d0
       Date:
-      - Thu, 25 Oct 2018 18:21:11 GMT
+      - Thu, 01 Nov 2018 18:36:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -13391,7 +14315,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:11 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:11 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?limit=1000
@@ -13406,7 +14330,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 760b2203b4a84c07b1aed9c8c673ab9f
+      - 402a9ca6fb904cd3bd12280339f0cc32
   response:
     status:
       code: 200
@@ -13417,9 +14341,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-b9c5c42f-cc4e-427f-8afc-50284225da60
+      - req-b4b95710-9768-44c0-ba5e-95a6fb34a019
       Date:
-      - Thu, 25 Oct 2018 18:21:11 GMT
+      - Thu, 01 Nov 2018 18:36:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -13451,7 +14375,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:11 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:12 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?limit=1000&marker=a41c036a-c34e-454b-851d-5eefd03888cb
@@ -13466,7 +14390,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 760b2203b4a84c07b1aed9c8c673ab9f
+      - 402a9ca6fb904cd3bd12280339f0cc32
   response:
     status:
       code: 200
@@ -13477,9 +14401,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-ac0fa52c-66ec-4a2d-9abd-f71a30c51212
+      - req-b1d7479e-9261-402c-a82e-3d4e5e156485
       Date:
-      - Thu, 25 Oct 2018 18:21:11 GMT
+      - Thu, 01 Nov 2018 18:36:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -13511,7 +14435,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:11 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:12 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?limit=1000
@@ -13526,7 +14450,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 62bde9868b734c38b919ebbf540a06f6
+      - 44cc1bab3e0e417982bdb110ea4cf40f
   response:
     status:
       code: 200
@@ -13537,9 +14461,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-08840a69-707a-4a98-9b93-e67c7c15e911
+      - req-98043aae-d12f-4c3e-8189-57819d5dec9d
       Date:
-      - Thu, 25 Oct 2018 18:21:11 GMT
+      - Thu, 01 Nov 2018 18:36:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -13571,7 +14495,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:11 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:12 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?limit=1000&marker=a41c036a-c34e-454b-851d-5eefd03888cb
@@ -13586,7 +14510,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 62bde9868b734c38b919ebbf540a06f6
+      - 44cc1bab3e0e417982bdb110ea4cf40f
   response:
     status:
       code: 200
@@ -13597,9 +14521,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-54899449-af0c-468c-896a-c7a741175507
+      - req-364e83b0-6862-45ab-a815-9532b2cdd403
       Date:
-      - Thu, 25 Oct 2018 18:21:11 GMT
+      - Thu, 01 Nov 2018 18:36:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -13631,7 +14555,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:11 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:12 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000
@@ -13646,7 +14570,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9cf592f4239141e4b04496837db81aa1
+      - 1fb6cdabc96d485eab51a006963c1507
   response:
     status:
       code: 200
@@ -13657,9 +14581,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-fd1b37ab-f6a4-4566-a256-bc64de9fe22d
+      - req-67bb79a3-35a0-4f2f-b99c-921f43ccf3c9
       Date:
-      - Thu, 25 Oct 2018 18:21:11 GMT
+      - Thu, 01 Nov 2018 18:36:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef",
@@ -13701,7 +14625,7 @@ http_interactions:
         null, "port_range_min": null, "id": "ff24dfac-169a-4238-b78b-ed1536a0bf06",
         "security_group_id": "5b2b42a6-1271-4c4a-b062-8e8ba299acef"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:11 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:12 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef
@@ -13716,7 +14640,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9cf592f4239141e4b04496837db81aa1
+      - 1fb6cdabc96d485eab51a006963c1507
   response:
     status:
       code: 200
@@ -13727,9 +14651,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-2bc26cda-130d-4173-b343-4a248f926d7f
+      - req-b6fe6e69-9e75-4ae2-b9b9-020ef34845ab
       Date:
-      - Thu, 25 Oct 2018 18:21:11 GMT
+      - Thu, 01 Nov 2018 18:36:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab",
@@ -13772,7 +14696,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "c06c0e71-2c18-43a9-ace9-91242f0251e2",
         "security_group_id": "98bfc20c-a897-42c5-b33c-f0d8317667ab"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:11 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:12 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab
@@ -13787,7 +14711,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9cf592f4239141e4b04496837db81aa1
+      - 1fb6cdabc96d485eab51a006963c1507
   response:
     status:
       code: 200
@@ -13798,9 +14722,9 @@ http_interactions:
       Content-Length:
       - '2717'
       X-Openstack-Request-Id:
-      - req-f7ac9d2a-ca36-4c2b-a3b0-0b64e0b85b27
+      - req-4c2b7a4d-3ede-4326-a78f-3180f203d478
       Date:
-      - Thu, 25 Oct 2018 18:21:12 GMT
+      - Thu, 01 Nov 2018 18:36:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4",
@@ -13835,7 +14759,7 @@ http_interactions:
         null, "port_range_min": null, "id": "75924ebc-4758-4042-ad04-4ef3c9189098",
         "security_group_id": "e4836528-d0df-425e-a117-ae8ec6f356d4"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:12 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:12 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4
@@ -13850,7 +14774,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9cf592f4239141e4b04496837db81aa1
+      - 1fb6cdabc96d485eab51a006963c1507
   response:
     status:
       code: 200
@@ -13861,9 +14785,9 @@ http_interactions:
       Content-Length:
       - '7080'
       X-Openstack-Request-Id:
-      - req-4657924b-8941-4c98-99d8-ef4b08da51f6
+      - req-297778c4-893b-435a-82c5-a41c47a9313e
       Date:
-      - Thu, 25 Oct 2018 18:21:12 GMT
+      - Thu, 01 Nov 2018 18:36:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=fd147cb7-7456-43d9-a01f-c06e21b4e6fb&page_reverse=True",
@@ -13950,7 +14874,7 @@ http_interactions:
         "port_range_max": 80, "port_range_min": 80, "id": "f79f0e32-b186-4778-952e-20827a60ef73",
         "security_group_id": "fd147cb7-7456-43d9-a01f-c06e21b4e6fb"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:12 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:12 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000
@@ -13965,7 +14889,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - dbfb886069a446f4b6195c8b336e80d1
+      - 7c4dc3f00fcc48fcafc57a21d0fe61b5
   response:
     status:
       code: 200
@@ -13976,9 +14900,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-d54e76fd-85cd-49e6-aa76-a410ff800357
+      - req-f7b468d2-b2af-40e0-b204-2f61782c09f9
       Date:
-      - Thu, 25 Oct 2018 18:21:12 GMT
+      - Thu, 01 Nov 2018 18:36:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef",
@@ -14020,7 +14944,7 @@ http_interactions:
         null, "port_range_min": null, "id": "ff24dfac-169a-4238-b78b-ed1536a0bf06",
         "security_group_id": "5b2b42a6-1271-4c4a-b062-8e8ba299acef"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:12 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:12 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef
@@ -14035,7 +14959,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - dbfb886069a446f4b6195c8b336e80d1
+      - 7c4dc3f00fcc48fcafc57a21d0fe61b5
   response:
     status:
       code: 200
@@ -14046,9 +14970,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-d8d6d9d7-7ac1-4d76-b3e8-3c570b95d0aa
+      - req-1bcf6a57-fdde-4262-945a-9a8fc8c581d0
       Date:
-      - Thu, 25 Oct 2018 18:21:12 GMT
+      - Thu, 01 Nov 2018 18:36:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab",
@@ -14091,7 +15015,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "c06c0e71-2c18-43a9-ace9-91242f0251e2",
         "security_group_id": "98bfc20c-a897-42c5-b33c-f0d8317667ab"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:12 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:13 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab
@@ -14106,7 +15030,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - dbfb886069a446f4b6195c8b336e80d1
+      - 7c4dc3f00fcc48fcafc57a21d0fe61b5
   response:
     status:
       code: 200
@@ -14117,9 +15041,9 @@ http_interactions:
       Content-Length:
       - '2717'
       X-Openstack-Request-Id:
-      - req-2a17f46c-fa81-4dd4-b477-9f4e49170551
+      - req-6ea75cab-ad4b-4a15-b418-4a256c3fea2e
       Date:
-      - Thu, 25 Oct 2018 18:21:12 GMT
+      - Thu, 01 Nov 2018 18:36:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4",
@@ -14154,7 +15078,7 @@ http_interactions:
         null, "port_range_min": null, "id": "75924ebc-4758-4042-ad04-4ef3c9189098",
         "security_group_id": "e4836528-d0df-425e-a117-ae8ec6f356d4"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:12 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:13 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4
@@ -14169,7 +15093,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - dbfb886069a446f4b6195c8b336e80d1
+      - 7c4dc3f00fcc48fcafc57a21d0fe61b5
   response:
     status:
       code: 200
@@ -14180,9 +15104,9 @@ http_interactions:
       Content-Length:
       - '7080'
       X-Openstack-Request-Id:
-      - req-3666e7da-fdd6-4216-94a5-9cfd1a2192b4
+      - req-f3a277a1-e9b9-4121-bcf1-2bd705d282cd
       Date:
-      - Thu, 25 Oct 2018 18:21:12 GMT
+      - Thu, 01 Nov 2018 18:36:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=fd147cb7-7456-43d9-a01f-c06e21b4e6fb&page_reverse=True",
@@ -14269,7 +15193,7 @@ http_interactions:
         "port_range_max": 80, "port_range_min": 80, "id": "f79f0e32-b186-4778-952e-20827a60ef73",
         "security_group_id": "fd147cb7-7456-43d9-a01f-c06e21b4e6fb"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:12 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:13 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000
@@ -14284,7 +15208,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 760b2203b4a84c07b1aed9c8c673ab9f
+      - 402a9ca6fb904cd3bd12280339f0cc32
   response:
     status:
       code: 200
@@ -14295,9 +15219,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-fcb15067-7921-452a-840f-1105a9f7984d
+      - req-b876657c-c905-4f22-a224-9153fbb37d6a
       Date:
-      - Thu, 25 Oct 2018 18:21:12 GMT
+      - Thu, 01 Nov 2018 18:36:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef",
@@ -14339,7 +15263,7 @@ http_interactions:
         null, "port_range_min": null, "id": "ff24dfac-169a-4238-b78b-ed1536a0bf06",
         "security_group_id": "5b2b42a6-1271-4c4a-b062-8e8ba299acef"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:12 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:13 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef
@@ -14354,7 +15278,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 760b2203b4a84c07b1aed9c8c673ab9f
+      - 402a9ca6fb904cd3bd12280339f0cc32
   response:
     status:
       code: 200
@@ -14365,9 +15289,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-37c9f231-8e87-4689-b2de-a42cb380cdfd
+      - req-2c8fcbfd-f9f8-4474-be86-332414e69c0c
       Date:
-      - Thu, 25 Oct 2018 18:21:12 GMT
+      - Thu, 01 Nov 2018 18:36:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab",
@@ -14410,7 +15334,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "c06c0e71-2c18-43a9-ace9-91242f0251e2",
         "security_group_id": "98bfc20c-a897-42c5-b33c-f0d8317667ab"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:12 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:13 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab
@@ -14425,7 +15349,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 760b2203b4a84c07b1aed9c8c673ab9f
+      - 402a9ca6fb904cd3bd12280339f0cc32
   response:
     status:
       code: 200
@@ -14436,9 +15360,9 @@ http_interactions:
       Content-Length:
       - '2717'
       X-Openstack-Request-Id:
-      - req-2bda4f40-1674-48bc-9084-4c73c988d729
+      - req-46d10ef4-e974-4e64-839b-a1b2acd22fd9
       Date:
-      - Thu, 25 Oct 2018 18:21:12 GMT
+      - Thu, 01 Nov 2018 18:36:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4",
@@ -14473,7 +15397,7 @@ http_interactions:
         null, "port_range_min": null, "id": "75924ebc-4758-4042-ad04-4ef3c9189098",
         "security_group_id": "e4836528-d0df-425e-a117-ae8ec6f356d4"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:12 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:13 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4
@@ -14488,7 +15412,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 760b2203b4a84c07b1aed9c8c673ab9f
+      - 402a9ca6fb904cd3bd12280339f0cc32
   response:
     status:
       code: 200
@@ -14499,9 +15423,9 @@ http_interactions:
       Content-Length:
       - '7080'
       X-Openstack-Request-Id:
-      - req-264ec232-cfb2-450b-a374-27a3b18174f0
+      - req-3e644065-adba-4f23-86f5-e0bc284b32a8
       Date:
-      - Thu, 25 Oct 2018 18:21:13 GMT
+      - Thu, 01 Nov 2018 18:36:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=fd147cb7-7456-43d9-a01f-c06e21b4e6fb&page_reverse=True",
@@ -14588,7 +15512,7 @@ http_interactions:
         "port_range_max": 80, "port_range_min": 80, "id": "f79f0e32-b186-4778-952e-20827a60ef73",
         "security_group_id": "fd147cb7-7456-43d9-a01f-c06e21b4e6fb"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:13 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:13 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000
@@ -14603,7 +15527,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 62bde9868b734c38b919ebbf540a06f6
+      - 44cc1bab3e0e417982bdb110ea4cf40f
   response:
     status:
       code: 200
@@ -14614,9 +15538,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-baf256bc-18d5-4255-9af3-afdbe8327599
+      - req-134c875f-7ccd-4043-bc34-19ad0993b061
       Date:
-      - Thu, 25 Oct 2018 18:21:13 GMT
+      - Thu, 01 Nov 2018 18:36:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef",
@@ -14658,7 +15582,7 @@ http_interactions:
         null, "port_range_min": null, "id": "ff24dfac-169a-4238-b78b-ed1536a0bf06",
         "security_group_id": "5b2b42a6-1271-4c4a-b062-8e8ba299acef"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:13 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:13 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef
@@ -14673,7 +15597,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 62bde9868b734c38b919ebbf540a06f6
+      - 44cc1bab3e0e417982bdb110ea4cf40f
   response:
     status:
       code: 200
@@ -14684,9 +15608,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-ede57b8f-1040-4a39-bdc5-1b44c0a72979
+      - req-e124ba5b-3156-4a3f-808d-0871388c41b0
       Date:
-      - Thu, 25 Oct 2018 18:21:13 GMT
+      - Thu, 01 Nov 2018 18:36:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab",
@@ -14729,7 +15653,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "c06c0e71-2c18-43a9-ace9-91242f0251e2",
         "security_group_id": "98bfc20c-a897-42c5-b33c-f0d8317667ab"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:13 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:13 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab
@@ -14744,7 +15668,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 62bde9868b734c38b919ebbf540a06f6
+      - 44cc1bab3e0e417982bdb110ea4cf40f
   response:
     status:
       code: 200
@@ -14755,9 +15679,9 @@ http_interactions:
       Content-Length:
       - '2717'
       X-Openstack-Request-Id:
-      - req-92d58dcb-ceed-42c4-83fb-a9240f66479e
+      - req-0bb34c39-4465-4cb7-9a9b-3a18a0c46df6
       Date:
-      - Thu, 25 Oct 2018 18:21:13 GMT
+      - Thu, 01 Nov 2018 18:36:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4",
@@ -14792,7 +15716,7 @@ http_interactions:
         null, "port_range_min": null, "id": "75924ebc-4758-4042-ad04-4ef3c9189098",
         "security_group_id": "e4836528-d0df-425e-a117-ae8ec6f356d4"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:13 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:14 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4
@@ -14807,7 +15731,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 62bde9868b734c38b919ebbf540a06f6
+      - 44cc1bab3e0e417982bdb110ea4cf40f
   response:
     status:
       code: 200
@@ -14818,9 +15742,9 @@ http_interactions:
       Content-Length:
       - '7080'
       X-Openstack-Request-Id:
-      - req-4ed0a935-5172-42f3-9795-15fbc91439f9
+      - req-fda134f0-bfa5-4d0b-9c94-89f7971e9422
       Date:
-      - Thu, 25 Oct 2018 18:21:13 GMT
+      - Thu, 01 Nov 2018 18:36:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=fd147cb7-7456-43d9-a01f-c06e21b4e6fb&page_reverse=True",
@@ -14907,7 +15831,7 @@ http_interactions:
         "port_range_max": 80, "port_range_min": 80, "id": "f79f0e32-b186-4778-952e-20827a60ef73",
         "security_group_id": "fd147cb7-7456-43d9-a01f-c06e21b4e6fb"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:13 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:14 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -14925,13 +15849,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:21:14 GMT
+      - Thu, 01 Nov 2018 18:36:14 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-dc788efe-315a-406c-8b5b-4495f0f3b0e7
+      - req-33d1b2e1-56e3-4d8c-b923-4340dfe36087
       Content-Length:
       - '4170'
       Connection:
@@ -14940,10 +15864,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:14.328745", "expires":
-        "2018-10-25T19:21:14Z", "id": "89ceb1c8d66a424ebf627fbcd08db792", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:36:14.833206", "expires":
+        "2018-11-01T19:36:14Z", "id": "2056bcca6f0c422db1db68ee2308e4da", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["PIIuMwTqSrG7P7eL2Vmr4g"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["QVR_RJ65SMK3m5SLm4FurA"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -14988,7 +15912,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:14 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:14 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -15006,13 +15930,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:21:14 GMT
+      - Thu, 01 Nov 2018 18:36:14 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-33071a01-f093-41d2-a89c-2a8669fd8fbd
+      - req-fa46949c-efd9-47d1-97d6-5202bfb40528
       Content-Length:
       - '4170'
       Connection:
@@ -15021,10 +15945,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:14.529666", "expires":
-        "2018-10-25T19:21:14Z", "id": "f5457a181dda4b939d613aff7e636b27", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:36:15.024512", "expires":
+        "2018-11-01T19:36:15Z", "id": "ac9804f3b1d04e58a9996b1e0cca0146", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["t-tfuec4TwKWRRraQihu0Q"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["29fjY9OtSuGlkTJVg8GJUg"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -15069,7 +15993,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:14 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:15 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -15087,13 +16011,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:21:14 GMT
+      - Thu, 01 Nov 2018 18:36:15 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-02671a97-494f-4907-b53f-d61473b79d79
+      - req-a8159a5d-cc51-41e7-96d2-0bef89b548b2
       Content-Length:
       - '370'
       Connection:
@@ -15102,13 +16026,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:14.679665", "expires":
-        "2018-10-25T19:21:14Z", "id": "11e47e3d30084de6986a3cc1683c249f", "audit_ids":
-        ["PyqyRXPrRVCauvPlXo2K6A"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:36:15.186471", "expires":
+        "2018-11-01T19:36:15Z", "id": "969ea724d7874543a83dbf0761c24687", "audit_ids":
+        ["elmSV9L8SWiykAhYfIYBgQ"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:14 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:15 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -15123,20 +16047,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 11e47e3d30084de6986a3cc1683c249f
+      - 969ea724d7874543a83dbf0761c24687
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:21:14 GMT
+      - Thu, 01 Nov 2018 18:36:15 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-dcee983e-25fb-4901-bec5-af44a18efbf1
+      - req-9925d3e4-cdb7-494d-a6bd-76f3af330793
       Content-Length:
       - '500'
       Connection:
@@ -15153,7 +16077,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:14 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:15 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -15171,13 +16095,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:21:14 GMT
+      - Thu, 01 Nov 2018 18:36:15 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-cd164a76-c5af-4b82-8acc-803a862a4647
+      - req-79c0dd00-cdc0-4a26-8599-3fca982c910d
       Content-Length:
       - '4117'
       Connection:
@@ -15186,10 +16110,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:14.987911", "expires":
-        "2018-10-25T19:21:14Z", "id": "79203508f4e54c38b405c3cd82ca963d", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:36:15.514595", "expires":
+        "2018-11-01T19:36:15Z", "id": "577b5768111a46b9b31aec120ad2559e", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["Ga8F5F-zS7KMe6QMc79KDA"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["2l2IZmF_QgW0jj1uKQ9_Wg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -15233,7 +16157,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:15 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:15 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -15251,13 +16175,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:21:15 GMT
+      - Thu, 01 Nov 2018 18:36:15 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-6284a4dc-628d-425f-a9f4-14c357ab2f2f
+      - req-40554c65-4525-4224-90b8-595f0b1190ea
       Content-Length:
       - '4131'
       Connection:
@@ -15266,10 +16190,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:15.200010", "expires":
-        "2018-10-25T19:21:15Z", "id": "c4e87db96afb44a7814e7ee8c4b7d17d", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:36:15.708972", "expires":
+        "2018-11-01T19:36:15Z", "id": "1971cd8c33634d0bb15e5b2436832dc0", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["9flt6kkqRdKU54g9S_RbsQ"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["Rlv1Js2jRsSOvaJ_fp3HsQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -15313,7 +16237,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:15 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:15 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -15331,13 +16255,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:21:15 GMT
+      - Thu, 01 Nov 2018 18:36:15 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-09b3737f-c34d-4a29-970f-809c195a11a3
+      - req-a43f4939-1c89-441d-a139-19fdd3064790
       Content-Length:
       - '4118'
       Connection:
@@ -15346,10 +16270,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:15.382445", "expires":
-        "2018-10-25T19:21:15Z", "id": "57d5fa8c300f4b998ed25afca629b962", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:36:15.906630", "expires":
+        "2018-11-01T19:36:15Z", "id": "a312dfadb8c449cdb420fe2fd24150a7", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["g85XElk4RTGD_aqh9CYYFg"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["Lewz4aYsR7Cy-PwjJ3cHAQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -15393,7 +16317,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:15 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:15 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -15411,13 +16335,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:21:15 GMT
+      - Thu, 01 Nov 2018 18:36:16 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-44663002-417d-4bd6-85c0-8c58f80b40e5
+      - req-817708e0-5684-495f-8327-4535f489cb3e
       Content-Length:
       - '4117'
       Connection:
@@ -15426,10 +16350,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:15.558540", "expires":
-        "2018-10-25T19:21:15Z", "id": "b85769cdd65a481084dabca28af7ca2c", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:36:16.113385", "expires":
+        "2018-11-01T19:36:16Z", "id": "bd97ebb4fd19470a9099c5edad0358f1", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["gn8ZY8MdQMKGGm84zy-SkQ"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["l3CmLhhfToiC4Nox9c2EYQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -15473,7 +16397,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:15 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:16 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000
@@ -15488,22 +16412,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b85769cdd65a481084dabca28af7ca2c
+      - bd97ebb4fd19470a9099c5edad0358f1
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-17614a7d-8961-49cb-8bc9-53a41dc7a00b
+      - req-eb530281-4fd5-4fa3-adb2-0f22e9b053ff
       Content-Type:
       - application/json
       Content-Length:
       - '2706'
       X-Openstack-Request-Id:
-      - req-17614a7d-8961-49cb-8bc9-53a41dc7a00b
+      - req-eb530281-4fd5-4fa3-adb2-0f22e9b053ff
       Date:
-      - Thu, 25 Oct 2018 18:21:15 GMT
+      - Thu, 01 Nov 2018 18:36:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=9bb99818-b339-4e31-b87f-e4181ec48acd",
@@ -15536,7 +16460,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-4", "bootable": "true", "created_at":
         "2016-11-11T13:49:53.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:15 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:16 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=9bb99818-b339-4e31-b87f-e4181ec48acd
@@ -15551,22 +16475,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b85769cdd65a481084dabca28af7ca2c
+      - bd97ebb4fd19470a9099c5edad0358f1
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-ee8eb45e-cdf4-407d-a68d-97683f7a70ef
+      - req-6ce298be-5ce3-4385-b572-e502095b368a
       Content-Type:
       - application/json
       Content-Length:
       - '3284'
       X-Openstack-Request-Id:
-      - req-ee8eb45e-cdf4-407d-a68d-97683f7a70ef
+      - req-6ce298be-5ce3-4385-b572-e502095b368a
       Date:
-      - Thu, 25 Oct 2018 18:21:15 GMT
+      - Thu, 01 Nov 2018 18:36:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=2c774148-c11a-434c-aabb-7fa9c82c37ce",
@@ -15607,7 +16531,7 @@ http_interactions:
         "name": "EmsRefreshSpec-Volume-2", "bootable": "false", "created_at": "2016-11-11T13:49:43.000000",
         "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:15 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:16 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=2c774148-c11a-434c-aabb-7fa9c82c37ce
@@ -15622,22 +16546,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b85769cdd65a481084dabca28af7ca2c
+      - bd97ebb4fd19470a9099c5edad0358f1
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-11895812-0509-4f44-9374-99494cd19a6a
+      - req-a6e4e881-7592-438a-b02e-847046669dc2
       Content-Type:
       - application/json
       Content-Length:
       - '2753'
       X-Openstack-Request-Id:
-      - req-11895812-0509-4f44-9374-99494cd19a6a
+      - req-a6e4e881-7592-438a-b02e-847046669dc2
       Date:
-      - Thu, 25 Oct 2018 18:21:16 GMT
+      - Thu, 01 Nov 2018 18:36:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=0a55c0d5-c780-4e7d-9d09-47f5520c7448",
@@ -15671,7 +16595,7 @@ http_interactions:
         "bootable": "false", "created_at": "2016-11-11T13:49:20.000000", "volume_type":
         "iscsi"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:16 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:16 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=0a55c0d5-c780-4e7d-9d09-47f5520c7448
@@ -15686,27 +16610,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b85769cdd65a481084dabca28af7ca2c
+      - bd97ebb4fd19470a9099c5edad0358f1
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-42da9c2d-b297-468f-b965-d61cb9670dac
+      - req-13606399-0a6c-483c-8a67-7c801161230d
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-42da9c2d-b297-468f-b965-d61cb9670dac
+      - req-13606399-0a6c-483c-8a67-7c801161230d
       Date:
-      - Thu, 25 Oct 2018 18:21:16 GMT
+      - Thu, 01 Nov 2018 18:36:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:16 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:16 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -15724,13 +16648,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:21:16 GMT
+      - Thu, 01 Nov 2018 18:36:16 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-60637d60-7f23-4494-a79b-3ae9c61b71b1
+      - req-276800c1-66b8-404f-b7b8-a768d03df820
       Content-Length:
       - '4131'
       Connection:
@@ -15739,10 +16663,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:16.435898", "expires":
-        "2018-10-25T19:21:16Z", "id": "1346862440464cab9413b733b6939f88", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:36:16.986119", "expires":
+        "2018-11-01T19:36:16Z", "id": "c5583f42ad6a4028bd4cd029f23cec24", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["yHs-Pu9DRuy3xqL4KxxG5g"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["8zjZ3YYnRTqo7wMTcV5mog"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -15786,7 +16710,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:16 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:17 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/volumes/detail?limit=1000
@@ -15801,27 +16725,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1346862440464cab9413b733b6939f88
+      - c5583f42ad6a4028bd4cd029f23cec24
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-deb68cc4-006f-4bb1-88ba-30908016b759
+      - req-410ec246-0f58-4360-befa-4ba2f6c795d7
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-deb68cc4-006f-4bb1-88ba-30908016b759
+      - req-410ec246-0f58-4360-befa-4ba2f6c795d7
       Date:
-      - Thu, 25 Oct 2018 18:21:16 GMT
+      - Thu, 01 Nov 2018 18:36:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:16 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:17 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/volumes/detail?limit=1000
@@ -15836,27 +16760,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f5457a181dda4b939d613aff7e636b27
+      - ac9804f3b1d04e58a9996b1e0cca0146
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-cbe3a09d-f026-4adf-b0a9-812c0a15c90d
+      - req-d8e8ff1f-e25b-4ccb-a44d-d9fa72ee63bd
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-cbe3a09d-f026-4adf-b0a9-812c0a15c90d
+      - req-d8e8ff1f-e25b-4ccb-a44d-d9fa72ee63bd
       Date:
-      - Thu, 25 Oct 2018 18:21:16 GMT
+      - Thu, 01 Nov 2018 18:36:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:16 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:17 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -15874,13 +16798,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:21:16 GMT
+      - Thu, 01 Nov 2018 18:36:17 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-52f19094-3604-49b5-a0a4-5992ed2ca878
+      - req-eae981de-9a39-4e18-b79b-5179b1ec2d10
       Content-Length:
       - '4118'
       Connection:
@@ -15889,10 +16813,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:17.038479", "expires":
-        "2018-10-25T19:21:17Z", "id": "cd218f4caea44b4cab83a6643d21d23d", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:36:17.544721", "expires":
+        "2018-11-01T19:36:17Z", "id": "b7f72bfb0c9c484ba79b6daea34b350d", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["-EV9wEKzRLu4yUM2D4kCig"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["MLvrjSvdS9eTiuOIFD-jjw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -15936,7 +16860,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:17 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:17 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/volumes/detail?limit=1000
@@ -15951,27 +16875,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cd218f4caea44b4cab83a6643d21d23d
+      - b7f72bfb0c9c484ba79b6daea34b350d
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-a0958315-a808-49ee-807a-47f97401c4ab
+      - req-6d702a53-4700-4e83-bb41-d601b9397b3d
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-a0958315-a808-49ee-807a-47f97401c4ab
+      - req-6d702a53-4700-4e83-bb41-d601b9397b3d
       Date:
-      - Thu, 25 Oct 2018 18:21:17 GMT
+      - Thu, 01 Nov 2018 18:36:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:17 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:17 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail
@@ -15986,22 +16910,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b85769cdd65a481084dabca28af7ca2c
+      - bd97ebb4fd19470a9099c5edad0358f1
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-80b77b80-f5a9-4698-a541-ee3d8e4b5f70
+      - req-7eec07b6-86ae-4496-a504-0d1c5fa5a499
       Content-Type:
       - application/json
       Content-Length:
       - '1053'
       X-Openstack-Request-Id:
-      - req-80b77b80-f5a9-4698-a541-ee3d8e4b5f70
+      - req-7eec07b6-86ae-4496-a504-0d1c5fa5a499
       Date:
-      - Thu, 25 Oct 2018 18:21:17 GMT
+      - Thu, 01 Nov 2018 18:36:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?marker=76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
@@ -16016,7 +16940,7 @@ http_interactions:
         "created_at": "2016-11-11T13:49:36.000000", "size": 1, "id": "76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:17 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:17 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?limit=1000
@@ -16031,22 +16955,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b85769cdd65a481084dabca28af7ca2c
+      - bd97ebb4fd19470a9099c5edad0358f1
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-ee0bbbed-632b-4264-bc29-01819c17ae4f
+      - req-63c9b285-b1b6-4b51-9aae-5f5c1f3a05d2
       Content-Type:
       - application/json
       Content-Length:
       - '1064'
       X-Openstack-Request-Id:
-      - req-ee0bbbed-632b-4264-bc29-01819c17ae4f
+      - req-63c9b285-b1b6-4b51-9aae-5f5c1f3a05d2
       Date:
-      - Thu, 25 Oct 2018 18:21:17 GMT
+      - Thu, 01 Nov 2018 18:36:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?limit=1000&marker=76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
@@ -16061,7 +16985,7 @@ http_interactions:
         "created_at": "2016-11-11T13:49:36.000000", "size": 1, "id": "76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:17 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:18 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/snapshots/detail
@@ -16076,27 +17000,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1346862440464cab9413b733b6939f88
+      - c5583f42ad6a4028bd4cd029f23cec24
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-24be1626-c233-4c67-a4da-5d7afdd38eec
+      - req-88a24f58-3564-4744-9ac5-307634c673e3
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-24be1626-c233-4c67-a4da-5d7afdd38eec
+      - req-88a24f58-3564-4744-9ac5-307634c673e3
       Date:
-      - Thu, 25 Oct 2018 18:21:17 GMT
+      - Thu, 01 Nov 2018 18:36:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:17 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:18 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/snapshots/detail?limit=1000
@@ -16111,27 +17035,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1346862440464cab9413b733b6939f88
+      - c5583f42ad6a4028bd4cd029f23cec24
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-8b87b3ed-64e1-434a-8a29-5002aa22936c
+      - req-7205ea1e-5f4e-4272-9f26-c66c0c534835
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-8b87b3ed-64e1-434a-8a29-5002aa22936c
+      - req-7205ea1e-5f4e-4272-9f26-c66c0c534835
       Date:
-      - Thu, 25 Oct 2018 18:21:17 GMT
+      - Thu, 01 Nov 2018 18:36:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:17 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:18 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/snapshots/detail
@@ -16146,27 +17070,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f5457a181dda4b939d613aff7e636b27
+      - ac9804f3b1d04e58a9996b1e0cca0146
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-ff9f24bd-c7ef-4129-95cd-48eac79b6b01
+      - req-db22ca0d-b4de-437e-9c63-18bcb7797330
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-ff9f24bd-c7ef-4129-95cd-48eac79b6b01
+      - req-db22ca0d-b4de-437e-9c63-18bcb7797330
       Date:
-      - Thu, 25 Oct 2018 18:21:17 GMT
+      - Thu, 01 Nov 2018 18:36:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:17 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:18 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/snapshots/detail?limit=1000
@@ -16181,27 +17105,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f5457a181dda4b939d613aff7e636b27
+      - ac9804f3b1d04e58a9996b1e0cca0146
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-674ad204-0fcd-4a7a-a96f-49dd76bb30ab
+      - req-68cb571e-c2f5-45a5-becb-e24f42d41ec0
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-674ad204-0fcd-4a7a-a96f-49dd76bb30ab
+      - req-68cb571e-c2f5-45a5-becb-e24f42d41ec0
       Date:
-      - Thu, 25 Oct 2018 18:21:17 GMT
+      - Thu, 01 Nov 2018 18:36:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:17 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:18 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/snapshots/detail
@@ -16216,27 +17140,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cd218f4caea44b4cab83a6643d21d23d
+      - b7f72bfb0c9c484ba79b6daea34b350d
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-120d8180-0bc8-410b-8d6f-62eb03b39b35
+      - req-9521f142-d5be-49e4-84e6-e77694a94cc2
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-120d8180-0bc8-410b-8d6f-62eb03b39b35
+      - req-9521f142-d5be-49e4-84e6-e77694a94cc2
       Date:
-      - Thu, 25 Oct 2018 18:21:18 GMT
+      - Thu, 01 Nov 2018 18:36:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:18 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:18 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/snapshots/detail?limit=1000
@@ -16251,27 +17175,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cd218f4caea44b4cab83a6643d21d23d
+      - b7f72bfb0c9c484ba79b6daea34b350d
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-802cfc1f-ecbf-47d9-840f-71207f1885f8
+      - req-e61376d3-7387-4b1b-a2a4-5741eb6100eb
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-802cfc1f-ecbf-47d9-840f-71207f1885f8
+      - req-e61376d3-7387-4b1b-a2a4-5741eb6100eb
       Date:
-      - Thu, 25 Oct 2018 18:21:18 GMT
+      - Thu, 01 Nov 2018 18:36:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:18 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:18 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/backups/detail
@@ -16286,27 +17210,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b85769cdd65a481084dabca28af7ca2c
+      - bd97ebb4fd19470a9099c5edad0358f1
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-6b51d03e-c352-4a5b-889e-0234c314d911
+      - req-bb2578b4-31c9-41c4-a986-a41e97e3bdca
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-6b51d03e-c352-4a5b-889e-0234c314d911
+      - req-bb2578b4-31c9-41c4-a986-a41e97e3bdca
       Date:
-      - Thu, 25 Oct 2018 18:21:18 GMT
+      - Thu, 01 Nov 2018 18:36:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:18 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:18 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/backups/detail?limit=1000
@@ -16321,27 +17245,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b85769cdd65a481084dabca28af7ca2c
+      - bd97ebb4fd19470a9099c5edad0358f1
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-4c0271b5-f9a3-4fa2-bb61-47aa3f2c96b0
+      - req-46e0bd9a-7114-4fce-9e01-3872bb140f5c
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-4c0271b5-f9a3-4fa2-bb61-47aa3f2c96b0
+      - req-46e0bd9a-7114-4fce-9e01-3872bb140f5c
       Date:
-      - Thu, 25 Oct 2018 18:21:18 GMT
+      - Thu, 01 Nov 2018 18:36:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:18 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:19 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/backups/detail
@@ -16356,27 +17280,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1346862440464cab9413b733b6939f88
+      - c5583f42ad6a4028bd4cd029f23cec24
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-63bebd6f-cf8f-487c-a0e1-ece783cc1e3f
+      - req-e1ea51a7-4bcc-4b7c-acaf-95f0909df083
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-63bebd6f-cf8f-487c-a0e1-ece783cc1e3f
+      - req-e1ea51a7-4bcc-4b7c-acaf-95f0909df083
       Date:
-      - Thu, 25 Oct 2018 18:21:18 GMT
+      - Thu, 01 Nov 2018 18:36:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:18 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:19 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/backups/detail?limit=1000
@@ -16391,27 +17315,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1346862440464cab9413b733b6939f88
+      - c5583f42ad6a4028bd4cd029f23cec24
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-23af9590-1851-47a7-a28d-064e72f6cc61
+      - req-b9ab7c98-9c8d-449e-b78c-0c08770e0e38
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-23af9590-1851-47a7-a28d-064e72f6cc61
+      - req-b9ab7c98-9c8d-449e-b78c-0c08770e0e38
       Date:
-      - Thu, 25 Oct 2018 18:21:18 GMT
+      - Thu, 01 Nov 2018 18:36:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:18 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:19 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/backups/detail
@@ -16426,27 +17350,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f5457a181dda4b939d613aff7e636b27
+      - ac9804f3b1d04e58a9996b1e0cca0146
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-17dc64ec-ade5-4869-bfec-5e5ee47c5c3f
+      - req-18f8ab6b-dbd2-4ac1-9441-2b6e23166bef
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-17dc64ec-ade5-4869-bfec-5e5ee47c5c3f
+      - req-18f8ab6b-dbd2-4ac1-9441-2b6e23166bef
       Date:
-      - Thu, 25 Oct 2018 18:21:18 GMT
+      - Thu, 01 Nov 2018 18:36:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:18 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:19 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/backups/detail?limit=1000
@@ -16461,27 +17385,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f5457a181dda4b939d613aff7e636b27
+      - ac9804f3b1d04e58a9996b1e0cca0146
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-b570dedc-1fef-46da-89c1-a1029d7a7615
+      - req-4489414d-83b9-48b8-b7b1-1d100f97ba11
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-b570dedc-1fef-46da-89c1-a1029d7a7615
+      - req-4489414d-83b9-48b8-b7b1-1d100f97ba11
       Date:
-      - Thu, 25 Oct 2018 18:21:18 GMT
+      - Thu, 01 Nov 2018 18:36:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:18 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:19 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/backups/detail
@@ -16496,27 +17420,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cd218f4caea44b4cab83a6643d21d23d
+      - b7f72bfb0c9c484ba79b6daea34b350d
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-23ff4da1-f622-4e47-8c65-9405d40f145b
+      - req-c00e0b27-69f6-4b08-9ef2-cb5146f47aff
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-23ff4da1-f622-4e47-8c65-9405d40f145b
+      - req-c00e0b27-69f6-4b08-9ef2-cb5146f47aff
       Date:
-      - Thu, 25 Oct 2018 18:21:18 GMT
+      - Thu, 01 Nov 2018 18:36:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:18 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:19 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/backups/detail?limit=1000
@@ -16531,27 +17455,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cd218f4caea44b4cab83a6643d21d23d
+      - b7f72bfb0c9c484ba79b6daea34b350d
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-7393fe52-5f2a-4769-8168-45f0436ccf18
+      - req-1fbc6445-1cd3-4571-bc56-a18474a00fde
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-7393fe52-5f2a-4769-8168-45f0436ccf18
+      - req-1fbc6445-1cd3-4571-bc56-a18474a00fde
       Date:
-      - Thu, 25 Oct 2018 18:21:18 GMT
+      - Thu, 01 Nov 2018 18:36:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:18 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:19 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/types?limit=1000
@@ -16566,22 +17490,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b85769cdd65a481084dabca28af7ca2c
+      - bd97ebb4fd19470a9099c5edad0358f1
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-d7a833f1-910a-4790-9103-66343928fc83
+      - req-58dcfe26-eac0-46c8-b690-aadbd723a29f
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-d7a833f1-910a-4790-9103-66343928fc83
+      - req-58dcfe26-eac0-46c8-b690-aadbd723a29f
       Date:
-      - Thu, 25 Oct 2018 18:21:19 GMT
+      - Thu, 01 Nov 2018 18:36:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -16593,7 +17517,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:19 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:19 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/types?limit=1000&marker=0d07f8c3-f295-48c7-b632-6b7d8bd860eb
@@ -16608,22 +17532,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b85769cdd65a481084dabca28af7ca2c
+      - bd97ebb4fd19470a9099c5edad0358f1
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-9f49b49f-8483-49d2-9801-3df45aa860de
+      - req-8380beb8-1184-48c4-9b8d-d8c13f6f7e53
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-9f49b49f-8483-49d2-9801-3df45aa860de
+      - req-8380beb8-1184-48c4-9b8d-d8c13f6f7e53
       Date:
-      - Thu, 25 Oct 2018 18:21:19 GMT
+      - Thu, 01 Nov 2018 18:36:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -16635,7 +17559,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:19 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:19 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/types?limit=1000
@@ -16650,22 +17574,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1346862440464cab9413b733b6939f88
+      - c5583f42ad6a4028bd4cd029f23cec24
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-67fccc65-4783-41fe-b0b8-f1294f9f7d59
+      - req-83ef7618-5a39-4862-bf66-bfcc89a6136e
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-67fccc65-4783-41fe-b0b8-f1294f9f7d59
+      - req-83ef7618-5a39-4862-bf66-bfcc89a6136e
       Date:
-      - Thu, 25 Oct 2018 18:21:19 GMT
+      - Thu, 01 Nov 2018 18:36:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -16677,7 +17601,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:19 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:19 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/types?limit=1000&marker=0d07f8c3-f295-48c7-b632-6b7d8bd860eb
@@ -16692,22 +17616,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1346862440464cab9413b733b6939f88
+      - c5583f42ad6a4028bd4cd029f23cec24
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-81ddeb9a-feab-44f2-a9b4-58b712f6ea3c
+      - req-b752f37a-e20d-456c-8af1-7a4bd84b3a4d
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-81ddeb9a-feab-44f2-a9b4-58b712f6ea3c
+      - req-b752f37a-e20d-456c-8af1-7a4bd84b3a4d
       Date:
-      - Thu, 25 Oct 2018 18:21:19 GMT
+      - Thu, 01 Nov 2018 18:36:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -16719,7 +17643,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:19 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:20 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/types?limit=1000
@@ -16734,22 +17658,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f5457a181dda4b939d613aff7e636b27
+      - ac9804f3b1d04e58a9996b1e0cca0146
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-e807f871-b781-4712-800d-4d9a24967d7b
+      - req-9da57631-043e-45a5-9336-3fe55b94a33b
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-e807f871-b781-4712-800d-4d9a24967d7b
+      - req-9da57631-043e-45a5-9336-3fe55b94a33b
       Date:
-      - Thu, 25 Oct 2018 18:21:19 GMT
+      - Thu, 01 Nov 2018 18:36:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -16761,7 +17685,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:19 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:20 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/types?limit=1000&marker=0d07f8c3-f295-48c7-b632-6b7d8bd860eb
@@ -16776,22 +17700,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f5457a181dda4b939d613aff7e636b27
+      - ac9804f3b1d04e58a9996b1e0cca0146
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-1dbf1943-00cb-489a-b6c6-db0657cd8dc8
+      - req-8bfe63f3-5893-42bc-9a9d-eaa58e828d8b
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-1dbf1943-00cb-489a-b6c6-db0657cd8dc8
+      - req-8bfe63f3-5893-42bc-9a9d-eaa58e828d8b
       Date:
-      - Thu, 25 Oct 2018 18:21:19 GMT
+      - Thu, 01 Nov 2018 18:36:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -16803,7 +17727,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:19 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:20 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/types?limit=1000
@@ -16818,22 +17742,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cd218f4caea44b4cab83a6643d21d23d
+      - b7f72bfb0c9c484ba79b6daea34b350d
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-d418becb-9a5b-4fd0-9a3d-c24bac759318
+      - req-1febd276-0631-467a-a7f5-a09c06ee9857
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-d418becb-9a5b-4fd0-9a3d-c24bac759318
+      - req-1febd276-0631-467a-a7f5-a09c06ee9857
       Date:
-      - Thu, 25 Oct 2018 18:21:19 GMT
+      - Thu, 01 Nov 2018 18:36:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -16845,7 +17769,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:19 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:20 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/types?limit=1000&marker=0d07f8c3-f295-48c7-b632-6b7d8bd860eb
@@ -16860,22 +17784,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cd218f4caea44b4cab83a6643d21d23d
+      - b7f72bfb0c9c484ba79b6daea34b350d
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-0a6578d7-b124-466d-a7ff-4e18f25dd856
+      - req-b3b3309a-a1b1-4112-9361-01a261105493
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-0a6578d7-b124-466d-a7ff-4e18f25dd856
+      - req-b3b3309a-a1b1-4112-9361-01a261105493
       Date:
-      - Thu, 25 Oct 2018 18:21:19 GMT
+      - Thu, 01 Nov 2018 18:36:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -16887,7 +17811,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:19 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:20 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -16905,13 +17829,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:21:19 GMT
+      - Thu, 01 Nov 2018 18:36:20 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-d33e5c0e-c869-4595-aa77-d0900e1bcf27
+      - req-792b80dc-e5ed-4c71-b26b-de75d69df098
       Content-Length:
       - '4170'
       Connection:
@@ -16920,10 +17844,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:20.020618", "expires":
-        "2018-10-25T19:21:20Z", "id": "6ecd103974dc4346ab70d9aa403d12f6", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:36:20.728181", "expires":
+        "2018-11-01T19:36:20Z", "id": "614ca61ffb31498289f796278d272de4", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["a7iJ5eSjQm2J3nJstUk-oA"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["yX5M2uBpQN2Py_cJwwCmtw"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -16968,7 +17892,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:20 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:20 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -16986,13 +17910,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:21:20 GMT
+      - Thu, 01 Nov 2018 18:36:20 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-e5b6193d-9f8d-438f-83c5-4a7274942c46
+      - req-e41d978f-8d60-428b-a993-37620f2b510c
       Content-Length:
       - '4170'
       Connection:
@@ -17001,10 +17925,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:20.208416", "expires":
-        "2018-10-25T19:21:20Z", "id": "8973904b93774e9a93c28a718f7d32b2", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:36:20.926221", "expires":
+        "2018-11-01T19:36:20Z", "id": "332608de26d34a7084b82f0a9d9dbf4f", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["jsEvT4ifRjumJ-npQZmFFw"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["NnRR_tVkS3qeFd_C0muDRQ"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -17049,7 +17973,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:20 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:20 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -17067,13 +17991,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:21:20 GMT
+      - Thu, 01 Nov 2018 18:36:21 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-b12cdd39-7af4-453c-83a3-a794032b85a3
+      - req-cc8737ea-768a-474c-b680-b433ed475168
       Content-Length:
       - '370'
       Connection:
@@ -17082,13 +18006,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:20.362404", "expires":
-        "2018-10-25T19:21:20Z", "id": "67fefa2f75184d658544b15708283729", "audit_ids":
-        ["JWPlqlpTT9iHDlW3wWeeew"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:36:21.096829", "expires":
+        "2018-11-01T19:36:21Z", "id": "5ad22b3074c5453e90f44b51acbc38f9", "audit_ids":
+        ["9LQluBJ5Qdi0RQNrmezCzQ"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:20 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:21 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -17103,20 +18027,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 67fefa2f75184d658544b15708283729
+      - 5ad22b3074c5453e90f44b51acbc38f9
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:21:20 GMT
+      - Thu, 01 Nov 2018 18:36:21 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-15be26df-ee31-45b3-a57c-b79c10882066
+      - req-6c511a0c-1110-43b6-b32e-98aeb5ac73b5
       Content-Length:
       - '500'
       Connection:
@@ -17133,7 +18057,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:20 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:21 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -17151,13 +18075,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:21:20 GMT
+      - Thu, 01 Nov 2018 18:36:21 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-f6804615-ce33-4045-9dea-3756e51e5cd9
+      - req-bf6ae8b8-3b68-4b3c-bb52-b9d0fddb4e8b
       Content-Length:
       - '4117'
       Connection:
@@ -17166,10 +18090,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:20.666144", "expires":
-        "2018-10-25T19:21:20Z", "id": "bcb8078777554cd7a54d65367304c3fe", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:36:21.438768", "expires":
+        "2018-11-01T19:36:21Z", "id": "1b3e53d51911434ea1314023c820cb60", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["RvWWutrZQA-pD3rmm5auMg"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["hmQbCBzyQt69PmR3wMCr0w"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -17213,7 +18137,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:20 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:21 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -17231,13 +18155,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:21:20 GMT
+      - Thu, 01 Nov 2018 18:36:21 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-d8cd641c-ed7e-4a74-9a30-cbe8a309ca73
+      - req-32c7addb-c19a-4e5d-a442-18c6dd3e1bfb
       Content-Length:
       - '4131'
       Connection:
@@ -17246,10 +18170,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:20.847017", "expires":
-        "2018-10-25T19:21:20Z", "id": "43305d2c02cc466f842471736326af86", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:36:21.639280", "expires":
+        "2018-11-01T19:36:21Z", "id": "6453c548a30d4e038d74bc09054f7b49", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["MtJsTRsfRXWHJj5tVUHt8A"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["gEX67fo_RcyVygneMIEcaA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -17293,7 +18217,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:20 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:21 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -17311,13 +18235,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:21:20 GMT
+      - Thu, 01 Nov 2018 18:36:21 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-61bfbe89-a883-4cdd-990c-621ba5654f5c
+      - req-b71ebaa9-867d-4abc-9f57-8fd0588f8913
       Content-Length:
       - '4118'
       Connection:
@@ -17326,10 +18250,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:21.032452", "expires":
-        "2018-10-25T19:21:21Z", "id": "6b8753aab5a148d69026ceabe73c4dd1", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:36:21.838809", "expires":
+        "2018-11-01T19:36:21Z", "id": "e58bea72565b4f25980e272f758b703a", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["kBMrsH4IQnOgFPyrA-XATA"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["JU2W7ubWTECwit5LeAQCiA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -17373,7 +18297,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:21 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:21 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -17391,13 +18315,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:21:21 GMT
+      - Thu, 01 Nov 2018 18:36:21 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-45126859-cdcf-444d-bca0-065be568485c
+      - req-660e308f-64e3-455e-84f0-79b7b97cc34a
       Content-Length:
       - '4117'
       Connection:
@@ -17406,10 +18330,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:21.216453", "expires":
-        "2018-10-25T19:21:21Z", "id": "7669184884184863b094d71cf7ee2b49", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:36:22.047743", "expires":
+        "2018-11-01T19:36:22Z", "id": "52a614d765154aa2804c64af67a4e39c", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["sSBI_6HjQ0-zL4mevH3kYQ"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["USZoopZfTdaqzzUSJFrgug"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -17453,7 +18377,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:21 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:22 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/?format=json&limit=1000
@@ -17468,7 +18392,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7669184884184863b094d71cf7ee2b49
+      - 52a614d765154aa2804c64af67a4e39c
   response:
     status:
       code: 200
@@ -17497,15 +18421,15 @@ http_interactions:
       X-Account-Project-Domain-Id:
       - default
       X-Trans-Id:
-      - txf35748f09ffa4551b8e32-005bd209a1
+      - tx416c515f289b46a8b92f4-005bdb47a6
       Date:
-      - Thu, 25 Oct 2018 18:21:21 GMT
+      - Thu, 01 Nov 2018 18:36:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '[{"count": 3, "bytes": 33, "name": "dir_1"}, {"count": 0, "bytes":
         0, "name": "dir_2"}, {"count": 0, "bytes": 0, "name": "dir_3"}]'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:21 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:22 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/?format=json&limit=1000&marker=dir_3
@@ -17520,7 +18444,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7669184884184863b094d71cf7ee2b49
+      - 52a614d765154aa2804c64af67a4e39c
   response:
     status:
       code: 200
@@ -17549,14 +18473,14 @@ http_interactions:
       X-Account-Project-Domain-Id:
       - default
       X-Trans-Id:
-      - tx680e9a2554ba4d3aad091-005bd209a1
+      - tx14c6f57b49b441649d33a-005bdb47a6
       Date:
-      - Thu, 25 Oct 2018 18:21:21 GMT
+      - Thu, 01 Nov 2018 18:36:22 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:21 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:22 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -17574,13 +18498,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:21:21 GMT
+      - Thu, 01 Nov 2018 18:36:22 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-fccf97f5-0de0-4217-bf56-5c9402093da7
+      - req-319e51b1-9962-42a9-9593-2939ac641b54
       Content-Length:
       - '4131'
       Connection:
@@ -17589,10 +18513,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:21.652846", "expires":
-        "2018-10-25T19:21:21Z", "id": "97ae1d29ff4240d39f7d22ca885a8421", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:36:22.536076", "expires":
+        "2018-11-01T19:36:22Z", "id": "0060aa1acee24c859bca6dfcaf558127", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["7TYmioPGSfqqU0hsU1gs7A"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["JHjZXmBeTLyO-BWeo66BHg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -17636,7 +18560,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:21 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:22 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_b458a5c25c3749758f4c0661940b3ba8/?format=json&limit=1000
@@ -17651,7 +18575,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 97ae1d29ff4240d39f7d22ca885a8421
+      - 0060aa1acee24c859bca6dfcaf558127
   response:
     status:
       code: 200
@@ -17664,22 +18588,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1540491681.81852'
+      - '1541097382.69077'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1540491681.81852'
+      - '1541097382.69077'
       X-Trans-Id:
-      - txbcbdaa303c104042a6a2a-005bd209a1
+      - txbfafe3abc3454e0fbe996-005bdb47a6
       Date:
-      - Thu, 25 Oct 2018 18:21:21 GMT
+      - Thu, 01 Nov 2018 18:36:22 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:21 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:22 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_e54e5c3c19e34720b05661f2ea1ea00a/?format=json&limit=1000
@@ -17694,7 +18618,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8973904b93774e9a93c28a718f7d32b2
+      - 332608de26d34a7084b82f0a9d9dbf4f
   response:
     status:
       code: 200
@@ -17707,22 +18631,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1540491681.96666'
+      - '1541097382.84374'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1540491681.96666'
+      - '1541097382.84374'
       X-Trans-Id:
-      - txcd7fd240686c40cd8644f-005bd209a1
+      - txee16acc54f974fde8e388-005bdb47a6
       Date:
-      - Thu, 25 Oct 2018 18:21:21 GMT
+      - Thu, 01 Nov 2018 18:36:22 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:21 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:22 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -17740,13 +18664,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:21:22 GMT
+      - Thu, 01 Nov 2018 18:36:23 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-ec3cd258-90d6-4c58-9dec-7ca7d0fa8451
+      - req-09e9b838-5bf8-4724-b6f1-5535185b01f4
       Content-Length:
       - '4118'
       Connection:
@@ -17755,10 +18679,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:22.145889", "expires":
-        "2018-10-25T19:21:22Z", "id": "691b20f1c95d42c4a8a1485ba69fbd20", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:36:23.055992", "expires":
+        "2018-11-01T19:36:23Z", "id": "f86e035138574a929a87d100c1d3b820", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["S7JWWsTYQ6iqITvLWY7MNg"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["P7a1xbWiTR-OIKEe2DFDnw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -17802,7 +18726,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:22 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:23 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_e8f744b1fc6a487681d35fb275252608/?format=json&limit=1000
@@ -17817,7 +18741,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 691b20f1c95d42c4a8a1485ba69fbd20
+      - f86e035138574a929a87d100c1d3b820
   response:
     status:
       code: 200
@@ -17830,22 +18754,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1540491682.30539'
+      - '1541097383.22101'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1540491682.30539'
+      - '1541097383.22101'
       X-Trans-Id:
-      - tx16b16ea1c03f489a8bf1a-005bd209a2
+      - tx47167fcaf66c4fa38ed79-005bdb47a7
       Date:
-      - Thu, 25 Oct 2018 18:21:22 GMT
+      - Thu, 01 Nov 2018 18:36:23 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:22 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:23 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/dir_1?format=json
@@ -17860,7 +18784,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7669184884184863b094d71cf7ee2b49
+      - 52a614d765154aa2804c64af67a4e39c
   response:
     status:
       code: 200
@@ -17881,9 +18805,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - tx4def278ec8a3432b87975-005bd209a2
+      - tx41f52ec99f6742379e593-005bdb47a7
       Date:
-      - Thu, 25 Oct 2018 18:21:22 GMT
+      - Thu, 01 Nov 2018 18:36:23 GMT
     body:
       encoding: ASCII-8BIT
       string: '[{"hash": "61257bf228e2f6802a196c9a460d19a8", "last_modified": "2016-11-11T13:50:03.869630",
@@ -17893,7 +18817,7 @@ http_interactions:
         {"hash": "1727a9b61bddf85bbe7a5710c9f45691", "last_modified": "2016-11-11T13:50:04.495640",
         "bytes": 11, "name": "file_3", "content_type": "application/octet-stream"}]'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:22 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:23 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/dir_2?format=json
@@ -17908,7 +18832,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7669184884184863b094d71cf7ee2b49
+      - 52a614d765154aa2804c64af67a4e39c
   response:
     status:
       code: 200
@@ -17929,14 +18853,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - tx13677c73b4084bdcbea51-005bd209a2
+      - tx98ccf43efd8647278ae50-005bdb47a7
       Date:
-      - Thu, 25 Oct 2018 18:21:22 GMT
+      - Thu, 01 Nov 2018 18:36:23 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:22 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:23 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/dir_3?format=json
@@ -17951,7 +18875,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7669184884184863b094d71cf7ee2b49
+      - 52a614d765154aa2804c64af67a4e39c
   response:
     status:
       code: 200
@@ -17972,14 +18896,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - txced2c36fd078497e9ffb0-005bd209a2
+      - txb9593e275bf94686bab30-005bdb47a7
       Date:
-      - Thu, 25 Oct 2018 18:21:22 GMT
+      - Thu, 01 Nov 2018 18:36:23 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:22 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:23 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/networks/20af6027-7aeb-432a-ab3b-d7217faa2f1c
@@ -17994,7 +18918,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1cd59edbcf224e6db6ef06e72bc7d90f
+      - 63656ee4958c4f0880a963dd3df5dc87
   response:
     status:
       code: 200
@@ -18005,9 +18929,9 @@ http_interactions:
       Content-Length:
       - '409'
       X-Openstack-Request-Id:
-      - req-65cf698f-1fdd-40d1-9956-1a81db6a1265
+      - req-f533af62-9515-45fa-b517-e5bcdcaea192
       Date:
-      - Thu, 25 Oct 2018 18:21:22 GMT
+      - Thu, 01 Nov 2018 18:36:23 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"network": {"status": "ACTIVE", "subnets": ["33da95a6-bded-44d8-be36-6cc97f3d72bd"],
@@ -18017,7 +18941,7 @@ http_interactions:
         "id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "provider:segmentation_id":
         null}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:22 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:23 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -18032,7 +18956,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - aef0c103e73b4b7e8e3cb8fefcfb3b94
+      - 9f190cd0c6b548318b10b08174b7622d
   response:
     status:
       code: 200
@@ -18043,545 +18967,35 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-3aafb83e-49a7-4d00-ae47-75feb88cc46e
+      - req-c0769823-f3a8-41a1-83cf-bf5677bcfb83
       Date:
-      - Thu, 25 Oct 2018 18:21:22 GMT
+      - Thu, 01 Nov 2018 18:36:23 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.50.4", "end": "192.168.50.4"}, {"start":
-        "192.168.50.2", "end": "192.168.50.2"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
-        false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
-        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:23 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - aef0c103e73b4b7e8e3cb8fefcfb3b94
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-20f4e979-7027-4f73-8ca3-4e5d66837b82
-      Date:
-      - Thu, 25 Oct 2018 18:21:23 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:23 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - fe0510d9d93f4ffdb2389d1acb3f1325
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-f5049700-f3f6-44a9-b8dc-808d09d66567
-      Date:
-      - Thu, 25 Oct 2018 18:21:23 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:23 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - fe0510d9d93f4ffdb2389d1acb3f1325
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-de86f432-9824-43d9-9b42-2207c89ff884
-      Date:
-      - Thu, 25 Oct 2018 18:21:23 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
-        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.4",
-        "end": "192.168.50.4"}, {"start": "192.168.50.2", "end": "192.168.50.2"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
-        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.20.0/24", "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
-        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
         false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
         "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:23 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 1cd59edbcf224e6db6ef06e72bc7d90f
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-3950406b-2b76-44e2-a91e-3c97e3b993fe
-      Date:
-      - Thu, 25 Oct 2018 18:21:23 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.50.4", "end": "192.168.50.4"}, {"start":
-        "192.168.50.2", "end": "192.168.50.2"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2",
+        "end": "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
         true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
@@ -18646,24 +19060,6 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
         "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
-        false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
-        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
@@ -18677,7 +19073,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:23 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:23 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
@@ -18692,7 +19088,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1cd59edbcf224e6db6ef06e72bc7d90f
+      - 9f190cd0c6b548318b10b08174b7622d
   response:
     status:
       code: 200
@@ -18703,231 +19099,99 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-abcbece9-fec7-43bb-8573-ecc318ed10cc
+      - req-4d6954fa-3aa8-48ab-9b66-33c783e302a2
       Date:
-      - Thu, 25 Oct 2018 18:21:23 GMT
+      - Thu, 01 Nov 2018 18:36:24 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:23 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 43c0d89129c1435a914bf45c29d2710d
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-473f05ec-34a4-4aa0-86ac-eb5548f29821
-      Date:
-      - Thu, 25 Oct 2018 18:21:23 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
-        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.4",
-        "end": "192.168.50.4"}, {"start": "192.168.50.2", "end": "192.168.50.2"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
-        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.20.0/24", "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
-        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
         false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
         "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2",
+        "end": "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
@@ -18941,7 +19205,139 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:23 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:24 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 5b85947db8fe4f1fba27ef99068eb04f
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-16aed951-bf2d-4d6f-85be-ac98bd19f668
+      Date:
+      - Thu, 01 Nov 2018 18:36:24 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2",
+        "end": "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 01 Nov 2018 18:36:24 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
@@ -18956,7 +19352,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 43c0d89129c1435a914bf45c29d2710d
+      - 5b85947db8fe4f1fba27ef99068eb04f
   response:
     status:
       code: 200
@@ -18967,9 +19363,9 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-37575096-6d80-4e63-9c7f-f41f619a82be
+      - req-c8d43c60-092d-4db7-bd0b-4106de80a9b0
       Date:
-      - Thu, 25 Oct 2018 18:21:24 GMT
+      - Thu, 01 Nov 2018 18:36:24 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
@@ -19060,6 +19456,138 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
         "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 01 Nov 2018 18:36:24 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 5b85947db8fe4f1fba27ef99068eb04f
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-ca27cd9a-3d28-430e-a77f-8fce19dbd864
+      Date:
+      - Thu, 01 Nov 2018 18:36:24 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2",
+        "end": "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
@@ -19073,5 +19601,665 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:24 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:24 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 5b85947db8fe4f1fba27ef99068eb04f
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-4bc4e727-0e40-4c93-90df-6d4186985bef
+      Date:
+      - Thu, 01 Nov 2018 18:36:24 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2",
+        "end": "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 01 Nov 2018 18:36:24 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 63656ee4958c4f0880a963dd3df5dc87
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-9c150a08-e2f8-421a-864b-dd60505f3587
+      Date:
+      - Thu, 01 Nov 2018 18:36:24 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2",
+        "end": "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 01 Nov 2018 18:36:24 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 63656ee4958c4f0880a963dd3df5dc87
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-f2f30330-1d9b-4371-b20d-5ea7c663d7e7
+      Date:
+      - Thu, 01 Nov 2018 18:36:25 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2",
+        "end": "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 01 Nov 2018 18:36:25 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - cf0e9ebfafdc4b1eb2bcb173674892d9
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-cb17f5fc-bfb8-4391-a8cd-112dec2702da
+      Date:
+      - Thu, 01 Nov 2018 18:36:25 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2",
+        "end": "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 01 Nov 2018 18:36:25 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - cf0e9ebfafdc4b1eb2bcb173674892d9
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-fdf09cc7-60ce-4ffb-945b-64f2ec21d0ce
+      Date:
+      - Thu, 01 Nov 2018 18:36:25 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2",
+        "end": "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 01 Nov 2018 18:36:25 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_port_targeted_refresh.yml
+++ b/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_port_targeted_refresh.yml
@@ -17,13 +17,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:21:35 GMT
+      - Thu, 01 Nov 2018 18:36:26 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-3c917584-f066-435f-99b1-1be4452a5f75
+      - req-232e4758-bbef-43b0-8b90-1b9f1eb12750
       Content-Length:
       - '4170'
       Connection:
@@ -32,10 +32,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:35.446459", "expires":
-        "2018-10-25T19:21:35Z", "id": "543db57a65e44b0fa7821c7948666f9a", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:36:26.461510", "expires":
+        "2018-11-01T19:36:26Z", "id": "7dde903e7a914b4dba9bdab02e20b550", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["avfnouqUTzujyiLK2Fpitw"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["xdsZ4wfcQF6qx7kH72zc3g"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -80,7 +80,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:35 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:26 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -95,7 +95,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 543db57a65e44b0fa7821c7948666f9a
+      - 7dde903e7a914b4dba9bdab02e20b550
   response:
     status:
       code: 200
@@ -106,7 +106,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Thu, 25 Oct 2018 18:21:35 GMT
+      - Thu, 01 Nov 2018 18:36:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -115,7 +115,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:35 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:26 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -133,13 +133,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:21:35 GMT
+      - Thu, 01 Nov 2018 18:36:26 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-93a8040e-1795-497e-8fc3-c6a55d0ec43a
+      - req-21ff0642-47fe-42e6-be95-74e3792b69ee
       Content-Length:
       - '4170'
       Connection:
@@ -148,10 +148,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:35.706780", "expires":
-        "2018-10-25T19:21:35Z", "id": "28daed0598044840bca27d756dd13dc2", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:36:26.748691", "expires":
+        "2018-11-01T19:36:26Z", "id": "8d70faaeffb940b0b1e061340a3c5d64", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["ovh9GvZOTE-onbmEF-KSyw"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["RdTAcMhDSny1euibg_34mg"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -196,7 +196,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:35 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:26 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -214,13 +214,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:21:35 GMT
+      - Thu, 01 Nov 2018 18:36:26 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-c2041df4-c012-489c-bd77-6f9dd5c903c9
+      - req-6f5b4a5e-ced6-45ba-84a5-2f345df48ed3
       Content-Length:
       - '370'
       Connection:
@@ -229,13 +229,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:35.865556", "expires":
-        "2018-10-25T19:21:35Z", "id": "477cc52733d045ae9b73e6dea13a5829", "audit_ids":
-        ["P0kbfbXlR82KDfqgolkpVw"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:36:26.909855", "expires":
+        "2018-11-01T19:36:26Z", "id": "0d486495676c4db1ae0b6362c05868b6", "audit_ids":
+        ["sjy3d4GMRtiNBcGo67I8qg"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:35 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:26 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -250,20 +250,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 477cc52733d045ae9b73e6dea13a5829
+      - 0d486495676c4db1ae0b6362c05868b6
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:21:35 GMT
+      - Thu, 01 Nov 2018 18:36:27 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-b0185b53-08f5-4517-8281-f86b9d0dbf66
+      - req-90bf4e8d-6e26-4272-98bc-0744293def83
       Content-Length:
       - '500'
       Connection:
@@ -280,7 +280,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:36 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:27 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -298,13 +298,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:21:36 GMT
+      - Thu, 01 Nov 2018 18:36:27 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-74dc1158-328c-47a9-8dc3-6eb30112ed5a
+      - req-5a7c201c-9055-4872-8e13-635c3b2118c5
       Content-Length:
       - '4117'
       Connection:
@@ -313,10 +313,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:36.171413", "expires":
-        "2018-10-25T19:21:36Z", "id": "e9dca4dca12d447e85fa2b511b90dac0", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:36:27.228842", "expires":
+        "2018-11-01T19:36:27Z", "id": "fbc075e2b97b40878a6c6d5abfba1afc", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["X7HvSYbKRZiB6cnPDkaBVQ"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["YNn6XKYzRxCvlbo1NFDIkw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -360,7 +360,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:36 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:27 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -375,7 +375,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e9dca4dca12d447e85fa2b511b90dac0
+      - fbc075e2b97b40878a6c6d5abfba1afc
   response:
     status:
       code: 200
@@ -386,7 +386,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Thu, 25 Oct 2018 18:21:36 GMT
+      - Thu, 01 Nov 2018 18:36:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -395,7 +395,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:36 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:27 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -413,13 +413,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:21:36 GMT
+      - Thu, 01 Nov 2018 18:36:27 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-0e76bb77-d36b-4196-ba62-8e9d6e97063d
+      - req-621e40e5-1972-49b1-9ea1-20ba3b2912b2
       Content-Length:
       - '4131'
       Connection:
@@ -428,10 +428,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:36.442279", "expires":
-        "2018-10-25T19:21:36Z", "id": "5eafda06977544e8b95f7105ffbe0643", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:36:27.505014", "expires":
+        "2018-11-01T19:36:27Z", "id": "4ad203925c4040978d5c34de19b79d8d", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["xld8jTNWTKCn68Z0RAIEJA"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["pLQFFIu2R5K9tbpcDf8Oog"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -475,7 +475,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:36 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:27 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -490,7 +490,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5eafda06977544e8b95f7105ffbe0643
+      - 4ad203925c4040978d5c34de19b79d8d
   response:
     status:
       code: 200
@@ -501,7 +501,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Thu, 25 Oct 2018 18:21:36 GMT
+      - Thu, 01 Nov 2018 18:36:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -510,7 +510,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:36 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:27 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -528,13 +528,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:21:36 GMT
+      - Thu, 01 Nov 2018 18:36:27 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-55afd107-f271-419b-9d7e-0bc1db3679e9
+      - req-2aead655-aa7b-4f8e-ae3a-499279318cb6
       Content-Length:
       - '4118'
       Connection:
@@ -543,10 +543,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:36.701153", "expires":
-        "2018-10-25T19:21:36Z", "id": "7af767ef40e949abae57b8e564968d36", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:36:27.783253", "expires":
+        "2018-11-01T19:36:27Z", "id": "5cf2d77da5f94a94822b362e63d35204", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["wq5sDPybRwap4dVXk0H64g"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["hmbxcdtUQ5eX0ES3YJjpEg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -590,7 +590,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:36 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:27 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -605,7 +605,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7af767ef40e949abae57b8e564968d36
+      - 5cf2d77da5f94a94822b362e63d35204
   response:
     status:
       code: 200
@@ -616,7 +616,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Thu, 25 Oct 2018 18:21:36 GMT
+      - Thu, 01 Nov 2018 18:36:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -625,7 +625,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:36 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:27 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -643,13 +643,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:21:36 GMT
+      - Thu, 01 Nov 2018 18:36:28 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-69ed5e78-43b8-408d-825d-822460b30fd2
+      - req-011522c3-55ae-4388-81e6-26db62abc265
       Content-Length:
       - '4117'
       Connection:
@@ -658,10 +658,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:36.959608", "expires":
-        "2018-10-25T19:21:36Z", "id": "7f4b1049f7484cedb463bb29d3ad2473", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:36:28.072350", "expires":
+        "2018-11-01T19:36:28Z", "id": "ea138824b3204fe4b0e14244eac1b45a", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["CL1zRdecQ--zHyoXXX3SXQ"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["4fLM03bQSYaYlDELh77IUA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -705,7 +705,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:36 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:28 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -720,7 +720,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7f4b1049f7484cedb463bb29d3ad2473
+      - ea138824b3204fe4b0e14244eac1b45a
   response:
     status:
       code: 200
@@ -731,625 +731,35 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-bbc275bd-8466-46c9-a77f-99fb688fde10
+      - req-8d331385-8350-46d3-bfb8-352458259e74
       Date:
-      - Thu, 25 Oct 2018 18:21:37 GMT
+      - Thu, 01 Nov 2018 18:36:28 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:37 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 7f4b1049f7484cedb463bb29d3ad2473
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-4e68ce13-451e-498d-8946-72cd26f45e48
-      Date:
-      - Thu, 25 Oct 2018 18:21:37 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.50.4", "end": "192.168.50.4"}, {"start":
-        "192.168.50.2", "end": "192.168.50.2"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
-        false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
-        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:37 GMT
-- request:
-    method: post
-    uri: http://11.22.33.44:5000/v2.0/tokens
-    body:
-      encoding: UTF-8
-      string: '{"auth":{"passwordCredentials":{"username":"admin","password":"password_2WpEraURh"},"tenantName":"EmsRefreshSpec-Project-No-Admin-Role"}}'
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 25 Oct 2018 18:21:37 GMT
-      Server:
-      - Apache/2.4.6 (Red Hat Enterprise Linux)
-      Vary:
-      - X-Auth-Token,Accept-Encoding
-      X-Openstack-Request-Id:
-      - req-0217f29a-17f1-43af-9494-fb289b2626b6
-      Content-Length:
-      - '4131'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:37.520305", "expires":
-        "2018-10-25T19:21:37Z", "id": "0a761362be3c41c3b1ada73ccb56fa75", "tenant":
-        {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["MdPScXXNTlSWtwxcqLIbpA"]},
-        "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
-        "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
-        "endpoints_links": [], "type": "compute", "name": "nova"}, {"endpoints": [{"adminURL":
-        "http://10.8.99.233:9696", "region": "RegionOne", "internalURL": "http://10.8.99.233:9696",
-        "id": "5b097055aff24a40aa4cd2d7317c9108", "publicURL": "http://10.8.99.233:9696"}],
-        "endpoints_links": [], "type": "network", "name": "neutron"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8",
-        "id": "13c4208d548d4bcdaedfe8296b6559ee", "publicURL": "http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8"}],
-        "endpoints_links": [], "type": "volumev2", "name": "cinderv2"}, {"endpoints":
-        [{"adminURL": "http://127.0.0.1:8774/v3", "region": "RegionOne", "internalURL":
-        "http://127.0.0.1:8774/v3", "id": "3874f107e1a0461596883a12743dbcc0", "publicURL":
-        "http://127.0.0.1:8774/v3"}], "endpoints_links": [], "type": "computev3",
-        "name": "novav3"}, {"endpoints": [{"adminURL": "http://10.8.99.233:9292",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:9292", "id": "75fcb24891654062ae1703e6b92f6018",
-        "publicURL": "http://10.8.99.233:9292"}], "endpoints_links": [], "type": "image",
-        "name": "glance"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8777",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8777", "id": "2c972a2880d1453aad86104dcda88a55",
-        "publicURL": "http://10.8.99.233:8777"}], "endpoints_links": [], "type": "metering",
-        "name": "ceilometer"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8776/v1/b458a5c25c3749758f4c0661940b3ba8",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v1/b458a5c25c3749758f4c0661940b3ba8",
-        "id": "410c753013fb430c9998f22f68c4cb18", "publicURL": "http://10.8.99.233:8776/v1/b458a5c25c3749758f4c0661940b3ba8"}],
-        "endpoints_links": [], "type": "volume", "name": "cinder"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8773/services/Admin", "region": "RegionOne",
-        "internalURL": "http://10.8.99.233:8773/services/Cloud", "id": "2833b001aa814ddf9216479d379cdac1",
-        "publicURL": "http://10.8.99.233:8773/services/Cloud"}], "endpoints_links":
-        [], "type": "ec2", "name": "nova_ec2"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8004/v1/b458a5c25c3749758f4c0661940b3ba8",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8004/v1/b458a5c25c3749758f4c0661940b3ba8",
-        "id": "a29a931a5667478c8b3724506a286144", "publicURL": "http://10.8.99.233:8004/v1/b458a5c25c3749758f4c0661940b3ba8"}],
-        "endpoints_links": [], "type": "orchestration", "name": "heat"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8080", "region": "RegionOne", "internalURL":
-        "http://10.8.99.233:8080/v1/AUTH_b458a5c25c3749758f4c0661940b3ba8", "id":
-        "7a2262abf515414ea08b3beedc87e51e", "publicURL": "http://10.8.99.233:8080/v1/AUTH_b458a5c25c3749758f4c0661940b3ba8"}],
-        "endpoints_links": [], "type": "object-store", "name": "swift"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:35357/v2.0", "region": "RegionOne", "internalURL":
-        "http://10.8.99.233:5000/v2.0", "id": "5d1b7edf24e14ce29abaeee69e84e529",
-        "publicURL": "http://10.8.99.233:5000/v2.0"}], "endpoints_links": [], "type":
-        "identity", "name": "keystone"}], "user": {"username": "admin", "roles_links":
-        [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
-        {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
-        0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:37 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 0a761362be3c41c3b1ada73ccb56fa75
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-e0a30e3e-3fdb-4ce7-8bb6-18b93c73fa2b
-      Date:
-      - Thu, 25 Oct 2018 18:21:37 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:37 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 0a761362be3c41c3b1ada73ccb56fa75
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-06a3c0f0-4152-480e-b770-e5d0aca952a5
-      Date:
-      - Thu, 25 Oct 2018 18:21:37 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
-        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.4",
-        "end": "192.168.50.4"}, {"start": "192.168.50.2", "end": "192.168.50.2"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
-        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.20.0/24", "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
-        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
         false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
         "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:37 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 28daed0598044840bca27d756dd13dc2
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-26fa68fb-e41b-4188-96a7-c3cd62b367db
-      Date:
-      - Thu, 25 Oct 2018 18:21:38 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.50.4", "end": "192.168.50.4"}, {"start":
-        "192.168.50.2", "end": "192.168.50.2"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2",
+        "end": "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
         true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
@@ -1414,24 +824,6 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
         "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
-        false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
-        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
@@ -1445,7 +837,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:38 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:28 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
@@ -1460,7 +852,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 28daed0598044840bca27d756dd13dc2
+      - ea138824b3204fe4b0e14244eac1b45a
   response:
     status:
       code: 200
@@ -1471,17 +863,52 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-ca3f356e-3608-4d7b-8985-f8565cce8451
+      - req-668060f8-31ba-46f1-8347-216d3b048de0
       Date:
-      - Thu, 25 Oct 2018 18:21:38 GMT
+      - Thu, 01 Nov 2018 18:36:28 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
@@ -1501,6 +928,97 @@ http_interactions:
         "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
         "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 01 Nov 2018 18:36:28 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - ea138824b3204fe4b0e14244eac1b45a
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-11e467e1-d520-4670-a798-17ad23ef7a99
+      Date:
+      - Thu, 01 Nov 2018 18:36:28 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2",
+        "end": "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
         "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
@@ -1553,6 +1071,12 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
         "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
         "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
@@ -1577,7 +1101,1011 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:38 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:28 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - ea138824b3204fe4b0e14244eac1b45a
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-5fd7c540-e621-469c-9268-e26b7dd68d37
+      Date:
+      - Thu, 01 Nov 2018 18:36:28 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 01 Nov 2018 18:36:28 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - ea138824b3204fe4b0e14244eac1b45a
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-8a195a55-73b4-4ec0-93b2-f6024714f7ac
+      Date:
+      - Thu, 01 Nov 2018 18:36:28 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2",
+        "end": "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 01 Nov 2018 18:36:29 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - ea138824b3204fe4b0e14244eac1b45a
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-f5b96a2b-b9ae-468a-8039-ade3d1b5e239
+      Date:
+      - Thu, 01 Nov 2018 18:36:29 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2",
+        "end": "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 01 Nov 2018 18:36:29 GMT
+- request:
+    method: post
+    uri: http://11.22.33.44:5000/v2.0/tokens
+    body:
+      encoding: UTF-8
+      string: '{"auth":{"passwordCredentials":{"username":"admin","password":"password_2WpEraURh"},"tenantName":"EmsRefreshSpec-Project-No-Admin-Role"}}'
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 01 Nov 2018 18:36:29 GMT
+      Server:
+      - Apache/2.4.6 (Red Hat Enterprise Linux)
+      Vary:
+      - X-Auth-Token,Accept-Encoding
+      X-Openstack-Request-Id:
+      - req-9e75aa0e-9436-48ea-afce-c94955368e34
+      Content-Length:
+      - '4131'
+      Connection:
+      - close
+      Content-Type:
+      - application/json
+    body:
+      encoding: ASCII-8BIT
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:36:29.339584", "expires":
+        "2018-11-01T19:36:29Z", "id": "60de57ca49554ffda1d3b45b3ca20998", "tenant":
+        {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["K52rKYu-RUqHwIQbNOiaVA"]},
+        "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
+        "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
+        "endpoints_links": [], "type": "compute", "name": "nova"}, {"endpoints": [{"adminURL":
+        "http://10.8.99.233:9696", "region": "RegionOne", "internalURL": "http://10.8.99.233:9696",
+        "id": "5b097055aff24a40aa4cd2d7317c9108", "publicURL": "http://10.8.99.233:9696"}],
+        "endpoints_links": [], "type": "network", "name": "neutron"}, {"endpoints":
+        [{"adminURL": "http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8",
+        "id": "13c4208d548d4bcdaedfe8296b6559ee", "publicURL": "http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8"}],
+        "endpoints_links": [], "type": "volumev2", "name": "cinderv2"}, {"endpoints":
+        [{"adminURL": "http://127.0.0.1:8774/v3", "region": "RegionOne", "internalURL":
+        "http://127.0.0.1:8774/v3", "id": "3874f107e1a0461596883a12743dbcc0", "publicURL":
+        "http://127.0.0.1:8774/v3"}], "endpoints_links": [], "type": "computev3",
+        "name": "novav3"}, {"endpoints": [{"adminURL": "http://10.8.99.233:9292",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:9292", "id": "75fcb24891654062ae1703e6b92f6018",
+        "publicURL": "http://10.8.99.233:9292"}], "endpoints_links": [], "type": "image",
+        "name": "glance"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8777",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:8777", "id": "2c972a2880d1453aad86104dcda88a55",
+        "publicURL": "http://10.8.99.233:8777"}], "endpoints_links": [], "type": "metering",
+        "name": "ceilometer"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8776/v1/b458a5c25c3749758f4c0661940b3ba8",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v1/b458a5c25c3749758f4c0661940b3ba8",
+        "id": "410c753013fb430c9998f22f68c4cb18", "publicURL": "http://10.8.99.233:8776/v1/b458a5c25c3749758f4c0661940b3ba8"}],
+        "endpoints_links": [], "type": "volume", "name": "cinder"}, {"endpoints":
+        [{"adminURL": "http://10.8.99.233:8773/services/Admin", "region": "RegionOne",
+        "internalURL": "http://10.8.99.233:8773/services/Cloud", "id": "2833b001aa814ddf9216479d379cdac1",
+        "publicURL": "http://10.8.99.233:8773/services/Cloud"}], "endpoints_links":
+        [], "type": "ec2", "name": "nova_ec2"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8004/v1/b458a5c25c3749758f4c0661940b3ba8",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:8004/v1/b458a5c25c3749758f4c0661940b3ba8",
+        "id": "a29a931a5667478c8b3724506a286144", "publicURL": "http://10.8.99.233:8004/v1/b458a5c25c3749758f4c0661940b3ba8"}],
+        "endpoints_links": [], "type": "orchestration", "name": "heat"}, {"endpoints":
+        [{"adminURL": "http://10.8.99.233:8080", "region": "RegionOne", "internalURL":
+        "http://10.8.99.233:8080/v1/AUTH_b458a5c25c3749758f4c0661940b3ba8", "id":
+        "7a2262abf515414ea08b3beedc87e51e", "publicURL": "http://10.8.99.233:8080/v1/AUTH_b458a5c25c3749758f4c0661940b3ba8"}],
+        "endpoints_links": [], "type": "object-store", "name": "swift"}, {"endpoints":
+        [{"adminURL": "http://10.8.99.233:35357/v2.0", "region": "RegionOne", "internalURL":
+        "http://10.8.99.233:5000/v2.0", "id": "5d1b7edf24e14ce29abaeee69e84e529",
+        "publicURL": "http://10.8.99.233:5000/v2.0"}], "endpoints_links": [], "type":
+        "identity", "name": "keystone"}], "user": {"username": "admin", "roles_links":
+        [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
+        {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
+        0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
+    http_version: 
+  recorded_at: Thu, 01 Nov 2018 18:36:29 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 60de57ca49554ffda1d3b45b3ca20998
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-d5f5af08-c05b-45bf-b379-5e8fd731d667
+      Date:
+      - Thu, 01 Nov 2018 18:36:29 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2",
+        "end": "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 01 Nov 2018 18:36:29 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 60de57ca49554ffda1d3b45b3ca20998
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-feee8128-6229-4f74-84cc-8656ef774831
+      Date:
+      - Thu, 01 Nov 2018 18:36:29 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2",
+        "end": "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 01 Nov 2018 18:36:29 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 8d70faaeffb940b0b1e061340a3c5d64
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-0e760d2f-5fcc-46ad-9b07-f07181afb66a
+      Date:
+      - Thu, 01 Nov 2018 18:36:29 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2",
+        "end": "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 01 Nov 2018 18:36:30 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 8d70faaeffb940b0b1e061340a3c5d64
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-fa7f27be-1021-4e6b-b831-d1a9b66db2a4
+      Date:
+      - Thu, 01 Nov 2018 18:36:30 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2",
+        "end": "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 01 Nov 2018 18:36:30 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1595,13 +2123,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:21:38 GMT
+      - Thu, 01 Nov 2018 18:36:30 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-16c6d7f8-424f-4395-94e3-cbbd881272eb
+      - req-6a5957f4-c31e-4995-b946-4f210e49c836
       Content-Length:
       - '4118'
       Connection:
@@ -1610,10 +2138,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:38.499123", "expires":
-        "2018-10-25T19:21:38Z", "id": "b43b26a984054fa6ac033b76a3ed8ba4", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:36:30.385582", "expires":
+        "2018-11-01T19:36:30Z", "id": "169393089aee470f9e3185a8e727d2ff", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["QXqBseMQRRya9j67A_BjWg"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["M1__VOGrRmeBuDel0Srnzg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -1657,7 +2185,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:38 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:30 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -1672,7 +2200,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b43b26a984054fa6ac033b76a3ed8ba4
+      - 169393089aee470f9e3185a8e727d2ff
   response:
     status:
       code: 200
@@ -1683,17 +2211,167 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-081fc975-a293-4aaa-85ab-3dd88bebf788
+      - req-d795b46e-240d-4958-ab51-c3e70d2b2c79
       Date:
-      - Thu, 25 Oct 2018 18:21:38 GMT
+      - Thu, 01 Nov 2018 18:36:30 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.50.4", "end": "192.168.50.4"}, {"start":
-        "192.168.50.2", "end": "192.168.50.2"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 01 Nov 2018 18:36:30 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 169393089aee470f9e3185a8e727d2ff
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-a380e674-eac2-4cba-bc05-d8c4e72fe2ff
+      Date:
+      - Thu, 01 Nov 2018 18:36:30 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2",
+        "end": "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
         true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
@@ -1758,24 +2436,6 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
         "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
-        false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
-        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
@@ -1789,7 +2449,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:38 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:30 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
@@ -1804,7 +2464,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b43b26a984054fa6ac033b76a3ed8ba4
+      - 169393089aee470f9e3185a8e727d2ff
   response:
     status:
       code: 200
@@ -1815,28 +2475,16 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-e51458b6-2dbf-4d37-8562-c2b10d6a0a0d
+      - req-b14e3b84-4c31-4225-b920-db3813299a9f
       Date:
-      - Thu, 25 Oct 2018 18:21:38 GMT
+      - Thu, 01 Nov 2018 18:36:30 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
         "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
@@ -1845,6 +2493,12 @@ http_interactions:
         "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
         "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2",
+        "end": "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
         "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
@@ -1897,6 +2551,12 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
         "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
         "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
@@ -1921,7 +2581,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:38 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:31 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports/02b5cbb1-6072-429c-b185-89f44b552d40
@@ -1936,7 +2596,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 28daed0598044840bca27d756dd13dc2
+      - 8d70faaeffb940b0b1e061340a3c5d64
   response:
     status:
       code: 200
@@ -1947,9 +2607,9 @@ http_interactions:
       Content-Length:
       - '888'
       X-Openstack-Request-Id:
-      - req-f043f7a4-ae52-432b-b34e-fc615944e3ab
+      - req-96bf8de3-1808-4658-962f-bc07601f8603
       Date:
-      - Thu, 25 Oct 2018 18:21:38 GMT
+      - Thu, 01 Nov 2018 18:36:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"port": {"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -1964,5 +2624,5 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:b5:f7:9c"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:38 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:31 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_router_targeted_refresh.yml
+++ b/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_router_targeted_refresh.yml
@@ -17,13 +17,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:21:24 GMT
+      - Thu, 01 Nov 2018 18:36:50 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-8222ae9f-7714-49dc-aebb-ba4c8e9cfd40
+      - req-b39eba43-f5be-454f-8751-a5374ae59a9b
       Content-Length:
       - '4170'
       Connection:
@@ -32,10 +32,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:24.797838", "expires":
-        "2018-10-25T19:21:24Z", "id": "14592e11da78491ea971c5863dda267a", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:36:50.524042", "expires":
+        "2018-11-01T19:36:50Z", "id": "c0978a4481784b02b68395934e6bcaee", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["PhISzFd7Q2aJHVhVZKnV3A"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["vA-77nYHRdOIZ2fXKfEDGw"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -80,7 +80,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:24 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:50 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -95,7 +95,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 14592e11da78491ea971c5863dda267a
+      - c0978a4481784b02b68395934e6bcaee
   response:
     status:
       code: 200
@@ -106,7 +106,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Thu, 25 Oct 2018 18:21:24 GMT
+      - Thu, 01 Nov 2018 18:36:50 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -115,7 +115,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:24 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:50 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -133,13 +133,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:21:25 GMT
+      - Thu, 01 Nov 2018 18:36:51 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-cfd19ce5-74b4-4f1d-89ea-d54ca4ec5c91
+      - req-59de08e2-f370-4dc8-8e36-9dbaa830ddc0
       Content-Length:
       - '4170'
       Connection:
@@ -148,10 +148,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:25.063213", "expires":
-        "2018-10-25T19:21:25Z", "id": "15344f26774f4ce6a4d85f6252b9aeba", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:36:51.295156", "expires":
+        "2018-11-01T19:36:51Z", "id": "c4836a7bd20d414d9c928096bf14a56b", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["XI9XPsbyRGOzMtzesDMxag"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["aozRYmWsSEqln4pp-ILjxQ"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -196,7 +196,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:25 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:51 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -214,13 +214,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:21:25 GMT
+      - Thu, 01 Nov 2018 18:36:51 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-041aad6c-cad9-46ed-9c36-7bd48c8a7228
+      - req-dc9f91ac-fdf6-4f2a-ac1a-bb1ba46fd041
       Content-Length:
       - '370'
       Connection:
@@ -229,13 +229,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:25.216823", "expires":
-        "2018-10-25T19:21:25Z", "id": "20fcf4d2c3db49179336a60df0beae17", "audit_ids":
-        ["1eeVdJMHQVqbqsPLJF-_8A"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:36:51.455930", "expires":
+        "2018-11-01T19:36:51Z", "id": "824fa63c697a4bc5b87680e2b9a183d9", "audit_ids":
+        ["Gtag0arWT5WOetvr4v1MPg"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:25 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:51 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -250,20 +250,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 20fcf4d2c3db49179336a60df0beae17
+      - 824fa63c697a4bc5b87680e2b9a183d9
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:21:25 GMT
+      - Thu, 01 Nov 2018 18:36:51 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-629ff670-c4b7-4e02-b66d-dc333c8ea4c3
+      - req-88d26cb2-558a-4ce9-b23c-abe8945613da
       Content-Length:
       - '500'
       Connection:
@@ -280,7 +280,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:25 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:51 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -298,13 +298,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:21:25 GMT
+      - Thu, 01 Nov 2018 18:36:51 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-ab5248bc-1b60-4c24-9eb5-09772c812993
+      - req-b53aaa2b-d577-4bbf-bc87-66a6e102d44e
       Content-Length:
       - '4117'
       Connection:
@@ -313,10 +313,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:25.533834", "expires":
-        "2018-10-25T19:21:25Z", "id": "660b400ea9ce49c1b570949c02c8b6b7", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:36:51.770530", "expires":
+        "2018-11-01T19:36:51Z", "id": "6cb19a2a789c4b4fbd04eb58916edb07", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["85GSgTqMTvu-FwIU4vxKIQ"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["XizUh2hZQQyZmlbhUuOXnQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -360,7 +360,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:25 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:51 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -375,7 +375,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 660b400ea9ce49c1b570949c02c8b6b7
+      - 6cb19a2a789c4b4fbd04eb58916edb07
   response:
     status:
       code: 200
@@ -386,7 +386,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Thu, 25 Oct 2018 18:21:25 GMT
+      - Thu, 01 Nov 2018 18:36:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -395,7 +395,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:25 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:51 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -413,13 +413,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:21:25 GMT
+      - Thu, 01 Nov 2018 18:36:51 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-31bece75-a461-4562-a464-6a7ca218c50f
+      - req-65e7b10b-2e0b-44b5-98b7-d3e9adc20c19
       Content-Length:
       - '4131'
       Connection:
@@ -428,10 +428,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:25.788287", "expires":
-        "2018-10-25T19:21:25Z", "id": "375cdc618b264a838a341f4efce0db31", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:36:52.042803", "expires":
+        "2018-11-01T19:36:52Z", "id": "b0d8e1ea07f04b718dd83eff92b5430a", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["tFqom_TcRL2XNDK_cgGYUQ"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["ddyMdneQRd60hSjw0qUQtA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -475,7 +475,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:26 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:52 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -490,7 +490,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 375cdc618b264a838a341f4efce0db31
+      - b0d8e1ea07f04b718dd83eff92b5430a
   response:
     status:
       code: 200
@@ -501,7 +501,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Thu, 25 Oct 2018 18:21:26 GMT
+      - Thu, 01 Nov 2018 18:36:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -510,7 +510,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:26 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:52 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -528,13 +528,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:21:26 GMT
+      - Thu, 01 Nov 2018 18:36:52 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-3cad0a25-a16b-4adc-951a-d28b27c865e2
+      - req-b15ac6ea-2970-4e97-976e-1e2c5b478024
       Content-Length:
       - '4118'
       Connection:
@@ -543,10 +543,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:26.339556", "expires":
-        "2018-10-25T19:21:26Z", "id": "87a2be87b2b74ee186d3ff6f497d4b8a", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:36:52.318756", "expires":
+        "2018-11-01T19:36:52Z", "id": "7aa7e6687fae4f45ad69dba588879f2d", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["4TYoMgk8RN62u5oPxeaftA"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["Tj82Ky38S3is9liNVVTR6w"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -590,7 +590,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:26 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:52 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -605,7 +605,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 87a2be87b2b74ee186d3ff6f497d4b8a
+      - 7aa7e6687fae4f45ad69dba588879f2d
   response:
     status:
       code: 200
@@ -616,7 +616,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Thu, 25 Oct 2018 18:21:26 GMT
+      - Thu, 01 Nov 2018 18:36:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -625,7 +625,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:26 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:52 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -643,13 +643,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:21:26 GMT
+      - Thu, 01 Nov 2018 18:36:52 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-d33436e4-db6c-462a-aef7-827ae344fa4f
+      - req-cea6d31e-07eb-4f39-b019-d66ee5952744
       Content-Length:
       - '4117'
       Connection:
@@ -658,10 +658,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:26.592725", "expires":
-        "2018-10-25T19:21:26Z", "id": "dca28787678c4687bef547289218e998", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:36:52.581332", "expires":
+        "2018-11-01T19:36:52Z", "id": "9848c1143e984c08a7ff5ecb7c0f07c5", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["ioU1xqowRpOAaUk4mmcRNg"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["0hM_417YT-CFxbrF8vDP7Q"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -705,7 +705,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:26 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:52 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -720,7 +720,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - dca28787678c4687bef547289218e998
+      - 9848c1143e984c08a7ff5ecb7c0f07c5
   response:
     status:
       code: 200
@@ -731,45 +731,51 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-f0c41635-f888-4e6a-bc61-9c13e8cebc1a
+      - req-165c866e-d78d-41c1-b582-3c55e279a6c7
       Date:
-      - Thu, 25 Oct 2018 18:21:26 GMT
+      - Thu, 01 Nov 2018 18:36:52 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
-        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2",
+        "end": "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
         "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
         "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
         "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.4",
-        "end": "192.168.50.4"}, {"start": "192.168.50.2", "end": "192.168.50.2"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
-        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.20.0/24", "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
-        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
         false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
@@ -818,12 +824,6 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
         "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
@@ -837,7 +837,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:26 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:52 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
@@ -852,7 +852,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - dca28787678c4687bef547289218e998
+      - 9848c1143e984c08a7ff5ecb7c0f07c5
   response:
     status:
       code: 200
@@ -863,9 +863,9 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-ecdc8324-962c-4e56-ae5e-d28251e6be0a
+      - req-92f17e27-1624-4307-ba48-502f65f38e05
       Date:
-      - Thu, 25 Oct 2018 18:21:26 GMT
+      - Thu, 01 Nov 2018 18:36:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
@@ -956,103 +956,23 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
         "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
         null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:26 GMT
-- request:
-    method: post
-    uri: http://11.22.33.44:5000/v2.0/tokens
-    body:
-      encoding: UTF-8
-      string: '{"auth":{"passwordCredentials":{"username":"admin","password":"password_2WpEraURh"},"tenantName":"EmsRefreshSpec-Project-No-Admin-Role"}}'
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 25 Oct 2018 18:21:27 GMT
-      Server:
-      - Apache/2.4.6 (Red Hat Enterprise Linux)
-      Vary:
-      - X-Auth-Token,Accept-Encoding
-      X-Openstack-Request-Id:
-      - req-553e5159-6143-4606-a1a6-4cc3397d1206
-      Content-Length:
-      - '4131'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:27.143753", "expires":
-        "2018-10-25T19:21:27Z", "id": "5f990704a90440cd91ee736e6d789f87", "tenant":
-        {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["XNESICAkQbu8GglvhCM-jA"]},
-        "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
-        "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
-        "endpoints_links": [], "type": "compute", "name": "nova"}, {"endpoints": [{"adminURL":
-        "http://10.8.99.233:9696", "region": "RegionOne", "internalURL": "http://10.8.99.233:9696",
-        "id": "5b097055aff24a40aa4cd2d7317c9108", "publicURL": "http://10.8.99.233:9696"}],
-        "endpoints_links": [], "type": "network", "name": "neutron"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8",
-        "id": "13c4208d548d4bcdaedfe8296b6559ee", "publicURL": "http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8"}],
-        "endpoints_links": [], "type": "volumev2", "name": "cinderv2"}, {"endpoints":
-        [{"adminURL": "http://127.0.0.1:8774/v3", "region": "RegionOne", "internalURL":
-        "http://127.0.0.1:8774/v3", "id": "3874f107e1a0461596883a12743dbcc0", "publicURL":
-        "http://127.0.0.1:8774/v3"}], "endpoints_links": [], "type": "computev3",
-        "name": "novav3"}, {"endpoints": [{"adminURL": "http://10.8.99.233:9292",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:9292", "id": "75fcb24891654062ae1703e6b92f6018",
-        "publicURL": "http://10.8.99.233:9292"}], "endpoints_links": [], "type": "image",
-        "name": "glance"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8777",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8777", "id": "2c972a2880d1453aad86104dcda88a55",
-        "publicURL": "http://10.8.99.233:8777"}], "endpoints_links": [], "type": "metering",
-        "name": "ceilometer"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8776/v1/b458a5c25c3749758f4c0661940b3ba8",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v1/b458a5c25c3749758f4c0661940b3ba8",
-        "id": "410c753013fb430c9998f22f68c4cb18", "publicURL": "http://10.8.99.233:8776/v1/b458a5c25c3749758f4c0661940b3ba8"}],
-        "endpoints_links": [], "type": "volume", "name": "cinder"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8773/services/Admin", "region": "RegionOne",
-        "internalURL": "http://10.8.99.233:8773/services/Cloud", "id": "2833b001aa814ddf9216479d379cdac1",
-        "publicURL": "http://10.8.99.233:8773/services/Cloud"}], "endpoints_links":
-        [], "type": "ec2", "name": "nova_ec2"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8004/v1/b458a5c25c3749758f4c0661940b3ba8",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8004/v1/b458a5c25c3749758f4c0661940b3ba8",
-        "id": "a29a931a5667478c8b3724506a286144", "publicURL": "http://10.8.99.233:8004/v1/b458a5c25c3749758f4c0661940b3ba8"}],
-        "endpoints_links": [], "type": "orchestration", "name": "heat"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8080", "region": "RegionOne", "internalURL":
-        "http://10.8.99.233:8080/v1/AUTH_b458a5c25c3749758f4c0661940b3ba8", "id":
-        "7a2262abf515414ea08b3beedc87e51e", "publicURL": "http://10.8.99.233:8080/v1/AUTH_b458a5c25c3749758f4c0661940b3ba8"}],
-        "endpoints_links": [], "type": "object-store", "name": "swift"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:35357/v2.0", "region": "RegionOne", "internalURL":
-        "http://10.8.99.233:5000/v2.0", "id": "5d1b7edf24e14ce29abaeee69e84e529",
-        "publicURL": "http://10.8.99.233:5000/v2.0"}], "endpoints_links": [], "type":
-        "identity", "name": "keystone"}], "user": {"username": "admin", "roles_links":
-        [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
-        {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
-        0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:27 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:52 GMT
 - request:
     method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
     body:
       encoding: US-ASCII
       string: ''
@@ -1064,7 +984,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5f990704a90440cd91ee736e6d789f87
+      - 9848c1143e984c08a7ff5ecb7c0f07c5
   response:
     status:
       code: 200
@@ -1075,28 +995,16 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-6d9ad09a-ad94-45eb-a5dd-b47e9f16d159
+      - req-1ad48c1d-7a4b-49f6-99f6-cb0f568bacfc
       Date:
-      - Thu, 25 Oct 2018 18:21:27 GMT
+      - Thu, 01 Nov 2018 18:36:53 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
         "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
@@ -1105,6 +1013,12 @@ http_interactions:
         "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
         "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2",
+        "end": "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
         "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
@@ -1157,6 +1071,12 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
         "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
         "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
@@ -1181,7 +1101,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:27 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:53 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
@@ -1196,7 +1116,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5f990704a90440cd91ee736e6d789f87
+      - 9848c1143e984c08a7ff5ecb7c0f07c5
   response:
     status:
       code: 200
@@ -1207,45 +1127,51 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-5d7b14df-a6b4-42a6-8a00-d5e3805fe7f2
+      - req-208f7d8c-c1ae-4c58-a425-de3466e9bfcd
       Date:
-      - Thu, 25 Oct 2018 18:21:27 GMT
+      - Thu, 01 Nov 2018 18:36:54 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
-        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2",
+        "end": "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
         "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
         "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
         "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.4",
-        "end": "192.168.50.4"}, {"start": "192.168.50.2", "end": "192.168.50.2"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
-        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.20.0/24", "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
-        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
         false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
@@ -1294,12 +1220,6 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
         "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
@@ -1313,7 +1233,87 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:27 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:54 GMT
+- request:
+    method: post
+    uri: http://11.22.33.44:5000/v2.0/tokens
+    body:
+      encoding: UTF-8
+      string: '{"auth":{"passwordCredentials":{"username":"admin","password":"password_2WpEraURh"},"tenantName":"EmsRefreshSpec-Project-No-Admin-Role"}}'
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 01 Nov 2018 18:36:54 GMT
+      Server:
+      - Apache/2.4.6 (Red Hat Enterprise Linux)
+      Vary:
+      - X-Auth-Token,Accept-Encoding
+      X-Openstack-Request-Id:
+      - req-ce6e0ad8-435c-4874-add1-2ed6eaaaa1f3
+      Content-Length:
+      - '4131'
+      Connection:
+      - close
+      Content-Type:
+      - application/json
+    body:
+      encoding: ASCII-8BIT
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:36:54.522310", "expires":
+        "2018-11-01T19:36:54Z", "id": "b9ccb25e83574ee38fa1f3b544553352", "tenant":
+        {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["1f-ponbdSpu3h1CExH-ntQ"]},
+        "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
+        "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
+        "endpoints_links": [], "type": "compute", "name": "nova"}, {"endpoints": [{"adminURL":
+        "http://10.8.99.233:9696", "region": "RegionOne", "internalURL": "http://10.8.99.233:9696",
+        "id": "5b097055aff24a40aa4cd2d7317c9108", "publicURL": "http://10.8.99.233:9696"}],
+        "endpoints_links": [], "type": "network", "name": "neutron"}, {"endpoints":
+        [{"adminURL": "http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8",
+        "id": "13c4208d548d4bcdaedfe8296b6559ee", "publicURL": "http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8"}],
+        "endpoints_links": [], "type": "volumev2", "name": "cinderv2"}, {"endpoints":
+        [{"adminURL": "http://127.0.0.1:8774/v3", "region": "RegionOne", "internalURL":
+        "http://127.0.0.1:8774/v3", "id": "3874f107e1a0461596883a12743dbcc0", "publicURL":
+        "http://127.0.0.1:8774/v3"}], "endpoints_links": [], "type": "computev3",
+        "name": "novav3"}, {"endpoints": [{"adminURL": "http://10.8.99.233:9292",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:9292", "id": "75fcb24891654062ae1703e6b92f6018",
+        "publicURL": "http://10.8.99.233:9292"}], "endpoints_links": [], "type": "image",
+        "name": "glance"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8777",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:8777", "id": "2c972a2880d1453aad86104dcda88a55",
+        "publicURL": "http://10.8.99.233:8777"}], "endpoints_links": [], "type": "metering",
+        "name": "ceilometer"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8776/v1/b458a5c25c3749758f4c0661940b3ba8",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v1/b458a5c25c3749758f4c0661940b3ba8",
+        "id": "410c753013fb430c9998f22f68c4cb18", "publicURL": "http://10.8.99.233:8776/v1/b458a5c25c3749758f4c0661940b3ba8"}],
+        "endpoints_links": [], "type": "volume", "name": "cinder"}, {"endpoints":
+        [{"adminURL": "http://10.8.99.233:8773/services/Admin", "region": "RegionOne",
+        "internalURL": "http://10.8.99.233:8773/services/Cloud", "id": "2833b001aa814ddf9216479d379cdac1",
+        "publicURL": "http://10.8.99.233:8773/services/Cloud"}], "endpoints_links":
+        [], "type": "ec2", "name": "nova_ec2"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8004/v1/b458a5c25c3749758f4c0661940b3ba8",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:8004/v1/b458a5c25c3749758f4c0661940b3ba8",
+        "id": "a29a931a5667478c8b3724506a286144", "publicURL": "http://10.8.99.233:8004/v1/b458a5c25c3749758f4c0661940b3ba8"}],
+        "endpoints_links": [], "type": "orchestration", "name": "heat"}, {"endpoints":
+        [{"adminURL": "http://10.8.99.233:8080", "region": "RegionOne", "internalURL":
+        "http://10.8.99.233:8080/v1/AUTH_b458a5c25c3749758f4c0661940b3ba8", "id":
+        "7a2262abf515414ea08b3beedc87e51e", "publicURL": "http://10.8.99.233:8080/v1/AUTH_b458a5c25c3749758f4c0661940b3ba8"}],
+        "endpoints_links": [], "type": "object-store", "name": "swift"}, {"endpoints":
+        [{"adminURL": "http://10.8.99.233:35357/v2.0", "region": "RegionOne", "internalURL":
+        "http://10.8.99.233:5000/v2.0", "id": "5d1b7edf24e14ce29abaeee69e84e529",
+        "publicURL": "http://10.8.99.233:5000/v2.0"}], "endpoints_links": [], "type":
+        "identity", "name": "keystone"}], "user": {"username": "admin", "roles_links":
+        [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
+        {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
+        0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
+    http_version: 
+  recorded_at: Thu, 01 Nov 2018 18:36:54 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -1328,7 +1328,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 15344f26774f4ce6a4d85f6252b9aeba
+      - b9ccb25e83574ee38fa1f3b544553352
   response:
     status:
       code: 200
@@ -1339,9 +1339,273 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-226ec008-1da1-4ef4-a496-2df3121559aa
+      - req-cd9a7bb5-4bee-47fa-b2ec-adbe0501fb1e
       Date:
-      - Thu, 25 Oct 2018 18:21:27 GMT
+      - Thu, 01 Nov 2018 18:36:54 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2",
+        "end": "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 01 Nov 2018 18:36:54 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - b9ccb25e83574ee38fa1f3b544553352
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-8779dca3-e0c3-4ec2-83b4-148f64aa6835
+      Date:
+      - Thu, 01 Nov 2018 18:36:54 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2",
+        "end": "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 01 Nov 2018 18:36:54 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - c4836a7bd20d414d9c928096bf14a56b
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-09878431-31e5-4f13-b2a6-8ade93d1c75a
+      Date:
+      - Thu, 01 Nov 2018 18:36:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
@@ -1432,23 +1696,23 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
         "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
         null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:27 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:55 GMT
 - request:
     method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
     body:
       encoding: US-ASCII
       string: ''
@@ -1460,7 +1724,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 15344f26774f4ce6a4d85f6252b9aeba
+      - c4836a7bd20d414d9c928096bf14a56b
   response:
     status:
       code: 200
@@ -1471,361 +1735,35 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-5e45265b-d880-4fcf-8027-2bc38ae8eaf7
+      - req-f1b7fb1b-4943-4601-b78c-3a853a4602d9
       Date:
-      - Thu, 25 Oct 2018 18:21:27 GMT
+      - Thu, 01 Nov 2018 18:36:55 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
-        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2",
+        "end": "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
         "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
         "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
         "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.4",
-        "end": "192.168.50.4"}, {"start": "192.168.50.2", "end": "192.168.50.2"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
-        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.20.0/24", "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
-        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:27 GMT
-- request:
-    method: post
-    uri: http://11.22.33.44:5000/v2.0/tokens
-    body:
-      encoding: UTF-8
-      string: '{"auth":{"passwordCredentials":{"username":"admin","password":"password_2WpEraURh"},"tenantName":"EmsRefreshSpec-Project2"}}'
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 25 Oct 2018 18:21:28 GMT
-      Server:
-      - Apache/2.4.6 (Red Hat Enterprise Linux)
-      Vary:
-      - X-Auth-Token,Accept-Encoding
-      X-Openstack-Request-Id:
-      - req-ea205466-76e2-47e3-8d27-62392ad4b390
-      Content-Length:
-      - '4118'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:28.124021", "expires":
-        "2018-10-25T19:21:28Z", "id": "ec9ee57533d44285a37329fb80bb5fc9", "tenant":
-        {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["v2HFT3JbSj2weZstOqL9LQ"]},
-        "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
-        "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
-        "endpoints_links": [], "type": "compute", "name": "nova"}, {"endpoints": [{"adminURL":
-        "http://10.8.99.233:9696", "region": "RegionOne", "internalURL": "http://10.8.99.233:9696",
-        "id": "5b097055aff24a40aa4cd2d7317c9108", "publicURL": "http://10.8.99.233:9696"}],
-        "endpoints_links": [], "type": "network", "name": "neutron"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608",
-        "id": "13c4208d548d4bcdaedfe8296b6559ee", "publicURL": "http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608"}],
-        "endpoints_links": [], "type": "volumev2", "name": "cinderv2"}, {"endpoints":
-        [{"adminURL": "http://127.0.0.1:8774/v3", "region": "RegionOne", "internalURL":
-        "http://127.0.0.1:8774/v3", "id": "3874f107e1a0461596883a12743dbcc0", "publicURL":
-        "http://127.0.0.1:8774/v3"}], "endpoints_links": [], "type": "computev3",
-        "name": "novav3"}, {"endpoints": [{"adminURL": "http://10.8.99.233:9292",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:9292", "id": "75fcb24891654062ae1703e6b92f6018",
-        "publicURL": "http://10.8.99.233:9292"}], "endpoints_links": [], "type": "image",
-        "name": "glance"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8777",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8777", "id": "2c972a2880d1453aad86104dcda88a55",
-        "publicURL": "http://10.8.99.233:8777"}], "endpoints_links": [], "type": "metering",
-        "name": "ceilometer"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8776/v1/e8f744b1fc6a487681d35fb275252608",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v1/e8f744b1fc6a487681d35fb275252608",
-        "id": "410c753013fb430c9998f22f68c4cb18", "publicURL": "http://10.8.99.233:8776/v1/e8f744b1fc6a487681d35fb275252608"}],
-        "endpoints_links": [], "type": "volume", "name": "cinder"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8773/services/Admin", "region": "RegionOne",
-        "internalURL": "http://10.8.99.233:8773/services/Cloud", "id": "2833b001aa814ddf9216479d379cdac1",
-        "publicURL": "http://10.8.99.233:8773/services/Cloud"}], "endpoints_links":
-        [], "type": "ec2", "name": "nova_ec2"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8004/v1/e8f744b1fc6a487681d35fb275252608",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8004/v1/e8f744b1fc6a487681d35fb275252608",
-        "id": "a29a931a5667478c8b3724506a286144", "publicURL": "http://10.8.99.233:8004/v1/e8f744b1fc6a487681d35fb275252608"}],
-        "endpoints_links": [], "type": "orchestration", "name": "heat"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8080", "region": "RegionOne", "internalURL":
-        "http://10.8.99.233:8080/v1/AUTH_e8f744b1fc6a487681d35fb275252608", "id":
-        "7a2262abf515414ea08b3beedc87e51e", "publicURL": "http://10.8.99.233:8080/v1/AUTH_e8f744b1fc6a487681d35fb275252608"}],
-        "endpoints_links": [], "type": "object-store", "name": "swift"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:35357/v2.0", "region": "RegionOne", "internalURL":
-        "http://10.8.99.233:5000/v2.0", "id": "5d1b7edf24e14ce29abaeee69e84e529",
-        "publicURL": "http://10.8.99.233:5000/v2.0"}], "endpoints_links": [], "type":
-        "identity", "name": "keystone"}], "user": {"username": "admin", "roles_links":
-        [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
-        {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
-        0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:28 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - ec9ee57533d44285a37329fb80bb5fc9
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-79584516-babb-42cb-9bf6-f9f25d5269dd
-      Date:
-      - Thu, 25 Oct 2018 18:21:28 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
-        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.4",
-        "end": "192.168.50.4"}, {"start": "192.168.50.2", "end": "192.168.50.2"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
-        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.20.0/24", "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
-        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:28 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - ec9ee57533d44285a37329fb80bb5fc9
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-2cca2a12-f004-45d7-9c4c-2e7b3f1d57ad
-      Date:
-      - Thu, 25 Oct 2018 18:21:28 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.50.4", "end": "192.168.50.4"}, {"start":
-        "192.168.50.2", "end": "192.168.50.2"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
         true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
@@ -1890,24 +1828,6 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
         "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
-        false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
-        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
@@ -1921,7 +1841,1011 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:28 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:55 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - c4836a7bd20d414d9c928096bf14a56b
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-c7e41a9d-406b-4708-8f12-603cfa52876f
+      Date:
+      - Thu, 01 Nov 2018 18:36:55 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 01 Nov 2018 18:36:55 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - c4836a7bd20d414d9c928096bf14a56b
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-3ca0cd74-20c2-4e95-854d-1863cc6ab2bf
+      Date:
+      - Thu, 01 Nov 2018 18:36:55 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2",
+        "end": "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 01 Nov 2018 18:36:55 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - c4836a7bd20d414d9c928096bf14a56b
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-e9da39c3-833e-41c9-b5b3-d75232bb31b9
+      Date:
+      - Thu, 01 Nov 2018 18:36:55 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2",
+        "end": "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 01 Nov 2018 18:36:55 GMT
+- request:
+    method: post
+    uri: http://11.22.33.44:5000/v2.0/tokens
+    body:
+      encoding: UTF-8
+      string: '{"auth":{"passwordCredentials":{"username":"admin","password":"password_2WpEraURh"},"tenantName":"EmsRefreshSpec-Project2"}}'
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 01 Nov 2018 18:36:56 GMT
+      Server:
+      - Apache/2.4.6 (Red Hat Enterprise Linux)
+      Vary:
+      - X-Auth-Token,Accept-Encoding
+      X-Openstack-Request-Id:
+      - req-68253bd2-5234-4b91-ae6d-96f4652945c5
+      Content-Length:
+      - '4118'
+      Connection:
+      - close
+      Content-Type:
+      - application/json
+    body:
+      encoding: ASCII-8BIT
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:36:56.060692", "expires":
+        "2018-11-01T19:36:56Z", "id": "4a88e26f49454259ac33ed23a94af4b3", "tenant":
+        {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["9r1mn7_UQImOFPb0a8I5mA"]},
+        "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
+        "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
+        "endpoints_links": [], "type": "compute", "name": "nova"}, {"endpoints": [{"adminURL":
+        "http://10.8.99.233:9696", "region": "RegionOne", "internalURL": "http://10.8.99.233:9696",
+        "id": "5b097055aff24a40aa4cd2d7317c9108", "publicURL": "http://10.8.99.233:9696"}],
+        "endpoints_links": [], "type": "network", "name": "neutron"}, {"endpoints":
+        [{"adminURL": "http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608",
+        "id": "13c4208d548d4bcdaedfe8296b6559ee", "publicURL": "http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608"}],
+        "endpoints_links": [], "type": "volumev2", "name": "cinderv2"}, {"endpoints":
+        [{"adminURL": "http://127.0.0.1:8774/v3", "region": "RegionOne", "internalURL":
+        "http://127.0.0.1:8774/v3", "id": "3874f107e1a0461596883a12743dbcc0", "publicURL":
+        "http://127.0.0.1:8774/v3"}], "endpoints_links": [], "type": "computev3",
+        "name": "novav3"}, {"endpoints": [{"adminURL": "http://10.8.99.233:9292",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:9292", "id": "75fcb24891654062ae1703e6b92f6018",
+        "publicURL": "http://10.8.99.233:9292"}], "endpoints_links": [], "type": "image",
+        "name": "glance"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8777",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:8777", "id": "2c972a2880d1453aad86104dcda88a55",
+        "publicURL": "http://10.8.99.233:8777"}], "endpoints_links": [], "type": "metering",
+        "name": "ceilometer"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8776/v1/e8f744b1fc6a487681d35fb275252608",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v1/e8f744b1fc6a487681d35fb275252608",
+        "id": "410c753013fb430c9998f22f68c4cb18", "publicURL": "http://10.8.99.233:8776/v1/e8f744b1fc6a487681d35fb275252608"}],
+        "endpoints_links": [], "type": "volume", "name": "cinder"}, {"endpoints":
+        [{"adminURL": "http://10.8.99.233:8773/services/Admin", "region": "RegionOne",
+        "internalURL": "http://10.8.99.233:8773/services/Cloud", "id": "2833b001aa814ddf9216479d379cdac1",
+        "publicURL": "http://10.8.99.233:8773/services/Cloud"}], "endpoints_links":
+        [], "type": "ec2", "name": "nova_ec2"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8004/v1/e8f744b1fc6a487681d35fb275252608",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:8004/v1/e8f744b1fc6a487681d35fb275252608",
+        "id": "a29a931a5667478c8b3724506a286144", "publicURL": "http://10.8.99.233:8004/v1/e8f744b1fc6a487681d35fb275252608"}],
+        "endpoints_links": [], "type": "orchestration", "name": "heat"}, {"endpoints":
+        [{"adminURL": "http://10.8.99.233:8080", "region": "RegionOne", "internalURL":
+        "http://10.8.99.233:8080/v1/AUTH_e8f744b1fc6a487681d35fb275252608", "id":
+        "7a2262abf515414ea08b3beedc87e51e", "publicURL": "http://10.8.99.233:8080/v1/AUTH_e8f744b1fc6a487681d35fb275252608"}],
+        "endpoints_links": [], "type": "object-store", "name": "swift"}, {"endpoints":
+        [{"adminURL": "http://10.8.99.233:35357/v2.0", "region": "RegionOne", "internalURL":
+        "http://10.8.99.233:5000/v2.0", "id": "5d1b7edf24e14ce29abaeee69e84e529",
+        "publicURL": "http://10.8.99.233:5000/v2.0"}], "endpoints_links": [], "type":
+        "identity", "name": "keystone"}], "user": {"username": "admin", "roles_links":
+        [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
+        {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
+        0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
+    http_version: 
+  recorded_at: Thu, 01 Nov 2018 18:36:56 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 4a88e26f49454259ac33ed23a94af4b3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-d6daf48a-5dc4-4ac2-b8e5-93a6e34a7168
+      Date:
+      - Thu, 01 Nov 2018 18:36:56 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2",
+        "end": "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 01 Nov 2018 18:36:56 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 4a88e26f49454259ac33ed23a94af4b3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-41e91fe9-8939-4f1b-b77e-ca59edaa7ba7
+      Date:
+      - Thu, 01 Nov 2018 18:36:56 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 01 Nov 2018 18:36:56 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 4a88e26f49454259ac33ed23a94af4b3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-ecdfa2db-ae41-471e-b1be-0d0102944c5d
+      Date:
+      - Thu, 01 Nov 2018 18:36:56 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2",
+        "end": "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 01 Nov 2018 18:36:56 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 4a88e26f49454259ac33ed23a94af4b3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-e160f77b-fef3-410e-b8a8-94de567754fc
+      Date:
+      - Thu, 01 Nov 2018 18:36:56 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2",
+        "end": "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 01 Nov 2018 18:36:56 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers/57e17608-8ac6-44a6-803e-f42ec15e9d1e
@@ -1936,7 +2860,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 15344f26774f4ce6a4d85f6252b9aeba
+      - c4836a7bd20d414d9c928096bf14a56b
   response:
     status:
       code: 200
@@ -1947,9 +2871,9 @@ http_interactions:
       Content-Length:
       - '443'
       X-Openstack-Request-Id:
-      - req-41f878a2-809e-49f0-9f46-dd37250566ec
+      - req-42ac7847-00db-4780-8373-a0743e8deb47
       Date:
-      - Thu, 25 Oct 2018 18:21:29 GMT
+      - Thu, 01 Nov 2018 18:36:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"router": {"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -1958,5 +2882,5 @@ http_interactions:
         "name": "EmsRefreshSpec-Router", "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "distributed": false, "routes": [], "ha": false, "id": "57e17608-8ac6-44a6-803e-f42ec15e9d1e"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:29 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:57 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_tenant_targeted_refresh.yml
+++ b/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_tenant_targeted_refresh.yml
@@ -17,13 +17,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:21:39 GMT
+      - Thu, 01 Nov 2018 18:36:58 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-2e12cb75-e789-481e-a8be-d5ceda6695a4
+      - req-9b4eaa02-b791-4efc-ab9d-41239377cf3a
       Content-Length:
       - '4170'
       Connection:
@@ -32,10 +32,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:39.784139", "expires":
-        "2018-10-25T19:21:39Z", "id": "eccf233bd29648f380affc03bf64f202", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:36:58.129065", "expires":
+        "2018-11-01T19:36:58Z", "id": "f3e8dfd8d0d34bbb98ededce240ee79d", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["3gveuSgET86OtAo7gHK_Cw"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["Zm0pK-86SPOINO1mkejatg"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -80,7 +80,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:39 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:58 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -95,7 +95,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - eccf233bd29648f380affc03bf64f202
+      - f3e8dfd8d0d34bbb98ededce240ee79d
   response:
     status:
       code: 200
@@ -106,7 +106,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Thu, 25 Oct 2018 18:21:39 GMT
+      - Thu, 01 Nov 2018 18:36:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -115,7 +115,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:39 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:58 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -133,13 +133,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:21:39 GMT
+      - Thu, 01 Nov 2018 18:36:58 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-53f47458-d52d-4db5-a677-6e553f9d52ff
+      - req-e50557ac-e6fa-4dd3-9ed7-8d82ae3d9ad0
       Content-Length:
       - '4170'
       Connection:
@@ -148,10 +148,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:40.056464", "expires":
-        "2018-10-25T19:21:40Z", "id": "500e06f2017b407fb39f0dd6d18485b8", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:36:58.421369", "expires":
+        "2018-11-01T19:36:58Z", "id": "984c780df2c44e7cb50676241149fa76", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["r-8p210rQoCt-TOdz3ptbQ"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["HTXx44sCR8WvnjTgK90e0Q"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -196,7 +196,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:40 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:58 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -211,20 +211,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 500e06f2017b407fb39f0dd6d18485b8
+      - 984c780df2c44e7cb50676241149fa76
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:21:40 GMT
+      - Thu, 01 Nov 2018 18:36:58 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-dd0b8ae3-7e34-469f-bb7c-32c0b1904cf7
+      - req-b52b7f5d-c0d8-4646-9848-4ccb666bf40b
       Content-Length:
       - '500'
       Connection:
@@ -241,7 +241,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:40 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:58 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -259,13 +259,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:21:40 GMT
+      - Thu, 01 Nov 2018 18:36:58 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-804fd885-62ef-445d-b731-e50a83b3b9e2
+      - req-573a2f0c-0ab8-4333-94d6-ce3a94162e16
       Content-Length:
       - '4170'
       Connection:
@@ -274,10 +274,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:40.464981", "expires":
-        "2018-10-25T19:21:40Z", "id": "7ba0b1feee0b414082dbb318b8e80388", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:36:58.850986", "expires":
+        "2018-11-01T19:36:58Z", "id": "cdd6f92e397c404fb3b43f6dceae38a5", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["Tac5fzEMQyODqr_DRdZUiw"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["za6YidZIS1q_r3XI8GmqTw"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -322,7 +322,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:40 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:58 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -340,13 +340,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:21:40 GMT
+      - Thu, 01 Nov 2018 18:36:58 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-a299ddd6-9117-4422-b9fe-291a3cad4cdf
+      - req-04e6ba27-38bf-4d70-92ef-048f749831b0
       Content-Length:
       - '370'
       Connection:
@@ -355,13 +355,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:40.616750", "expires":
-        "2018-10-25T19:21:40Z", "id": "81d7c232c71c4356b6b09d93920fba1f", "audit_ids":
-        ["Of_XNewATmqGoBaKq4QedQ"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:36:59.018459", "expires":
+        "2018-11-01T19:36:59Z", "id": "84ad0c29dc9e418393f0366a9ad27705", "audit_ids":
+        ["EYHHyy9nTL6KjCKG1SmODg"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:40 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:59 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -376,20 +376,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 81d7c232c71c4356b6b09d93920fba1f
+      - 84ad0c29dc9e418393f0366a9ad27705
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:21:40 GMT
+      - Thu, 01 Nov 2018 18:36:59 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-c9650c0b-4d0e-4ebd-8524-2b44b75ec073
+      - req-c39e15dc-3ae8-4860-b223-5b5694d77a10
       Content-Length:
       - '500'
       Connection:
@@ -406,7 +406,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:40 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:59 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -424,13 +424,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:21:40 GMT
+      - Thu, 01 Nov 2018 18:36:59 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-7121633e-3f26-453f-bc24-c9d7fae4beb3
+      - req-c97657c9-345e-468f-8add-a714780bd83e
       Content-Length:
       - '4117'
       Connection:
@@ -439,10 +439,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:40.924622", "expires":
-        "2018-10-25T19:21:40Z", "id": "80400ff4122a470db640faaa57ea0f68", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:36:59.344051", "expires":
+        "2018-11-01T19:36:59Z", "id": "d6d87741219146f28994c1f1b27ed842", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["PtN1MDcVToe7s2ky61D4wg"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["4ehdlDlpTF2Ut8z3DxI16Q"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -486,7 +486,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:40 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:59 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -501,7 +501,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 80400ff4122a470db640faaa57ea0f68
+      - d6d87741219146f28994c1f1b27ed842
   response:
     status:
       code: 200
@@ -512,7 +512,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Thu, 25 Oct 2018 18:21:41 GMT
+      - Thu, 01 Nov 2018 18:36:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -521,7 +521,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:41 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:59 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -539,13 +539,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:21:41 GMT
+      - Thu, 01 Nov 2018 18:36:59 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-e02af5bd-a8e8-448b-9e55-24b13fd769bf
+      - req-f9fb5e9c-363e-4217-a445-966545665c98
       Content-Length:
       - '4131'
       Connection:
@@ -554,10 +554,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:41.220843", "expires":
-        "2018-10-25T19:21:41Z", "id": "3c884d5a49384bedbf07018d8d31b2f4", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:36:59.633781", "expires":
+        "2018-11-01T19:36:59Z", "id": "a4dd143cf71943adbf8e147ac64ad785", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["vd7FS91dRzeIYLAmAN_TYA"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["eQZvqN8QR8WelTIumkKklg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -601,7 +601,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:41 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:59 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -616,7 +616,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3c884d5a49384bedbf07018d8d31b2f4
+      - a4dd143cf71943adbf8e147ac64ad785
   response:
     status:
       code: 200
@@ -627,7 +627,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Thu, 25 Oct 2018 18:21:41 GMT
+      - Thu, 01 Nov 2018 18:36:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -636,7 +636,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:41 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:59 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -654,13 +654,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:21:41 GMT
+      - Thu, 01 Nov 2018 18:36:59 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-f0f2d8e3-86b4-4766-80b4-1bcae556e112
+      - req-7784360b-5265-4e95-988f-7a4c93582d75
       Content-Length:
       - '4118'
       Connection:
@@ -669,10 +669,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:41.488889", "expires":
-        "2018-10-25T19:21:41Z", "id": "15b46970b8e142089c1195a3b2410975", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:36:59.912265", "expires":
+        "2018-11-01T19:36:59Z", "id": "8f174c2338c74bca9faa03054856a477", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["7NVtFmqvRjOihFG_Rtu0HA"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["NQUD3kalRUCij5BagcgC-g"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -716,7 +716,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:41 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:59 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -731,7 +731,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 15b46970b8e142089c1195a3b2410975
+      - 8f174c2338c74bca9faa03054856a477
   response:
     status:
       code: 200
@@ -742,7 +742,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Thu, 25 Oct 2018 18:21:41 GMT
+      - Thu, 01 Nov 2018 18:37:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -751,7 +751,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:41 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:00 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -769,13 +769,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:21:41 GMT
+      - Thu, 01 Nov 2018 18:37:00 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-213d49f1-32f9-4dda-919f-5551de76d4b7
+      - req-6b7dee96-694e-40ed-93e4-042b7047ec29
       Content-Length:
       - '4117'
       Connection:
@@ -784,10 +784,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:41.756598", "expires":
-        "2018-10-25T19:21:41Z", "id": "b1f194f3adde4624af002baf282cbcaf", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:37:00.216282", "expires":
+        "2018-11-01T19:37:00Z", "id": "8ac742727f3a4ed19eed7d4738687f00", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["e6YCQ1gkRJeuLBhWpwdn8w"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["66veqMUDQ7qQodBaDetsvg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -831,7 +831,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:41 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:00 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -846,7 +846,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b1f194f3adde4624af002baf282cbcaf
+      - 8ac742727f3a4ed19eed7d4738687f00
   response:
     status:
       code: 200
@@ -857,28 +857,16 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-0249391d-e45f-4942-a52b-4e97145828a3
+      - req-31f0d8bd-17a9-4dad-992d-9e2d4c168749
       Date:
-      - Thu, 25 Oct 2018 18:21:41 GMT
+      - Thu, 01 Nov 2018 18:37:00 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
         "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
@@ -887,119 +875,17 @@ http_interactions:
         "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
         "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2",
+        "end": "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
         "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
         "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:41 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - b1f194f3adde4624af002baf282cbcaf
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-5f3da23e-c03d-4b6f-88d3-08a450a8debb
-      Date:
-      - Thu, 25 Oct 2018 18:21:42 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.50.4", "end": "192.168.50.4"}, {"start":
-        "192.168.50.2", "end": "192.168.50.2"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
         true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
@@ -1064,24 +950,6 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
         "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
-        false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
-        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
@@ -1095,219 +963,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:42 GMT
-- request:
-    method: post
-    uri: http://11.22.33.44:5000/v2.0/tokens
-    body:
-      encoding: UTF-8
-      string: '{"auth":{"passwordCredentials":{"username":"admin","password":"password_2WpEraURh"},"tenantName":"EmsRefreshSpec-Project-No-Admin-Role"}}'
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 25 Oct 2018 18:21:42 GMT
-      Server:
-      - Apache/2.4.6 (Red Hat Enterprise Linux)
-      Vary:
-      - X-Auth-Token,Accept-Encoding
-      X-Openstack-Request-Id:
-      - req-d1520020-47cd-4bcd-ac62-4706bb4e0c9c
-      Content-Length:
-      - '4131'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:42.300596", "expires":
-        "2018-10-25T19:21:42Z", "id": "0e4574895ddf4ee4bb20452f04954ddd", "tenant":
-        {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["zRzQ5empTD6Y1xA4lwqw5Q"]},
-        "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
-        "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
-        "endpoints_links": [], "type": "compute", "name": "nova"}, {"endpoints": [{"adminURL":
-        "http://10.8.99.233:9696", "region": "RegionOne", "internalURL": "http://10.8.99.233:9696",
-        "id": "5b097055aff24a40aa4cd2d7317c9108", "publicURL": "http://10.8.99.233:9696"}],
-        "endpoints_links": [], "type": "network", "name": "neutron"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8",
-        "id": "13c4208d548d4bcdaedfe8296b6559ee", "publicURL": "http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8"}],
-        "endpoints_links": [], "type": "volumev2", "name": "cinderv2"}, {"endpoints":
-        [{"adminURL": "http://127.0.0.1:8774/v3", "region": "RegionOne", "internalURL":
-        "http://127.0.0.1:8774/v3", "id": "3874f107e1a0461596883a12743dbcc0", "publicURL":
-        "http://127.0.0.1:8774/v3"}], "endpoints_links": [], "type": "computev3",
-        "name": "novav3"}, {"endpoints": [{"adminURL": "http://10.8.99.233:9292",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:9292", "id": "75fcb24891654062ae1703e6b92f6018",
-        "publicURL": "http://10.8.99.233:9292"}], "endpoints_links": [], "type": "image",
-        "name": "glance"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8777",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8777", "id": "2c972a2880d1453aad86104dcda88a55",
-        "publicURL": "http://10.8.99.233:8777"}], "endpoints_links": [], "type": "metering",
-        "name": "ceilometer"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8776/v1/b458a5c25c3749758f4c0661940b3ba8",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v1/b458a5c25c3749758f4c0661940b3ba8",
-        "id": "410c753013fb430c9998f22f68c4cb18", "publicURL": "http://10.8.99.233:8776/v1/b458a5c25c3749758f4c0661940b3ba8"}],
-        "endpoints_links": [], "type": "volume", "name": "cinder"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8773/services/Admin", "region": "RegionOne",
-        "internalURL": "http://10.8.99.233:8773/services/Cloud", "id": "2833b001aa814ddf9216479d379cdac1",
-        "publicURL": "http://10.8.99.233:8773/services/Cloud"}], "endpoints_links":
-        [], "type": "ec2", "name": "nova_ec2"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8004/v1/b458a5c25c3749758f4c0661940b3ba8",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8004/v1/b458a5c25c3749758f4c0661940b3ba8",
-        "id": "a29a931a5667478c8b3724506a286144", "publicURL": "http://10.8.99.233:8004/v1/b458a5c25c3749758f4c0661940b3ba8"}],
-        "endpoints_links": [], "type": "orchestration", "name": "heat"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8080", "region": "RegionOne", "internalURL":
-        "http://10.8.99.233:8080/v1/AUTH_b458a5c25c3749758f4c0661940b3ba8", "id":
-        "7a2262abf515414ea08b3beedc87e51e", "publicURL": "http://10.8.99.233:8080/v1/AUTH_b458a5c25c3749758f4c0661940b3ba8"}],
-        "endpoints_links": [], "type": "object-store", "name": "swift"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:35357/v2.0", "region": "RegionOne", "internalURL":
-        "http://10.8.99.233:5000/v2.0", "id": "5d1b7edf24e14ce29abaeee69e84e529",
-        "publicURL": "http://10.8.99.233:5000/v2.0"}], "endpoints_links": [], "type":
-        "identity", "name": "keystone"}], "user": {"username": "admin", "roles_links":
-        [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
-        {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
-        0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:42 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 0e4574895ddf4ee4bb20452f04954ddd
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-b03ee33b-1756-4b57-ad09-3c66fab52fc1
-      Date:
-      - Thu, 25 Oct 2018 18:21:42 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:42 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:00 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
@@ -1322,7 +978,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0e4574895ddf4ee4bb20452f04954ddd
+      - 8ac742727f3a4ed19eed7d4738687f00
   response:
     status:
       code: 200
@@ -1333,485 +989,9 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-4433031f-2db1-43c7-abbf-b31b41fa80c3
+      - req-c9a956f3-8e15-4fd3-9289-e20b0c25fd03
       Date:
-      - Thu, 25 Oct 2018 18:21:42 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.50.4", "end": "192.168.50.4"}, {"start":
-        "192.168.50.2", "end": "192.168.50.2"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
-        false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
-        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:42 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 7ba0b1feee0b414082dbb318b8e80388
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-49a3b36e-5442-46b1-bad1-c6d1f5611012
-      Date:
-      - Thu, 25 Oct 2018 18:21:42 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:42 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 7ba0b1feee0b414082dbb318b8e80388
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-284a0aec-da9b-4887-8bee-89ec388c9f47
-      Date:
-      - Thu, 25 Oct 2018 18:21:43 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.50.4", "end": "192.168.50.4"}, {"start":
-        "192.168.50.2", "end": "192.168.50.2"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
-        false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
-        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:43 GMT
-- request:
-    method: post
-    uri: http://11.22.33.44:5000/v2.0/tokens
-    body:
-      encoding: UTF-8
-      string: '{"auth":{"passwordCredentials":{"username":"admin","password":"password_2WpEraURh"},"tenantName":"EmsRefreshSpec-Project2"}}'
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 25 Oct 2018 18:21:43 GMT
-      Server:
-      - Apache/2.4.6 (Red Hat Enterprise Linux)
-      Vary:
-      - X-Auth-Token,Accept-Encoding
-      X-Openstack-Request-Id:
-      - req-ec8dceb4-193b-4d31-8965-eff800cce8d3
-      Content-Length:
-      - '4118'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:43.228976", "expires":
-        "2018-10-25T19:21:43Z", "id": "de1f44ea44f44ce4bbbc76d0071e7916", "tenant":
-        {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["dEP5vAVfTxSCSIfSk9ct2g"]},
-        "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
-        "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
-        "endpoints_links": [], "type": "compute", "name": "nova"}, {"endpoints": [{"adminURL":
-        "http://10.8.99.233:9696", "region": "RegionOne", "internalURL": "http://10.8.99.233:9696",
-        "id": "5b097055aff24a40aa4cd2d7317c9108", "publicURL": "http://10.8.99.233:9696"}],
-        "endpoints_links": [], "type": "network", "name": "neutron"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608",
-        "id": "13c4208d548d4bcdaedfe8296b6559ee", "publicURL": "http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608"}],
-        "endpoints_links": [], "type": "volumev2", "name": "cinderv2"}, {"endpoints":
-        [{"adminURL": "http://127.0.0.1:8774/v3", "region": "RegionOne", "internalURL":
-        "http://127.0.0.1:8774/v3", "id": "3874f107e1a0461596883a12743dbcc0", "publicURL":
-        "http://127.0.0.1:8774/v3"}], "endpoints_links": [], "type": "computev3",
-        "name": "novav3"}, {"endpoints": [{"adminURL": "http://10.8.99.233:9292",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:9292", "id": "75fcb24891654062ae1703e6b92f6018",
-        "publicURL": "http://10.8.99.233:9292"}], "endpoints_links": [], "type": "image",
-        "name": "glance"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8777",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8777", "id": "2c972a2880d1453aad86104dcda88a55",
-        "publicURL": "http://10.8.99.233:8777"}], "endpoints_links": [], "type": "metering",
-        "name": "ceilometer"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8776/v1/e8f744b1fc6a487681d35fb275252608",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v1/e8f744b1fc6a487681d35fb275252608",
-        "id": "410c753013fb430c9998f22f68c4cb18", "publicURL": "http://10.8.99.233:8776/v1/e8f744b1fc6a487681d35fb275252608"}],
-        "endpoints_links": [], "type": "volume", "name": "cinder"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8773/services/Admin", "region": "RegionOne",
-        "internalURL": "http://10.8.99.233:8773/services/Cloud", "id": "2833b001aa814ddf9216479d379cdac1",
-        "publicURL": "http://10.8.99.233:8773/services/Cloud"}], "endpoints_links":
-        [], "type": "ec2", "name": "nova_ec2"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8004/v1/e8f744b1fc6a487681d35fb275252608",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8004/v1/e8f744b1fc6a487681d35fb275252608",
-        "id": "a29a931a5667478c8b3724506a286144", "publicURL": "http://10.8.99.233:8004/v1/e8f744b1fc6a487681d35fb275252608"}],
-        "endpoints_links": [], "type": "orchestration", "name": "heat"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8080", "region": "RegionOne", "internalURL":
-        "http://10.8.99.233:8080/v1/AUTH_e8f744b1fc6a487681d35fb275252608", "id":
-        "7a2262abf515414ea08b3beedc87e51e", "publicURL": "http://10.8.99.233:8080/v1/AUTH_e8f744b1fc6a487681d35fb275252608"}],
-        "endpoints_links": [], "type": "object-store", "name": "swift"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:35357/v2.0", "region": "RegionOne", "internalURL":
-        "http://10.8.99.233:5000/v2.0", "id": "5d1b7edf24e14ce29abaeee69e84e529",
-        "publicURL": "http://10.8.99.233:5000/v2.0"}], "endpoints_links": [], "type":
-        "identity", "name": "keystone"}], "user": {"username": "admin", "roles_links":
-        [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
-        {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
-        0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:43 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - de1f44ea44f44ce4bbbc76d0071e7916
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-556ba2c6-a30a-4d68-838c-b1037811d335
-      Date:
-      - Thu, 25 Oct 2018 18:21:43 GMT
+      - Thu, 01 Nov 2018 18:37:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
@@ -1902,23 +1082,23 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
         "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
         null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:43 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:00 GMT
 - request:
     method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
     body:
       encoding: US-ASCII
       string: ''
@@ -1930,7 +1110,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - de1f44ea44f44ce4bbbc76d0071e7916
+      - 8ac742727f3a4ed19eed7d4738687f00
   response:
     status:
       code: 200
@@ -1941,28 +1121,16 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-86751095-f2ff-46fd-b146-049288c84e95
+      - req-076ebf7b-bc36-4e9a-ac81-09c3d5c9abb6
       Date:
-      - Thu, 25 Oct 2018 18:21:43 GMT
+      - Thu, 01 Nov 2018 18:37:00 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
         "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
@@ -1971,6 +1139,12 @@ http_interactions:
         "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
         "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2",
+        "end": "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
         "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
@@ -2023,6 +1197,12 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
         "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
         "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
@@ -2047,5 +1227,3333 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:21:43 GMT
+  recorded_at: Thu, 01 Nov 2018 18:37:00 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 8ac742727f3a4ed19eed7d4738687f00
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-ed496c3f-a65f-44d7-ba1f-eabaf8dd5fb5
+      Date:
+      - Thu, 01 Nov 2018 18:37:00 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 01 Nov 2018 18:37:00 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 8ac742727f3a4ed19eed7d4738687f00
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-ac129f97-b942-476d-9f72-ccba4633790c
+      Date:
+      - Thu, 01 Nov 2018 18:37:01 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2",
+        "end": "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 01 Nov 2018 18:37:01 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 8ac742727f3a4ed19eed7d4738687f00
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-f6a40ef2-baff-4b91-a2e8-03f71f53354d
+      Date:
+      - Thu, 01 Nov 2018 18:37:01 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2",
+        "end": "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 01 Nov 2018 18:37:01 GMT
+- request:
+    method: post
+    uri: http://11.22.33.44:5000/v2.0/tokens
+    body:
+      encoding: UTF-8
+      string: '{"auth":{"passwordCredentials":{"username":"admin","password":"password_2WpEraURh"},"tenantName":"EmsRefreshSpec-Project-No-Admin-Role"}}'
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 01 Nov 2018 18:37:01 GMT
+      Server:
+      - Apache/2.4.6 (Red Hat Enterprise Linux)
+      Vary:
+      - X-Auth-Token,Accept-Encoding
+      X-Openstack-Request-Id:
+      - req-ba840c4e-286b-4ffa-8b86-e99ce734003e
+      Content-Length:
+      - '4131'
+      Connection:
+      - close
+      Content-Type:
+      - application/json
+    body:
+      encoding: ASCII-8BIT
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:37:01.544328", "expires":
+        "2018-11-01T19:37:01Z", "id": "55c20ed70b7f4207ad59af564256c0be", "tenant":
+        {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["NqciwVneR4y6wiXNvAR4BA"]},
+        "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
+        "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
+        "endpoints_links": [], "type": "compute", "name": "nova"}, {"endpoints": [{"adminURL":
+        "http://10.8.99.233:9696", "region": "RegionOne", "internalURL": "http://10.8.99.233:9696",
+        "id": "5b097055aff24a40aa4cd2d7317c9108", "publicURL": "http://10.8.99.233:9696"}],
+        "endpoints_links": [], "type": "network", "name": "neutron"}, {"endpoints":
+        [{"adminURL": "http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8",
+        "id": "13c4208d548d4bcdaedfe8296b6559ee", "publicURL": "http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8"}],
+        "endpoints_links": [], "type": "volumev2", "name": "cinderv2"}, {"endpoints":
+        [{"adminURL": "http://127.0.0.1:8774/v3", "region": "RegionOne", "internalURL":
+        "http://127.0.0.1:8774/v3", "id": "3874f107e1a0461596883a12743dbcc0", "publicURL":
+        "http://127.0.0.1:8774/v3"}], "endpoints_links": [], "type": "computev3",
+        "name": "novav3"}, {"endpoints": [{"adminURL": "http://10.8.99.233:9292",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:9292", "id": "75fcb24891654062ae1703e6b92f6018",
+        "publicURL": "http://10.8.99.233:9292"}], "endpoints_links": [], "type": "image",
+        "name": "glance"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8777",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:8777", "id": "2c972a2880d1453aad86104dcda88a55",
+        "publicURL": "http://10.8.99.233:8777"}], "endpoints_links": [], "type": "metering",
+        "name": "ceilometer"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8776/v1/b458a5c25c3749758f4c0661940b3ba8",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v1/b458a5c25c3749758f4c0661940b3ba8",
+        "id": "410c753013fb430c9998f22f68c4cb18", "publicURL": "http://10.8.99.233:8776/v1/b458a5c25c3749758f4c0661940b3ba8"}],
+        "endpoints_links": [], "type": "volume", "name": "cinder"}, {"endpoints":
+        [{"adminURL": "http://10.8.99.233:8773/services/Admin", "region": "RegionOne",
+        "internalURL": "http://10.8.99.233:8773/services/Cloud", "id": "2833b001aa814ddf9216479d379cdac1",
+        "publicURL": "http://10.8.99.233:8773/services/Cloud"}], "endpoints_links":
+        [], "type": "ec2", "name": "nova_ec2"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8004/v1/b458a5c25c3749758f4c0661940b3ba8",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:8004/v1/b458a5c25c3749758f4c0661940b3ba8",
+        "id": "a29a931a5667478c8b3724506a286144", "publicURL": "http://10.8.99.233:8004/v1/b458a5c25c3749758f4c0661940b3ba8"}],
+        "endpoints_links": [], "type": "orchestration", "name": "heat"}, {"endpoints":
+        [{"adminURL": "http://10.8.99.233:8080", "region": "RegionOne", "internalURL":
+        "http://10.8.99.233:8080/v1/AUTH_b458a5c25c3749758f4c0661940b3ba8", "id":
+        "7a2262abf515414ea08b3beedc87e51e", "publicURL": "http://10.8.99.233:8080/v1/AUTH_b458a5c25c3749758f4c0661940b3ba8"}],
+        "endpoints_links": [], "type": "object-store", "name": "swift"}, {"endpoints":
+        [{"adminURL": "http://10.8.99.233:35357/v2.0", "region": "RegionOne", "internalURL":
+        "http://10.8.99.233:5000/v2.0", "id": "5d1b7edf24e14ce29abaeee69e84e529",
+        "publicURL": "http://10.8.99.233:5000/v2.0"}], "endpoints_links": [], "type":
+        "identity", "name": "keystone"}], "user": {"username": "admin", "roles_links":
+        [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
+        {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
+        0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
+    http_version: 
+  recorded_at: Thu, 01 Nov 2018 18:37:01 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 55c20ed70b7f4207ad59af564256c0be
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-c26933a1-ff69-443a-bbb5-d1d37197bf17
+      Date:
+      - Thu, 01 Nov 2018 18:37:01 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2",
+        "end": "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 01 Nov 2018 18:37:01 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 55c20ed70b7f4207ad59af564256c0be
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-91af88a4-9794-446a-b65f-6362681fd134
+      Date:
+      - Thu, 01 Nov 2018 18:37:01 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2",
+        "end": "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 01 Nov 2018 18:37:01 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - cdd6f92e397c404fb3b43f6dceae38a5
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-c3929651-2937-4cec-a108-89652c36cd0f
+      Date:
+      - Thu, 01 Nov 2018 18:37:02 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2",
+        "end": "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 01 Nov 2018 18:37:02 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - cdd6f92e397c404fb3b43f6dceae38a5
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-86e297d2-ae78-4e15-8302-f8f54f7ce7ed
+      Date:
+      - Thu, 01 Nov 2018 18:37:02 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 01 Nov 2018 18:37:02 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - cdd6f92e397c404fb3b43f6dceae38a5
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-200cb048-25d8-4e23-8203-c70bdc5179f5
+      Date:
+      - Thu, 01 Nov 2018 18:37:02 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2",
+        "end": "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 01 Nov 2018 18:37:02 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - cdd6f92e397c404fb3b43f6dceae38a5
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-0e0f44f5-826f-43be-8dba-f7c32b2a4d77
+      Date:
+      - Thu, 01 Nov 2018 18:37:02 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 01 Nov 2018 18:37:02 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - cdd6f92e397c404fb3b43f6dceae38a5
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-cbb280c0-1193-4843-8f24-812b9eea7a2b
+      Date:
+      - Thu, 01 Nov 2018 18:37:02 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2",
+        "end": "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 01 Nov 2018 18:37:02 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - cdd6f92e397c404fb3b43f6dceae38a5
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-af51cd55-1fc2-40ff-92a6-72b0ac47ec5b
+      Date:
+      - Thu, 01 Nov 2018 18:37:02 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 01 Nov 2018 18:37:03 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - cdd6f92e397c404fb3b43f6dceae38a5
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-c59ad954-3ab3-4e7e-bcbb-6560be263063
+      Date:
+      - Thu, 01 Nov 2018 18:37:03 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2",
+        "end": "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 01 Nov 2018 18:37:03 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - cdd6f92e397c404fb3b43f6dceae38a5
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-e72c20f7-f2e2-491c-92cd-3818eb714778
+      Date:
+      - Thu, 01 Nov 2018 18:37:03 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 01 Nov 2018 18:37:03 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - cdd6f92e397c404fb3b43f6dceae38a5
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-387cce7b-a4b0-4fae-8e2e-1d6592bd8cc2
+      Date:
+      - Thu, 01 Nov 2018 18:37:03 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2",
+        "end": "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 01 Nov 2018 18:37:03 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - cdd6f92e397c404fb3b43f6dceae38a5
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-6ff0b877-6481-40c1-bd65-e2d1eb393857
+      Date:
+      - Thu, 01 Nov 2018 18:37:03 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2",
+        "end": "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 01 Nov 2018 18:37:03 GMT
+- request:
+    method: post
+    uri: http://11.22.33.44:5000/v2.0/tokens
+    body:
+      encoding: UTF-8
+      string: '{"auth":{"passwordCredentials":{"username":"admin","password":"password_2WpEraURh"},"tenantName":"EmsRefreshSpec-Project2"}}'
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 01 Nov 2018 18:37:03 GMT
+      Server:
+      - Apache/2.4.6 (Red Hat Enterprise Linux)
+      Vary:
+      - X-Auth-Token,Accept-Encoding
+      X-Openstack-Request-Id:
+      - req-0c61b517-a7c4-4971-8f8c-0cdfcf480dec
+      Content-Length:
+      - '4118'
+      Connection:
+      - close
+      Content-Type:
+      - application/json
+    body:
+      encoding: ASCII-8BIT
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:37:03.844211", "expires":
+        "2018-11-01T19:37:03Z", "id": "570a8fb63a714828aa57cf74ab3de447", "tenant":
+        {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["HfB3LhdNSnCGX1QwoLOniQ"]},
+        "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
+        "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
+        "endpoints_links": [], "type": "compute", "name": "nova"}, {"endpoints": [{"adminURL":
+        "http://10.8.99.233:9696", "region": "RegionOne", "internalURL": "http://10.8.99.233:9696",
+        "id": "5b097055aff24a40aa4cd2d7317c9108", "publicURL": "http://10.8.99.233:9696"}],
+        "endpoints_links": [], "type": "network", "name": "neutron"}, {"endpoints":
+        [{"adminURL": "http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608",
+        "id": "13c4208d548d4bcdaedfe8296b6559ee", "publicURL": "http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608"}],
+        "endpoints_links": [], "type": "volumev2", "name": "cinderv2"}, {"endpoints":
+        [{"adminURL": "http://127.0.0.1:8774/v3", "region": "RegionOne", "internalURL":
+        "http://127.0.0.1:8774/v3", "id": "3874f107e1a0461596883a12743dbcc0", "publicURL":
+        "http://127.0.0.1:8774/v3"}], "endpoints_links": [], "type": "computev3",
+        "name": "novav3"}, {"endpoints": [{"adminURL": "http://10.8.99.233:9292",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:9292", "id": "75fcb24891654062ae1703e6b92f6018",
+        "publicURL": "http://10.8.99.233:9292"}], "endpoints_links": [], "type": "image",
+        "name": "glance"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8777",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:8777", "id": "2c972a2880d1453aad86104dcda88a55",
+        "publicURL": "http://10.8.99.233:8777"}], "endpoints_links": [], "type": "metering",
+        "name": "ceilometer"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8776/v1/e8f744b1fc6a487681d35fb275252608",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v1/e8f744b1fc6a487681d35fb275252608",
+        "id": "410c753013fb430c9998f22f68c4cb18", "publicURL": "http://10.8.99.233:8776/v1/e8f744b1fc6a487681d35fb275252608"}],
+        "endpoints_links": [], "type": "volume", "name": "cinder"}, {"endpoints":
+        [{"adminURL": "http://10.8.99.233:8773/services/Admin", "region": "RegionOne",
+        "internalURL": "http://10.8.99.233:8773/services/Cloud", "id": "2833b001aa814ddf9216479d379cdac1",
+        "publicURL": "http://10.8.99.233:8773/services/Cloud"}], "endpoints_links":
+        [], "type": "ec2", "name": "nova_ec2"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8004/v1/e8f744b1fc6a487681d35fb275252608",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:8004/v1/e8f744b1fc6a487681d35fb275252608",
+        "id": "a29a931a5667478c8b3724506a286144", "publicURL": "http://10.8.99.233:8004/v1/e8f744b1fc6a487681d35fb275252608"}],
+        "endpoints_links": [], "type": "orchestration", "name": "heat"}, {"endpoints":
+        [{"adminURL": "http://10.8.99.233:8080", "region": "RegionOne", "internalURL":
+        "http://10.8.99.233:8080/v1/AUTH_e8f744b1fc6a487681d35fb275252608", "id":
+        "7a2262abf515414ea08b3beedc87e51e", "publicURL": "http://10.8.99.233:8080/v1/AUTH_e8f744b1fc6a487681d35fb275252608"}],
+        "endpoints_links": [], "type": "object-store", "name": "swift"}, {"endpoints":
+        [{"adminURL": "http://10.8.99.233:35357/v2.0", "region": "RegionOne", "internalURL":
+        "http://10.8.99.233:5000/v2.0", "id": "5d1b7edf24e14ce29abaeee69e84e529",
+        "publicURL": "http://10.8.99.233:5000/v2.0"}], "endpoints_links": [], "type":
+        "identity", "name": "keystone"}], "user": {"username": "admin", "roles_links":
+        [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
+        {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
+        0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
+    http_version: 
+  recorded_at: Thu, 01 Nov 2018 18:37:03 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 570a8fb63a714828aa57cf74ab3de447
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-843899ab-2a74-4ae0-bf2c-4b1027c9b432
+      Date:
+      - Thu, 01 Nov 2018 18:37:04 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 01 Nov 2018 18:37:04 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 570a8fb63a714828aa57cf74ab3de447
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-dfbf5b66-e84d-4d71-826e-cab25fbd92ac
+      Date:
+      - Thu, 01 Nov 2018 18:37:04 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2",
+        "end": "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 01 Nov 2018 18:37:04 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 570a8fb63a714828aa57cf74ab3de447
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-61dceb36-ffbc-4f34-84aa-018278982a40
+      Date:
+      - Thu, 01 Nov 2018 18:37:04 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 01 Nov 2018 18:37:04 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 570a8fb63a714828aa57cf74ab3de447
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-2960a667-5805-4add-a14a-796b7737637d
+      Date:
+      - Thu, 01 Nov 2018 18:37:04 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2",
+        "end": "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 01 Nov 2018 18:37:04 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 570a8fb63a714828aa57cf74ab3de447
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-3662d8b7-d920-4597-b917-88f2aee614bb
+      Date:
+      - Thu, 01 Nov 2018 18:37:04 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 01 Nov 2018 18:37:04 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 570a8fb63a714828aa57cf74ab3de447
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-c17fa5d6-ea81-43af-98d1-b557e0b3bb39
+      Date:
+      - Thu, 01 Nov 2018 18:37:04 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2",
+        "end": "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 01 Nov 2018 18:37:04 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 570a8fb63a714828aa57cf74ab3de447
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-16de29d7-b313-4254-a7c4-0f8e9572658f
+      Date:
+      - Thu, 01 Nov 2018 18:37:05 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 01 Nov 2018 18:37:05 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 570a8fb63a714828aa57cf74ab3de447
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-01aed6c9-cfb8-4a3d-b163-13c9a99e3a7c
+      Date:
+      - Thu, 01 Nov 2018 18:37:05 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2",
+        "end": "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 01 Nov 2018 18:37:05 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 570a8fb63a714828aa57cf74ab3de447
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-18362992-8c11-4e06-b9b4-5fb8ad01f4c3
+      Date:
+      - Thu, 01 Nov 2018 18:37:05 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2",
+        "end": "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 01 Nov 2018 18:37:05 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_vm_targeted_refresh.yml
+++ b/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_vm_targeted_refresh.yml
@@ -17,13 +17,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:20:19 GMT
+      - Thu, 01 Nov 2018 18:35:15 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-d977eefd-30d3-441e-acb4-e0e00d4f9ce2
+      - req-20b87898-0ad5-4cf7-a954-34bfe1194111
       Content-Length:
       - '4170'
       Connection:
@@ -32,10 +32,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:20:19.839001", "expires":
-        "2018-10-25T19:20:19Z", "id": "0564c5e3558741d9a30288fe73a41418", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:35:15.333818", "expires":
+        "2018-11-01T19:35:15Z", "id": "f3fa57f9ffdd453fa78854d1700b2f78", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["fDDjJstvQVK6Kzc-uYajXA"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["Ow_6qLqBS9ebL5E0UJyOCA"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -80,7 +80,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:19 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:15 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -95,7 +95,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0564c5e3558741d9a30288fe73a41418
+      - f3fa57f9ffdd453fa78854d1700b2f78
   response:
     status:
       code: 200
@@ -106,7 +106,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Thu, 25 Oct 2018 18:20:19 GMT
+      - Thu, 01 Nov 2018 18:35:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -115,7 +115,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:19 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:15 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/ca4f3a16-bae3-4407-83e9-f77b28af0f2b
@@ -130,7 +130,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0564c5e3558741d9a30288fe73a41418
+      - f3fa57f9ffdd453fa78854d1700b2f78
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -143,9 +143,9 @@ http_interactions:
       Content-Length:
       - '2088'
       X-Compute-Request-Id:
-      - req-d0857a27-f32c-41f2-8a5b-a4552e43c657
+      - req-e0fc576b-cdda-48f9-bf60-2fe89a94a8a3
       Date:
-      - Thu, 25 Oct 2018 18:20:20 GMT
+      - Thu, 01 Nov 2018 18:35:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"server": {"status": "ACTIVE", "updated": "2018-10-09T18:40:19Z",
@@ -172,7 +172,7 @@ http_interactions:
         "", "progress": 0, "OS-EXT-STS:power_state": 1, "config_drive": "", "metadata":
         {}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:20 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:15 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/ca4f3a16-bae3-4407-83e9-f77b28af0f2b/os-interface
@@ -187,7 +187,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0564c5e3558741d9a30288fe73a41418
+      - f3fa57f9ffdd453fa78854d1700b2f78
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -200,9 +200,9 @@ http_interactions:
       Content-Length:
       - '285'
       X-Compute-Request-Id:
-      - req-d807ca4f-8115-4dc0-a627-1aef927d7964
+      - req-b1cff9ad-990d-42a2-98a6-368748782dea
       Date:
-      - Thu, 25 Oct 2018 18:20:20 GMT
+      - Thu, 01 Nov 2018 18:35:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"interfaceAttachments": [{"port_state": "ACTIVE", "fixed_ips": [{"subnet_id":
@@ -210,7 +210,7 @@ http_interactions:
         "dda2ebad-f144-4f63-9a75-cbd4fe25e3e9", "net_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
         "mac_addr": "fa:16:3e:e1:0b:2c"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:20 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:15 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/ca4f3a16-bae3-4407-83e9-f77b28af0f2b/os-security-groups
@@ -225,7 +225,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0564c5e3558741d9a30288fe73a41418
+      - f3fa57f9ffdd453fa78854d1700b2f78
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -238,9 +238,9 @@ http_interactions:
       Content-Length:
       - '3931'
       X-Compute-Request-Id:
-      - req-031d2b7d-93f6-4ccf-a6f6-1cef3ca452c1
+      - req-1d1f70ed-a518-4e19-9586-7087d76a64f2
       Date:
-      - Thu, 25 Oct 2018 18:20:20 GMT
+      - Thu, 01 Nov 2018 18:35:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups": [{"rules": [{"from_port": 3, "group": {"tenant_id":
@@ -292,7 +292,7 @@ http_interactions:
         "name": "EmsRefreshSpec-SecurityGroup2", "description": "EmsRefreshSpec-SecurityGroup2
         description"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:20 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:16 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-floating-ips
@@ -307,7 +307,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0564c5e3558741d9a30288fe73a41418
+      - f3fa57f9ffdd453fa78854d1700b2f78
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -320,14 +320,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-6c538e8d-3aed-4ec2-92b9-5a0cb3c685f0
+      - req-01ddc8ff-d7cc-4318-b76b-1152aba5eb1c
       Date:
-      - Thu, 25 Oct 2018 18:20:20 GMT
+      - Thu, 01 Nov 2018 18:35:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:20 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:16 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -345,13 +345,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:20:21 GMT
+      - Thu, 01 Nov 2018 18:35:16 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-f56ec43b-38d4-44e9-bcdb-e53078f8f1a1
+      - req-43ad08b5-3a8f-4996-83c6-ea6bd237be31
       Content-Length:
       - '4170'
       Connection:
@@ -360,10 +360,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:20:21.175327", "expires":
-        "2018-10-25T19:20:21Z", "id": "63fa622f04674ed4a4a6bd2df37f8f56", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:35:16.667890", "expires":
+        "2018-11-01T19:35:16Z", "id": "78665c4ce12d4d0aae50467b05fd657b", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["haSaVWWjSE6x9hI8w3fX4w"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["mwkWikV4SmmbERS9wgUvsg"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -408,7 +408,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:21 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:16 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?floating_ip_address=172.16.17.4
@@ -423,7 +423,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 63fa622f04674ed4a4a6bd2df37f8f56
+      - 78665c4ce12d4d0aae50467b05fd657b
   response:
     status:
       code: 200
@@ -434,9 +434,9 @@ http_interactions:
       Content-Length:
       - '374'
       X-Openstack-Request-Id:
-      - req-873042cb-c31e-437a-b216-421696d8937c
+      - req-75c483d5-bc97-4780-a8e0-c70b8b6efb38
       Date:
-      - Thu, 25 Oct 2018 18:20:21 GMT
+      - Thu, 01 Nov 2018 18:35:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -445,7 +445,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "dda2ebad-f144-4f63-9a75-cbd4fe25e3e9", "id":
         "855b23e7-1ace-4c22-8c02-2160d3cde900"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:21 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:16 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -463,13 +463,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:20:21 GMT
+      - Thu, 01 Nov 2018 18:35:16 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-35a2ffc1-ac3f-4701-833a-961052a33724
+      - req-760a4e95-979e-4f61-80af-a4d7ccad2f1e
       Content-Length:
       - '4170'
       Connection:
@@ -478,10 +478,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:20:21.562371", "expires":
-        "2018-10-25T19:20:21Z", "id": "63af1f8154ad41e6a0862aa1e413369e", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:35:17.013329", "expires":
+        "2018-11-01T19:35:16Z", "id": "7beb338534a94848ae24aad59abbbaa2", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["XfsAQGUKQaapY0MMD929hg"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["k8KzeMIkRjOMfxXl-MNS7g"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -526,7 +526,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:21 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:17 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -541,20 +541,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 63af1f8154ad41e6a0862aa1e413369e
+      - 7beb338534a94848ae24aad59abbbaa2
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:20:21 GMT
+      - Thu, 01 Nov 2018 18:35:17 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-4ee39689-2ae1-4c9d-ac30-50feb262ead2
+      - req-c1fb80bc-9ce9-4749-bf25-91afcbfe402c
       Content-Length:
       - '500'
       Connection:
@@ -571,7 +571,189 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:21 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:17 GMT
+- request:
+    method: post
+    uri: http://11.22.33.44:5000/v2.0/tokens
+    body:
+      encoding: UTF-8
+      string: '{"auth":{"passwordCredentials":{"username":"admin","password":"password_2WpEraURh"},"tenantName":"EmsRefreshSpec-Project"}}'
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 01 Nov 2018 18:35:17 GMT
+      Server:
+      - Apache/2.4.6 (Red Hat Enterprise Linux)
+      Vary:
+      - X-Auth-Token,Accept-Encoding
+      X-Openstack-Request-Id:
+      - req-45623188-f774-4468-82c6-b5c9fd4adcdd
+      Content-Length:
+      - '4117'
+      Connection:
+      - close
+      Content-Type:
+      - application/json
+    body:
+      encoding: ASCII-8BIT
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:35:17.344765", "expires":
+        "2018-11-01T19:35:17Z", "id": "c686c8ac92874b739794e9508b147955", "tenant":
+        {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["EDjoPfjnQb-alSrWniXKSg"]},
+        "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
+        "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
+        "endpoints_links": [], "type": "compute", "name": "nova"}, {"endpoints": [{"adminURL":
+        "http://10.8.99.233:9696", "region": "RegionOne", "internalURL": "http://10.8.99.233:9696",
+        "id": "5b097055aff24a40aa4cd2d7317c9108", "publicURL": "http://10.8.99.233:9696"}],
+        "endpoints_links": [], "type": "network", "name": "neutron"}, {"endpoints":
+        [{"adminURL": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a",
+        "id": "13c4208d548d4bcdaedfe8296b6559ee", "publicURL": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
+        "endpoints_links": [], "type": "volumev2", "name": "cinderv2"}, {"endpoints":
+        [{"adminURL": "http://127.0.0.1:8774/v3", "region": "RegionOne", "internalURL":
+        "http://127.0.0.1:8774/v3", "id": "3874f107e1a0461596883a12743dbcc0", "publicURL":
+        "http://127.0.0.1:8774/v3"}], "endpoints_links": [], "type": "computev3",
+        "name": "novav3"}, {"endpoints": [{"adminURL": "http://10.8.99.233:9292",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:9292", "id": "75fcb24891654062ae1703e6b92f6018",
+        "publicURL": "http://10.8.99.233:9292"}], "endpoints_links": [], "type": "image",
+        "name": "glance"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8777",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:8777", "id": "2c972a2880d1453aad86104dcda88a55",
+        "publicURL": "http://10.8.99.233:8777"}], "endpoints_links": [], "type": "metering",
+        "name": "ceilometer"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8776/v1/69f8f7205ade4aa59084c32c83e60b5a",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v1/69f8f7205ade4aa59084c32c83e60b5a",
+        "id": "410c753013fb430c9998f22f68c4cb18", "publicURL": "http://10.8.99.233:8776/v1/69f8f7205ade4aa59084c32c83e60b5a"}],
+        "endpoints_links": [], "type": "volume", "name": "cinder"}, {"endpoints":
+        [{"adminURL": "http://10.8.99.233:8773/services/Admin", "region": "RegionOne",
+        "internalURL": "http://10.8.99.233:8773/services/Cloud", "id": "2833b001aa814ddf9216479d379cdac1",
+        "publicURL": "http://10.8.99.233:8773/services/Cloud"}], "endpoints_links":
+        [], "type": "ec2", "name": "nova_ec2"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a",
+        "id": "a29a931a5667478c8b3724506a286144", "publicURL": "http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a"}],
+        "endpoints_links": [], "type": "orchestration", "name": "heat"}, {"endpoints":
+        [{"adminURL": "http://10.8.99.233:8080", "region": "RegionOne", "internalURL":
+        "http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a", "id":
+        "7a2262abf515414ea08b3beedc87e51e", "publicURL": "http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a"}],
+        "endpoints_links": [], "type": "object-store", "name": "swift"}, {"endpoints":
+        [{"adminURL": "http://10.8.99.233:35357/v2.0", "region": "RegionOne", "internalURL":
+        "http://10.8.99.233:5000/v2.0", "id": "5d1b7edf24e14ce29abaeee69e84e529",
+        "publicURL": "http://10.8.99.233:5000/v2.0"}], "endpoints_links": [], "type":
+        "identity", "name": "keystone"}], "user": {"username": "admin", "roles_links":
+        [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
+        {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
+        0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
+    http_version: 
+  recorded_at: Thu, 01 Nov 2018 18:35:17 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/0a55c0d5-c780-4e7d-9d09-47f5520c7448
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - c686c8ac92874b739794e9508b147955
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Compute-Request-Id:
+      - req-131688cb-aaec-485f-9235-2accfed1a29a
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1406'
+      X-Openstack-Request-Id:
+      - req-131688cb-aaec-485f-9235-2accfed1a29a
+      Date:
+      - Thu, 01 Nov 2018 18:35:17 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"volume": {"migration_status": null, "attachments": [{"server_id":
+        "ca4f3a16-bae3-4407-83e9-f77b28af0f2b", "attachment_id": "7913f588-2068-4b0c-810f-5e8cf00a4754",
+        "host_name": null, "volume_id": "0a55c0d5-c780-4e7d-9d09-47f5520c7448", "device":
+        "/dev/vdd", "id": "0a55c0d5-c780-4e7d-9d09-47f5520c7448"}], "links": [{"href":
+        "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/0a55c0d5-c780-4e7d-9d09-47f5520c7448",
+        "rel": "self"}, {"href": "http://10.8.99.233:8776/69f8f7205ade4aa59084c32c83e60b5a/volumes/0a55c0d5-c780-4e7d-9d09-47f5520c7448",
+        "rel": "bookmark"}], "availability_zone": "nova", "os-vol-host-attr:host":
+        "dhcp-8-99-233@lvm#lvm", "encrypted": false, "os-volume-replication:extended_status":
+        null, "replication_status": "disabled", "snapshot_id": null, "id": "0a55c0d5-c780-4e7d-9d09-47f5520c7448",
+        "size": 1, "user_id": "80ea157498b44d08aa6d6f54b8a7c3e7", "os-vol-tenant-attr:tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "os-vol-mig-status-attr:migstat": null,
+        "metadata": {"readonly": "False", "attached_mode": "rw"}, "status": "in-use",
+        "description": "EmsRefreshSpec-Volume description", "multiattach": false,
+        "os-volume-replication:driver_data": null, "source_volid": null, "consistencygroup_id":
+        null, "os-vol-mig-status-attr:name_id": null, "name": "EmsRefreshSpec-Volume",
+        "bootable": "false", "created_at": "2016-11-11T13:49:20.000000", "volume_type":
+        "iscsi"}}'
+    http_version: 
+  recorded_at: Thu, 01 Nov 2018 18:35:17 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/2c774148-c11a-434c-aabb-7fa9c82c37ce
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - c686c8ac92874b739794e9508b147955
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Compute-Request-Id:
+      - req-991e2937-29f4-4398-a283-35eaead850ed
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1408'
+      X-Openstack-Request-Id:
+      - req-991e2937-29f4-4398-a283-35eaead850ed
+      Date:
+      - Thu, 01 Nov 2018 18:35:17 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"volume": {"migration_status": null, "attachments": [{"server_id":
+        "ca4f3a16-bae3-4407-83e9-f77b28af0f2b", "attachment_id": "31311772-106c-4128-a1f0-f3b4cd4e34e3",
+        "host_name": null, "volume_id": "2c774148-c11a-434c-aabb-7fa9c82c37ce", "device":
+        "/dev/vde", "id": "2c774148-c11a-434c-aabb-7fa9c82c37ce"}], "links": [{"href":
+        "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/2c774148-c11a-434c-aabb-7fa9c82c37ce",
+        "rel": "self"}, {"href": "http://10.8.99.233:8776/69f8f7205ade4aa59084c32c83e60b5a/volumes/2c774148-c11a-434c-aabb-7fa9c82c37ce",
+        "rel": "bookmark"}], "availability_zone": "nova", "os-vol-host-attr:host":
+        "dhcp-8-99-233@lvm#lvm", "encrypted": false, "os-volume-replication:extended_status":
+        null, "replication_status": "disabled", "snapshot_id": null, "id": "2c774148-c11a-434c-aabb-7fa9c82c37ce",
+        "size": 1, "user_id": "80ea157498b44d08aa6d6f54b8a7c3e7", "os-vol-tenant-attr:tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "os-vol-mig-status-attr:migstat": null,
+        "metadata": {"readonly": "False", "attached_mode": "rw"}, "status": "in-use",
+        "description": "EmsRefreshSpec-Volume description", "multiattach": false,
+        "os-volume-replication:driver_data": null, "source_volid": null, "consistencygroup_id":
+        null, "os-vol-mig-status-attr:name_id": null, "name": "EmsRefreshSpec-Volume-2",
+        "bootable": "false", "created_at": "2016-11-11T13:49:43.000000", "volume_type":
+        "iscsi"}}'
+    http_version: 
+  recorded_at: Thu, 01 Nov 2018 18:35:17 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/6
@@ -586,7 +768,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0564c5e3558741d9a30288fe73a41418
+      - f3fa57f9ffdd453fa78854d1700b2f78
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -599,9 +781,9 @@ http_interactions:
       Content-Length:
       - '433'
       X-Compute-Request-Id:
-      - req-98078ca5-787f-4e26-a1d9-3e606c60d8ae
+      - req-6d6b96c3-23d4-4253-ac93-aec7b346d644
       Date:
-      - Thu, 25 Oct 2018 18:20:21 GMT
+      - Thu, 01 Nov 2018 18:35:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavor": {"name": "m1.ems_refresh_spec", "links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/6",
@@ -610,7 +792,7 @@ http_interactions:
         1, "swap": 512, "os-flavor-access:is_public": true, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         1, "disk": 1, "id": "6"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:21 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:18 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -628,13 +810,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:20:22 GMT
+      - Thu, 01 Nov 2018 18:35:18 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-532ce73f-79c5-410e-8240-5814f33405fe
+      - req-46f7a235-f4a0-4887-b832-e60dc164a427
       Content-Length:
       - '4170'
       Connection:
@@ -643,10 +825,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:20:22.057420", "expires":
-        "2018-10-25T19:20:22Z", "id": "566a56322f6343068a6c5b9f9adcd20c", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:35:18.229971", "expires":
+        "2018-11-01T19:35:18Z", "id": "2112025a49244bdfa817233a73d847a0", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["4G1rGQQuQBKHcZ4ZArV-1A"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["eyMe4bRcTxOJ52J3bxR91g"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -691,7 +873,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:22 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:18 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images/bb799f70-5e02-461b-8324-17ee88259c7b
@@ -706,7 +888,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 566a56322f6343068a6c5b9f9adcd20c
+      - 2112025a49244bdfa817233a73d847a0
   response:
     status:
       code: 200
@@ -717,9 +899,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-6c9cea6a-4661-44c7-9f04-715c3e76f7c1
+      - req-a5f0704d-747f-452a-ae8b-5ed87ec5850e
       Date:
-      - Thu, 25 Oct 2018 18:20:22 GMT
+      - Thu, 01 Nov 2018 18:35:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"status": "active", "name": "EmsRefreshSpec-Image", "tags": [], "container_format":
@@ -730,7 +912,7 @@ http_interactions:
         "checksum": "ee1eca47dc88f4879d8a229cc70a07c6", "owner": "69f8f7205ade4aa59084c32c83e60b5a",
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:22 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:18 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -748,13 +930,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:20:22 GMT
+      - Thu, 01 Nov 2018 18:35:18 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-b47855e0-4f72-470f-a0f2-1677bbd04cd6
+      - req-fd1247ca-c28a-44d7-b7dc-ebaf1a08c96f
       Content-Length:
       - '370'
       Connection:
@@ -763,13 +945,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:20:22.413437", "expires":
-        "2018-10-25T19:20:22Z", "id": "25111928c8ef493b98d32d137de79528", "audit_ids":
-        ["2hubWOM0R5W6pSLod9GScA"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:35:18.574283", "expires":
+        "2018-11-01T19:35:18Z", "id": "81ceb347147b47869ad1329a6260ded4", "audit_ids":
+        ["JenRQqxpT46eKHIAYY_5Jg"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:22 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:18 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -784,20 +966,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 25111928c8ef493b98d32d137de79528
+      - 81ceb347147b47869ad1329a6260ded4
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:20:22 GMT
+      - Thu, 01 Nov 2018 18:35:18 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-927dfb0d-2c97-45f2-88b1-5a557f8c3d89
+      - req-5bb1e846-c4ac-4a5c-9049-01f5c646a17a
       Content-Length:
       - '500'
       Connection:
@@ -814,7 +996,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:22 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:18 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -832,13 +1014,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:20:22 GMT
+      - Thu, 01 Nov 2018 18:35:18 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-6142b91d-faae-46c4-a691-ae1cc599ed2c
+      - req-12f38197-871a-4344-9a38-0bfe4854d935
       Content-Length:
       - '4117'
       Connection:
@@ -847,10 +1029,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:20:22.761694", "expires":
-        "2018-10-25T19:20:22Z", "id": "9a5e4d7a8d234d56b6d0186a36d142a2", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:35:18.924293", "expires":
+        "2018-11-01T19:35:18Z", "id": "2bf7b7b4143249ebb30fc05b90468d69", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["zSxcH-DETLSKZbNbBgMhvA"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["3u1KjRfNRGSDD3QXClqueQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -894,7 +1076,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:22 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:18 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -909,7 +1091,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9a5e4d7a8d234d56b6d0186a36d142a2
+      - 2bf7b7b4143249ebb30fc05b90468d69
   response:
     status:
       code: 200
@@ -920,7 +1102,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Thu, 25 Oct 2018 18:20:22 GMT
+      - Thu, 01 Nov 2018 18:35:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -929,7 +1111,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:22 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:19 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -947,13 +1129,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:20:22 GMT
+      - Thu, 01 Nov 2018 18:35:19 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-37691ff4-bb5d-4374-892d-03f0d01928d7
+      - req-f7739345-3afd-4ce0-85d6-3dd0c2cc0a18
       Content-Length:
       - '4131'
       Connection:
@@ -962,10 +1144,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:20:23.031383", "expires":
-        "2018-10-25T19:20:23Z", "id": "18fd93bee33e48709b93255d6bab9550", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:35:19.197459", "expires":
+        "2018-11-01T19:35:19Z", "id": "fcde3b41acea4c5590a5140f149c1a11", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["pcx88lvHT9SLYTGq5EYBLA"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["kL3FxhiVQn6pj7fDppBSfQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -1009,7 +1191,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:23 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:19 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -1024,7 +1206,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 18fd93bee33e48709b93255d6bab9550
+      - fcde3b41acea4c5590a5140f149c1a11
   response:
     status:
       code: 200
@@ -1035,7 +1217,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Thu, 25 Oct 2018 18:20:23 GMT
+      - Thu, 01 Nov 2018 18:35:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -1044,7 +1226,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:23 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:19 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1062,13 +1244,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:20:23 GMT
+      - Thu, 01 Nov 2018 18:35:19 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-9ddeb3a6-d3b8-48a4-b5b1-82e62cf19680
+      - req-c52c2e12-1901-4a6d-93f7-34cdae433f78
       Content-Length:
       - '4118'
       Connection:
@@ -1077,10 +1259,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:20:23.379732", "expires":
-        "2018-10-25T19:20:23Z", "id": "40b2a4c92b4e4ca3bba30613156bded9", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:35:19.482013", "expires":
+        "2018-11-01T19:35:19Z", "id": "6e98255413b843e4a86c3ff0c48fdd3e", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["5eUUGNDXQ92SeMAF1-Qbxg"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["iWHdHeiSQjebUQskIxXfpA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -1124,7 +1306,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:23 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:19 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -1139,7 +1321,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 40b2a4c92b4e4ca3bba30613156bded9
+      - 6e98255413b843e4a86c3ff0c48fdd3e
   response:
     status:
       code: 200
@@ -1150,7 +1332,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Thu, 25 Oct 2018 18:20:23 GMT
+      - Thu, 01 Nov 2018 18:35:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -1159,7 +1341,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:23 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:19 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-keypairs?limit=1000
@@ -1174,7 +1356,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9a5e4d7a8d234d56b6d0186a36d142a2
+      - 2bf7b7b4143249ebb30fc05b90468d69
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1187,9 +1369,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-558bf934-ef64-40b4-a102-f6045d000912
+      - req-f7809f36-7797-4d2f-a3ea-2279501488ac
       Date:
-      - Thu, 25 Oct 2018 18:20:23 GMT
+      - Thu, 01 Nov 2018 18:35:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -1199,7 +1381,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:23 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:19 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -1214,7 +1396,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9a5e4d7a8d234d56b6d0186a36d142a2
+      - 2bf7b7b4143249ebb30fc05b90468d69
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1227,9 +1409,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-c87d98c6-4f23-4a8e-b116-73c18667ee95
+      - req-c5302bb3-25e5-4d59-960a-7527c04bc119
       Date:
-      - Thu, 25 Oct 2018 18:20:23 GMT
+      - Thu, 01 Nov 2018 18:35:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -1239,7 +1421,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:24 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:19 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8/os-keypairs?limit=1000
@@ -1254,7 +1436,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 18fd93bee33e48709b93255d6bab9550
+      - fcde3b41acea4c5590a5140f149c1a11
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1267,9 +1449,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-c3ba2dcb-6eb5-492f-a7c2-4eeb3158e4a0
+      - req-9eeb0b34-522b-41de-876e-e50075c187d9
       Date:
-      - Thu, 25 Oct 2018 18:20:24 GMT
+      - Thu, 01 Nov 2018 18:35:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -1279,7 +1461,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:24 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:20 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -1294,7 +1476,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 18fd93bee33e48709b93255d6bab9550
+      - fcde3b41acea4c5590a5140f149c1a11
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1307,9 +1489,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-8cfe277f-6544-4509-9b56-6e85441fed08
+      - req-d58fde85-37c2-428b-8e26-a357e1f6b7c1
       Date:
-      - Thu, 25 Oct 2018 18:20:24 GMT
+      - Thu, 01 Nov 2018 18:35:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -1319,7 +1501,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:24 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:20 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-keypairs?limit=1000
@@ -1334,7 +1516,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0564c5e3558741d9a30288fe73a41418
+      - f3fa57f9ffdd453fa78854d1700b2f78
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1347,9 +1529,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-d884e3be-dd9b-4617-9b26-e1b5d47db35e
+      - req-90157c8e-001f-4115-8536-36e3b0aaf418
       Date:
-      - Thu, 25 Oct 2018 18:20:24 GMT
+      - Thu, 01 Nov 2018 18:35:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -1359,7 +1541,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:24 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:20 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -1374,7 +1556,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0564c5e3558741d9a30288fe73a41418
+      - f3fa57f9ffdd453fa78854d1700b2f78
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1387,9 +1569,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-1b65c711-60e9-426f-8a51-a8d2d69c6909
+      - req-c531aac3-7450-4948-b7d9-77cc90dd995e
       Date:
-      - Thu, 25 Oct 2018 18:20:24 GMT
+      - Thu, 01 Nov 2018 18:35:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -1399,7 +1581,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:24 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:20 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608/os-keypairs?limit=1000
@@ -1414,7 +1596,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 40b2a4c92b4e4ca3bba30613156bded9
+      - 6e98255413b843e4a86c3ff0c48fdd3e
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1427,9 +1609,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-acf7fb1c-02c1-4f35-addb-620d8b574063
+      - req-f26ac5e1-1b09-42c4-a5cd-a3c7ad745401
       Date:
-      - Thu, 25 Oct 2018 18:20:24 GMT
+      - Thu, 01 Nov 2018 18:35:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -1439,7 +1621,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:24 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:21 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -1454,7 +1636,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 40b2a4c92b4e4ca3bba30613156bded9
+      - 6e98255413b843e4a86c3ff0c48fdd3e
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1467,9 +1649,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-e941cd20-6a4b-4bb4-8139-d41a131c26cc
+      - req-6662f1d5-dae3-4e83-93c8-805222100dc7
       Date:
-      - Thu, 25 Oct 2018 18:20:24 GMT
+      - Thu, 01 Nov 2018 18:35:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -1479,7 +1661,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:24 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:21 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/6
@@ -1494,7 +1676,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0564c5e3558741d9a30288fe73a41418
+      - f3fa57f9ffdd453fa78854d1700b2f78
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1507,9 +1689,9 @@ http_interactions:
       Content-Length:
       - '433'
       X-Compute-Request-Id:
-      - req-3e448106-1f25-466d-b8f8-3dbfb4345230
+      - req-38ba0246-5a6b-46d1-a71b-aaba67602baf
       Date:
-      - Thu, 25 Oct 2018 18:20:24 GMT
+      - Thu, 01 Nov 2018 18:35:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavor": {"name": "m1.ems_refresh_spec", "links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/6",
@@ -1518,7 +1700,7 @@ http_interactions:
         1, "swap": 512, "os-flavor-access:is_public": true, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         1, "disk": 1, "id": "6"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:24 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:21 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/ca4f3a16-bae3-4407-83e9-f77b28af0f2b/os-volume_attachments
@@ -1533,7 +1715,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0564c5e3558741d9a30288fe73a41418
+      - f3fa57f9ffdd453fa78854d1700b2f78
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1546,15 +1728,15 @@ http_interactions:
       Content-Length:
       - '197'
       X-Compute-Request-Id:
-      - req-1efb0297-ffd2-4961-b88c-5a4b4fb419e1
+      - req-33117f77-8fa5-4bc1-a01a-f5bb58b08d40
       Date:
-      - Thu, 25 Oct 2018 18:20:24 GMT
+      - Thu, 01 Nov 2018 18:35:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumeAttachments": [{"device": "/dev/vdd", "serverId": "ca4f3a16-bae3-4407-83e9-f77b28af0f2b",
         "id": "0a55c0d5-c780-4e7d-9d09-47f5520c7448", "volumeId": "0a55c0d5-c780-4e7d-9d09-47f5520c7448"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:24 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:21 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/networks/c0e8e42b-005e-4183-8f25-fa91b3e441c1
@@ -1569,7 +1751,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 63fa622f04674ed4a4a6bd2df37f8f56
+      - 78665c4ce12d4d0aae50467b05fd657b
   response:
     status:
       code: 200
@@ -1580,9 +1762,9 @@ http_interactions:
       Content-Length:
       - '440'
       X-Openstack-Request-Id:
-      - req-34951384-0c35-4c7e-b48b-e5816cd436a0
+      - req-36389b7d-5539-475e-a6eb-bc781688c126
       Date:
-      - Thu, 25 Oct 2018 18:20:25 GMT
+      - Thu, 01 Nov 2018 18:35:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"network": {"status": "ACTIVE", "subnets": ["104c081f-97dd-42b7-8930-98abbd015c74",
@@ -1592,7 +1774,7 @@ http_interactions:
         "vxlan", "id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "provider:segmentation_id":
         14}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:25 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:22 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/networks/20af6027-7aeb-432a-ab3b-d7217faa2f1c
@@ -1607,7 +1789,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 63fa622f04674ed4a4a6bd2df37f8f56
+      - 78665c4ce12d4d0aae50467b05fd657b
   response:
     status:
       code: 200
@@ -1618,9 +1800,9 @@ http_interactions:
       Content-Length:
       - '409'
       X-Openstack-Request-Id:
-      - req-da8c4b7a-62df-4d13-92db-b172970b53d2
+      - req-1d4fe3b5-8750-4570-83e0-cb79fd96dbd5
       Date:
-      - Thu, 25 Oct 2018 18:20:25 GMT
+      - Thu, 01 Nov 2018 18:35:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"network": {"status": "ACTIVE", "subnets": ["33da95a6-bded-44d8-be36-6cc97f3d72bd"],
@@ -1630,7 +1812,7 @@ http_interactions:
         "id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "provider:segmentation_id":
         null}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:25 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:22 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1648,13 +1830,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:20:25 GMT
+      - Thu, 01 Nov 2018 18:35:22 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-eaa7a5ab-4294-4728-9be8-cc401d74e631
+      - req-13d01b38-96cd-466e-8430-38d28ffad509
       Content-Length:
       - '4117'
       Connection:
@@ -1663,10 +1845,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:20:25.435797", "expires":
-        "2018-10-25T19:20:25Z", "id": "243def16d5da4d85bc7fc5d469a751d5", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:35:22.371262", "expires":
+        "2018-11-01T19:35:22Z", "id": "083e70d988934f4a9a6d98d0c1da26a0", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["Gw9yY1z7TeeaNaNKg0emLA"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["_FXe2S_ySCK_3WDpsMyirg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -1710,7 +1892,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:25 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:22 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -1725,7 +1907,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 243def16d5da4d85bc7fc5d469a751d5
+      - '083e70d988934f4a9a6d98d0c1da26a0'
   response:
     status:
       code: 200
@@ -1736,141 +1918,9 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-1fd27076-9d48-434d-b1d5-2f53ed7c15a1
+      - req-18e5305d-2670-410c-b1a6-d0ae83644fa3
       Date:
-      - Thu, 25 Oct 2018 18:20:25 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.50.4", "end": "192.168.50.4"}, {"start":
-        "192.168.50.2", "end": "192.168.50.2"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
-        false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
-        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:25 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 243def16d5da4d85bc7fc5d469a751d5
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-c14bcf0f-949b-406d-892a-924ad38fb374
-      Date:
-      - Thu, 25 Oct 2018 18:20:25 GMT
+      - Thu, 01 Nov 2018 18:35:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
@@ -1974,7 +2024,271 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:25 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:22 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - '083e70d988934f4a9a6d98d0c1da26a0'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-68dc18da-7629-4f36-b720-550c382e3431
+      Date:
+      - Thu, 01 Nov 2018 18:35:22 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 01 Nov 2018 18:35:22 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - '083e70d988934f4a9a6d98d0c1da26a0'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-a50306b2-2862-4fb3-bd9a-e2db72a4bb1c
+      Date:
+      - Thu, 01 Nov 2018 18:35:22 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 01 Nov 2018 18:35:23 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1992,13 +2306,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:20:25 GMT
+      - Thu, 01 Nov 2018 18:35:23 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-2fde00e7-9688-4304-a831-f9f5c4b3f9c0
+      - req-427c4e77-1b0e-48c7-af8d-5c30dd46de35
       Content-Length:
       - '4131'
       Connection:
@@ -2007,10 +2321,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:20:25.955455", "expires":
-        "2018-10-25T19:20:25Z", "id": "371865eb4ce842ea983d259a8c5daae2", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:35:23.206655", "expires":
+        "2018-11-01T19:35:23Z", "id": "7fd8ff36e69c493b95973e692dc1ee28", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["poa6LNoAS_CNiqoDjHPfdg"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["w0NotVHnR2OulxxHYPgWag"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -2054,7 +2368,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:25 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:23 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -2069,7 +2383,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 371865eb4ce842ea983d259a8c5daae2
+      - 7fd8ff36e69c493b95973e692dc1ee28
   response:
     status:
       code: 200
@@ -2080,141 +2394,9 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-488cb4a2-5f0f-44de-97bb-725220e607be
+      - req-bf162be1-571d-4584-a11f-d41dba3e4457
       Date:
-      - Thu, 25 Oct 2018 18:20:26 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.50.4", "end": "192.168.50.4"}, {"start":
-        "192.168.50.2", "end": "192.168.50.2"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
-        false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
-        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:26 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 371865eb4ce842ea983d259a8c5daae2
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-617bf20c-532e-4c1e-b83c-eb9313da2433
-      Date:
-      - Thu, 25 Oct 2018 18:20:26 GMT
+      - Thu, 01 Nov 2018 18:35:23 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
@@ -2318,139 +2500,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:26 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 63fa622f04674ed4a4a6bd2df37f8f56
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-f58e217d-1fee-4b01-8cb3-eb781109620a
-      Date:
-      - Thu, 25 Oct 2018 18:20:26 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.50.4", "end": "192.168.50.4"}, {"start":
-        "192.168.50.2", "end": "192.168.50.2"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
-        false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
-        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:26 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:23 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
@@ -2465,7 +2515,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 63fa622f04674ed4a4a6bd2df37f8f56
+      - 7fd8ff36e69c493b95973e692dc1ee28
   response:
     status:
       code: 200
@@ -2476,52 +2526,28 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-9928b513-0c8e-4902-ad6a-0047ab1e95db
+      - req-eac60b1c-dad5-47e1-9ae7-31fd29fc8038
       Date:
-      - Thu, 25 Oct 2018 18:20:26 GMT
+      - Thu, 01 Nov 2018 18:35:23 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
         true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
@@ -2569,91 +2595,6 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
         "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:26 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 63fa622f04674ed4a4a6bd2df37f8f56
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-c991867b-f814-42cc-a5da-7739e12780dc
-      Date:
-      - Thu, 25 Oct 2018 18:20:26 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
-        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.4",
-        "end": "192.168.50.4"}, {"start": "192.168.50.2", "end": "192.168.50.2"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
-        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.20.0/24", "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
-        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
         false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
@@ -2678,175 +2619,20 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
         "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
         "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:26 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 63fa622f04674ed4a4a6bd2df37f8f56
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-1d687b89-2422-40d3-8823-c2ca612c31f8
-      Date:
-      - Thu, 25 Oct 2018 18:20:26 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:26 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:23 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
@@ -2861,7 +2647,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 63fa622f04674ed4a4a6bd2df37f8f56
+      - 7fd8ff36e69c493b95973e692dc1ee28
   response:
     status:
       code: 200
@@ -2872,9 +2658,9 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-ba82aedf-3ee5-4535-8162-c73f680316e9
+      - req-14297619-b614-43ab-9a27-c8af419cd5b6
       Date:
-      - Thu, 25 Oct 2018 18:20:27 GMT
+      - Thu, 01 Nov 2018 18:35:23 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
@@ -2978,7 +2764,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:27 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:23 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
@@ -2993,7 +2779,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 63fa622f04674ed4a4a6bd2df37f8f56
+      - 7fd8ff36e69c493b95973e692dc1ee28
   response:
     status:
       code: 200
@@ -3004,53 +2790,12 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-f3f89b19-748f-4ff6-8e40-5316832a1f1b
+      - req-1457074c-91a0-4d69-a4df-baa15d82150a
       Date:
-      - Thu, 25 Oct 2018 18:20:27 GMT
+      - Thu, 01 Nov 2018 18:35:23 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
-        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.4",
-        "end": "192.168.50.4"}, {"start": "192.168.50.2", "end": "192.168.50.2"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
-        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.20.0/24", "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
-        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
         false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
@@ -3091,26 +2836,463 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
         "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
         null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 01 Nov 2018 18:35:23 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 7fd8ff36e69c493b95973e692dc1ee28
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-5cdb9442-0be9-4a46-a836-ff22b5aa5def
+      Date:
+      - Thu, 01 Nov 2018 18:35:24 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
         "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:27 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:24 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 78665c4ce12d4d0aae50467b05fd657b
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-5fc03e29-07e6-4c3b-abb2-3aaf4590e142
+      Date:
+      - Thu, 01 Nov 2018 18:35:24 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 01 Nov 2018 18:35:24 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 78665c4ce12d4d0aae50467b05fd657b
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-21e8b0e5-4540-498f-99d1-00273e6942ff
+      Date:
+      - Thu, 01 Nov 2018 18:35:24 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 01 Nov 2018 18:35:24 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -3128,13 +3310,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:20:27 GMT
+      - Thu, 01 Nov 2018 18:35:24 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-23a7ac6f-5dde-4aaf-aec4-e6ea7fabd875
+      - req-00fbfd2c-e26d-4668-ad3c-20068bfb9773
       Content-Length:
       - '4118'
       Connection:
@@ -3143,10 +3325,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:20:27.402507", "expires":
-        "2018-10-25T19:20:27Z", "id": "f69916843b0e4a8fae307ea1259c7676", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:35:24.941437", "expires":
+        "2018-11-01T19:35:24Z", "id": "e23a2dea99c24a7fbc6bc682f62daa64", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["gr2f5sCCRwSNN96ZtIV3mw"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["tUi-rNCrRIu-kDJ7gWcHIQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -3190,7 +3372,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:27 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:24 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -3205,7 +3387,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f69916843b0e4a8fae307ea1259c7676
+      - e23a2dea99c24a7fbc6bc682f62daa64
   response:
     status:
       code: 200
@@ -3216,9 +3398,9 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-84609bbd-30bb-41e7-9da8-b5b9151978a7
+      - req-f36d2008-8a26-4a90-8b3f-1673476af596
       Date:
-      - Thu, 25 Oct 2018 18:20:27 GMT
+      - Thu, 01 Nov 2018 18:35:25 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
@@ -3322,7 +3504,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
         "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:27 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:25 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
@@ -3337,7 +3519,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f69916843b0e4a8fae307ea1259c7676
+      - e23a2dea99c24a7fbc6bc682f62daa64
   response:
     status:
       code: 200
@@ -3348,184 +3530,28 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-addbe0d7-29e5-4f70-b0fd-727e93cbec37
+      - req-ceec0f76-5f21-427b-87ec-a43332c41fc5
       Date:
-      - Thu, 25 Oct 2018 18:20:27 GMT
+      - Thu, 01 Nov 2018 18:35:25 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
-        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.4",
-        "end": "192.168.50.4"}, {"start": "192.168.50.2", "end": "192.168.50.2"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
-        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.20.0/24", "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
-        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
         true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:27 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - f69916843b0e4a8fae307ea1259c7676
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-db03b15f-1ebf-4dec-b28f-07fc23c87228
-      Date:
-      - Thu, 25 Oct 2018 18:20:27 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
@@ -3573,91 +3599,6 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
         "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:27 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - f69916843b0e4a8fae307ea1259c7676
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-aee93c8b-d1fa-4d47-8c8d-281b4136cddb
-      Date:
-      - Thu, 25 Oct 2018 18:20:28 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
-        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.4",
-        "end": "192.168.50.4"}, {"start": "192.168.50.2", "end": "192.168.50.2"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
-        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.20.0/24", "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
-        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
         false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
@@ -3682,703 +3623,20 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
         "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
         "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:28 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - f69916843b0e4a8fae307ea1259c7676
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-45dacfca-bff6-41de-bb8c-02102e04a4cc
-      Date:
-      - Thu, 25 Oct 2018 18:20:28 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:28 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - f69916843b0e4a8fae307ea1259c7676
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-d8c8b1ec-fa13-48ec-94c9-d0462400f13f
-      Date:
-      - Thu, 25 Oct 2018 18:20:28 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
-        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.4",
-        "end": "192.168.50.4"}, {"start": "192.168.50.2", "end": "192.168.50.2"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
-        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.20.0/24", "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
-        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:28 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - f69916843b0e4a8fae307ea1259c7676
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-f55303a2-240c-4588-b428-2f9eca4cdaba
-      Date:
-      - Thu, 25 Oct 2018 18:20:28 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:28 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - f69916843b0e4a8fae307ea1259c7676
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-09a31e45-3706-4c60-8b7d-653dcb393051
-      Date:
-      - Thu, 25 Oct 2018 18:20:28 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.50.4", "end": "192.168.50.4"}, {"start":
-        "192.168.50.2", "end": "192.168.50.2"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
-        false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
-        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:28 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - f69916843b0e4a8fae307ea1259c7676
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-7607502e-ea23-435d-baf1-cfaf0cad3cba
-      Date:
-      - Thu, 25 Oct 2018 18:20:28 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2",
-        "end": "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:28 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:25 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports/dda2ebad-f144-4f63-9a75-cbd4fe25e3e9
@@ -4393,7 +3651,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 63fa622f04674ed4a4a6bd2df37f8f56
+      - 78665c4ce12d4d0aae50467b05fd657b
   response:
     status:
       code: 200
@@ -4404,9 +3662,9 @@ http_interactions:
       Content-Length:
       - '954'
       X-Openstack-Request-Id:
-      - req-45087ba8-1ec1-4e29-b0f9-f24ccd0e2362
+      - req-3588c068-958f-4009-8960-d9c323da5964
       Date:
-      - Thu, 25 Oct 2018 18:20:28 GMT
+      - Thu, 01 Nov 2018 18:35:25 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"port": {"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -4421,7 +3679,7 @@ http_interactions:
         true}, "binding:vnic_type": "normal", "binding:vif_type": "ovs", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "mac_address": "fa:16:3e:e1:0b:2c"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:29 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:25 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?device_id=57e17608-8ac6-44a6-803e-f42ec15e9d1e&limit=1000
@@ -4436,7 +3694,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 243def16d5da4d85bc7fc5d469a751d5
+      - '083e70d988934f4a9a6d98d0c1da26a0'
   response:
     status:
       code: 200
@@ -4447,9 +3705,9 @@ http_interactions:
       Content-Length:
       - '2617'
       X-Openstack-Request-Id:
-      - req-0e141367-dd98-44e0-aff1-2509f97ed902
+      - req-fdb60793-66cc-4624-9e68-cea142d9ba7a
       Date:
-      - Thu, 25 Oct 2018 18:20:29 GMT
+      - Thu, 01 Nov 2018 18:35:25 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -4485,7 +3743,7 @@ http_interactions:
         {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
         "binding:vif_type": "ovs", "tenant_id": "", "mac_address": "fa:16:3e:2e:66:be"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:29 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:25 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?device_id=57e17608-8ac6-44a6-803e-f42ec15e9d1e&limit=1000&marker=9330caba-d3ec-4675-b68a-b80fffae6365
@@ -4500,7 +3758,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 243def16d5da4d85bc7fc5d469a751d5
+      - '083e70d988934f4a9a6d98d0c1da26a0'
   response:
     status:
       code: 200
@@ -4511,9 +3769,9 @@ http_interactions:
       Content-Length:
       - '2617'
       X-Openstack-Request-Id:
-      - req-63b5162c-d824-4658-a763-76fa384ea206
+      - req-e75d59a4-0838-4b62-bd50-68b0f305687b
       Date:
-      - Thu, 25 Oct 2018 18:20:29 GMT
+      - Thu, 01 Nov 2018 18:35:25 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -4549,7 +3807,7 @@ http_interactions:
         {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
         "binding:vif_type": "ovs", "tenant_id": "", "mac_address": "fa:16:3e:2e:66:be"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:29 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:25 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?device_id=57e17608-8ac6-44a6-803e-f42ec15e9d1e&limit=1000
@@ -4564,7 +3822,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 371865eb4ce842ea983d259a8c5daae2
+      - 7fd8ff36e69c493b95973e692dc1ee28
   response:
     status:
       code: 200
@@ -4575,9 +3833,9 @@ http_interactions:
       Content-Length:
       - '2617'
       X-Openstack-Request-Id:
-      - req-8439ff33-282a-4bae-9131-b8a2c4cbb37f
+      - req-780ff5bb-d6fc-452a-911d-71bc0446be9c
       Date:
-      - Thu, 25 Oct 2018 18:20:29 GMT
+      - Thu, 01 Nov 2018 18:35:25 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -4613,7 +3871,7 @@ http_interactions:
         {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
         "binding:vif_type": "ovs", "tenant_id": "", "mac_address": "fa:16:3e:2e:66:be"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:29 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:25 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?device_id=57e17608-8ac6-44a6-803e-f42ec15e9d1e&limit=1000&marker=9330caba-d3ec-4675-b68a-b80fffae6365
@@ -4628,7 +3886,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 371865eb4ce842ea983d259a8c5daae2
+      - 7fd8ff36e69c493b95973e692dc1ee28
   response:
     status:
       code: 200
@@ -4639,9 +3897,9 @@ http_interactions:
       Content-Length:
       - '2617'
       X-Openstack-Request-Id:
-      - req-2061d381-6fc0-465b-9293-538e45915db1
+      - req-c3352dbd-399b-4249-b1f0-b88d9ca73760
       Date:
-      - Thu, 25 Oct 2018 18:20:29 GMT
+      - Thu, 01 Nov 2018 18:35:25 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -4677,7 +3935,7 @@ http_interactions:
         {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
         "binding:vif_type": "ovs", "tenant_id": "", "mac_address": "fa:16:3e:2e:66:be"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:29 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:25 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?device_id=57e17608-8ac6-44a6-803e-f42ec15e9d1e&limit=1000
@@ -4692,7 +3950,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 63fa622f04674ed4a4a6bd2df37f8f56
+      - 78665c4ce12d4d0aae50467b05fd657b
   response:
     status:
       code: 200
@@ -4703,9 +3961,9 @@ http_interactions:
       Content-Length:
       - '2617'
       X-Openstack-Request-Id:
-      - req-315ad307-cc88-48a8-89bc-b4673695a867
+      - req-1b8be4ee-3288-4f49-8edd-e8371dfec0a5
       Date:
-      - Thu, 25 Oct 2018 18:20:29 GMT
+      - Thu, 01 Nov 2018 18:35:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -4741,7 +3999,7 @@ http_interactions:
         {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
         "binding:vif_type": "ovs", "tenant_id": "", "mac_address": "fa:16:3e:2e:66:be"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:29 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:26 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?device_id=57e17608-8ac6-44a6-803e-f42ec15e9d1e&limit=1000&marker=9330caba-d3ec-4675-b68a-b80fffae6365
@@ -4756,7 +4014,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 63fa622f04674ed4a4a6bd2df37f8f56
+      - 78665c4ce12d4d0aae50467b05fd657b
   response:
     status:
       code: 200
@@ -4767,9 +4025,9 @@ http_interactions:
       Content-Length:
       - '2617'
       X-Openstack-Request-Id:
-      - req-ed5ffb8d-afb5-4170-9ae3-71eecaa194a6
+      - req-008b7137-2432-43a7-911d-7a2d59efb36b
       Date:
-      - Thu, 25 Oct 2018 18:20:29 GMT
+      - Thu, 01 Nov 2018 18:35:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -4805,7 +4063,7 @@ http_interactions:
         {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
         "binding:vif_type": "ovs", "tenant_id": "", "mac_address": "fa:16:3e:2e:66:be"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:29 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:26 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?device_id=57e17608-8ac6-44a6-803e-f42ec15e9d1e&limit=1000
@@ -4820,7 +4078,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f69916843b0e4a8fae307ea1259c7676
+      - e23a2dea99c24a7fbc6bc682f62daa64
   response:
     status:
       code: 200
@@ -4831,9 +4089,9 @@ http_interactions:
       Content-Length:
       - '2617'
       X-Openstack-Request-Id:
-      - req-459dfd94-54ab-4f34-90df-1a991575c441
+      - req-919de56c-d79b-46b8-8e7e-0327a030ffec
       Date:
-      - Thu, 25 Oct 2018 18:20:29 GMT
+      - Thu, 01 Nov 2018 18:35:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -4869,7 +4127,7 @@ http_interactions:
         {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
         "binding:vif_type": "ovs", "tenant_id": "", "mac_address": "fa:16:3e:2e:66:be"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:29 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:26 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?device_id=57e17608-8ac6-44a6-803e-f42ec15e9d1e&limit=1000&marker=9330caba-d3ec-4675-b68a-b80fffae6365
@@ -4884,7 +4142,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f69916843b0e4a8fae307ea1259c7676
+      - e23a2dea99c24a7fbc6bc682f62daa64
   response:
     status:
       code: 200
@@ -4895,9 +4153,9 @@ http_interactions:
       Content-Length:
       - '2617'
       X-Openstack-Request-Id:
-      - req-ab5f8efd-4ca6-41a3-8b9e-99490000604c
+      - req-7afdcbfb-1f8c-4206-8bc7-8aa6af427314
       Date:
-      - Thu, 25 Oct 2018 18:20:29 GMT
+      - Thu, 01 Nov 2018 18:35:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -4933,7 +4191,7 @@ http_interactions:
         {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
         "binding:vif_type": "ovs", "tenant_id": "", "mac_address": "fa:16:3e:2e:66:be"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:29 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:26 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers/57e17608-8ac6-44a6-803e-f42ec15e9d1e
@@ -4948,7 +4206,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 63fa622f04674ed4a4a6bd2df37f8f56
+      - 78665c4ce12d4d0aae50467b05fd657b
   response:
     status:
       code: 200
@@ -4959,9 +4217,9 @@ http_interactions:
       Content-Length:
       - '443'
       X-Openstack-Request-Id:
-      - req-47ce6228-67b9-437f-b4c0-242673985b43
+      - req-b1a91228-c739-4fe0-9b16-54f8d1d4c856
       Date:
-      - Thu, 25 Oct 2018 18:20:29 GMT
+      - Thu, 01 Nov 2018 18:35:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"router": {"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -4970,7 +4228,7 @@ http_interactions:
         "name": "EmsRefreshSpec-Router", "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "distributed": false, "routes": [], "ha": false, "id": "57e17608-8ac6-44a6-803e-f42ec15e9d1e"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:30 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:26 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups/fd147cb7-7456-43d9-a01f-c06e21b4e6fb
@@ -4985,7 +4243,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 63fa622f04674ed4a4a6bd2df37f8f56
+      - 78665c4ce12d4d0aae50467b05fd657b
   response:
     status:
       code: 200
@@ -4996,9 +4254,9 @@ http_interactions:
       Content-Length:
       - '6900'
       X-Openstack-Request-Id:
-      - req-6e0e1671-cadd-44a9-bcb8-e8ca2cfc93e4
+      - req-02c3a429-fb92-452e-b30b-3b7ab9ac2ac7
       Date:
-      - Thu, 25 Oct 2018 18:20:30 GMT
+      - Thu, 01 Nov 2018 18:35:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_group": {"tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
@@ -5084,7 +4342,7 @@ http_interactions:
         "port_range_max": 80, "port_range_min": 80, "id": "f79f0e32-b186-4778-952e-20827a60ef73",
         "security_group_id": "fd147cb7-7456-43d9-a01f-c06e21b4e6fb"}], "name": "EmsRefreshSpec-SecurityGroup"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:30 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:26 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups/e4836528-d0df-425e-a117-ae8ec6f356d4
@@ -5099,7 +4357,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 63fa622f04674ed4a4a6bd2df37f8f56
+      - 78665c4ce12d4d0aae50467b05fd657b
   response:
     status:
       code: 200
@@ -5110,9 +4368,9 @@ http_interactions:
       Content-Length:
       - '880'
       X-Openstack-Request-Id:
-      - req-c7382c56-3d02-41f8-b9d1-b66e4a33dd13
+      - req-30e4a98e-10f1-40d4-88c0-fc1a168cb722
       Date:
-      - Thu, 25 Oct 2018 18:20:30 GMT
+      - Thu, 01 Nov 2018 18:35:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_group": {"tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
@@ -5126,189 +4384,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "75924ebc-4758-4042-ad04-4ef3c9189098",
         "security_group_id": "e4836528-d0df-425e-a117-ae8ec6f356d4"}], "name": "EmsRefreshSpec-SecurityGroup2"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:30 GMT
-- request:
-    method: post
-    uri: http://11.22.33.44:5000/v2.0/tokens
-    body:
-      encoding: UTF-8
-      string: '{"auth":{"passwordCredentials":{"username":"admin","password":"password_2WpEraURh"},"tenantName":"EmsRefreshSpec-Project"}}'
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 25 Oct 2018 18:20:30 GMT
-      Server:
-      - Apache/2.4.6 (Red Hat Enterprise Linux)
-      Vary:
-      - X-Auth-Token,Accept-Encoding
-      X-Openstack-Request-Id:
-      - req-632f4194-267a-4e0f-a586-3977f07b4e75
-      Content-Length:
-      - '4117'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-10-25T18:20:30.369443", "expires":
-        "2018-10-25T19:20:30Z", "id": "3f4cc4b7b7e24246a2ed48f35d2937f3", "tenant":
-        {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["chG8bbF-QrC4ZPWtqxUVhg"]},
-        "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
-        "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
-        "endpoints_links": [], "type": "compute", "name": "nova"}, {"endpoints": [{"adminURL":
-        "http://10.8.99.233:9696", "region": "RegionOne", "internalURL": "http://10.8.99.233:9696",
-        "id": "5b097055aff24a40aa4cd2d7317c9108", "publicURL": "http://10.8.99.233:9696"}],
-        "endpoints_links": [], "type": "network", "name": "neutron"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a",
-        "id": "13c4208d548d4bcdaedfe8296b6559ee", "publicURL": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
-        "endpoints_links": [], "type": "volumev2", "name": "cinderv2"}, {"endpoints":
-        [{"adminURL": "http://127.0.0.1:8774/v3", "region": "RegionOne", "internalURL":
-        "http://127.0.0.1:8774/v3", "id": "3874f107e1a0461596883a12743dbcc0", "publicURL":
-        "http://127.0.0.1:8774/v3"}], "endpoints_links": [], "type": "computev3",
-        "name": "novav3"}, {"endpoints": [{"adminURL": "http://10.8.99.233:9292",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:9292", "id": "75fcb24891654062ae1703e6b92f6018",
-        "publicURL": "http://10.8.99.233:9292"}], "endpoints_links": [], "type": "image",
-        "name": "glance"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8777",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8777", "id": "2c972a2880d1453aad86104dcda88a55",
-        "publicURL": "http://10.8.99.233:8777"}], "endpoints_links": [], "type": "metering",
-        "name": "ceilometer"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8776/v1/69f8f7205ade4aa59084c32c83e60b5a",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v1/69f8f7205ade4aa59084c32c83e60b5a",
-        "id": "410c753013fb430c9998f22f68c4cb18", "publicURL": "http://10.8.99.233:8776/v1/69f8f7205ade4aa59084c32c83e60b5a"}],
-        "endpoints_links": [], "type": "volume", "name": "cinder"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8773/services/Admin", "region": "RegionOne",
-        "internalURL": "http://10.8.99.233:8773/services/Cloud", "id": "2833b001aa814ddf9216479d379cdac1",
-        "publicURL": "http://10.8.99.233:8773/services/Cloud"}], "endpoints_links":
-        [], "type": "ec2", "name": "nova_ec2"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a",
-        "id": "a29a931a5667478c8b3724506a286144", "publicURL": "http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a"}],
-        "endpoints_links": [], "type": "orchestration", "name": "heat"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8080", "region": "RegionOne", "internalURL":
-        "http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a", "id":
-        "7a2262abf515414ea08b3beedc87e51e", "publicURL": "http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a"}],
-        "endpoints_links": [], "type": "object-store", "name": "swift"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:35357/v2.0", "region": "RegionOne", "internalURL":
-        "http://10.8.99.233:5000/v2.0", "id": "5d1b7edf24e14ce29abaeee69e84e529",
-        "publicURL": "http://10.8.99.233:5000/v2.0"}], "endpoints_links": [], "type":
-        "identity", "name": "keystone"}], "user": {"username": "admin", "roles_links":
-        [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
-        {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
-        0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:30 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/0a55c0d5-c780-4e7d-9d09-47f5520c7448
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 3f4cc4b7b7e24246a2ed48f35d2937f3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      X-Compute-Request-Id:
-      - req-652dffa4-8db5-49ba-ae20-6903abef136b
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '1406'
-      X-Openstack-Request-Id:
-      - req-652dffa4-8db5-49ba-ae20-6903abef136b
-      Date:
-      - Thu, 25 Oct 2018 18:20:30 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"volume": {"migration_status": null, "attachments": [{"server_id":
-        "ca4f3a16-bae3-4407-83e9-f77b28af0f2b", "attachment_id": "7913f588-2068-4b0c-810f-5e8cf00a4754",
-        "host_name": null, "volume_id": "0a55c0d5-c780-4e7d-9d09-47f5520c7448", "device":
-        "/dev/vdd", "id": "0a55c0d5-c780-4e7d-9d09-47f5520c7448"}], "links": [{"href":
-        "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/0a55c0d5-c780-4e7d-9d09-47f5520c7448",
-        "rel": "self"}, {"href": "http://10.8.99.233:8776/69f8f7205ade4aa59084c32c83e60b5a/volumes/0a55c0d5-c780-4e7d-9d09-47f5520c7448",
-        "rel": "bookmark"}], "availability_zone": "nova", "os-vol-host-attr:host":
-        "dhcp-8-99-233@lvm#lvm", "encrypted": false, "os-volume-replication:extended_status":
-        null, "replication_status": "disabled", "snapshot_id": null, "id": "0a55c0d5-c780-4e7d-9d09-47f5520c7448",
-        "size": 1, "user_id": "80ea157498b44d08aa6d6f54b8a7c3e7", "os-vol-tenant-attr:tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "os-vol-mig-status-attr:migstat": null,
-        "metadata": {"readonly": "False", "attached_mode": "rw"}, "status": "in-use",
-        "description": "EmsRefreshSpec-Volume description", "multiattach": false,
-        "os-volume-replication:driver_data": null, "source_volid": null, "consistencygroup_id":
-        null, "os-vol-mig-status-attr:name_id": null, "name": "EmsRefreshSpec-Volume",
-        "bootable": "false", "created_at": "2016-11-11T13:49:20.000000", "volume_type":
-        "iscsi"}}'
-    http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:30 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/2c774148-c11a-434c-aabb-7fa9c82c37ce
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 3f4cc4b7b7e24246a2ed48f35d2937f3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      X-Compute-Request-Id:
-      - req-77c4fabd-1faf-44f2-b3ae-2bfbae8b3122
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '1408'
-      X-Openstack-Request-Id:
-      - req-77c4fabd-1faf-44f2-b3ae-2bfbae8b3122
-      Date:
-      - Thu, 25 Oct 2018 18:20:30 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"volume": {"migration_status": null, "attachments": [{"server_id":
-        "ca4f3a16-bae3-4407-83e9-f77b28af0f2b", "attachment_id": "31311772-106c-4128-a1f0-f3b4cd4e34e3",
-        "host_name": null, "volume_id": "2c774148-c11a-434c-aabb-7fa9c82c37ce", "device":
-        "/dev/vde", "id": "2c774148-c11a-434c-aabb-7fa9c82c37ce"}], "links": [{"href":
-        "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/2c774148-c11a-434c-aabb-7fa9c82c37ce",
-        "rel": "self"}, {"href": "http://10.8.99.233:8776/69f8f7205ade4aa59084c32c83e60b5a/volumes/2c774148-c11a-434c-aabb-7fa9c82c37ce",
-        "rel": "bookmark"}], "availability_zone": "nova", "os-vol-host-attr:host":
-        "dhcp-8-99-233@lvm#lvm", "encrypted": false, "os-volume-replication:extended_status":
-        null, "replication_status": "disabled", "snapshot_id": null, "id": "2c774148-c11a-434c-aabb-7fa9c82c37ce",
-        "size": 1, "user_id": "80ea157498b44d08aa6d6f54b8a7c3e7", "os-vol-tenant-attr:tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "os-vol-mig-status-attr:migstat": null,
-        "metadata": {"readonly": "False", "attached_mode": "rw"}, "status": "in-use",
-        "description": "EmsRefreshSpec-Volume description", "multiattach": false,
-        "os-volume-replication:driver_data": null, "source_volid": null, "consistencygroup_id":
-        null, "os-vol-mig-status-attr:name_id": null, "name": "EmsRefreshSpec-Volume-2",
-        "bootable": "false", "created_at": "2016-11-11T13:49:43.000000", "volume_type":
-        "iscsi"}}'
-    http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:30 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:26 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/ca4f3a16-bae3-4407-83e9-f77b28af0f2b
@@ -5323,7 +4399,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0564c5e3558741d9a30288fe73a41418
+      - f3fa57f9ffdd453fa78854d1700b2f78
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5336,9 +4412,9 @@ http_interactions:
       Content-Length:
       - '2088'
       X-Compute-Request-Id:
-      - req-454b89c7-699c-4af2-8fa5-8c996a80ffcc
+      - req-d4730c23-3749-43dd-96ce-2ab68622070a
       Date:
-      - Thu, 25 Oct 2018 18:20:31 GMT
+      - Thu, 01 Nov 2018 18:35:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"server": {"status": "ACTIVE", "updated": "2018-10-09T18:40:19Z",
@@ -5365,7 +4441,7 @@ http_interactions:
         "", "progress": 0, "OS-EXT-STS:power_state": 1, "config_drive": "", "metadata":
         {}}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:31 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:27 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/ca4f3a16-bae3-4407-83e9-f77b28af0f2b/os-interface
@@ -5380,7 +4456,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0564c5e3558741d9a30288fe73a41418
+      - f3fa57f9ffdd453fa78854d1700b2f78
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5393,9 +4469,9 @@ http_interactions:
       Content-Length:
       - '285'
       X-Compute-Request-Id:
-      - req-3b73539f-03ef-4904-ab3b-94dc08f63a12
+      - req-37764fe1-3658-438a-a5b5-88363063b7e0
       Date:
-      - Thu, 25 Oct 2018 18:20:31 GMT
+      - Thu, 01 Nov 2018 18:35:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"interfaceAttachments": [{"port_state": "ACTIVE", "fixed_ips": [{"subnet_id":
@@ -5403,7 +4479,7 @@ http_interactions:
         "dda2ebad-f144-4f63-9a75-cbd4fe25e3e9", "net_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
         "mac_addr": "fa:16:3e:e1:0b:2c"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:31 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:27 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/ca4f3a16-bae3-4407-83e9-f77b28af0f2b/os-security-groups
@@ -5418,7 +4494,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0564c5e3558741d9a30288fe73a41418
+      - f3fa57f9ffdd453fa78854d1700b2f78
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5431,9 +4507,9 @@ http_interactions:
       Content-Length:
       - '3931'
       X-Compute-Request-Id:
-      - req-902ee120-8052-488b-8823-be0c97937815
+      - req-7d625816-4e7c-4025-b0c8-97b40a4fb5eb
       Date:
-      - Thu, 25 Oct 2018 18:20:32 GMT
+      - Thu, 01 Nov 2018 18:35:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups": [{"rules": [{"from_port": 3, "group": {"tenant_id":
@@ -5485,7 +4561,7 @@ http_interactions:
         "name": "EmsRefreshSpec-SecurityGroup2", "description": "EmsRefreshSpec-SecurityGroup2
         description"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:32 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:27 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-floating-ips
@@ -5500,7 +4576,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0564c5e3558741d9a30288fe73a41418
+      - f3fa57f9ffdd453fa78854d1700b2f78
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5513,14 +4589,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-bdde8ce7-c576-43db-b762-9d3be83c09ff
+      - req-95f99d61-2542-4e6e-b936-0f4c12ec5a1b
       Date:
-      - Thu, 25 Oct 2018 18:20:32 GMT
+      - Thu, 01 Nov 2018 18:35:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:32 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:28 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?floating_ip_address=172.16.17.4
@@ -5535,7 +4611,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 63fa622f04674ed4a4a6bd2df37f8f56
+      - 78665c4ce12d4d0aae50467b05fd657b
   response:
     status:
       code: 200
@@ -5546,9 +4622,9 @@ http_interactions:
       Content-Length:
       - '374'
       X-Openstack-Request-Id:
-      - req-0b4b412c-3278-4fb5-bfc9-139a12c3f92e
+      - req-d96e84fd-7377-4e5d-af5a-d344c9e74b81
       Date:
-      - Thu, 25 Oct 2018 18:20:32 GMT
+      - Thu, 01 Nov 2018 18:35:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -5557,7 +4633,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "dda2ebad-f144-4f63-9a75-cbd4fe25e3e9", "id":
         "855b23e7-1ace-4c22-8c02-2160d3cde900"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:32 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:28 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips/855b23e7-1ace-4c22-8c02-2160d3cde900
@@ -5572,7 +4648,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 63fa622f04674ed4a4a6bd2df37f8f56
+      - 78665c4ce12d4d0aae50467b05fd657b
   response:
     status:
       code: 200
@@ -5583,9 +4659,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Openstack-Request-Id:
-      - req-7c96041b-6f85-4bac-b11a-ce5034a4cec6
+      - req-71bfb370-3b75-493c-97b6-369c55ac2cdc
       Date:
-      - Thu, 25 Oct 2018 18:20:32 GMT
+      - Thu, 01 Nov 2018 18:35:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingip": {"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -5594,7 +4670,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "dda2ebad-f144-4f63-9a75-cbd4fe25e3e9", "id":
         "855b23e7-1ace-4c22-8c02-2160d3cde900"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:32 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:28 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -5609,20 +4685,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 63af1f8154ad41e6a0862aa1e413369e
+      - 7beb338534a94848ae24aad59abbbaa2
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Thu, 25 Oct 2018 18:20:32 GMT
+      - Thu, 01 Nov 2018 18:35:28 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-4fc180ae-f349-43b9-9948-7d4c5ed461c0
+      - req-0e4cae26-2400-42a4-983d-601c1f8400af
       Content-Length:
       - '500'
       Connection:
@@ -5639,7 +4715,109 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:32 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:28 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/0a55c0d5-c780-4e7d-9d09-47f5520c7448
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - c686c8ac92874b739794e9508b147955
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Compute-Request-Id:
+      - req-4b212476-7d92-4506-b091-feacf4d65eb4
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1406'
+      X-Openstack-Request-Id:
+      - req-4b212476-7d92-4506-b091-feacf4d65eb4
+      Date:
+      - Thu, 01 Nov 2018 18:35:28 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"volume": {"migration_status": null, "attachments": [{"server_id":
+        "ca4f3a16-bae3-4407-83e9-f77b28af0f2b", "attachment_id": "7913f588-2068-4b0c-810f-5e8cf00a4754",
+        "host_name": null, "volume_id": "0a55c0d5-c780-4e7d-9d09-47f5520c7448", "device":
+        "/dev/vdd", "id": "0a55c0d5-c780-4e7d-9d09-47f5520c7448"}], "links": [{"href":
+        "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/0a55c0d5-c780-4e7d-9d09-47f5520c7448",
+        "rel": "self"}, {"href": "http://10.8.99.233:8776/69f8f7205ade4aa59084c32c83e60b5a/volumes/0a55c0d5-c780-4e7d-9d09-47f5520c7448",
+        "rel": "bookmark"}], "availability_zone": "nova", "os-vol-host-attr:host":
+        "dhcp-8-99-233@lvm#lvm", "encrypted": false, "os-volume-replication:extended_status":
+        null, "replication_status": "disabled", "snapshot_id": null, "id": "0a55c0d5-c780-4e7d-9d09-47f5520c7448",
+        "size": 1, "user_id": "80ea157498b44d08aa6d6f54b8a7c3e7", "os-vol-tenant-attr:tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "os-vol-mig-status-attr:migstat": null,
+        "metadata": {"readonly": "False", "attached_mode": "rw"}, "status": "in-use",
+        "description": "EmsRefreshSpec-Volume description", "multiattach": false,
+        "os-volume-replication:driver_data": null, "source_volid": null, "consistencygroup_id":
+        null, "os-vol-mig-status-attr:name_id": null, "name": "EmsRefreshSpec-Volume",
+        "bootable": "false", "created_at": "2016-11-11T13:49:20.000000", "volume_type":
+        "iscsi"}}'
+    http_version: 
+  recorded_at: Thu, 01 Nov 2018 18:35:28 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/2c774148-c11a-434c-aabb-7fa9c82c37ce
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - c686c8ac92874b739794e9508b147955
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Compute-Request-Id:
+      - req-e23b6996-17f1-491c-9819-9da66e894d43
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1408'
+      X-Openstack-Request-Id:
+      - req-e23b6996-17f1-491c-9819-9da66e894d43
+      Date:
+      - Thu, 01 Nov 2018 18:35:28 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"volume": {"migration_status": null, "attachments": [{"server_id":
+        "ca4f3a16-bae3-4407-83e9-f77b28af0f2b", "attachment_id": "31311772-106c-4128-a1f0-f3b4cd4e34e3",
+        "host_name": null, "volume_id": "2c774148-c11a-434c-aabb-7fa9c82c37ce", "device":
+        "/dev/vde", "id": "2c774148-c11a-434c-aabb-7fa9c82c37ce"}], "links": [{"href":
+        "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/2c774148-c11a-434c-aabb-7fa9c82c37ce",
+        "rel": "self"}, {"href": "http://10.8.99.233:8776/69f8f7205ade4aa59084c32c83e60b5a/volumes/2c774148-c11a-434c-aabb-7fa9c82c37ce",
+        "rel": "bookmark"}], "availability_zone": "nova", "os-vol-host-attr:host":
+        "dhcp-8-99-233@lvm#lvm", "encrypted": false, "os-volume-replication:extended_status":
+        null, "replication_status": "disabled", "snapshot_id": null, "id": "2c774148-c11a-434c-aabb-7fa9c82c37ce",
+        "size": 1, "user_id": "80ea157498b44d08aa6d6f54b8a7c3e7", "os-vol-tenant-attr:tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "os-vol-mig-status-attr:migstat": null,
+        "metadata": {"readonly": "False", "attached_mode": "rw"}, "status": "in-use",
+        "description": "EmsRefreshSpec-Volume description", "multiattach": false,
+        "os-volume-replication:driver_data": null, "source_volid": null, "consistencygroup_id":
+        null, "os-vol-mig-status-attr:name_id": null, "name": "EmsRefreshSpec-Volume-2",
+        "bootable": "false", "created_at": "2016-11-11T13:49:43.000000", "volume_type":
+        "iscsi"}}'
+    http_version: 
+  recorded_at: Thu, 01 Nov 2018 18:35:28 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/6
@@ -5654,7 +4832,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0564c5e3558741d9a30288fe73a41418
+      - f3fa57f9ffdd453fa78854d1700b2f78
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5667,9 +4845,9 @@ http_interactions:
       Content-Length:
       - '433'
       X-Compute-Request-Id:
-      - req-18850e8f-88bf-44ac-871e-18d16539f391
+      - req-356db556-c139-4f13-9bdf-084684f20426
       Date:
-      - Thu, 25 Oct 2018 18:20:32 GMT
+      - Thu, 01 Nov 2018 18:35:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavor": {"name": "m1.ems_refresh_spec", "links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/6",
@@ -5678,7 +4856,7 @@ http_interactions:
         1, "swap": 512, "os-flavor-access:is_public": true, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         1, "disk": 1, "id": "6"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:32 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:29 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images/bb799f70-5e02-461b-8324-17ee88259c7b
@@ -5693,7 +4871,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 566a56322f6343068a6c5b9f9adcd20c
+      - 2112025a49244bdfa817233a73d847a0
   response:
     status:
       code: 200
@@ -5704,9 +4882,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-45bf64e6-d1fa-4ca5-adf2-5318025deb56
+      - req-c20ade18-5b96-45c6-b32b-763425ecd563
       Date:
-      - Thu, 25 Oct 2018 18:20:32 GMT
+      - Thu, 01 Nov 2018 18:35:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"status": "active", "name": "EmsRefreshSpec-Image", "tags": [], "container_format":
@@ -5717,7 +4895,7 @@ http_interactions:
         "checksum": "ee1eca47dc88f4879d8a229cc70a07c6", "owner": "69f8f7205ade4aa59084c32c83e60b5a",
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:32 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:29 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-keypairs?limit=1000
@@ -5732,7 +4910,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9a5e4d7a8d234d56b6d0186a36d142a2
+      - 2bf7b7b4143249ebb30fc05b90468d69
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5745,9 +4923,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-2ea07a3d-21f0-4eb0-bf61-76f6b8f9b534
+      - req-11c0d4bd-b477-4675-8daf-760cd5ec656b
       Date:
-      - Thu, 25 Oct 2018 18:20:33 GMT
+      - Thu, 01 Nov 2018 18:35:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -5757,7 +4935,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:33 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:29 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -5772,7 +4950,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9a5e4d7a8d234d56b6d0186a36d142a2
+      - 2bf7b7b4143249ebb30fc05b90468d69
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5785,9 +4963,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-a2aefaff-ec48-4a41-b926-a68ae183a6dd
+      - req-77465ae7-c08d-48cf-8ec1-8fec03e9a7a4
       Date:
-      - Thu, 25 Oct 2018 18:20:33 GMT
+      - Thu, 01 Nov 2018 18:35:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -5797,7 +4975,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:33 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:29 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8/os-keypairs?limit=1000
@@ -5812,7 +4990,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 18fd93bee33e48709b93255d6bab9550
+      - fcde3b41acea4c5590a5140f149c1a11
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5825,9 +5003,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-cc0f17a3-e782-4f41-92b3-d17a9bb2ce57
+      - req-e9da1805-63c5-4779-ac6b-065c584e29f0
       Date:
-      - Thu, 25 Oct 2018 18:20:33 GMT
+      - Thu, 01 Nov 2018 18:35:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -5837,7 +5015,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:33 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:29 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -5852,7 +5030,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 18fd93bee33e48709b93255d6bab9550
+      - fcde3b41acea4c5590a5140f149c1a11
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5865,9 +5043,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-acf19e06-5556-46c1-90c6-40d86acf17e5
+      - req-da701234-5b27-424e-9001-75a3fd40f6ff
       Date:
-      - Thu, 25 Oct 2018 18:20:33 GMT
+      - Thu, 01 Nov 2018 18:35:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -5877,7 +5055,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:33 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:29 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-keypairs?limit=1000
@@ -5892,7 +5070,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0564c5e3558741d9a30288fe73a41418
+      - f3fa57f9ffdd453fa78854d1700b2f78
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5905,9 +5083,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-97b97910-f044-4829-a4e5-42de2a15cd6f
+      - req-3dd16563-eec1-417d-add3-786d13f623e2
       Date:
-      - Thu, 25 Oct 2018 18:20:33 GMT
+      - Thu, 01 Nov 2018 18:35:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -5917,7 +5095,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:33 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:29 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -5932,7 +5110,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0564c5e3558741d9a30288fe73a41418
+      - f3fa57f9ffdd453fa78854d1700b2f78
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5945,9 +5123,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-532464bc-368a-4d9b-b5de-e7c3c5696edb
+      - req-0a9cfe1d-e2f0-49e0-b326-fc24f1ead581
       Date:
-      - Thu, 25 Oct 2018 18:20:33 GMT
+      - Thu, 01 Nov 2018 18:35:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -5957,7 +5135,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:33 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:29 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608/os-keypairs?limit=1000
@@ -5972,7 +5150,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 40b2a4c92b4e4ca3bba30613156bded9
+      - 6e98255413b843e4a86c3ff0c48fdd3e
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5985,9 +5163,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-7552426f-a81c-44e8-a7dd-9eb0c9061285
+      - req-2aa92f7d-5921-40ed-8536-24dc4640002e
       Date:
-      - Thu, 25 Oct 2018 18:20:33 GMT
+      - Thu, 01 Nov 2018 18:35:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -5997,7 +5175,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:33 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:30 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -6012,7 +5190,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 40b2a4c92b4e4ca3bba30613156bded9
+      - 6e98255413b843e4a86c3ff0c48fdd3e
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6025,9 +5203,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-ca3746a3-af6d-426c-af47-e3fb560cda9d
+      - req-efd9b365-117f-45f5-a03c-424bc7ce0b38
       Date:
-      - Thu, 25 Oct 2018 18:20:33 GMT
+      - Thu, 01 Nov 2018 18:35:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -6037,7 +5215,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:33 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:30 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/6
@@ -6052,7 +5230,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0564c5e3558741d9a30288fe73a41418
+      - f3fa57f9ffdd453fa78854d1700b2f78
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6065,9 +5243,9 @@ http_interactions:
       Content-Length:
       - '433'
       X-Compute-Request-Id:
-      - req-b6241de6-31d2-4b72-82f8-14a58d55764e
+      - req-95798edd-5b20-40a2-8c8d-267c72d568c1
       Date:
-      - Thu, 25 Oct 2018 18:20:33 GMT
+      - Thu, 01 Nov 2018 18:35:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavor": {"name": "m1.ems_refresh_spec", "links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/6",
@@ -6076,7 +5254,7 @@ http_interactions:
         1, "swap": 512, "os-flavor-access:is_public": true, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         1, "disk": 1, "id": "6"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:33 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:30 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/ca4f3a16-bae3-4407-83e9-f77b28af0f2b/os-volume_attachments
@@ -6091,7 +5269,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0564c5e3558741d9a30288fe73a41418
+      - f3fa57f9ffdd453fa78854d1700b2f78
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6104,15 +5282,15 @@ http_interactions:
       Content-Length:
       - '197'
       X-Compute-Request-Id:
-      - req-c56f59c7-435d-4994-8036-8847ff44c72b
+      - req-78cb8ad3-f55a-4882-8835-c9bb77af4eb6
       Date:
-      - Thu, 25 Oct 2018 18:20:33 GMT
+      - Thu, 01 Nov 2018 18:35:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumeAttachments": [{"device": "/dev/vdd", "serverId": "ca4f3a16-bae3-4407-83e9-f77b28af0f2b",
         "id": "0a55c0d5-c780-4e7d-9d09-47f5520c7448", "volumeId": "0a55c0d5-c780-4e7d-9d09-47f5520c7448"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:33 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:30 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/networks/c0e8e42b-005e-4183-8f25-fa91b3e441c1
@@ -6127,7 +5305,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 63fa622f04674ed4a4a6bd2df37f8f56
+      - 78665c4ce12d4d0aae50467b05fd657b
   response:
     status:
       code: 200
@@ -6138,19 +5316,19 @@ http_interactions:
       Content-Length:
       - '440'
       X-Openstack-Request-Id:
-      - req-2e07dbe8-9c98-4023-904f-0c701cfb22e5
+      - req-7e0dd794-171c-40fb-ba9c-9e22b27bd724
       Date:
-      - Thu, 25 Oct 2018 18:20:33 GMT
+      - Thu, 01 Nov 2018 18:35:30 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"network": {"status": "ACTIVE", "subnets": ["d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "104c081f-97dd-42b7-8930-98abbd015c74"], "name": "EmsRefreshSpec-NetworkPrivate",
+      string: '{"network": {"status": "ACTIVE", "subnets": ["104c081f-97dd-42b7-8930-98abbd015c74",
+        "d53802a5-f0f6-48ba-9207-dbd9b13acac3"], "name": "EmsRefreshSpec-NetworkPrivate",
         "provider:physical_network": null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
         "vxlan", "id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "provider:segmentation_id":
         14}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:33 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:30 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/networks/20af6027-7aeb-432a-ab3b-d7217faa2f1c
@@ -6165,7 +5343,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 63fa622f04674ed4a4a6bd2df37f8f56
+      - 78665c4ce12d4d0aae50467b05fd657b
   response:
     status:
       code: 200
@@ -6176,9 +5354,9 @@ http_interactions:
       Content-Length:
       - '409'
       X-Openstack-Request-Id:
-      - req-8fb81297-2d77-4763-a957-b4d6a0dfa2ad
+      - req-66433369-65f7-4e47-aa4e-c257014f4a1e
       Date:
-      - Thu, 25 Oct 2018 18:20:34 GMT
+      - Thu, 01 Nov 2018 18:35:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"network": {"status": "ACTIVE", "subnets": ["33da95a6-bded-44d8-be36-6cc97f3d72bd"],
@@ -6188,7 +5366,7 @@ http_interactions:
         "id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "provider:segmentation_id":
         null}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:34 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:30 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -6203,7 +5381,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 243def16d5da4d85bc7fc5d469a751d5
+      - '083e70d988934f4a9a6d98d0c1da26a0'
   response:
     status:
       code: 200
@@ -6214,141 +5392,9 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-041f752b-8cfb-4648-999a-e5eb3cbceadc
+      - req-5355bf75-c147-4888-94a4-cd4418975c8f
       Date:
-      - Thu, 25 Oct 2018 18:20:34 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
-        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.4",
-        "end": "192.168.50.4"}, {"start": "192.168.50.2", "end": "192.168.50.2"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
-        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.20.0/24", "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
-        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:34 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 243def16d5da4d85bc7fc5d469a751d5
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-c01cb7c7-158a-4047-bb5d-634967744281
-      Date:
-      - Thu, 25 Oct 2018 18:20:34 GMT
+      - Thu, 01 Nov 2018 18:35:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
@@ -6452,10 +5498,10 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:34 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:30 GMT
 - request:
     method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
     body:
       encoding: US-ASCII
       string: ''
@@ -6467,7 +5513,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 371865eb4ce842ea983d259a8c5daae2
+      - '083e70d988934f4a9a6d98d0c1da26a0'
   response:
     status:
       code: 200
@@ -6478,9 +5524,9 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-30042ef3-2ad6-4b09-9e20-a67fa0dbc8e8
+      - req-e10be85e-7768-4c6c-97a2-cb789d3887ed
       Date:
-      - Thu, 25 Oct 2018 18:20:34 GMT
+      - Thu, 01 Nov 2018 18:35:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
@@ -6584,7 +5630,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
         "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:34 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:31 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
@@ -6599,7 +5645,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 371865eb4ce842ea983d259a8c5daae2
+      - '083e70d988934f4a9a6d98d0c1da26a0'
   response:
     status:
       code: 200
@@ -6610,184 +5656,28 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-2696430d-d216-4d22-a1d2-73ce89bd0c75
+      - req-7d878f6b-6693-4ab7-9107-3be23a93f3d9
       Date:
-      - Thu, 25 Oct 2018 18:20:34 GMT
+      - Thu, 01 Nov 2018 18:35:31 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
-        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.4",
-        "end": "192.168.50.4"}, {"start": "192.168.50.2", "end": "192.168.50.2"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
-        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.20.0/24", "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
-        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
         true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:34 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 371865eb4ce842ea983d259a8c5daae2
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-deaaa603-9fbc-450f-a817-0847f543cbc3
-      Date:
-      - Thu, 25 Oct 2018 18:20:34 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
@@ -6835,91 +5725,6 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
         "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:34 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 371865eb4ce842ea983d259a8c5daae2
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-cf6e83ca-efaf-427d-9519-682110930c51
-      Date:
-      - Thu, 25 Oct 2018 18:20:34 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
-        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.4",
-        "end": "192.168.50.4"}, {"start": "192.168.50.2", "end": "192.168.50.2"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
-        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.20.0/24", "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
-        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
         false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
@@ -6944,46 +5749,23 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
         "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
         "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:35 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:31 GMT
 - request:
     method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
     body:
       encoding: US-ASCII
       string: ''
@@ -6995,7 +5777,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 371865eb4ce842ea983d259a8c5daae2
+      - 7fd8ff36e69c493b95973e692dc1ee28
   response:
     status:
       code: 200
@@ -7006,17 +5788,52 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-3a9273f2-a124-4d60-855f-d79173b85ab5
+      - req-f13d9b23-1cec-4ef0-b3cb-efc631a44bad
       Date:
-      - Thu, 25 Oct 2018 18:20:35 GMT
+      - Thu, 01 Nov 2018 18:35:31 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.50.4", "end": "192.168.50.4"}, {"start":
-        "192.168.50.2", "end": "192.168.50.2"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
         true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
@@ -7064,58 +5881,23 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
         "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
-        false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
-        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
         "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:35 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:31 GMT
 - request:
     method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
     body:
       encoding: US-ASCII
       string: ''
@@ -7127,7 +5909,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 63fa622f04674ed4a4a6bd2df37f8f56
+      - 7fd8ff36e69c493b95973e692dc1ee28
   response:
     status:
       code: 200
@@ -7138,9 +5920,9 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-9bd92741-1ba7-4b28-9c62-cad5f46dc4e3
+      - req-84dd59d4-6cdd-4d76-9689-b5057b5f5581
       Date:
-      - Thu, 25 Oct 2018 18:20:35 GMT
+      - Thu, 01 Nov 2018 18:35:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
@@ -7244,7 +6026,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:35 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:31 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
@@ -7259,7 +6041,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 63fa622f04674ed4a4a6bd2df37f8f56
+      - 7fd8ff36e69c493b95973e692dc1ee28
   response:
     status:
       code: 200
@@ -7270,52 +6052,28 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-958761d1-6b4a-4447-b51e-c04460a1d61b
+      - req-39fa18d8-b5f0-4212-8e5c-9e1cd82ca6b9
       Date:
-      - Thu, 25 Oct 2018 18:20:35 GMT
+      - Thu, 01 Nov 2018 18:35:31 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
         true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
@@ -7363,91 +6121,6 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
         "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:35 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 63fa622f04674ed4a4a6bd2df37f8f56
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-6754eb81-69a1-4931-b4a5-737160f44295
-      Date:
-      - Thu, 25 Oct 2018 18:20:35 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
-        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.4",
-        "end": "192.168.50.4"}, {"start": "192.168.50.2", "end": "192.168.50.2"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
-        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.20.0/24", "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
-        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
         false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
@@ -7472,175 +6145,20 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
         "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
         "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:35 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 63fa622f04674ed4a4a6bd2df37f8f56
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-14302b75-1296-4a13-8155-ceed40cde131
-      Date:
-      - Thu, 25 Oct 2018 18:20:36 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:36 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:31 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
@@ -7655,7 +6173,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 63fa622f04674ed4a4a6bd2df37f8f56
+      - 7fd8ff36e69c493b95973e692dc1ee28
   response:
     status:
       code: 200
@@ -7666,669 +6184,9 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-a74ba70d-22c7-4c48-a693-2a65c2c727eb
+      - req-c0d4d3bf-d072-4ac7-a073-98afef3a12e1
       Date:
-      - Thu, 25 Oct 2018 18:20:36 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
-        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.4",
-        "end": "192.168.50.4"}, {"start": "192.168.50.2", "end": "192.168.50.2"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
-        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.20.0/24", "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
-        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:36 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 63fa622f04674ed4a4a6bd2df37f8f56
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-11e1ffeb-ae96-4c78-8deb-88a4a7d3f0c9
-      Date:
-      - Thu, 25 Oct 2018 18:20:36 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.50.4", "end": "192.168.50.4"}, {"start":
-        "192.168.50.2", "end": "192.168.50.2"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
-        false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
-        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:36 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - f69916843b0e4a8fae307ea1259c7676
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-162c0a13-e4f4-4cd5-a7ed-397c8da48704
-      Date:
-      - Thu, 25 Oct 2018 18:20:36 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:36 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - f69916843b0e4a8fae307ea1259c7676
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-7f8d4ec7-2705-4d7f-86b3-1fb1b87e178f
-      Date:
-      - Thu, 25 Oct 2018 18:20:36 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
-        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.4",
-        "end": "192.168.50.4"}, {"start": "192.168.50.2", "end": "192.168.50.2"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
-        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.20.0/24", "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
-        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:36 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - f69916843b0e4a8fae307ea1259c7676
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-9bf4e7bd-3930-4cd5-bfb6-8009c58ce325
-      Date:
-      - Thu, 25 Oct 2018 18:20:36 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:36 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - f69916843b0e4a8fae307ea1259c7676
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-102c6f59-4d3c-4f78-ba1b-33c5f5061faf
-      Date:
-      - Thu, 25 Oct 2018 18:20:36 GMT
+      - Thu, 01 Nov 2018 18:35:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
@@ -8432,7 +6290,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:36 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:31 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
@@ -8447,7 +6305,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f69916843b0e4a8fae307ea1259c7676
+      - 7fd8ff36e69c493b95973e692dc1ee28
   response:
     status:
       code: 200
@@ -8458,45 +6316,315 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-067f4ddf-1c46-4ef8-a9b9-66abc3e07aec
+      - req-c9b5de07-054e-46d4-908d-8356eea154f7
       Date:
-      - Thu, 25 Oct 2018 18:20:37 GMT
+      - Thu, 01 Nov 2018 18:35:31 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
-        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
         [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 01 Nov 2018 18:35:32 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 7fd8ff36e69c493b95973e692dc1ee28
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-c224e4bc-a2cd-4d69-844c-e68e69f678cc
+      Date:
+      - Thu, 01 Nov 2018 18:35:32 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 01 Nov 2018 18:35:32 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 78665c4ce12d4d0aae50467b05fd657b
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-d8f5c8d7-a074-4a6e-a5c1-def18b76c081
+      Date:
+      - Thu, 01 Nov 2018 18:35:32 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2",
+        "end": "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
         "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
         "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
         "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.4",
-        "end": "192.168.50.4"}, {"start": "192.168.50.2", "end": "192.168.50.2"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
-        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.20.0/24", "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
-        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
         false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
@@ -8545,12 +6673,6 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
         "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
@@ -8564,7 +6686,799 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:37 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:32 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 78665c4ce12d4d0aae50467b05fd657b
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-3b919041-a94e-4529-afa2-dcc88eeb270b
+      Date:
+      - Thu, 01 Nov 2018 18:35:32 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 01 Nov 2018 18:35:32 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 78665c4ce12d4d0aae50467b05fd657b
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-fadf44a6-1ca1-43aa-93a3-2e6252a9d757
+      Date:
+      - Thu, 01 Nov 2018 18:35:32 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 01 Nov 2018 18:35:32 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - e23a2dea99c24a7fbc6bc682f62daa64
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-ab344544-12a5-400a-949d-8f8ebce7df99
+      Date:
+      - Thu, 01 Nov 2018 18:35:32 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 01 Nov 2018 18:35:32 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - e23a2dea99c24a7fbc6bc682f62daa64
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-afe72272-517d-43a3-a7c0-a9443e328493
+      Date:
+      - Thu, 01 Nov 2018 18:35:32 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2",
+        "end": "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 01 Nov 2018 18:35:33 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - e23a2dea99c24a7fbc6bc682f62daa64
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-e258d8f2-7498-4f71-b3b1-8d5068bc1f7c
+      Date:
+      - Thu, 01 Nov 2018 18:35:33 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 01 Nov 2018 18:35:33 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - e23a2dea99c24a7fbc6bc682f62daa64
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-5c8b0b28-1d6c-4e90-a4b4-4bacd78005c3
+      Date:
+      - Thu, 01 Nov 2018 18:35:33 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 01 Nov 2018 18:35:33 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports/dda2ebad-f144-4f63-9a75-cbd4fe25e3e9
@@ -8579,7 +7493,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 63fa622f04674ed4a4a6bd2df37f8f56
+      - 78665c4ce12d4d0aae50467b05fd657b
   response:
     status:
       code: 200
@@ -8590,9 +7504,9 @@ http_interactions:
       Content-Length:
       - '954'
       X-Openstack-Request-Id:
-      - req-07fe0016-780e-45e6-8f9a-5d099a106bd0
+      - req-e0a31dfe-7f24-4546-a254-706aaa3db252
       Date:
-      - Thu, 25 Oct 2018 18:20:37 GMT
+      - Thu, 01 Nov 2018 18:35:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"port": {"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -8607,7 +7521,7 @@ http_interactions:
         true}, "binding:vnic_type": "normal", "binding:vif_type": "ovs", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "mac_address": "fa:16:3e:e1:0b:2c"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:37 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:33 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?device_id=57e17608-8ac6-44a6-803e-f42ec15e9d1e&limit=1000
@@ -8622,7 +7536,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 243def16d5da4d85bc7fc5d469a751d5
+      - '083e70d988934f4a9a6d98d0c1da26a0'
   response:
     status:
       code: 200
@@ -8633,9 +7547,9 @@ http_interactions:
       Content-Length:
       - '2617'
       X-Openstack-Request-Id:
-      - req-a5ed9bc0-20ff-4221-9852-63b7614114c1
+      - req-4cc73326-f48f-4055-8e62-57624196fcb8
       Date:
-      - Thu, 25 Oct 2018 18:20:37 GMT
+      - Thu, 01 Nov 2018 18:35:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -8671,7 +7585,7 @@ http_interactions:
         {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
         "binding:vif_type": "ovs", "tenant_id": "", "mac_address": "fa:16:3e:2e:66:be"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:37 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:33 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?device_id=57e17608-8ac6-44a6-803e-f42ec15e9d1e&limit=1000&marker=9330caba-d3ec-4675-b68a-b80fffae6365
@@ -8686,7 +7600,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 243def16d5da4d85bc7fc5d469a751d5
+      - '083e70d988934f4a9a6d98d0c1da26a0'
   response:
     status:
       code: 200
@@ -8697,9 +7611,9 @@ http_interactions:
       Content-Length:
       - '2617'
       X-Openstack-Request-Id:
-      - req-8b029848-2976-40e4-a137-dc668355ea00
+      - req-b84d8d31-0292-4fba-a1be-58e65d8457ef
       Date:
-      - Thu, 25 Oct 2018 18:20:37 GMT
+      - Thu, 01 Nov 2018 18:35:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -8735,7 +7649,7 @@ http_interactions:
         {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
         "binding:vif_type": "ovs", "tenant_id": "", "mac_address": "fa:16:3e:2e:66:be"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:37 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:33 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?device_id=57e17608-8ac6-44a6-803e-f42ec15e9d1e&limit=1000
@@ -8750,7 +7664,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 371865eb4ce842ea983d259a8c5daae2
+      - 7fd8ff36e69c493b95973e692dc1ee28
   response:
     status:
       code: 200
@@ -8761,9 +7675,9 @@ http_interactions:
       Content-Length:
       - '2617'
       X-Openstack-Request-Id:
-      - req-9ef4f4f2-9e67-436f-ab6c-35fb52d4fdc3
+      - req-905f8d52-2c6f-4a9d-aaec-c8c59bbcb68f
       Date:
-      - Thu, 25 Oct 2018 18:20:37 GMT
+      - Thu, 01 Nov 2018 18:35:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -8799,7 +7713,7 @@ http_interactions:
         {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
         "binding:vif_type": "ovs", "tenant_id": "", "mac_address": "fa:16:3e:2e:66:be"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:37 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:33 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?device_id=57e17608-8ac6-44a6-803e-f42ec15e9d1e&limit=1000&marker=9330caba-d3ec-4675-b68a-b80fffae6365
@@ -8814,7 +7728,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 371865eb4ce842ea983d259a8c5daae2
+      - 7fd8ff36e69c493b95973e692dc1ee28
   response:
     status:
       code: 200
@@ -8825,9 +7739,9 @@ http_interactions:
       Content-Length:
       - '2617'
       X-Openstack-Request-Id:
-      - req-2f382233-146f-4366-9dab-f93232456697
+      - req-13925c7e-5776-403f-8129-3ab9b503dc5a
       Date:
-      - Thu, 25 Oct 2018 18:20:37 GMT
+      - Thu, 01 Nov 2018 18:35:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -8863,7 +7777,7 @@ http_interactions:
         {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
         "binding:vif_type": "ovs", "tenant_id": "", "mac_address": "fa:16:3e:2e:66:be"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:37 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:33 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?device_id=57e17608-8ac6-44a6-803e-f42ec15e9d1e&limit=1000
@@ -8878,7 +7792,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 63fa622f04674ed4a4a6bd2df37f8f56
+      - 78665c4ce12d4d0aae50467b05fd657b
   response:
     status:
       code: 200
@@ -8889,9 +7803,9 @@ http_interactions:
       Content-Length:
       - '2617'
       X-Openstack-Request-Id:
-      - req-fd6130dd-78fc-400c-9715-9196f2a628dc
+      - req-43c8f25c-cb30-40ab-bf14-e606b04741b6
       Date:
-      - Thu, 25 Oct 2018 18:20:37 GMT
+      - Thu, 01 Nov 2018 18:35:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -8927,7 +7841,7 @@ http_interactions:
         {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
         "binding:vif_type": "ovs", "tenant_id": "", "mac_address": "fa:16:3e:2e:66:be"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:37 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:34 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?device_id=57e17608-8ac6-44a6-803e-f42ec15e9d1e&limit=1000&marker=9330caba-d3ec-4675-b68a-b80fffae6365
@@ -8942,7 +7856,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 63fa622f04674ed4a4a6bd2df37f8f56
+      - 78665c4ce12d4d0aae50467b05fd657b
   response:
     status:
       code: 200
@@ -8953,9 +7867,9 @@ http_interactions:
       Content-Length:
       - '2617'
       X-Openstack-Request-Id:
-      - req-25807423-21b8-4181-a96f-c5eb31d1a9a1
+      - req-9705c90c-85ce-45bd-a283-b436634a644d
       Date:
-      - Thu, 25 Oct 2018 18:20:37 GMT
+      - Thu, 01 Nov 2018 18:35:34 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -8991,7 +7905,7 @@ http_interactions:
         {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
         "binding:vif_type": "ovs", "tenant_id": "", "mac_address": "fa:16:3e:2e:66:be"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:37 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:34 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?device_id=57e17608-8ac6-44a6-803e-f42ec15e9d1e&limit=1000
@@ -9006,7 +7920,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f69916843b0e4a8fae307ea1259c7676
+      - e23a2dea99c24a7fbc6bc682f62daa64
   response:
     status:
       code: 200
@@ -9017,9 +7931,9 @@ http_interactions:
       Content-Length:
       - '2617'
       X-Openstack-Request-Id:
-      - req-304065f9-787c-4f3c-8898-56e5b25acf63
+      - req-04806c38-4383-4862-8323-f72821ee0a6a
       Date:
-      - Thu, 25 Oct 2018 18:20:37 GMT
+      - Thu, 01 Nov 2018 18:35:34 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -9055,7 +7969,7 @@ http_interactions:
         {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
         "binding:vif_type": "ovs", "tenant_id": "", "mac_address": "fa:16:3e:2e:66:be"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:37 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:34 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?device_id=57e17608-8ac6-44a6-803e-f42ec15e9d1e&limit=1000&marker=9330caba-d3ec-4675-b68a-b80fffae6365
@@ -9070,7 +7984,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f69916843b0e4a8fae307ea1259c7676
+      - e23a2dea99c24a7fbc6bc682f62daa64
   response:
     status:
       code: 200
@@ -9081,9 +7995,9 @@ http_interactions:
       Content-Length:
       - '2617'
       X-Openstack-Request-Id:
-      - req-90ff9623-fb55-4cf3-b5cc-d2c974311834
+      - req-6814a144-9619-44ee-a1b7-44039ac5dd93
       Date:
-      - Thu, 25 Oct 2018 18:20:38 GMT
+      - Thu, 01 Nov 2018 18:35:34 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -9119,7 +8033,7 @@ http_interactions:
         {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
         "binding:vif_type": "ovs", "tenant_id": "", "mac_address": "fa:16:3e:2e:66:be"}]}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:38 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:34 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers/57e17608-8ac6-44a6-803e-f42ec15e9d1e
@@ -9134,7 +8048,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 63fa622f04674ed4a4a6bd2df37f8f56
+      - 78665c4ce12d4d0aae50467b05fd657b
   response:
     status:
       code: 200
@@ -9145,9 +8059,9 @@ http_interactions:
       Content-Length:
       - '443'
       X-Openstack-Request-Id:
-      - req-be909b09-5c20-4122-a54a-0db0dc328415
+      - req-bd7a7070-ce62-4ed6-a624-713f991b40ad
       Date:
-      - Thu, 25 Oct 2018 18:20:38 GMT
+      - Thu, 01 Nov 2018 18:35:34 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"router": {"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -9156,7 +8070,7 @@ http_interactions:
         "name": "EmsRefreshSpec-Router", "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "distributed": false, "routes": [], "ha": false, "id": "57e17608-8ac6-44a6-803e-f42ec15e9d1e"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:38 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:34 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups/fd147cb7-7456-43d9-a01f-c06e21b4e6fb
@@ -9171,7 +8085,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 63fa622f04674ed4a4a6bd2df37f8f56
+      - 78665c4ce12d4d0aae50467b05fd657b
   response:
     status:
       code: 200
@@ -9182,9 +8096,9 @@ http_interactions:
       Content-Length:
       - '6900'
       X-Openstack-Request-Id:
-      - req-d51ed974-7246-479c-afc8-56491929ddda
+      - req-f1f132c8-0365-4c42-b6b5-b84f15b65814
       Date:
-      - Thu, 25 Oct 2018 18:20:38 GMT
+      - Thu, 01 Nov 2018 18:35:34 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_group": {"tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
@@ -9270,7 +8184,7 @@ http_interactions:
         "port_range_max": 80, "port_range_min": 80, "id": "f79f0e32-b186-4778-952e-20827a60ef73",
         "security_group_id": "fd147cb7-7456-43d9-a01f-c06e21b4e6fb"}], "name": "EmsRefreshSpec-SecurityGroup"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:38 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:34 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups/e4836528-d0df-425e-a117-ae8ec6f356d4
@@ -9285,7 +8199,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 63fa622f04674ed4a4a6bd2df37f8f56
+      - 78665c4ce12d4d0aae50467b05fd657b
   response:
     status:
       code: 200
@@ -9296,9 +8210,9 @@ http_interactions:
       Content-Length:
       - '880'
       X-Openstack-Request-Id:
-      - req-7ee63c02-4924-428d-afb5-7f09b1793b65
+      - req-819b251c-727e-4a43-9039-755024da933d
       Date:
-      - Thu, 25 Oct 2018 18:20:38 GMT
+      - Thu, 01 Nov 2018 18:35:34 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_group": {"tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
@@ -9312,107 +8226,5 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "75924ebc-4758-4042-ad04-4ef3c9189098",
         "security_group_id": "e4836528-d0df-425e-a117-ae8ec6f356d4"}], "name": "EmsRefreshSpec-SecurityGroup2"}}'
     http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:38 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/0a55c0d5-c780-4e7d-9d09-47f5520c7448
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 3f4cc4b7b7e24246a2ed48f35d2937f3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      X-Compute-Request-Id:
-      - req-953588ad-010e-44cb-b1db-b732415266b1
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '1406'
-      X-Openstack-Request-Id:
-      - req-953588ad-010e-44cb-b1db-b732415266b1
-      Date:
-      - Thu, 25 Oct 2018 18:20:38 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"volume": {"migration_status": null, "attachments": [{"server_id":
-        "ca4f3a16-bae3-4407-83e9-f77b28af0f2b", "attachment_id": "7913f588-2068-4b0c-810f-5e8cf00a4754",
-        "host_name": null, "volume_id": "0a55c0d5-c780-4e7d-9d09-47f5520c7448", "device":
-        "/dev/vdd", "id": "0a55c0d5-c780-4e7d-9d09-47f5520c7448"}], "links": [{"href":
-        "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/0a55c0d5-c780-4e7d-9d09-47f5520c7448",
-        "rel": "self"}, {"href": "http://10.8.99.233:8776/69f8f7205ade4aa59084c32c83e60b5a/volumes/0a55c0d5-c780-4e7d-9d09-47f5520c7448",
-        "rel": "bookmark"}], "availability_zone": "nova", "os-vol-host-attr:host":
-        "dhcp-8-99-233@lvm#lvm", "encrypted": false, "os-volume-replication:extended_status":
-        null, "replication_status": "disabled", "snapshot_id": null, "id": "0a55c0d5-c780-4e7d-9d09-47f5520c7448",
-        "size": 1, "user_id": "80ea157498b44d08aa6d6f54b8a7c3e7", "os-vol-tenant-attr:tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "os-vol-mig-status-attr:migstat": null,
-        "metadata": {"readonly": "False", "attached_mode": "rw"}, "status": "in-use",
-        "description": "EmsRefreshSpec-Volume description", "multiattach": false,
-        "os-volume-replication:driver_data": null, "source_volid": null, "consistencygroup_id":
-        null, "os-vol-mig-status-attr:name_id": null, "name": "EmsRefreshSpec-Volume",
-        "bootable": "false", "created_at": "2016-11-11T13:49:20.000000", "volume_type":
-        "iscsi"}}'
-    http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:38 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/2c774148-c11a-434c-aabb-7fa9c82c37ce
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 3f4cc4b7b7e24246a2ed48f35d2937f3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      X-Compute-Request-Id:
-      - req-5abb3837-5c46-4a8c-ae1c-90cec51fc7ff
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '1408'
-      X-Openstack-Request-Id:
-      - req-5abb3837-5c46-4a8c-ae1c-90cec51fc7ff
-      Date:
-      - Thu, 25 Oct 2018 18:20:38 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"volume": {"migration_status": null, "attachments": [{"server_id":
-        "ca4f3a16-bae3-4407-83e9-f77b28af0f2b", "attachment_id": "31311772-106c-4128-a1f0-f3b4cd4e34e3",
-        "host_name": null, "volume_id": "2c774148-c11a-434c-aabb-7fa9c82c37ce", "device":
-        "/dev/vde", "id": "2c774148-c11a-434c-aabb-7fa9c82c37ce"}], "links": [{"href":
-        "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/2c774148-c11a-434c-aabb-7fa9c82c37ce",
-        "rel": "self"}, {"href": "http://10.8.99.233:8776/69f8f7205ade4aa59084c32c83e60b5a/volumes/2c774148-c11a-434c-aabb-7fa9c82c37ce",
-        "rel": "bookmark"}], "availability_zone": "nova", "os-vol-host-attr:host":
-        "dhcp-8-99-233@lvm#lvm", "encrypted": false, "os-volume-replication:extended_status":
-        null, "replication_status": "disabled", "snapshot_id": null, "id": "2c774148-c11a-434c-aabb-7fa9c82c37ce",
-        "size": 1, "user_id": "80ea157498b44d08aa6d6f54b8a7c3e7", "os-vol-tenant-attr:tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "os-vol-mig-status-attr:migstat": null,
-        "metadata": {"readonly": "False", "attached_mode": "rw"}, "status": "in-use",
-        "description": "EmsRefreshSpec-Volume description", "multiattach": false,
-        "os-volume-replication:driver_data": null, "source_volid": null, "consistencygroup_id":
-        null, "os-vol-mig-status-attr:name_id": null, "name": "EmsRefreshSpec-Volume-2",
-        "bootable": "false", "created_at": "2016-11-11T13:49:43.000000", "volume_type":
-        "iscsi"}}'
-    http_version: 
-  recorded_at: Thu, 25 Oct 2018 18:20:38 GMT
+  recorded_at: Thu, 01 Nov 2018 18:35:34 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_volume_targeted_refresh.yml
+++ b/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_volume_targeted_refresh.yml
@@ -17,13 +17,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 01 Nov 2018 18:36:32 GMT
+      - Thu, 01 Nov 2018 18:36:41 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-7daa8dcf-feb0-4238-a24b-0702f86f7943
+      - req-5f888e91-3e3a-4a1f-886c-70bf662d6534
       Content-Length:
       - '4170'
       Connection:
@@ -32,10 +32,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-11-01T18:36:32.281609", "expires":
-        "2018-11-01T19:36:32Z", "id": "31ecc100db9540979f17697583f40c88", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:36:41.254155", "expires":
+        "2018-11-01T19:36:41Z", "id": "c33a7157e96f43ffa4a77a3ee6d43b74", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["hf5q8cbHRN-dl3924xt-BQ"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["Fd4lTFo9SayUPYbI5ItAXA"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -80,7 +80,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 01 Nov 2018 18:36:32 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:41 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -95,7 +95,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 31ecc100db9540979f17697583f40c88
+      - c33a7157e96f43ffa4a77a3ee6d43b74
   response:
     status:
       code: 200
@@ -106,7 +106,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Thu, 01 Nov 2018 18:36:32 GMT
+      - Thu, 01 Nov 2018 18:36:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -115,7 +115,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Thu, 01 Nov 2018 18:36:32 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:41 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -133,13 +133,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 01 Nov 2018 18:36:32 GMT
+      - Thu, 01 Nov 2018 18:36:41 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-2119ab3b-6a74-4d40-a993-1b573998755c
+      - req-aab35d3e-47ad-45db-b433-2589ddd55aba
       Content-Length:
       - '4170'
       Connection:
@@ -148,10 +148,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-11-01T18:36:32.553747", "expires":
-        "2018-11-01T19:36:32Z", "id": "5c161243a4084e98a9ef8069da2749b5", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:36:41.554476", "expires":
+        "2018-11-01T19:36:41Z", "id": "073b679c5c8047f69d64b7ee17ec5c56", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["fIRsXecaRvuOsSdLa8uvqA"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["uKZk1CY5RJ-A4vSVgsbPjw"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -196,7 +196,235 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 01 Nov 2018 18:36:32 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:41 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/volumes/0a55c0d5-c780-4e7d-9d09-47f5520c7448
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 073b679c5c8047f69d64b7ee17ec5c56
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Compute-Request-Id:
+      - req-a9620b73-8ac9-4247-8c36-5c88747a0956
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1406'
+      X-Openstack-Request-Id:
+      - req-a9620b73-8ac9-4247-8c36-5c88747a0956
+      Date:
+      - Thu, 01 Nov 2018 18:36:41 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"volume": {"migration_status": null, "attachments": [{"server_id":
+        "ca4f3a16-bae3-4407-83e9-f77b28af0f2b", "attachment_id": "7913f588-2068-4b0c-810f-5e8cf00a4754",
+        "host_name": null, "volume_id": "0a55c0d5-c780-4e7d-9d09-47f5520c7448", "device":
+        "/dev/vdd", "id": "0a55c0d5-c780-4e7d-9d09-47f5520c7448"}], "links": [{"href":
+        "http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/volumes/0a55c0d5-c780-4e7d-9d09-47f5520c7448",
+        "rel": "self"}, {"href": "http://10.8.99.233:8776/e54e5c3c19e34720b05661f2ea1ea00a/volumes/0a55c0d5-c780-4e7d-9d09-47f5520c7448",
+        "rel": "bookmark"}], "availability_zone": "nova", "os-vol-host-attr:host":
+        "dhcp-8-99-233@lvm#lvm", "encrypted": false, "os-volume-replication:extended_status":
+        null, "replication_status": "disabled", "snapshot_id": null, "id": "0a55c0d5-c780-4e7d-9d09-47f5520c7448",
+        "size": 1, "user_id": "80ea157498b44d08aa6d6f54b8a7c3e7", "os-vol-tenant-attr:tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "os-vol-mig-status-attr:migstat": null,
+        "metadata": {"readonly": "False", "attached_mode": "rw"}, "status": "in-use",
+        "description": "EmsRefreshSpec-Volume description", "multiattach": false,
+        "os-volume-replication:driver_data": null, "source_volid": null, "consistencygroup_id":
+        null, "os-vol-mig-status-attr:name_id": null, "name": "EmsRefreshSpec-Volume",
+        "bootable": "false", "created_at": "2016-11-11T13:49:20.000000", "volume_type":
+        "iscsi"}}'
+    http_version: 
+  recorded_at: Thu, 01 Nov 2018 18:36:41 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/ca4f3a16-bae3-4407-83e9-f77b28af0f2b
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - c33a7157e96f43ffa4a77a3ee6d43b74
+      X-Openstack-Nova-Api-Version:
+      - '2.12'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '2088'
+      X-Compute-Request-Id:
+      - req-b7836be7-74ce-4af0-9412-e2915643207d
+      Date:
+      - Thu, 01 Nov 2018 18:36:42 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"server": {"status": "ACTIVE", "updated": "2018-10-09T18:40:19Z",
+        "hostId": "bb5e57f091d4c5737235b6ea23cd3cf06921fdb1ff1e90c2eb3098a9", "OS-EXT-SRV-ATTR:host":
+        "11.22.33.44", "addresses": {"EmsRefreshSpec-NetworkPrivate":
+        [{"OS-EXT-IPS-MAC:mac_addr": "fa:16:3e:e1:0b:2c", "version": 4, "addr": "192.168.0.5",
+        "OS-EXT-IPS:type": "fixed"}, {"OS-EXT-IPS-MAC:mac_addr": "fa:16:3e:e1:0b:2c",
+        "version": 4, "addr": "172.16.17.4", "OS-EXT-IPS:type": "floating"}]}, "links":
+        [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/ca4f3a16-bae3-4407-83e9-f77b28af0f2b",
+        "rel": "self"}, {"href": "http://10.8.99.233:8774/e54e5c3c19e34720b05661f2ea1ea00a/servers/ca4f3a16-bae3-4407-83e9-f77b28af0f2b",
+        "rel": "bookmark"}], "key_name": "EmsRefreshSpec-KeyPair", "image": {"id":
+        "bb799f70-5e02-461b-8324-17ee88259c7b", "links": [{"href": "http://10.8.99.233:8774/e54e5c3c19e34720b05661f2ea1ea00a/images/bb799f70-5e02-461b-8324-17ee88259c7b",
+        "rel": "bookmark"}]}, "OS-EXT-STS:task_state": null, "OS-EXT-STS:vm_state":
+        "active", "OS-EXT-SRV-ATTR:instance_name": "instance-00000004", "OS-SRV-USG:launched_at":
+        "2016-11-11T13:51:08.000000", "OS-EXT-SRV-ATTR:hypervisor_hostname": "11.22.33.44",
+        "flavor": {"id": "6", "links": [{"href": "http://10.8.99.233:8774/e54e5c3c19e34720b05661f2ea1ea00a/flavors/6",
+        "rel": "bookmark"}]}, "id": "ca4f3a16-bae3-4407-83e9-f77b28af0f2b", "security_groups":
+        [{"name": "EmsRefreshSpec-SecurityGroup2"}, {"name": "EmsRefreshSpec-SecurityGroup"}],
+        "OS-SRV-USG:terminated_at": null, "OS-EXT-AZ:availability_zone": "nova", "user_id":
+        "80ea157498b44d08aa6d6f54b8a7c3e7", "name": "EmsRefreshSpec-PoweredOn", "created":
+        "2016-11-11T13:50:32Z", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "OS-DCF:diskConfig":
+        "MANUAL", "os-extended-volumes:volumes_attached": [{"id": "0a55c0d5-c780-4e7d-9d09-47f5520c7448"},
+        {"id": "2c774148-c11a-434c-aabb-7fa9c82c37ce"}], "accessIPv4": "", "accessIPv6":
+        "", "progress": 0, "OS-EXT-STS:power_state": 1, "config_drive": "", "metadata":
+        {}}}'
+    http_version: 
+  recorded_at: Thu, 01 Nov 2018 18:36:42 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/6
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - c33a7157e96f43ffa4a77a3ee6d43b74
+      X-Openstack-Nova-Api-Version:
+      - '2.12'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '433'
+      X-Compute-Request-Id:
+      - req-0a42538b-8cb3-4ed5-af0c-3aa5a44375fb
+      Date:
+      - Thu, 01 Nov 2018 18:36:42 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"flavor": {"name": "m1.ems_refresh_spec", "links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/6",
+        "rel": "self"}, {"href": "http://10.8.99.233:8774/e54e5c3c19e34720b05661f2ea1ea00a/flavors/6",
+        "rel": "bookmark"}], "ram": 512, "OS-FLV-DISABLED:disabled": false, "vcpus":
+        1, "swap": 512, "os-flavor-access:is_public": true, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
+        1, "disk": 1, "id": "6"}}'
+    http_version: 
+  recorded_at: Thu, 01 Nov 2018 18:36:42 GMT
+- request:
+    method: post
+    uri: http://11.22.33.44:5000/v2.0/tokens
+    body:
+      encoding: UTF-8
+      string: '{"auth":{"passwordCredentials":{"username":"admin","password":"password_2WpEraURh"},"tenantName":"admin"}}'
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 01 Nov 2018 18:36:42 GMT
+      Server:
+      - Apache/2.4.6 (Red Hat Enterprise Linux)
+      Vary:
+      - X-Auth-Token,Accept-Encoding
+      X-Openstack-Request-Id:
+      - req-6daab7a5-abd0-40d0-8792-6f0a26530e5c
+      Content-Length:
+      - '4170'
+      Connection:
+      - close
+      Content-Type:
+      - application/json
+    body:
+      encoding: ASCII-8BIT
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:36:42.715459", "expires":
+        "2018-11-01T19:36:42Z", "id": "f521c435d50a45b5a66d956cf7f4811c", "tenant":
+        {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
+        "name": "admin"}, "audit_ids": ["ZowtzdImRBK2fgMuVcMc6Q"]}, "serviceCatalog":
+        [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
+        "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
+        "endpoints_links": [], "type": "compute", "name": "nova"}, {"endpoints": [{"adminURL":
+        "http://10.8.99.233:9696", "region": "RegionOne", "internalURL": "http://10.8.99.233:9696",
+        "id": "5b097055aff24a40aa4cd2d7317c9108", "publicURL": "http://10.8.99.233:9696"}],
+        "endpoints_links": [], "type": "network", "name": "neutron"}, {"endpoints":
+        [{"adminURL": "http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a",
+        "id": "13c4208d548d4bcdaedfe8296b6559ee", "publicURL": "http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
+        "endpoints_links": [], "type": "volumev2", "name": "cinderv2"}, {"endpoints":
+        [{"adminURL": "http://127.0.0.1:8774/v3", "region": "RegionOne", "internalURL":
+        "http://127.0.0.1:8774/v3", "id": "3874f107e1a0461596883a12743dbcc0", "publicURL":
+        "http://127.0.0.1:8774/v3"}], "endpoints_links": [], "type": "computev3",
+        "name": "novav3"}, {"endpoints": [{"adminURL": "http://10.8.99.233:9292",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:9292", "id": "75fcb24891654062ae1703e6b92f6018",
+        "publicURL": "http://10.8.99.233:9292"}], "endpoints_links": [], "type": "image",
+        "name": "glance"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8777",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:8777", "id": "2c972a2880d1453aad86104dcda88a55",
+        "publicURL": "http://10.8.99.233:8777"}], "endpoints_links": [], "type": "metering",
+        "name": "ceilometer"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8776/v1/e54e5c3c19e34720b05661f2ea1ea00a",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v1/e54e5c3c19e34720b05661f2ea1ea00a",
+        "id": "410c753013fb430c9998f22f68c4cb18", "publicURL": "http://10.8.99.233:8776/v1/e54e5c3c19e34720b05661f2ea1ea00a"}],
+        "endpoints_links": [], "type": "volume", "name": "cinder"}, {"endpoints":
+        [{"adminURL": "http://10.8.99.233:8773/services/Admin", "region": "RegionOne",
+        "internalURL": "http://10.8.99.233:8773/services/Cloud", "id": "2833b001aa814ddf9216479d379cdac1",
+        "publicURL": "http://10.8.99.233:8773/services/Cloud"}], "endpoints_links":
+        [], "type": "ec2", "name": "nova_ec2"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8004/v1/e54e5c3c19e34720b05661f2ea1ea00a",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:8004/v1/e54e5c3c19e34720b05661f2ea1ea00a",
+        "id": "a29a931a5667478c8b3724506a286144", "publicURL": "http://10.8.99.233:8004/v1/e54e5c3c19e34720b05661f2ea1ea00a"}],
+        "endpoints_links": [], "type": "orchestration", "name": "heat"}, {"endpoints":
+        [{"adminURL": "http://10.8.99.233:8080", "region": "RegionOne", "internalURL":
+        "http://10.8.99.233:8080/v1/AUTH_e54e5c3c19e34720b05661f2ea1ea00a", "id":
+        "7a2262abf515414ea08b3beedc87e51e", "publicURL": "http://10.8.99.233:8080/v1/AUTH_e54e5c3c19e34720b05661f2ea1ea00a"}],
+        "endpoints_links": [], "type": "object-store", "name": "swift"}, {"endpoints":
+        [{"adminURL": "http://10.8.99.233:35357/v2.0", "region": "RegionOne", "internalURL":
+        "http://10.8.99.233:5000/v2.0", "id": "5d1b7edf24e14ce29abaeee69e84e529",
+        "publicURL": "http://10.8.99.233:5000/v2.0"}], "endpoints_links": [], "type":
+        "identity", "name": "keystone"}], "user": {"username": "admin", "roles_links":
+        [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
+        {"name": "_member_"}, {"name": "heat_stack_owner"}], "name": "admin"}, "metadata":
+        {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
+        "725d26e4ae494cc689c60f857e347267"]}}}'
+    http_version: 
+  recorded_at: Thu, 01 Nov 2018 18:36:42 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -211,20 +439,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5c161243a4084e98a9ef8069da2749b5
+      - f521c435d50a45b5a66d956cf7f4811c
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Thu, 01 Nov 2018 18:36:32 GMT
+      - Thu, 01 Nov 2018 18:36:42 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-87e3009a-4e76-4cd4-b89a-b8edc9e4e3f5
+      - req-1daa491f-8067-4017-8d08-e94c948e85db
       Content-Length:
       - '500'
       Connection:
@@ -241,90 +469,10 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Thu, 01 Nov 2018 18:36:32 GMT
-- request:
-    method: post
-    uri: http://11.22.33.44:5000/v2.0/tokens
-    body:
-      encoding: UTF-8
-      string: '{"auth":{"passwordCredentials":{"username":"admin","password":"password_2WpEraURh"},"tenantName":"EmsRefreshSpec-Project"}}'
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 01 Nov 2018 18:36:32 GMT
-      Server:
-      - Apache/2.4.6 (Red Hat Enterprise Linux)
-      Vary:
-      - X-Auth-Token,Accept-Encoding
-      X-Openstack-Request-Id:
-      - req-0f5dc551-92f2-4430-a497-c8151322a801
-      Content-Length:
-      - '4117'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-11-01T18:36:32.880721", "expires":
-        "2018-11-01T19:36:32Z", "id": "d4ddb4cfda924ba6aab211031061ca8d", "tenant":
-        {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["AoxDllPLQ5OTTnoHPbMfjA"]},
-        "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
-        "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
-        "endpoints_links": [], "type": "compute", "name": "nova"}, {"endpoints": [{"adminURL":
-        "http://10.8.99.233:9696", "region": "RegionOne", "internalURL": "http://10.8.99.233:9696",
-        "id": "5b097055aff24a40aa4cd2d7317c9108", "publicURL": "http://10.8.99.233:9696"}],
-        "endpoints_links": [], "type": "network", "name": "neutron"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a",
-        "id": "13c4208d548d4bcdaedfe8296b6559ee", "publicURL": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
-        "endpoints_links": [], "type": "volumev2", "name": "cinderv2"}, {"endpoints":
-        [{"adminURL": "http://127.0.0.1:8774/v3", "region": "RegionOne", "internalURL":
-        "http://127.0.0.1:8774/v3", "id": "3874f107e1a0461596883a12743dbcc0", "publicURL":
-        "http://127.0.0.1:8774/v3"}], "endpoints_links": [], "type": "computev3",
-        "name": "novav3"}, {"endpoints": [{"adminURL": "http://10.8.99.233:9292",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:9292", "id": "75fcb24891654062ae1703e6b92f6018",
-        "publicURL": "http://10.8.99.233:9292"}], "endpoints_links": [], "type": "image",
-        "name": "glance"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8777",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8777", "id": "2c972a2880d1453aad86104dcda88a55",
-        "publicURL": "http://10.8.99.233:8777"}], "endpoints_links": [], "type": "metering",
-        "name": "ceilometer"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8776/v1/69f8f7205ade4aa59084c32c83e60b5a",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v1/69f8f7205ade4aa59084c32c83e60b5a",
-        "id": "410c753013fb430c9998f22f68c4cb18", "publicURL": "http://10.8.99.233:8776/v1/69f8f7205ade4aa59084c32c83e60b5a"}],
-        "endpoints_links": [], "type": "volume", "name": "cinder"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8773/services/Admin", "region": "RegionOne",
-        "internalURL": "http://10.8.99.233:8773/services/Cloud", "id": "2833b001aa814ddf9216479d379cdac1",
-        "publicURL": "http://10.8.99.233:8773/services/Cloud"}], "endpoints_links":
-        [], "type": "ec2", "name": "nova_ec2"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a",
-        "id": "a29a931a5667478c8b3724506a286144", "publicURL": "http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a"}],
-        "endpoints_links": [], "type": "orchestration", "name": "heat"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8080", "region": "RegionOne", "internalURL":
-        "http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a", "id":
-        "7a2262abf515414ea08b3beedc87e51e", "publicURL": "http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a"}],
-        "endpoints_links": [], "type": "object-store", "name": "swift"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:35357/v2.0", "region": "RegionOne", "internalURL":
-        "http://10.8.99.233:5000/v2.0", "id": "5d1b7edf24e14ce29abaeee69e84e529",
-        "publicURL": "http://10.8.99.233:5000/v2.0"}], "endpoints_links": [], "type":
-        "identity", "name": "keystone"}], "user": {"username": "admin", "roles_links":
-        [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
-        {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
-        0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
-  recorded_at: Thu, 01 Nov 2018 18:36:32 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:42 GMT
 - request:
     method: get
-    uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks
+    uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-floating-ips
     body:
       encoding: US-ASCII
       string: ''
@@ -336,57 +484,30 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d4ddb4cfda924ba6aab211031061ca8d
+      - c33a7157e96f43ffa4a77a3ee6d43b74
+      X-Openstack-Nova-Api-Version:
+      - '2.12'
   response:
     status:
       code: 200
       message: OK
     headers:
       Content-Type:
-      - application/json; charset=UTF-8
+      - application/json
       Content-Length:
-      - '2559'
-      X-Openstack-Request-Id:
-      - req-e87f8ed0-75bd-4d75-ac96-20eb3dfacaa3
+      - '20'
+      X-Compute-Request-Id:
+      - req-11c06169-ca3c-4238-9f60-2e5f61f1208d
       Date:
-      - Thu, 01 Nov 2018 18:36:33 GMT
+      - Thu, 01 Nov 2018 18:36:43 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"stacks": [{"description": "Heat WordPress template to support F20,
-        using only Heat OpenStack-native resource types, and without the requirement
-        for heat-cfntools in the image. WordPress is web software you can use to create
-        a beautiful website or blog. This template installs a single-instance WordPress
-        deployment using a local MySQL database to store the data.\n", "parent": null,
-        "stack_status_reason": "Stack CREATE completed successfully", "stack_name":
-        "stack3", "stack_user_project_id": "334baf07bb9d466e8b5868dc1a1ffb5b", "tags":
-        null, "creation_time": "2016-11-11T13:50:12", "links": [{"href": "http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack3/45d2af82-eff9-4483-a1f0-f19c44d96146",
-        "rel": "self"}], "updated_time": null, "stack_owner": null, "stack_status":
-        "CREATE_COMPLETE", "id": "45d2af82-eff9-4483-a1f0-f19c44d96146"}, {"description":
-        "Heat WordPress template to support F20, using only Heat OpenStack-native
-        resource types, and without the requirement for heat-cfntools in the image.
-        WordPress is web software you can use to create a beautiful website or blog.
-        This template installs a single-instance WordPress deployment using a local
-        MySQL database to store the data.\n", "parent": null, "stack_status_reason":
-        "Stack CREATE completed successfully", "stack_name": "stack2", "stack_user_project_id":
-        "5a0ed3f20bb741dbbd70b957fd6b462b", "tags": null, "creation_time": "2016-11-11T13:50:10",
-        "links": [{"href": "http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack2/4cf24b12-29fc-4529-a8ed-6b079dea7c17",
-        "rel": "self"}], "updated_time": null, "stack_owner": null, "stack_status":
-        "CREATE_COMPLETE", "id": "4cf24b12-29fc-4529-a8ed-6b079dea7c17"}, {"description":
-        "Heat WordPress template to support F20, using only Heat OpenStack-native
-        resource types, and without the requirement for heat-cfntools in the image.
-        WordPress is web software you can use to create a beautiful website or blog.
-        This template installs a single-instance WordPress deployment using a local
-        MySQL database to store the data.\n", "parent": null, "stack_status_reason":
-        "Stack CREATE completed successfully", "stack_name": "stack1", "stack_user_project_id":
-        "8aa9524c3bfa41669b9e0837fc091e22", "tags": null, "creation_time": "2016-11-11T13:50:09",
-        "links": [{"href": "http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c",
-        "rel": "self"}], "updated_time": null, "stack_owner": null, "stack_status":
-        "CREATE_COMPLETE", "id": "091e1e54-e01c-4ec5-a0ab-b00bee4d425c"}]}'
+      string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Thu, 01 Nov 2018 18:36:33 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:43 GMT
 - request:
     method: get
-    uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c/template
+    uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/ca4f3a16-bae3-4407-83e9-f77b28af0f2b/os-volume_attachments
     body:
       encoding: US-ASCII
       string: ''
@@ -398,116 +519,28 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d4ddb4cfda924ba6aab211031061ca8d
+      - c33a7157e96f43ffa4a77a3ee6d43b74
+      X-Openstack-Nova-Api-Version:
+      - '2.12'
   response:
     status:
       code: 200
       message: OK
     headers:
       Content-Type:
-      - application/json; charset=UTF-8
+      - application/json
       Content-Length:
-      - '4249'
-      X-Openstack-Request-Id:
-      - req-004e2240-d1f5-4a54-8797-beb89d17364b
+      - '197'
+      X-Compute-Request-Id:
+      - req-a110e671-8db4-4163-8d69-191c8ac6faf6
       Date:
-      - Thu, 01 Nov 2018 18:36:33 GMT
+      - Thu, 01 Nov 2018 18:36:43 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
-        "value": {"str_replace": {"params": {"host": {"get_attr": ["wordpress_instance",
-        "first_address"]}}, "template": "http://host/wordpress"}}}}, "heat_template_version":
-        "2013-05-23", "description": "Heat WordPress template to support F20, using
-        only Heat OpenStack-native resource types, and without the requirement for
-        heat-cfntools in the image. WordPress is web software you can use to create
-        a beautiful website or blog. This template installs a single-instance WordPress
-        deployment using a local MySQL database to store the data.\n", "parameters":
-        {"instance_type": {"default": "m1.small", "type": "string", "description":
-        "Instance type for WordPress server", "constraints": [{"description": "instance_type
-        must be one of m1.small, m1.medium or m1.large", "allowed_values": ["m1.tiny",
-        "m1.small", "m1.medium", "m1.large"]}]}, "network_id": {"type": "string",
-        "description": "Name or ID of the network to use"}, "db_password": {"default":
-        "admin", "hidden": true, "type": "string", "description": "The WordPress database
-        admin account password", "constraints": [{"length": {"max": 41, "min": 1},
-        "description": "db_password must be between 1 and 41 characters"}, {"allowed_pattern":
-        "[a-zA-Z0-9]*", "description": "db_password must contain only alphanumeric
-        characters"}]}, "image_id": {"default": "fedora-20.x86_64", "type": "string",
-        "description": "Name or ID of the image to use for the WordPress server. Recommended
-        values are fedora-20.i386 or fedora-20.x86_64; get them from http://cloud.fedoraproject.org/fedora-20.i386.qcow2
-        or http://cloud.fedoraproject.org/fedora-20.x86_64.qcow2 .\n"}, "db_name":
-        {"default": "wordpress", "type": "string", "description": "WordPress database
-        name", "constraints": [{"length": {"max": 64, "min": 1}, "description": "db_name
-        must be between 1 and 64 characters"}, {"allowed_pattern": "[a-zA-Z][a-zA-Z0-9]*",
-        "description": "db_name must begin with a letter and contain only alphanumeric
-        characters\n"}]}, "db_username": {"default": "admin", "hidden": true, "type":
-        "string", "description": "The WordPress database admin account username",
-        "constraints": [{"length": {"max": 16, "min": 1}, "description": "db_username
-        must be between 1 and 16 characters"}, {"allowed_pattern": "[a-zA-Z][a-zA-Z0-9]*",
-        "description": "db_username must begin with a letter and contain only alphanumeric
-        characters\n"}]}, "db_root_password": {"default": "admin", "hidden": true,
-        "type": "string", "description": "Root password for MySQLMultiple possible",
-        "constraints": [{"length": {"max": 41, "min": 1}, "description": "db_root_password
-        must be between 1 and 41 characters"}, {"allowed_pattern": "[a-zA-Z0-9]*",
-        "description": "db_root_password must contain only alphanumeric characters"}]},
-        "key_name": {"type": "string", "description": "Name of a KeyPair to enable
-        SSH access to the instance"}}, "resources": {"wordpress_instance": {"type":
-        "OS::Nova::Server", "properties": {"key_name": {"get_param": "key_name"},
-        "image": {"get_param": "image_id"}, "user_data": {"str_replace": {"params":
-        {"db_password": {"get_param": "db_password"}, "db_name": {"get_param": "db_name"},
-        "db_rootpassword": {"get_param": "db_root_password"}, "db_user": {"get_param":
-        "db_username"}}, "template": "#!/bin/bash -v\n\nyum -y install mariadb mariadb-server
-        httpd wordpress\ntouch /var/log/mariadb/mariadb.log\nchown mysql.mysql /var/log/mariadb/mariadb.log\nsystemctl
-        start mariadb.service\n\n# Setup MySQL root password and create a user\nmysqladmin
-        -u root password db_rootpassword\ncat << EOF | mysql -u root --password=db_rootpassword\nCREATE
-        DATABASE db_name;\nGRANT ALL PRIVILEGES ON db_name.* TO \"db_user\"@\"localhost\"\nIDENTIFIED
-        BY \"db_password\";\nFLUSH PRIVILEGES;\nEXIT\nEOF\n\nsed -i \"/Deny from All/d\"
-        /etc/httpd/conf.d/wordpress.conf\nsed -i \"s/Require local/Require all granted/\"
-        /etc/httpd/conf.d/wordpress.conf\nsed -i s/database_name_here/db_name/ /etc/wordpress/wp-config.php\nsed
-        -i s/username_here/db_user/ /etc/wordpress/wp-config.php\nsed -i s/password_here/db_password/
-        /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
-        {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
+      string: '{"volumeAttachments": [{"device": "/dev/vdd", "serverId": "ca4f3a16-bae3-4407-83e9-f77b28af0f2b",
+        "id": "0a55c0d5-c780-4e7d-9d09-47f5520c7448", "volumeId": "0a55c0d5-c780-4e7d-9d09-47f5520c7448"}]}'
     http_version: 
-  recorded_at: Thu, 01 Nov 2018 18:36:33 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c/resources
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - d4ddb4cfda924ba6aab211031061ca8d
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '700'
-      X-Openstack-Request-Id:
-      - req-38df9b22-dc54-4a37-b6a6-b2e8f83889cc
-      Date:
-      - Thu, 01 Nov 2018 18:36:33 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
-        "http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c/resources/wordpress_instance",
-        "rel": "self"}, {"href": "http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c",
-        "rel": "stack"}], "logical_resource_id": "wordpress_instance", "creation_time":
-        "2016-11-11T13:50:09", "resource_status": "CREATE_COMPLETE", "updated_time":
-        "2016-11-11T13:50:09", "required_by": [], "resource_status_reason": "state
-        changed", "physical_resource_id": "b686353f-0da0-48bf-bc35-8ea411a67dfd",
-        "resource_type": "OS::Nova::Server"}]}'
-    http_version: 
-  recorded_at: Thu, 01 Nov 2018 18:36:33 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:43 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -525,13 +558,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 01 Nov 2018 18:36:33 GMT
+      - Thu, 01 Nov 2018 18:36:44 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-83dd5594-135f-40ef-8933-06a1c43d21d8
+      - req-4e0095fd-db81-47d0-945e-f6a1aaecbb1b
       Content-Length:
       - '4170'
       Connection:
@@ -540,10 +573,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-11-01T18:36:33.578177", "expires":
-        "2018-11-01T19:36:33Z", "id": "0e20c2d604524719a4906c872861ca28", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:36:44.465031", "expires":
+        "2018-11-01T19:36:44Z", "id": "c60b0dc1f7dd4dbd861827e91718299f", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["hy3s7YhVRpGw6A1WnkanKQ"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["O1p-rMy2Q96Lk4Ye5P_qvg"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -588,7 +621,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 01 Nov 2018 18:36:33 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:44 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -606,13 +639,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 01 Nov 2018 18:36:34 GMT
+      - Thu, 01 Nov 2018 18:36:44 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-1ed76f39-ace9-48da-a070-06fc0d13a09b
+      - req-94141b81-2f3f-4a6c-88df-16427459032c
       Content-Length:
       - '370'
       Connection:
@@ -621,13 +654,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-11-01T18:36:34.731966", "expires":
-        "2018-11-01T19:36:34Z", "id": "3a3e431a2fd245149ad695adf8faf89b", "audit_ids":
-        ["zhP-x3VhTZScnkc0bzVRAg"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:36:44.622442", "expires":
+        "2018-11-01T19:36:44Z", "id": "84a9cda44adc4a1bb7385054ac18f8e4", "audit_ids":
+        ["Q7PhIHdwR_CNSvexVr0pVg"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Thu, 01 Nov 2018 18:36:36 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:44 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -642,20 +675,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3a3e431a2fd245149ad695adf8faf89b
+      - 84a9cda44adc4a1bb7385054ac18f8e4
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Thu, 01 Nov 2018 18:36:36 GMT
+      - Thu, 01 Nov 2018 18:36:44 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-260d456f-2480-4451-9dca-ec1c710028ff
+      - req-602284f9-2ee4-4574-8426-151bf63c707a
       Content-Length:
       - '500'
       Connection:
@@ -672,7 +705,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Thu, 01 Nov 2018 18:36:36 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:44 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -690,13 +723,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 01 Nov 2018 18:36:36 GMT
+      - Thu, 01 Nov 2018 18:36:44 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-45a956a3-6e5f-4830-ab9e-c9aafac2e728
+      - req-cd225e74-46bb-40e9-991a-c79cc158ea13
       Content-Length:
       - '4117'
       Connection:
@@ -705,10 +738,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-11-01T18:36:36.720537", "expires":
-        "2018-11-01T19:36:36Z", "id": "21228954dbb14c5c833d9a66af46a377", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:36:44.959657", "expires":
+        "2018-11-01T19:36:44Z", "id": "da7cca20ecf844a4898dae2916d8d12c", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["uaSkzR0TQSuu4amSfQH8kQ"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["BJhqIOr8SHWUPFKvTyr1qg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -752,7 +785,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 01 Nov 2018 18:36:36 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:44 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -767,7 +800,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 21228954dbb14c5c833d9a66af46a377
+      - da7cca20ecf844a4898dae2916d8d12c
   response:
     status:
       code: 200
@@ -778,7 +811,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Thu, 01 Nov 2018 18:36:36 GMT
+      - Thu, 01 Nov 2018 18:36:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -787,7 +820,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Thu, 01 Nov 2018 18:36:36 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:45 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -805,13 +838,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 01 Nov 2018 18:36:36 GMT
+      - Thu, 01 Nov 2018 18:36:45 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-ccca72a8-2c3a-402d-98f0-db7e55da14f7
+      - req-c82c2f69-5111-4ba2-a64d-8876a3ec2dab
       Content-Length:
       - '4131'
       Connection:
@@ -820,10 +853,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-11-01T18:36:36.990303", "expires":
-        "2018-11-01T19:36:36Z", "id": "95ec0f6f61e94df68a0991741a23d8a8", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:36:45.240814", "expires":
+        "2018-11-01T19:36:45Z", "id": "0f63bfacc4a64ea5978352c4cef9b7a6", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["_WMlKWgKQracvnzLD92vpw"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["KgTf3_wlSCWnJdIvjza6Nw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -867,7 +900,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 01 Nov 2018 18:36:37 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:45 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -882,7 +915,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 95ec0f6f61e94df68a0991741a23d8a8
+      - 0f63bfacc4a64ea5978352c4cef9b7a6
   response:
     status:
       code: 200
@@ -893,7 +926,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Thu, 01 Nov 2018 18:36:37 GMT
+      - Thu, 01 Nov 2018 18:36:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -902,7 +935,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Thu, 01 Nov 2018 18:36:37 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:45 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -920,13 +953,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 01 Nov 2018 18:36:37 GMT
+      - Thu, 01 Nov 2018 18:36:45 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-35893fef-5b7f-4962-b835-c51626e7af70
+      - req-8508915d-d019-4dd8-b188-08696efa7f68
       Content-Length:
       - '4118'
       Connection:
@@ -935,10 +968,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-11-01T18:36:37.281471", "expires":
-        "2018-11-01T19:36:37Z", "id": "18f833c6126f40e780dec498043f784b", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:36:45.518873", "expires":
+        "2018-11-01T19:36:45Z", "id": "394713e42c234e6ba8c506a7524792e7", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["pWqrU9N-QCK8yCQVdX8JPQ"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["cPsRFkxLSmGh9XiinFSRKA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -982,7 +1015,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 01 Nov 2018 18:36:37 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:45 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -997,7 +1030,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 18f833c6126f40e780dec498043f784b
+      - 394713e42c234e6ba8c506a7524792e7
   response:
     status:
       code: 200
@@ -1008,7 +1041,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Thu, 01 Nov 2018 18:36:37 GMT
+      - Thu, 01 Nov 2018 18:36:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -1017,7 +1050,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Thu, 01 Nov 2018 18:36:37 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:45 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1035,13 +1068,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 01 Nov 2018 18:36:37 GMT
+      - Thu, 01 Nov 2018 18:36:45 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-2e40bd5d-db33-4c6f-a32e-e8c007177b79
+      - req-449dbd40-c0ec-4a5f-a29a-8ccb5d85c7b1
       Content-Length:
       - '4117'
       Connection:
@@ -1050,10 +1083,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-11-01T18:36:37.554552", "expires":
-        "2018-11-01T19:36:37Z", "id": "2741acb0c1aa443b9e529587c3cef53a", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:36:45.798674", "expires":
+        "2018-11-01T19:36:45Z", "id": "ed2ae7e9b8a441e792ca8db8ab304aff", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["Rz36Gu8uS76OeDE3kEljUw"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["OrBh8ILgQ1mzQS4j4A9-ZA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -1097,7 +1130,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 01 Nov 2018 18:36:37 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:45 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -1112,7 +1145,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2741acb0c1aa443b9e529587c3cef53a
+      - ed2ae7e9b8a441e792ca8db8ab304aff
   response:
     status:
       code: 200
@@ -1123,9 +1156,353 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-ab897bf6-1470-4c94-ada3-09208bd541aa
+      - req-c5f75bab-5a6a-4476-9823-921c369665a9
       Date:
-      - Thu, 01 Nov 2018 18:36:37 GMT
+      - Thu, 01 Nov 2018 18:36:45 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2",
+        "end": "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 01 Nov 2018 18:36:46 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - ed2ae7e9b8a441e792ca8db8ab304aff
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-e19ff39a-74e7-4151-9d7b-e958deaf3cf1
+      Date:
+      - Thu, 01 Nov 2018 18:36:46 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2",
+        "end": "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 01 Nov 2018 18:36:46 GMT
+- request:
+    method: post
+    uri: http://11.22.33.44:5000/v2.0/tokens
+    body:
+      encoding: UTF-8
+      string: '{"auth":{"passwordCredentials":{"username":"admin","password":"password_2WpEraURh"},"tenantName":"EmsRefreshSpec-Project-No-Admin-Role"}}'
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 01 Nov 2018 18:36:46 GMT
+      Server:
+      - Apache/2.4.6 (Red Hat Enterprise Linux)
+      Vary:
+      - X-Auth-Token,Accept-Encoding
+      X-Openstack-Request-Id:
+      - req-ee31e7ec-a438-4bf0-81e0-ef05822fb3c2
+      Content-Length:
+      - '4131'
+      Connection:
+      - close
+      Content-Type:
+      - application/json
+    body:
+      encoding: ASCII-8BIT
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:36:46.448418", "expires":
+        "2018-11-01T19:36:46Z", "id": "eff304abb8e84738ba212d901da611ef", "tenant":
+        {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["8Lf-aYbXQG69rt9Y42ZlCA"]},
+        "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
+        "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
+        "endpoints_links": [], "type": "compute", "name": "nova"}, {"endpoints": [{"adminURL":
+        "http://10.8.99.233:9696", "region": "RegionOne", "internalURL": "http://10.8.99.233:9696",
+        "id": "5b097055aff24a40aa4cd2d7317c9108", "publicURL": "http://10.8.99.233:9696"}],
+        "endpoints_links": [], "type": "network", "name": "neutron"}, {"endpoints":
+        [{"adminURL": "http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8",
+        "id": "13c4208d548d4bcdaedfe8296b6559ee", "publicURL": "http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8"}],
+        "endpoints_links": [], "type": "volumev2", "name": "cinderv2"}, {"endpoints":
+        [{"adminURL": "http://127.0.0.1:8774/v3", "region": "RegionOne", "internalURL":
+        "http://127.0.0.1:8774/v3", "id": "3874f107e1a0461596883a12743dbcc0", "publicURL":
+        "http://127.0.0.1:8774/v3"}], "endpoints_links": [], "type": "computev3",
+        "name": "novav3"}, {"endpoints": [{"adminURL": "http://10.8.99.233:9292",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:9292", "id": "75fcb24891654062ae1703e6b92f6018",
+        "publicURL": "http://10.8.99.233:9292"}], "endpoints_links": [], "type": "image",
+        "name": "glance"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8777",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:8777", "id": "2c972a2880d1453aad86104dcda88a55",
+        "publicURL": "http://10.8.99.233:8777"}], "endpoints_links": [], "type": "metering",
+        "name": "ceilometer"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8776/v1/b458a5c25c3749758f4c0661940b3ba8",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v1/b458a5c25c3749758f4c0661940b3ba8",
+        "id": "410c753013fb430c9998f22f68c4cb18", "publicURL": "http://10.8.99.233:8776/v1/b458a5c25c3749758f4c0661940b3ba8"}],
+        "endpoints_links": [], "type": "volume", "name": "cinder"}, {"endpoints":
+        [{"adminURL": "http://10.8.99.233:8773/services/Admin", "region": "RegionOne",
+        "internalURL": "http://10.8.99.233:8773/services/Cloud", "id": "2833b001aa814ddf9216479d379cdac1",
+        "publicURL": "http://10.8.99.233:8773/services/Cloud"}], "endpoints_links":
+        [], "type": "ec2", "name": "nova_ec2"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8004/v1/b458a5c25c3749758f4c0661940b3ba8",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:8004/v1/b458a5c25c3749758f4c0661940b3ba8",
+        "id": "a29a931a5667478c8b3724506a286144", "publicURL": "http://10.8.99.233:8004/v1/b458a5c25c3749758f4c0661940b3ba8"}],
+        "endpoints_links": [], "type": "orchestration", "name": "heat"}, {"endpoints":
+        [{"adminURL": "http://10.8.99.233:8080", "region": "RegionOne", "internalURL":
+        "http://10.8.99.233:8080/v1/AUTH_b458a5c25c3749758f4c0661940b3ba8", "id":
+        "7a2262abf515414ea08b3beedc87e51e", "publicURL": "http://10.8.99.233:8080/v1/AUTH_b458a5c25c3749758f4c0661940b3ba8"}],
+        "endpoints_links": [], "type": "object-store", "name": "swift"}, {"endpoints":
+        [{"adminURL": "http://10.8.99.233:35357/v2.0", "region": "RegionOne", "internalURL":
+        "http://10.8.99.233:5000/v2.0", "id": "5d1b7edf24e14ce29abaeee69e84e529",
+        "publicURL": "http://10.8.99.233:5000/v2.0"}], "endpoints_links": [], "type":
+        "identity", "name": "keystone"}], "user": {"username": "admin", "roles_links":
+        [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
+        {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
+        0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
+    http_version: 
+  recorded_at: Thu, 01 Nov 2018 18:36:46 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - eff304abb8e84738ba212d901da611ef
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-1016454a-2e0b-4c30-a61d-3b95537e0bcb
+      Date:
+      - Thu, 01 Nov 2018 18:36:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
@@ -1229,7 +1606,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
         "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 01 Nov 2018 18:36:37 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:46 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
@@ -1244,7 +1621,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2741acb0c1aa443b9e529587c3cef53a
+      - eff304abb8e84738ba212d901da611ef
   response:
     status:
       code: 200
@@ -1255,9 +1632,9 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-b172d133-c64d-467a-9692-94bd2a4673f6
+      - req-8899bfa1-93c4-49b7-b229-475cd91147ed
       Date:
-      - Thu, 01 Nov 2018 18:36:37 GMT
+      - Thu, 01 Nov 2018 18:36:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
@@ -1361,7 +1738,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 01 Nov 2018 18:36:38 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:46 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
@@ -1376,7 +1753,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2741acb0c1aa443b9e529587c3cef53a
+      - eff304abb8e84738ba212d901da611ef
   response:
     status:
       code: 200
@@ -1387,9 +1764,9 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-aca20832-d677-414f-9b53-ffc107969504
+      - req-a8aa555f-70a5-414b-b50a-5f361aad7c0f
       Date:
-      - Thu, 01 Nov 2018 18:36:38 GMT
+      - Thu, 01 Nov 2018 18:36:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
@@ -1493,87 +1870,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 01 Nov 2018 18:36:38 GMT
-- request:
-    method: post
-    uri: http://11.22.33.44:5000/v2.0/tokens
-    body:
-      encoding: UTF-8
-      string: '{"auth":{"passwordCredentials":{"username":"admin","password":"password_2WpEraURh"},"tenantName":"EmsRefreshSpec-Project-No-Admin-Role"}}'
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 01 Nov 2018 18:36:38 GMT
-      Server:
-      - Apache/2.4.6 (Red Hat Enterprise Linux)
-      Vary:
-      - X-Auth-Token,Accept-Encoding
-      X-Openstack-Request-Id:
-      - req-ce4a3897-b23c-48dd-9943-d2700fef7121
-      Content-Length:
-      - '4131'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-11-01T18:36:38.349001", "expires":
-        "2018-11-01T19:36:38Z", "id": "df937615826e490fa9f91b6fd75d9fc3", "tenant":
-        {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["-7Fr-sTHSOiUpGyMMET12g"]},
-        "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
-        "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
-        "endpoints_links": [], "type": "compute", "name": "nova"}, {"endpoints": [{"adminURL":
-        "http://10.8.99.233:9696", "region": "RegionOne", "internalURL": "http://10.8.99.233:9696",
-        "id": "5b097055aff24a40aa4cd2d7317c9108", "publicURL": "http://10.8.99.233:9696"}],
-        "endpoints_links": [], "type": "network", "name": "neutron"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8",
-        "id": "13c4208d548d4bcdaedfe8296b6559ee", "publicURL": "http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8"}],
-        "endpoints_links": [], "type": "volumev2", "name": "cinderv2"}, {"endpoints":
-        [{"adminURL": "http://127.0.0.1:8774/v3", "region": "RegionOne", "internalURL":
-        "http://127.0.0.1:8774/v3", "id": "3874f107e1a0461596883a12743dbcc0", "publicURL":
-        "http://127.0.0.1:8774/v3"}], "endpoints_links": [], "type": "computev3",
-        "name": "novav3"}, {"endpoints": [{"adminURL": "http://10.8.99.233:9292",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:9292", "id": "75fcb24891654062ae1703e6b92f6018",
-        "publicURL": "http://10.8.99.233:9292"}], "endpoints_links": [], "type": "image",
-        "name": "glance"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8777",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8777", "id": "2c972a2880d1453aad86104dcda88a55",
-        "publicURL": "http://10.8.99.233:8777"}], "endpoints_links": [], "type": "metering",
-        "name": "ceilometer"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8776/v1/b458a5c25c3749758f4c0661940b3ba8",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v1/b458a5c25c3749758f4c0661940b3ba8",
-        "id": "410c753013fb430c9998f22f68c4cb18", "publicURL": "http://10.8.99.233:8776/v1/b458a5c25c3749758f4c0661940b3ba8"}],
-        "endpoints_links": [], "type": "volume", "name": "cinder"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8773/services/Admin", "region": "RegionOne",
-        "internalURL": "http://10.8.99.233:8773/services/Cloud", "id": "2833b001aa814ddf9216479d379cdac1",
-        "publicURL": "http://10.8.99.233:8773/services/Cloud"}], "endpoints_links":
-        [], "type": "ec2", "name": "nova_ec2"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8004/v1/b458a5c25c3749758f4c0661940b3ba8",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8004/v1/b458a5c25c3749758f4c0661940b3ba8",
-        "id": "a29a931a5667478c8b3724506a286144", "publicURL": "http://10.8.99.233:8004/v1/b458a5c25c3749758f4c0661940b3ba8"}],
-        "endpoints_links": [], "type": "orchestration", "name": "heat"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8080", "region": "RegionOne", "internalURL":
-        "http://10.8.99.233:8080/v1/AUTH_b458a5c25c3749758f4c0661940b3ba8", "id":
-        "7a2262abf515414ea08b3beedc87e51e", "publicURL": "http://10.8.99.233:8080/v1/AUTH_b458a5c25c3749758f4c0661940b3ba8"}],
-        "endpoints_links": [], "type": "object-store", "name": "swift"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:35357/v2.0", "region": "RegionOne", "internalURL":
-        "http://10.8.99.233:5000/v2.0", "id": "5d1b7edf24e14ce29abaeee69e84e529",
-        "publicURL": "http://10.8.99.233:5000/v2.0"}], "endpoints_links": [], "type":
-        "identity", "name": "keystone"}], "user": {"username": "admin", "roles_links":
-        [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
-        {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
-        0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
-  recorded_at: Thu, 01 Nov 2018 18:36:38 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:47 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -1588,7 +1885,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - df937615826e490fa9f91b6fd75d9fc3
+      - c60b0dc1f7dd4dbd861827e91718299f
   response:
     status:
       code: 200
@@ -1599,9 +1896,9 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-d4156c18-75bd-4dd7-8b8f-99a932047fba
+      - req-83022e2c-3d08-4e5b-907b-3417b3734d31
       Date:
-      - Thu, 01 Nov 2018 18:36:38 GMT
+      - Thu, 01 Nov 2018 18:36:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
@@ -1705,7 +2002,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 01 Nov 2018 18:36:38 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:47 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
@@ -1720,7 +2017,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - df937615826e490fa9f91b6fd75d9fc3
+      - c60b0dc1f7dd4dbd861827e91718299f
   response:
     status:
       code: 200
@@ -1731,617 +2028,9 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-8668d0ed-28cd-4f2d-b7a0-014f6c6125c7
+      - req-ac81066f-a38e-4e2a-88df-6da4a89ed6bf
       Date:
-      - Thu, 01 Nov 2018 18:36:38 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2",
-        "end": "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 01 Nov 2018 18:36:38 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 0e20c2d604524719a4906c872861ca28
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-bbb1687e-fbc9-40eb-a9f7-64ffe3040933
-      Date:
-      - Thu, 01 Nov 2018 18:36:38 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2",
-        "end": "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 01 Nov 2018 18:36:38 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 0e20c2d604524719a4906c872861ca28
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-a3c10b4c-9ece-4e1c-b9d6-5d59092d6f82
-      Date:
-      - Thu, 01 Nov 2018 18:36:39 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2",
-        "end": "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 01 Nov 2018 18:36:39 GMT
-- request:
-    method: post
-    uri: http://11.22.33.44:5000/v2.0/tokens
-    body:
-      encoding: UTF-8
-      string: '{"auth":{"passwordCredentials":{"username":"admin","password":"password_2WpEraURh"},"tenantName":"EmsRefreshSpec-Project2"}}'
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 01 Nov 2018 18:36:39 GMT
-      Server:
-      - Apache/2.4.6 (Red Hat Enterprise Linux)
-      Vary:
-      - X-Auth-Token,Accept-Encoding
-      X-Openstack-Request-Id:
-      - req-0ef3bc49-20d8-4627-9c84-87a45a493e46
-      Content-Length:
-      - '4118'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-11-01T18:36:39.277556", "expires":
-        "2018-11-01T19:36:39Z", "id": "bf7c8b14f5b54168bfcddb73c91a6fa0", "tenant":
-        {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["AqwZPVx2RlSjKNJme4uybQ"]},
-        "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
-        "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
-        "endpoints_links": [], "type": "compute", "name": "nova"}, {"endpoints": [{"adminURL":
-        "http://10.8.99.233:9696", "region": "RegionOne", "internalURL": "http://10.8.99.233:9696",
-        "id": "5b097055aff24a40aa4cd2d7317c9108", "publicURL": "http://10.8.99.233:9696"}],
-        "endpoints_links": [], "type": "network", "name": "neutron"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608",
-        "id": "13c4208d548d4bcdaedfe8296b6559ee", "publicURL": "http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608"}],
-        "endpoints_links": [], "type": "volumev2", "name": "cinderv2"}, {"endpoints":
-        [{"adminURL": "http://127.0.0.1:8774/v3", "region": "RegionOne", "internalURL":
-        "http://127.0.0.1:8774/v3", "id": "3874f107e1a0461596883a12743dbcc0", "publicURL":
-        "http://127.0.0.1:8774/v3"}], "endpoints_links": [], "type": "computev3",
-        "name": "novav3"}, {"endpoints": [{"adminURL": "http://10.8.99.233:9292",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:9292", "id": "75fcb24891654062ae1703e6b92f6018",
-        "publicURL": "http://10.8.99.233:9292"}], "endpoints_links": [], "type": "image",
-        "name": "glance"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8777",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8777", "id": "2c972a2880d1453aad86104dcda88a55",
-        "publicURL": "http://10.8.99.233:8777"}], "endpoints_links": [], "type": "metering",
-        "name": "ceilometer"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8776/v1/e8f744b1fc6a487681d35fb275252608",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v1/e8f744b1fc6a487681d35fb275252608",
-        "id": "410c753013fb430c9998f22f68c4cb18", "publicURL": "http://10.8.99.233:8776/v1/e8f744b1fc6a487681d35fb275252608"}],
-        "endpoints_links": [], "type": "volume", "name": "cinder"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8773/services/Admin", "region": "RegionOne",
-        "internalURL": "http://10.8.99.233:8773/services/Cloud", "id": "2833b001aa814ddf9216479d379cdac1",
-        "publicURL": "http://10.8.99.233:8773/services/Cloud"}], "endpoints_links":
-        [], "type": "ec2", "name": "nova_ec2"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8004/v1/e8f744b1fc6a487681d35fb275252608",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8004/v1/e8f744b1fc6a487681d35fb275252608",
-        "id": "a29a931a5667478c8b3724506a286144", "publicURL": "http://10.8.99.233:8004/v1/e8f744b1fc6a487681d35fb275252608"}],
-        "endpoints_links": [], "type": "orchestration", "name": "heat"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8080", "region": "RegionOne", "internalURL":
-        "http://10.8.99.233:8080/v1/AUTH_e8f744b1fc6a487681d35fb275252608", "id":
-        "7a2262abf515414ea08b3beedc87e51e", "publicURL": "http://10.8.99.233:8080/v1/AUTH_e8f744b1fc6a487681d35fb275252608"}],
-        "endpoints_links": [], "type": "object-store", "name": "swift"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:35357/v2.0", "region": "RegionOne", "internalURL":
-        "http://10.8.99.233:5000/v2.0", "id": "5d1b7edf24e14ce29abaeee69e84e529",
-        "publicURL": "http://10.8.99.233:5000/v2.0"}], "endpoints_links": [], "type":
-        "identity", "name": "keystone"}], "user": {"username": "admin", "roles_links":
-        [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
-        {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
-        0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
-  recorded_at: Thu, 01 Nov 2018 18:36:39 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - bf7c8b14f5b54168bfcddb73c91a6fa0
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-3ee22298-2924-49cb-8a09-9da33c664ac6
-      Date:
-      - Thu, 01 Nov 2018 18:36:39 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2",
-        "end": "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 01 Nov 2018 18:36:39 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - bf7c8b14f5b54168bfcddb73c91a6fa0
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-9c4dabb5-f8fd-4fd3-b905-6302178849d7
-      Date:
-      - Thu, 01 Nov 2018 18:36:39 GMT
+      - Thu, 01 Nov 2018 18:36:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
@@ -2445,7 +2134,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
         "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 01 Nov 2018 18:36:39 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:47 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
@@ -2460,7 +2149,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bf7c8b14f5b54168bfcddb73c91a6fa0
+      - c60b0dc1f7dd4dbd861827e91718299f
   response:
     status:
       code: 200
@@ -2471,9 +2160,9 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-d13cc5a9-aa0f-42bf-9a1a-7ba865b437f5
+      - req-c1726cce-cd06-4ebc-adce-f6cd775de321
       Date:
-      - Thu, 01 Nov 2018 18:36:39 GMT
+      - Thu, 01 Nov 2018 18:36:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
@@ -2577,7 +2266,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 01 Nov 2018 18:36:39 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:47 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
@@ -2592,7 +2281,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bf7c8b14f5b54168bfcddb73c91a6fa0
+      - c60b0dc1f7dd4dbd861827e91718299f
   response:
     status:
       code: 200
@@ -2603,9 +2292,9 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-62f7c197-a9f4-40c7-967c-5f81ed17bb45
+      - req-94eaf8cd-7140-44d5-a07d-64d0d093a8fc
       Date:
-      - Thu, 01 Nov 2018 18:36:40 GMT
+      - Thu, 01 Nov 2018 18:36:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
@@ -2709,5 +2398,745 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 01 Nov 2018 18:36:40 GMT
+  recorded_at: Thu, 01 Nov 2018 18:36:47 GMT
+- request:
+    method: post
+    uri: http://11.22.33.44:5000/v2.0/tokens
+    body:
+      encoding: UTF-8
+      string: '{"auth":{"passwordCredentials":{"username":"admin","password":"password_2WpEraURh"},"tenantName":"EmsRefreshSpec-Project2"}}'
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 01 Nov 2018 18:36:47 GMT
+      Server:
+      - Apache/2.4.6 (Red Hat Enterprise Linux)
+      Vary:
+      - X-Auth-Token,Accept-Encoding
+      X-Openstack-Request-Id:
+      - req-423cf5aa-9f2d-4e32-911f-8fcf93949af3
+      Content-Length:
+      - '4118'
+      Connection:
+      - close
+      Content-Type:
+      - application/json
+    body:
+      encoding: ASCII-8BIT
+      string: '{"access": {"token": {"issued_at": "2018-11-01T18:36:48.026491", "expires":
+        "2018-11-01T19:36:48Z", "id": "6c910bfadfda483db6f3c83f1ba37b90", "tenant":
+        {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["4wXh5riyT0Cgw4D_LtfLcw"]},
+        "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
+        "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
+        "endpoints_links": [], "type": "compute", "name": "nova"}, {"endpoints": [{"adminURL":
+        "http://10.8.99.233:9696", "region": "RegionOne", "internalURL": "http://10.8.99.233:9696",
+        "id": "5b097055aff24a40aa4cd2d7317c9108", "publicURL": "http://10.8.99.233:9696"}],
+        "endpoints_links": [], "type": "network", "name": "neutron"}, {"endpoints":
+        [{"adminURL": "http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608",
+        "id": "13c4208d548d4bcdaedfe8296b6559ee", "publicURL": "http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608"}],
+        "endpoints_links": [], "type": "volumev2", "name": "cinderv2"}, {"endpoints":
+        [{"adminURL": "http://127.0.0.1:8774/v3", "region": "RegionOne", "internalURL":
+        "http://127.0.0.1:8774/v3", "id": "3874f107e1a0461596883a12743dbcc0", "publicURL":
+        "http://127.0.0.1:8774/v3"}], "endpoints_links": [], "type": "computev3",
+        "name": "novav3"}, {"endpoints": [{"adminURL": "http://10.8.99.233:9292",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:9292", "id": "75fcb24891654062ae1703e6b92f6018",
+        "publicURL": "http://10.8.99.233:9292"}], "endpoints_links": [], "type": "image",
+        "name": "glance"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8777",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:8777", "id": "2c972a2880d1453aad86104dcda88a55",
+        "publicURL": "http://10.8.99.233:8777"}], "endpoints_links": [], "type": "metering",
+        "name": "ceilometer"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8776/v1/e8f744b1fc6a487681d35fb275252608",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v1/e8f744b1fc6a487681d35fb275252608",
+        "id": "410c753013fb430c9998f22f68c4cb18", "publicURL": "http://10.8.99.233:8776/v1/e8f744b1fc6a487681d35fb275252608"}],
+        "endpoints_links": [], "type": "volume", "name": "cinder"}, {"endpoints":
+        [{"adminURL": "http://10.8.99.233:8773/services/Admin", "region": "RegionOne",
+        "internalURL": "http://10.8.99.233:8773/services/Cloud", "id": "2833b001aa814ddf9216479d379cdac1",
+        "publicURL": "http://10.8.99.233:8773/services/Cloud"}], "endpoints_links":
+        [], "type": "ec2", "name": "nova_ec2"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8004/v1/e8f744b1fc6a487681d35fb275252608",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:8004/v1/e8f744b1fc6a487681d35fb275252608",
+        "id": "a29a931a5667478c8b3724506a286144", "publicURL": "http://10.8.99.233:8004/v1/e8f744b1fc6a487681d35fb275252608"}],
+        "endpoints_links": [], "type": "orchestration", "name": "heat"}, {"endpoints":
+        [{"adminURL": "http://10.8.99.233:8080", "region": "RegionOne", "internalURL":
+        "http://10.8.99.233:8080/v1/AUTH_e8f744b1fc6a487681d35fb275252608", "id":
+        "7a2262abf515414ea08b3beedc87e51e", "publicURL": "http://10.8.99.233:8080/v1/AUTH_e8f744b1fc6a487681d35fb275252608"}],
+        "endpoints_links": [], "type": "object-store", "name": "swift"}, {"endpoints":
+        [{"adminURL": "http://10.8.99.233:35357/v2.0", "region": "RegionOne", "internalURL":
+        "http://10.8.99.233:5000/v2.0", "id": "5d1b7edf24e14ce29abaeee69e84e529",
+        "publicURL": "http://10.8.99.233:5000/v2.0"}], "endpoints_links": [], "type":
+        "identity", "name": "keystone"}], "user": {"username": "admin", "roles_links":
+        [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
+        {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
+        0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
+    http_version: 
+  recorded_at: Thu, 01 Nov 2018 18:36:48 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 6c910bfadfda483db6f3c83f1ba37b90
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-5d8debfa-0162-4461-b3e4-915a86b93dba
+      Date:
+      - Thu, 01 Nov 2018 18:36:48 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 01 Nov 2018 18:36:48 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 6c910bfadfda483db6f3c83f1ba37b90
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-bb719898-e2fb-4251-a977-b756909ba39c
+      Date:
+      - Thu, 01 Nov 2018 18:36:48 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2",
+        "end": "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 01 Nov 2018 18:36:48 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 6c910bfadfda483db6f3c83f1ba37b90
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-b0a9add2-6ad0-4c70-b376-6aacd8895330
+      Date:
+      - Thu, 01 Nov 2018 18:36:48 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 01 Nov 2018 18:36:48 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 6c910bfadfda483db6f3c83f1ba37b90
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-0ba39912-74fe-49aa-ba4d-ed5fd332d925
+      Date:
+      - Thu, 01 Nov 2018 18:36:48 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2",
+        "end": "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 01 Nov 2018 18:36:48 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 6c910bfadfda483db6f3c83f1ba37b90
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-45c0882a-b2d4-460a-a42f-5be9b622b917
+      Date:
+      - Thu, 01 Nov 2018 18:36:49 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2",
+        "end": "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 01 Nov 2018 18:36:49 GMT
 recorded_with: VCR 3.0.3


### PR DESCRIPTION
If a volume that is attached to one or more VMs is subject to targeted refresh, but one of the VMs it is attached to hasn't yet been pulled into the inventory, then building the association between the volume and its attachments could fail. This PR collects any attached VMs as part of targeted refresh for a volume.