### PR TITLE
Refresh an attached undercloud when saving changes to an overcloud

### DIFF
--- a/app/models/manageiq/providers/openstack/cloud_manager.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager.rb
@@ -54,9 +54,17 @@ class ManageIQ::Providers::Openstack::CloudManager < ManageIQ::Providers::CloudM
                 :ensure_swift_managers
 
   before_update :ensure_managers_zone_and_provider_region
+  after_save :refresh_parent_infra_provider
 
   def hostname_required?
     enabled?
+  end
+
+  def refresh_parent_infra_provider
+    if provider
+      EmsRefresh.queue_refresh(provider)
+      _log.info("EMS: [#{name}] refreshing attached infra provider [#{provider.name}]")
+    end
   end
 
   def ensure_managers_zone_and_provider_region


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1445717 by kicking off a refresh when the overcloud is saved.

![image](https://user-images.githubusercontent.com/628956/48093123-8a0d9200-e1dc-11e8-93f0-17fe000a2366.png)
