### PR TITLE
bug 1614567: Allow user to select Network Port for provisioning

### DIFF
--- a/app/models/manageiq/providers/openstack/cloud_manager/provision/configuration.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/provision/configuration.rb
@@ -11,7 +11,12 @@ module ManageIQ::Providers::Openstack::CloudManager::Provision::Configuration
       networks = Array(options[:networks])
 
       # Set the first nic to whatever was selected in the dialog if not set by automate
-      networks[0] ||= {:network_id => cloud_network.id} if cloud_network
+      if (cloud_network_selection_method == "network" && cloud_network) || (cloud_network_selection_method == "port" && network_port)
+        entry_from_dialog = {}
+        entry_from_dialog[:network_id] = cloud_network.id if cloud_network_selection_method == "network"
+        entry_from_dialog[:port_id] = network_port.id if cloud_network_selection_method == "port"
+        networks[0] ||= entry_from_dialog
+      end
 
       options[:networks] = convert_networks_to_openstack_nics(networks)
     end
@@ -20,6 +25,12 @@ module ManageIQ::Providers::Openstack::CloudManager::Provision::Configuration
   private
 
   def convert_networks_to_openstack_nics(networks)
-    networks.delete_blanks.collect { |nic| {"net_id" => CloudNetwork.find_by(:id => nic[:network_id]).ems_ref} }
+    networks.delete_blanks.collect do |nic|
+      if nic[:network_id]
+        {"net_id" => CloudNetwork.find_by(:id => nic[:network_id]).ems_ref}
+      elsif nic[:port_id]
+        {"port_id" => NetworkPort.find_by(:id => nic[:port_id]).ems_ref}
+      end
+    end.compact
   end
 end

--- a/app/models/manageiq/providers/openstack/cloud_manager/provision/options_helper.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/provision/options_helper.rb
@@ -2,4 +2,12 @@ module ManageIQ::Providers::Openstack::CloudManager::Provision::OptionsHelper
   def cloud_tenant
     @cloud_tenant ||= CloudTenant.find_by(:id => get_option(:cloud_tenant))
   end
+
+  def network_port
+    @network_port ||= NetworkPort.find_by(:id => get_option(:network_port))
+  end
+
+  def cloud_network_selection_method
+    @cloud_network_selection_method ||= get_option(:cloud_network_selection_method)
+  end
 end

--- a/app/models/manageiq/providers/openstack/cloud_manager/provision_workflow/dialog_field_validation.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/provision_workflow/dialog_field_validation.rb
@@ -2,6 +2,12 @@
 module ManageIQ::Providers::Openstack::CloudManager::ProvisionWorkflow::DialogFieldValidation
   def validate_cloud_network(field, values, dlg, fld, value)
     return nil if allowed_cloud_networks.length <= 1
+    return nil unless get_value(values[:cloud_network_selection_method]) == 'network'
+    validate_placement(field, values, dlg, fld, value)
+  end
+
+  def validate_network_port(field, values, dlg, fld, value)
+    return nil unless get_value(values[:cloud_network_selection_method]) == 'port'
     validate_placement(field, values, dlg, fld, value)
   end
 end

