### PR TITLE
New Cloud provider: Fix event creds validation for AMQP

### DIFF
--- a/app/models/manageiq/providers/openstack/manager_mixin.rb
+++ b/app/models/manageiq/providers/openstack/manager_mixin.rb
@@ -12,12 +12,12 @@ module ManageIQ::Providers::Openstack::ManagerMixin
   # OpenStack interactions
   #
   module ClassMethods
-    def amqp_available?(params)
+    def amqp_available?(password, params)
       require 'manageiq/providers/openstack/legacy/events/openstack_rabbit_event_monitor'
       OpenstackRabbitEventMonitor.available?(
         :hostname => params[:amqp_hostname],
         :username => params[:amqp_userid],
-        :password => params[:amqp_password],
+        :password => MiqPassword.try_decrypt(password),
         :port     => params[:amqp_api_port]
       )
     end
@@ -51,8 +51,8 @@ module ManageIQ::Providers::Openstack::ManagerMixin
     private :ems_connect?
 
     def raw_connect(password, params, service = "Compute")
-      if params[:cred_type] == 'amqp'
-        amqp_available?(params)
+      if params[:event_stream_selection] == 'amqp'
+        amqp_available?(password, params)
       else
         ems_connect?(password, params, service)
       end


### PR DESCRIPTION
- selection made using `params[:event_stream_selection]`
- Password is passed as separate parameter

https://bugzilla.redhat.com/show_bug.cgi?id=1593663