### PR TITLE
Exclude already attached VMs from the volume attachment form

### DIFF
--- a/app/models/manageiq/providers/openstack/cloud_manager/cloud_volume.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/cloud_volume.rb
@@ -137,7 +137,7 @@ class ManageIQ::Providers::Openstack::CloudManager::CloudVolume < ::CloudVolume
   end
 
   def available_vms
-    cloud_tenant.vms
+    cloud_tenant.vms.where.not(:id => vms.select(&:id))
   end
 
   def provider_object(connection)

--- a/spec/models/manageiq/providers/openstack/cloud_manager/cloud_volume_spec.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/cloud_volume_spec.rb
@@ -144,5 +144,11 @@ describe ManageIQ::Providers::Openstack::CloudManager::CloudVolume do
     it "supports attachment to only those instances that are in the same tenant" do
       expect(cloud_volume.available_vms).to contain_exactly(first_instance, second_instance)
     end
+
+    it "should exclude instances that are already attached to the volume" do
+      attached_instance = FactoryGirl.create(:vm_openstack, :ext_management_system => ems, :ems_ref => "attached_instance", :cloud_tenant => tenant)
+      allow(cloud_volume).to receive(:vms).and_return([attached_instance])
+      expect(cloud_volume.available_vms).to contain_exactly(first_instance, second_instance)
+    end
   end
 end


### PR DESCRIPTION
This PR updates the Volume -> Attach to Instance form to exclude instances that are already attached to the selected volume.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1653062