### PR TITLE
Add explicit runtime dependency on the "parallel" gem

### DIFF
--- a/manageiq-providers-openstack.gemspec
+++ b/manageiq-providers-openstack.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "excon",                "~> 0.40"
   s.add_runtime_dependency "fog-openstack",        ">= 0.3.9"
   s.add_runtime_dependency "more_core_extensions", "~> 3.2"
+  s.add_runtime_dependency "parallel",             "~> 1.12.0"
 
   s.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"
   s.add_development_dependency "simplecov"


### PR DESCRIPTION
The `parallel` gem is apparently only normally pulled in via the `parallel_tests` gem during development. This means the tests were passing, but it was causing failures in an appliance environment. This PR makes the dependency explicit.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1652574