### PR TITLE
Get tenant for stack from parameters

### DIFF
--- a/app/models/manageiq/providers/openstack/inventory/parser/cloud_manager.rb
+++ b/app/models/manageiq/providers/openstack/inventory/parser/cloud_manager.rb
@@ -281,7 +281,13 @@ class ManageIQ::Providers::Openstack::Inventory::Parser::CloudManager < ManageIQ
       o.status_reason = stack.stack_status_reason
       o.parent = persister.orchestration_stacks.lazy_find(stack.parent)
       o.orchestration_template = orchestration_template(stack)
-      o.cloud_tenant = persister.cloud_tenants.lazy_find(stack.service.current_tenant["id"])
+      # stack parameters can miss tenant_id, so we make admin default tenant
+      tenant_id = if stack.parameters && stack.parameters["OS::project_id"]
+                    stack.parameters["OS::project_id"]
+                  else
+                    stack.service.current_tenant["id"]
+                  end
+      o.cloud_tenant = persister.cloud_tenants.lazy_find(tenant_id)
 
       orchestration_stack_resources(stack, o)
       orchestration_stack_outputs(stack, o)

--- a/spec/models/manageiq/providers/openstack/openstack_stubs.rb
+++ b/spec/models/manageiq/providers/openstack/openstack_stubs.rb
@@ -179,9 +179,8 @@ module OpenstackStubs
           'output_value' => "output_value_#{i}",
           'description'  => "output_description_#{i}"
         }],
-        :parameters          => [{
-          "parameter_#{i}" => "key_#{i}"
-        }],
+        :parameters          => {"OS::project_id" => "project_id_#{i}"},
+        :links               => [{"href"=>"http://42.42.42.42:4242/v1/project_id_#{i}/stacks/orchestration_stack_#{i}/#{i}"}],
         :resources           => [OpenStruct.new(
           :physical_resource_id   => "vm_#{i}",
           :logical_resource_id    => "logical_resource_#{i}",


### PR DESCRIPTION
Get tenant for stack from parameters, not from service, because service seems to always be admin

@aufi @mansam 

https://bugzilla.redhat.com/show_bug.cgi?id=1597125