### PR TITLE
Add supports_conversion_host to Vm

### DIFF
--- a/app/models/manageiq/providers/openstack/cloud_manager/vm.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/vm.rb
@@ -15,6 +15,7 @@ class ManageIQ::Providers::Openstack::CloudManager::Vm < ManageIQ::Providers::Cl
   end
 
   supports :snapshots
+  supports :conversion_host
 
   POWER_STATES = {
     "ACTIVE"            => "on",

--- a/spec/models/manageiq/providers/openstack/cloud_manager/vm_spec.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/vm_spec.rb
@@ -156,6 +156,12 @@ describe ManageIQ::Providers::Openstack::CloudManager::Vm do
         expect(vm.supports_revert_to_snapshot?).to eq false
       end
     end
+
+    context "v2v actions" do
+      it "supports conversion_host" do
+        expect(vm.supports_conversion_host?).to eq true
+      end
+    end
   end
 
   context "#is_available?" do


### PR DESCRIPTION
This sets supports :conversion_host to the Vm model.

The main purpose for this is for the ManageIQ REST API, where support for conversion_host will be checked before attempting to enable or disable the resource.

Part of the V2V effort.