### PR TITLE
Add a default parallel thread limit to the settings yaml

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -6,6 +6,7 @@
       :is_global_admin: false
     :inventory_object_refresh: true
     :allow_targeted_refresh: true
+    :parallel_thread_limit: 0
   :openstack_network:
     :is_admin: false
     :inventory_object_refresh: true


### PR DESCRIPTION
This is a QoL improvement, should not be necessary for any functionality.