### PR TITLE
Refresh an attached undercloud when saving changes to an overcloud

### DIFF
--- a/spec/models/manageiq/providers/openstack/cloud_manager_spec.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager_spec.rb
@@ -209,8 +209,8 @@ describe ManageIQ::Providers::Openstack::CloudManager do
   context "availability zone disk usage" do
     before do
       @provider = FactoryGirl.create(:provider_openstack, :name => "undercloud")
-      @cloud = FactoryGirl.create(:ems_openstack, :name => "overcloud", :provider => @provider)
       @infra = FactoryGirl.create(:ems_openstack_infra_with_stack, :name => "undercloud", :provider => @provider)
+      @cloud = FactoryGirl.create(:ems_openstack, :name => "overcloud", :provider => @provider)
       @az = FactoryGirl.create(:availability_zone_openstack, :ext_management_system => @cloud, :name => "nova")
       @cluster = FactoryGirl.create(:ems_cluster_openstack, :ext_management_system => @infra, :name => "BlockStorage")
       @host = FactoryGirl.create(:host_openstack_infra)


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1445717 by kicking off a refresh when the overcloud is saved.

Fixed problems with https://github.com/ManageIQ/manageiq-providers-openstack/pull/389