--- a/content/miq_dialogs/miq_provision_openstack_dialogs_template.yaml
+++ b/content/miq_dialogs/miq_provision_openstack_dialogs_template.yaml
@@ -1,0 +1,409 @@
+---
+:name: miq_provision_openstack_dialogs_template
+:description: Sample Openstack Instance Provisioning Dialog
+:dialog_type: MiqProvisionWorkflow
+:content:
+  :buttons:
+  - :submit
+  - :cancel
+  :dialogs:
+    :requester:
+      :description: Request
+      :fields:
+        :owner_phone:
+          :description: Phone
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_country:
+          :description: Country/Region
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_phone_mobile:
+          :description: Mobile
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_title:
+          :description: Title
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_first_name:
+          :description: First Name
+          :required: false
+          :display: :edit
+          :data_type: :string
+        :owner_manager:
+          :description: Name
+          :required: false
+          :display: :edit
+          :data_type: :string
+        :owner_address:
+          :description: Address
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_company:
+          :description: Company
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_last_name:
+          :description: Last Name
+          :required: false
+          :display: :edit
+          :data_type: :string
+        :owner_manager_mail:
+          :description: E-Mail
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_city:
+          :description: City
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_department:
+          :description: Department
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_load_ldap:
+          :pressed:
+            :method: :retrieve_ldap
+          :description: Look Up LDAP Email
+          :required: false
+          :display: :show
+          :data_type: :button
+        :owner_manager_phone:
+          :description: Phone
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_state:
+          :description: State
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_office:
+          :description: Office
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_zip:
+          :description: Zip code
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_email:
+          :description: E-Mail
+          :required_method: :validate_regex
+          :required_regex: !ruby/regexp /\A[\w!#$\%&'*+\/=?`\{|\}~^-]+(?:\.[\w!#$\%&'*+\/=?`\{|\}~^-]+)*@(?:[A-Z0-9-]+\.)+[A-Z]{2,6}\Z/i
+          :required: true
+          :display: :edit
+          :data_type: :string
+        :request_notes:
+          :description: Notes
+          :required: false
+          :display: :edit
+          :data_type: :string
+      :display: :show
+      :field_order:
+    :purpose:
+      :description: Purpose
+      :fields:
+        :vm_tags:
+          :required_method: :validate_tags
+          :description: Tags
+          :required: false
+          :options:
+            :include: []
+
+            :order: []
+
+            :single_select: []
+
+            :exclude: []
+
+          :display: :edit
+          :required_tags: []
+
+          :data_type: :integer
+      :display: :show
+      :field_order:
+    :environment:
+      :description: Environment
+      :fields:
+        :placement_auto:
+          :values:
+            false: 0
+            true: 1
+          :description: Choose Automatically
+          :required: false
+          :display: :edit
+          :default: false
+          :data_type: :boolean
+        :placement_availability_zone:
+          :values_from:
+            :method: :allowed_availability_zones
+          :auto_select_single: false
+          :description: Availability Zones
+          :required_method: :validate_placement
+          :required: false
+          :display: :edit
+          :data_type: :integer
+          :required_description: Availability Zone Name
+        :cloud_tenant:
+          :values_from:
+            :method: :allowed_cloud_tenants
+          :auto_select_single: false
+          :description: Cloud Tenant
+          :required_method: :validate_placement
+          :required: true
+          :display: :edit
+          :data_type: :integer
+        :cloud_network:
+          :values_from:
+            :method: :allowed_cloud_networks
+          :description: Cloud Network
+          :auto_select_single: false
+          :required: true
+          :required_method: :validate_cloud_network
+          :display: :edit
+          :data_type: :integer
+        :security_groups:
+          :values_from:
+            :method: :allowed_security_groups
+          :description: Security Groups
+          :required: false
+          :display: :edit
+          :data_type: :array_integer
+          :auto_select_single: false
+        :floating_ip_address:
+          :values_from:
+            :method: :allowed_floating_ip_addresses
+          :description: Public IP Address
+          :auto_select_single: false
+          :default: nil
+          :required: false
+          :display: :edit
+          :data_type: :integer
+      :display: :show
+    :service:
+      :description: Catalog
+      :fields:
+        :number_of_vms:
+          :values_from:
+            :options:
+              :max: 50
+            :method: :allowed_number_of_vms
+          :description: Count
+          :required: false
+          :display: :edit
+          :default: 1
+          :data_type: :integer
+        :vm_description:
+          :description: Instance Description
+          :required: false
+          :display: :edit
+          :data_type: :string
+          :min_length:
+          :max_length: 100
+        :vm_prefix:
+          :description: Instance Name Prefix/Suffix
+          :required_method: :validate_vm_name
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :src_vm_id:
+          :values_from:
+            :options:
+              :tag_filters: []
+
+            :method: :allowed_templates
+          :description: Name
+          :required: true
+          :notes:
+          :display: :edit
+          :data_type: :integer
+          :notes_display: :show
+        :vm_name:
+          :description: Instance Name
+          :required_method: :validate_vm_name
+          :required: true
+          :notes:
+          :display: :edit
+          :data_type: :string
+          :notes_display: :show
+          :min_length:
+          :max_length:
+      :display: :show
+    :schedule:
+      :description: Schedule
+      :fields:
+        :schedule_type:
+          :values:
+            schedule: Schedule
+            immediately: Immediately on Approval
+          :description: When to Provision
+          :required: false
+          :display: :edit
+          :default: immediately
+          :data_type: :string
+        :schedule_time:
+          :values_from:
+            :options:
+              :offset: 1.day
+            :method: :default_schedule_time
+          :description: Provision on
+          :required: false
+          :display: :edit
+          :data_type: :time
+        :retirement:
+          :values:
+            0: Indefinite
+            1.month: 1 Month
+            3.months: 3 Months
+            6.months: 6 Months
+          :description: Time until Retirement
+          :required: false
+          :display: :edit
+          :default: 0
+          :data_type: :integer
+        :retirement_warn:
+          :values_from:
+            :options:
+              :values:
+                1.week: 1 Week
+                2.weeks: 2 Weeks
+                30.days: 30 Days
+              :include_equals: false
+              :field: :retirement
+            :method: :values_less_then
+          :description: Retirement Warning
+          :required: true
+          :display: :edit
+          :default: 1.week
+          :data_type: :integer
+      :display: :show
+    :hardware:
+      :description: Properties
+      :fields:
+        :instance_type:
+          :values_from:
+            :method: :allowed_instance_types
+          :description: Instance Type
+          :required: true
+          :display: :edit
+          :data_type: :integer
+        :guest_access_key_pair:
+          :values_from:
+            :method: :allowed_guest_access_key_pairs
+          :description: Guest Access Key Pair
+          :auto_select_single: false
+          :default: nil
+          :required: false
+          :display: :edit
+          :data_type: :integer
+      :display: :show
+    :volumes:
+      :description: Volumes
+      :fields:
+        :name:
+          :description: Volume Name
+          :required: false
+          :display: :edit
+          :data_type: :string
+          :min_length:
+          :max_length: 100
+        :size:
+          :description: Size (gigabytes)
+          :required: false
+          :display: :edit
+          :data_type: :string
+          :min_length:
+          :max_length: 10
+        :delete_on_terminate:
+          :description: Delete on Instance Terminate
+          :required: false
+          :display: :edit
+          :data_type: :boolean
+          :default: false
+      :display: :show
+    :customize:
+      :description: Customize
+      :fields:
+        :dns_servers:
+          :description: DNS Server list
+          :required: false
+          :display: :edit
+          :data_type: :string
+        :dns_suffixes:
+          :description: DNS Suffix List
+          :required: false
+          :display: :edit
+          :data_type: :string
+        :addr_mode:
+          :values:
+            static: Static
+            dhcp: DHCP
+          :description: Address Mode
+          :required: false
+          :display: :edit
+          :default: dhcp
+          :data_type: :string
+        :linux_host_name:
+          :description: Computer Name
+          :required: false
+          :display: :edit
+          :data_type: :string
+        :gateway:
+          :description: Gateway
+          :required: false
+          :display: :edit
+          :data_type: :string
+        :linux_domain_name:
+          :description: Domain Name
+          :required: false
+          :display: :edit
+          :data_type: :string
+        :subnet_mask:
+          :description: Subnet Mask
+          :required: false
+          :display: :edit
+          :data_type: :string
+        :customization_template_id:
+          :values_from:
+            :method: :allowed_customization_templates
+          :auto_select_single: false
+          :description: Script Name
+          :required: false
+          :display: :edit
+          :data_type: :integer
+        :customization_template_script:
+          :description: Script Text
+          :required: false
+          :display: :edit
+          :data_type: :string
+        :root_password:
+          :description: Root Password
+          :required: false
+          :display: :edit
+          :data_type: :string
+        :hostname:
+          :description: Host Name
+          :required: false
+          :display: :edit
+          :data_type: :string
+      :display: :show
+  :dialog_order:
+  - :requester
+  - :purpose
+  - :service
+  - :environment
+  - :hardware
+  - :volumes
+  - :customize
+  - :schedule

--- a/content/miq_dialogs/miq_provision_openstack_dialogs_template.yaml
+++ b/content/miq_dialogs/miq_provision_openstack_dialogs_template.yaml
@@ -164,6 +164,15 @@
           :required: true
           :display: :edit
           :data_type: :integer
+        :cloud_network_selection_method:
+          :values:
+            network: Cloud Network
+            port: Network Port
+          :description: Network Selection Method
+          :required: false
+          :display: :edit
+          :default: network
+          :data_type: :string
         :cloud_network:
           :values_from:
             :method: :allowed_cloud_networks
@@ -171,6 +180,15 @@
           :auto_select_single: false
           :required: true
           :required_method: :validate_cloud_network
+          :display: :edit
+          :data_type: :integer
+        :network_port:
+          :values_from:
+            :method: :allowed_network_ports
+          :description: Network Port
+          :auto_select_single: false
+          :required: true
+          :required_method: :validate_network_port
           :display: :edit
           :data_type: :integer
         :security_groups:


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1614567

Allow user to select Network Port or Cloud Network when provisioning an OpenStack cloud instance.

Related to 
https://github.com/ManageIQ/manageiq/pull/18303
https://github.com/ManageIQ/manageiq-ui-classic/pull/5103