### PR TITLE
[HAMMER] Bump fog-openstack to v0.1.29

### DIFF
--- a/manageiq-providers-openstack.gemspec
+++ b/manageiq-providers-openstack.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "activesupport",        ">= 5.0", "< 5.2"
   s.add_runtime_dependency "bunny",                "~>2.1.0"
   s.add_runtime_dependency "excon",                "~>0.40"
-  s.add_runtime_dependency "fog-openstack",        "=0.1.28"
+  s.add_runtime_dependency "fog-openstack",        "=0.1.29"
   s.add_runtime_dependency "more_core_extensions", "~>3.2"
 
   s.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"


### PR DESCRIPTION
fog-openstack v0.1.29 has the back port for instance evacuation for Nova 1.24+:
https://bugzilla.redhat.com/show_bug.cgi?id=1644613