### PR TITLE
[GAPRINDASHVILI] Bump fog-openstack to v0.1.29

### DIFF
--- a/manageiq-providers-openstack.gemspec
+++ b/manageiq-providers-openstack.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "activesupport",        ">= 5.0", "< 5.2"
   s.add_runtime_dependency "bunny",                "~>2.1.0"
   s.add_runtime_dependency "excon",                "~>0.40"
-  s.add_runtime_dependency "fog-openstack",        "=0.1.27"
+  s.add_runtime_dependency "fog-openstack",        "=0.1.29"
   s.add_runtime_dependency "more_core_extensions", "~>3.2"
 
   s.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"


### PR DESCRIPTION
(cherry picked from commit 9b5dace4a61f2420a6b09c6949d052e8612cf8cb)

https://bugzilla.redhat.com/show_bug.cgi?id=1648674