### PR TITLE
Collect Panko events for all tenants.

### DIFF
--- a/lib/manageiq/providers/openstack/legacy/events/openstack_ceilometer_event_monitor.rb
+++ b/lib/manageiq/providers/openstack/legacy/events/openstack_ceilometer_event_monitor.rb
@@ -95,6 +95,10 @@ class OpenstackCeilometerEventMonitor < OpenstackEventMonitor
       'field' => 'start_timestamp',
       'op'    => 'ge',
       'value' => latest_event_timestamp || ''
+    },
+    {
+      'field' => 'all_tenants',
+      'value' => 'True'
     }]
   end
 


### PR DESCRIPTION
It appears that by default Panko events are only returned for a single tenant at a time. There's a query parameter that returns all events for an admin user, which this PR enables. https://docs.openstack.org/panko/latest/webapi/v2.html

@fdupont-redhat