### PR TITLE
Don't collect volume attachments for missing servers

### DIFF
--- a/app/models/manageiq/providers/openstack/inventory/parser/storage_manager/cinder_manager.rb
+++ b/app/models/manageiq/providers/openstack/inventory/parser/storage_manager/cinder_manager.rb
@@ -82,9 +82,12 @@ class ManageIQ::Providers::Openstack::Inventory::Parser::StorageManager::CinderM
 
       dev = File.basename(a['device'])
 
+      server = persister.vms.find(a["server_id"])
+      next unless server
+
       attachment_names = {'vda' => 'Root disk', 'vdb' => 'Ephemeral disk', 'vdc' => 'Swap disk'}
       persister.disks.find_or_build_by(
-        :hardware    => persister.hardwares.lazy_find(persister.vms.lazy_find(a["server_id"])),
+        :hardware    => persister.hardwares.lazy_find(server),
         :device_name => attachment_names.fetch(dev, dev)
       ).assign_attributes(
         :location        => dev,

--- a/app/models/manageiq/providers/openstack/inventory/persister/storage_manager/cinder_manager.rb
+++ b/app/models/manageiq/providers/openstack/inventory/persister/storage_manager/cinder_manager.rb
@@ -17,7 +17,7 @@ class ManageIQ::Providers::Openstack::Inventory::Persister::StorageManager::Cind
        disks).each do |name|
 
       add_collection(cloud, name, shared_cloud_properties) do |builder|
-        builder.add_properties(:strategy => :local_db_cache_all) unless name == :disks
+        builder.add_properties(:strategy => :local_db_find_references) unless name == :disks
         builder.add_properties(:complete => false) if name == :disks
       end
     end


### PR DESCRIPTION
This PR causes the creation of disks for volume attachments to be skipped when the instance the attachments refer to can't be found in the db. This is intended to help fix 1651340, where refresh of a migrated server fails with a referential integrity error while saving volume attachments, because `lazy_find` on a server id ultimately resolved to nil.

https://bugzilla.redhat.com/show_bug.cgi?id=1651340

@Ladas with the change to using `find`, the vcr specs fail because they get the wrong count of disks. (presumably the servers turn up later which lazy_find takes care of, but since find is immediate some get left out?). Changing the inventory strategy solves that problem, but I don't have much more than an intuition about why that is. Any thoughts on whether this makes sense?