### PR TITLE
Add support for multiple amqp endpoints

### DIFF
--- a/app/models/manageiq/providers/openstack/manager_mixin.rb
+++ b/app/models/manageiq/providers/openstack/manager_mixin.rb
@@ -143,6 +143,14 @@ module ManageIQ::Providers::Openstack::ManagerMixin
           opts[:username] = authentication.userid
           opts[:password] = authentication.password
         end
+
+        if (amqp_fallback1_endpoint = connection_configuration_by_role("amqp_fallback1").try(:endpoint))
+          opts[:amqp_fallback_hostname1] = amqp_fallback1_endpoint.hostname
+        end
+
+        if (amqp_fallback2_endpoint = connection_configuration_by_role("amqp_fallback2").try(:endpoint))
+          opts[:amqp_fallback_hostname2] = amqp_fallback2_endpoint.hostname
+        end
       end
       opts
     end

--- a/spec/legacy/events/openstack_rabbit_event_monitor_spec.rb
+++ b/spec/legacy/events/openstack_rabbit_event_monitor_spec.rb
@@ -31,22 +31,22 @@ describe OpenstackRabbitEventMonitor do
       expect(OpenstackRabbitEventMonitor.test_connection(@options)).to be_truthy
     end
 
-    it "raise exception on an unsuccessful test with bad credentials" do
+    it "return false on an unsuccessful test with bad credentials" do
       expect(@rabbit_connection).to receive(:start).and_raise(Bunny::AuthenticationFailureError.new('test', 'test', 5))
       expect(@rabbit_connection).to receive(:close)
-      expect { OpenstackRabbitEventMonitor.test_connection(@options) }.to raise_error(MiqException::MiqInvalidCredentialsError)
+      expect(OpenstackRabbitEventMonitor.test_connection(@options)).to eq(false)
     end
 
-    it "raise exception on an unsuccessful test with unreachable hostname" do
+    it "return false on an unsuccessful test with unreachable hostname" do
       expect(@rabbit_connection).to receive(:start).and_raise(Bunny::TCPConnectionFailedForAllHosts.new)
       expect(@rabbit_connection).to receive(:close)
-      expect { OpenstackRabbitEventMonitor.test_connection(@options) }.to raise_error(MiqException::MiqHostError)
+      expect(OpenstackRabbitEventMonitor.test_connection(@options)).to eq(false)
     end
 
-    it "raise exception on an unsuccessful test with unexpected exception" do
+    it "return false on an unsuccessful test with unexpected exception" do
       expect(@rabbit_connection).to receive(:start).and_raise("Cannot connect to rabbit amqp")
       expect(@rabbit_connection).to receive(:close)
-      expect { OpenstackRabbitEventMonitor.test_connection(@options) }.to raise_error("Cannot connect to rabbit amqp")
+      expect(OpenstackRabbitEventMonitor.test_connection(@options)).to eq(false)
     end
   end
 


### PR DESCRIPTION
This PR adds support for multiple amqp endpoints. Currently, it's possible to use only one endpoint when adding a provider. If amqp server is not available CF should switch to another. Amqp is out of openstack HA proxy, so there is no other way to handle server fails. I replaced raising exceptions with returning false in case of fail for being able to iterate through hostnames.
We would need UI for this.

@aufi @mansam 

https://bugzilla.redhat.com/show_bug.cgi?id=1595558