### PR TITLE
bug 1475616: Save all disks from infra host on refresh

### DIFF
--- a/app/models/manageiq/providers/openstack/infra_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/openstack/infra_manager/refresh_parser.rb
@@ -278,7 +278,7 @@ module ManageIQ
             :controller_type => 'scsi',
             :present         => true,
             :filename        => disks.fetch_path(disk, 'id') || disks.fetch_path(disk, 'scsi-id'),
-            :location        => nil,
+            :location        => disk,
             :size            => disk_size,
             :disk_type       => nil,
             :mode            => 'persistent'


### PR DESCRIPTION
fixes https://bugzilla.redhat.com/show_bug.cgi?id=1475616

This commit fixes the refresh parser for disks attached to infra
nodes so that all disks associated with the node will be saved
rather than only the last one.