### PR TITLE
 Targeted refresh: Collect tenant ems references last

### DIFF
--- a/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty.yml
+++ b/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty.yml
@@ -17,13 +17,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:23:58 GMT
+      - Fri, 04 Jan 2019 16:55:27 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-38d4cfbd-4ef5-49c8-8eef-3854bd5094c1
+      - req-c8cf4ca0-623c-4d72-a6f8-c8415484c94e
       Content-Length:
       - '4170'
       Connection:
@@ -32,10 +32,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:23:58.206507", "expires":
-        "2019-01-03T20:23:58Z", "id": "b01fd47331c64b49b3f5ac4abdf92277", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:55:27.263170", "expires":
+        "2019-01-04T17:55:27Z", "id": "19ec8e33c03e44058f7aad942b071b6b", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["EqrK1cTjSp2I00Hw2RN-xQ"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["H5e2p6ydQcy76qEaXS6_ng"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -80,7 +80,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:58 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:27 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -95,7 +95,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b01fd47331c64b49b3f5ac4abdf92277
+      - 19ec8e33c03e44058f7aad942b071b6b
   response:
     status:
       code: 200
@@ -106,7 +106,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Thu, 03 Jan 2019 19:23:58 GMT
+      - Fri, 04 Jan 2019 16:55:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -115,7 +115,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:58 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:27 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-availability-zone
@@ -130,7 +130,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b01fd47331c64b49b3f5ac4abdf92277
+      - 19ec8e33c03e44058f7aad942b071b6b
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -143,15 +143,15 @@ http_interactions:
       Content-Length:
       - '97'
       X-Compute-Request-Id:
-      - req-6a56ee7c-b9e5-4f2b-b497-861cad198235
+      - req-a98a2596-0a54-4ebd-b21f-777ac6b15c83
       Date:
-      - Thu, 03 Jan 2019 19:23:58 GMT
+      - Fri, 04 Jan 2019 16:55:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"availabilityZoneInfo": [{"zoneState": {"available": true}, "hosts":
         null, "zoneName": "nova"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:58 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:27 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -169,13 +169,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:23:58 GMT
+      - Fri, 04 Jan 2019 16:55:27 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-3dc697fa-3ecb-416a-8f60-eeb2f8a85e5b
+      - req-0b04a6f7-6dab-4611-b3f6-660bbec9a78d
       Content-Length:
       - '4170'
       Connection:
@@ -184,10 +184,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:23:58.668071", "expires":
-        "2019-01-03T20:23:58Z", "id": "9cb8a4edcc494b91bab973cff4f04e11", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:55:27.757136", "expires":
+        "2019-01-04T17:55:27Z", "id": "941b81cd623d4d87a6c1ad2bc9340889", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["6Lnahp5MSHOI0V5N3niYOg"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["3dId64COTD-lb-r-1T4b4Q"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -232,7 +232,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:58 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:27 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-availability-zone.json
@@ -247,28 +247,28 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9cb8a4edcc494b91bab973cff4f04e11
+      - 941b81cd623d4d87a6c1ad2bc9340889
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-07b47f0f-2d74-41b4-b683-8ac0f061e14e
+      - req-2f148044-fcfa-4756-8ff6-c62c835db37d
       Content-Type:
       - application/json
       Content-Length:
       - '82'
       X-Openstack-Request-Id:
-      - req-07b47f0f-2d74-41b4-b683-8ac0f061e14e
+      - req-2f148044-fcfa-4756-8ff6-c62c835db37d
       Date:
-      - Thu, 03 Jan 2019 19:23:58 GMT
+      - Fri, 04 Jan 2019 16:55:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"availabilityZoneInfo": [{"zoneState": {"available": true}, "zoneName":
         "nova"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:58 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:27 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -286,13 +286,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:23:58 GMT
+      - Fri, 04 Jan 2019 16:55:28 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-3884b848-e9f9-43a1-8d5d-f28cbb41ca6c
+      - req-e9f5276e-27d3-407d-9739-2c34959eb237
       Content-Length:
       - '370'
       Connection:
@@ -301,13 +301,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:23:58.988363", "expires":
-        "2019-01-03T20:23:58Z", "id": "707f8a20555e4d44bb75578f0c98ab9d", "audit_ids":
-        ["baTbwd7FR0ynn6wVgh2GaA"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:55:28.145816", "expires":
+        "2019-01-04T17:55:28Z", "id": "f83353c3082841849e94b6e2fd766ebb", "audit_ids":
+        ["mfnjREGtT9Gn0LnefvhQOg"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:59 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:28 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -322,20 +322,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 707f8a20555e4d44bb75578f0c98ab9d
+      - f83353c3082841849e94b6e2fd766ebb
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:23:59 GMT
+      - Fri, 04 Jan 2019 16:55:28 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-d058ac92-0bcc-4365-8854-c599647e9fc9
+      - req-029ca49b-bef8-416e-87c4-aae7478395ff
       Content-Length:
       - '500'
       Connection:
@@ -352,7 +352,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:59 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:28 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -370,13 +370,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:23:59 GMT
+      - Fri, 04 Jan 2019 16:55:28 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-a6eac607-8120-4805-947c-af62906ff5bf
+      - req-9046872a-de64-47a6-b8fc-41083540f6cf
       Content-Length:
       - '4117'
       Connection:
@@ -385,10 +385,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:23:59.304370", "expires":
-        "2019-01-03T20:23:59Z", "id": "c821165ce6754779b0b6073410f07e17", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:55:28.483945", "expires":
+        "2019-01-04T17:55:28Z", "id": "75da2323456849fda593bc809361b6d2", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["vzOrrdTUROynt-JGl1bVlA"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["wjInoLCXRBKU3sN4-DLfMQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -432,7 +432,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:59 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:28 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -447,7 +447,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c821165ce6754779b0b6073410f07e17
+      - 75da2323456849fda593bc809361b6d2
   response:
     status:
       code: 200
@@ -458,7 +458,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Thu, 03 Jan 2019 19:23:59 GMT
+      - Fri, 04 Jan 2019 16:55:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -467,7 +467,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:59 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:28 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -485,13 +485,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:23:59 GMT
+      - Fri, 04 Jan 2019 16:55:28 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-7f2d0e48-9239-4f28-85ec-9c8fdadec30f
+      - req-d6eb450f-889f-48cc-981d-31ac08d4bd5e
       Content-Length:
       - '4131'
       Connection:
@@ -500,10 +500,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:23:59.585967", "expires":
-        "2019-01-03T20:23:59Z", "id": "65cefc2443fb41ee8f90bb86b17d574c", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:55:28.801154", "expires":
+        "2019-01-04T17:55:28Z", "id": "e0da2087300843a3bb44437fb2e7e6b3", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["sogDhtUbRYqXCOAAyOSHXw"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["7aTzbWNLQsmYK8bxOzEN3w"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -547,7 +547,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:59 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:28 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -562,7 +562,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 65cefc2443fb41ee8f90bb86b17d574c
+      - e0da2087300843a3bb44437fb2e7e6b3
   response:
     status:
       code: 200
@@ -573,7 +573,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Thu, 03 Jan 2019 19:23:59 GMT
+      - Fri, 04 Jan 2019 16:55:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -582,7 +582,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:59 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:28 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -600,13 +600,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:23:59 GMT
+      - Fri, 04 Jan 2019 16:55:29 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-6ff55960-77c0-427a-9feb-42f139bec736
+      - req-f9816137-302b-4ecd-a9c9-1f0152dbc031
       Content-Length:
       - '4118'
       Connection:
@@ -615,10 +615,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:23:59.853756", "expires":
-        "2019-01-03T20:23:59Z", "id": "822b1453956942e4a678a1e94da08f25", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:55:29.076384", "expires":
+        "2019-01-04T17:55:29Z", "id": "a1dd59a73f4c44eba8a5d8b7ac2b5c17", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["UYVIHtgDSmCjnKdH1cYICw"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["Y-_Fd40TQOiTIsFxDW5Bdg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -662,7 +662,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:59 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:29 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -677,7 +677,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 822b1453956942e4a678a1e94da08f25
+      - a1dd59a73f4c44eba8a5d8b7ac2b5c17
   response:
     status:
       code: 200
@@ -688,7 +688,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Thu, 03 Jan 2019 19:23:59 GMT
+      - Fri, 04 Jan 2019 16:55:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -697,7 +697,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:59 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:29 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-services?limit=1000
@@ -712,7 +712,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c821165ce6754779b0b6073410f07e17
+      - 75da2323456849fda593bc809361b6d2
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -725,26 +725,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-902b02b7-ffe5-4771-8816-014ca2ab9827
+      - req-f7a31b5a-064a-4478-b89e-5c356cf52567
       Date:
-      - Thu, 03 Jan 2019 19:24:00 GMT
+      - Fri, 04 Jan 2019 16:55:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-01-03T19:23:55.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-01-04T16:55:28.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2019-01-03T19:23:53.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2019-01-04T16:55:27.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-01-03T19:23:55.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-01-04T16:55:28.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2019-01-03T19:23:59.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2019-01-04T16:55:22.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2019-01-03T19:23:58.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2019-01-04T16:55:22.000000"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:00 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:29 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-services?limit=1000&marker=5
@@ -759,7 +759,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c821165ce6754779b0b6073410f07e17
+      - 75da2323456849fda593bc809361b6d2
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -772,26 +772,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-37e5a995-ce7e-43a1-a5ac-6afce0438b20
+      - req-29997664-b63b-4350-8d91-194a461f419a
       Date:
-      - Thu, 03 Jan 2019 19:24:00 GMT
+      - Fri, 04 Jan 2019 16:55:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-01-03T19:23:55.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-01-04T16:55:28.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2019-01-03T19:23:53.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2019-01-04T16:55:27.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-01-03T19:23:55.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-01-04T16:55:28.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2019-01-03T19:23:59.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2019-01-04T16:55:22.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2019-01-03T19:23:58.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2019-01-04T16:55:22.000000"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:00 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:29 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8/os-services?limit=1000
@@ -806,7 +806,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 65cefc2443fb41ee8f90bb86b17d574c
+      - e0da2087300843a3bb44437fb2e7e6b3
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -819,26 +819,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-ff1f1f51-011e-452c-9d1b-c4520a6f3aa4
+      - req-cba5a98a-accf-4960-9da2-c7ae52087e6d
       Date:
-      - Thu, 03 Jan 2019 19:24:00 GMT
+      - Fri, 04 Jan 2019 16:55:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-01-03T19:23:55.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-01-04T16:55:28.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2019-01-03T19:23:53.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2019-01-04T16:55:27.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-01-03T19:23:55.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-01-04T16:55:28.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2019-01-03T19:23:59.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2019-01-04T16:55:22.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2019-01-03T19:23:58.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2019-01-04T16:55:22.000000"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:00 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:29 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8/os-services?limit=1000&marker=5
@@ -853,7 +853,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 65cefc2443fb41ee8f90bb86b17d574c
+      - e0da2087300843a3bb44437fb2e7e6b3
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -866,26 +866,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-ae07502a-ccb4-47da-80a2-d0a1e037ec43
+      - req-63f7e5fc-b281-40bf-9d2f-96c543d50e95
       Date:
-      - Thu, 03 Jan 2019 19:24:00 GMT
+      - Fri, 04 Jan 2019 16:55:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-01-03T19:23:55.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-01-04T16:55:28.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2019-01-03T19:23:53.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2019-01-04T16:55:27.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-01-03T19:23:55.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-01-04T16:55:28.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2019-01-03T19:23:59.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2019-01-04T16:55:22.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2019-01-03T19:23:58.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2019-01-04T16:55:22.000000"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:00 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:29 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-services?limit=1000
@@ -900,7 +900,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b01fd47331c64b49b3f5ac4abdf92277
+      - 19ec8e33c03e44058f7aad942b071b6b
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -913,26 +913,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-7f45163b-977f-4115-aa2a-c48c4253b829
+      - req-635b9bba-89c1-419c-8333-d9959801facf
       Date:
-      - Thu, 03 Jan 2019 19:24:00 GMT
+      - Fri, 04 Jan 2019 16:55:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-01-03T19:23:55.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-01-04T16:55:28.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2019-01-03T19:23:53.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2019-01-04T16:55:27.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-01-03T19:23:55.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-01-04T16:55:28.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2019-01-03T19:23:59.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2019-01-04T16:55:22.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2019-01-03T19:23:58.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2019-01-04T16:55:22.000000"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:00 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:29 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-services?limit=1000&marker=5
@@ -947,7 +947,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b01fd47331c64b49b3f5ac4abdf92277
+      - 19ec8e33c03e44058f7aad942b071b6b
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -960,26 +960,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-9dad8909-453a-4c0c-b09a-15e97857bdb2
+      - req-6b283661-1a11-434e-870a-154fac15a9d1
       Date:
-      - Thu, 03 Jan 2019 19:24:00 GMT
+      - Fri, 04 Jan 2019 16:55:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-01-03T19:23:55.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-01-04T16:55:28.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2019-01-03T19:23:53.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2019-01-04T16:55:27.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-01-03T19:23:55.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-01-04T16:55:28.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2019-01-03T19:23:59.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2019-01-04T16:55:22.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2019-01-03T19:23:58.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2019-01-04T16:55:22.000000"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:00 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:30 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608/os-services?limit=1000
@@ -994,7 +994,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 822b1453956942e4a678a1e94da08f25
+      - a1dd59a73f4c44eba8a5d8b7ac2b5c17
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1007,26 +1007,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-0390cfa0-0808-46af-b81e-dd29ce3cf13b
+      - req-5d5d9ae3-4cd8-400c-85ae-8a60337cbe79
       Date:
-      - Thu, 03 Jan 2019 19:24:00 GMT
+      - Fri, 04 Jan 2019 16:55:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-01-03T19:23:55.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-01-04T16:55:28.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2019-01-03T19:23:53.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2019-01-04T16:55:27.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-01-03T19:23:55.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-01-04T16:55:28.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2019-01-03T19:23:59.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2019-01-04T16:55:22.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2019-01-03T19:23:58.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2019-01-04T16:55:22.000000"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:00 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:30 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608/os-services?limit=1000&marker=5
@@ -1041,7 +1041,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 822b1453956942e4a678a1e94da08f25
+      - a1dd59a73f4c44eba8a5d8b7ac2b5c17
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1054,26 +1054,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-c6b5d925-eb65-460b-8eed-52c2f2c17733
+      - req-63ceeeb4-3f77-44b7-b504-49e268555e6c
       Date:
-      - Thu, 03 Jan 2019 19:24:01 GMT
+      - Fri, 04 Jan 2019 16:55:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-01-03T19:23:55.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-01-04T16:55:28.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2019-01-03T19:23:53.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2019-01-04T16:55:27.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-01-03T19:23:55.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-01-04T16:55:28.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2019-01-03T19:23:59.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2019-01-04T16:55:22.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2019-01-03T19:23:58.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2019-01-04T16:55:22.000000"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:01 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:30 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000
@@ -1088,7 +1088,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b01fd47331c64b49b3f5ac4abdf92277
+      - 19ec8e33c03e44058f7aad942b071b6b
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1101,9 +1101,9 @@ http_interactions:
       Content-Length:
       - '1010'
       X-Compute-Request-Id:
-      - req-3972b3d8-bae9-49d2-86dc-731e13072c84
+      - req-a6cba81c-3002-4657-9705-a1ea9c043436
       Date:
-      - Thu, 03 Jan 2019 19:24:01 GMT
+      - Fri, 04 Jan 2019 16:55:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.tiny", "links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/1",
@@ -1117,7 +1117,7 @@ http_interactions:
         0, "disk": 20, "id": "2"}], "flavors_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=2",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:01 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:30 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=2
@@ -1132,7 +1132,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b01fd47331c64b49b3f5ac4abdf92277
+      - 19ec8e33c03e44058f7aad942b071b6b
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1145,9 +1145,9 @@ http_interactions:
       Content-Length:
       - '1014'
       X-Compute-Request-Id:
-      - req-d1b325ea-f547-4f82-a258-7aef7ef37fc0
+      - req-b028ab19-d2b6-4467-9ee0-7c1abbbcbe67
       Date:
-      - Thu, 03 Jan 2019 19:24:01 GMT
+      - Fri, 04 Jan 2019 16:55:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.medium", "links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/3",
@@ -1161,7 +1161,7 @@ http_interactions:
         0, "disk": 80, "id": "4"}], "flavors_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=4",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:01 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:30 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=4
@@ -1176,7 +1176,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b01fd47331c64b49b3f5ac4abdf92277
+      - 19ec8e33c03e44058f7aad942b071b6b
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1189,9 +1189,9 @@ http_interactions:
       Content-Length:
       - '1026'
       X-Compute-Request-Id:
-      - req-d9618a5b-9bb8-4b33-8f78-2e1391319bec
+      - req-45952034-88c9-41af-8b79-d643ce3358a3
       Date:
-      - Thu, 03 Jan 2019 19:24:01 GMT
+      - Fri, 04 Jan 2019 16:55:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.xlarge", "links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/5",
@@ -1206,7 +1206,7 @@ http_interactions:
         1, "disk": 1, "id": "6"}], "flavors_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=6",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:01 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:30 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=6
@@ -1221,7 +1221,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b01fd47331c64b49b3f5ac4abdf92277
+      - 19ec8e33c03e44058f7aad942b071b6b
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1234,9 +1234,9 @@ http_interactions:
       Content-Length:
       - '448'
       X-Compute-Request-Id:
-      - req-bb779930-f222-4aaf-8ee7-a481e231852a
+      - req-17aecaa1-23cf-4d75-b9ee-92eb5d748b0e
       Date:
-      - Thu, 03 Jan 2019 19:24:01 GMT
+      - Fri, 04 Jan 2019 16:55:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.ems_refresh_spec_private", "links": [{"href":
@@ -1246,7 +1246,7 @@ http_interactions:
         8, "swap": "", "os-flavor-access:is_public": false, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         0, "disk": 160, "id": "7"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:01 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:30 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/7/os-flavor-access
@@ -1261,7 +1261,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b01fd47331c64b49b3f5ac4abdf92277
+      - 19ec8e33c03e44058f7aad942b071b6b
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1274,15 +1274,15 @@ http_interactions:
       Content-Length:
       - '88'
       X-Compute-Request-Id:
-      - req-1bb29bb9-c172-4008-b58c-442b9f65abf0
+      - req-b53831b6-7e30-4321-8b51-b6b8cf3f0f67
       Date:
-      - Thu, 03 Jan 2019 19:24:01 GMT
+      - Fri, 04 Jan 2019 16:55:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavor_access": [{"tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "flavor_id": "7"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:01 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:31 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1300,13 +1300,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:24:01 GMT
+      - Fri, 04 Jan 2019 16:55:31 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-34c70ef1-fe5a-4f53-8fc5-352942dde688
+      - req-13049356-a21e-40f3-9a1f-482c9d28eefe
       Content-Length:
       - '4170'
       Connection:
@@ -1315,10 +1315,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:24:01.843494", "expires":
-        "2019-01-03T20:24:01Z", "id": "f8a97a3e800b49b1a4829795b8a62ae1", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:55:31.241167", "expires":
+        "2019-01-04T17:55:31Z", "id": "94c7246b751247e1a23803290b85486f", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["_TiHzp1iT9CkVJx6ykaQfA"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["1_UYoWNGT4W7vuSeR70UVQ"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -1363,7 +1363,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:01 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:31 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1381,13 +1381,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:24:01 GMT
+      - Fri, 04 Jan 2019 16:55:31 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-75cf587f-22ba-4d13-8ccf-b02742c8dd8b
+      - req-fce6638b-1b2f-4ff5-841f-9de81e86093f
       Content-Length:
       - '4117'
       Connection:
@@ -1396,10 +1396,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:24:02.029596", "expires":
-        "2019-01-03T20:24:02Z", "id": "9c10175393634da6bef5aa07939e70dc", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:55:31.429446", "expires":
+        "2019-01-04T17:55:31Z", "id": "2ca1134cef1f4e54bb27e66eba4056ab", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["JAYdcGnTQjqMhcqBhf1ZhQ"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["HD5BT9y7QRyl6m9ss6HloA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -1443,7 +1443,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:02 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:31 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1461,13 +1461,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:24:02 GMT
+      - Fri, 04 Jan 2019 16:55:31 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-7e90d3d3-3a42-4fb4-8dbe-b89cf0956535
+      - req-b8cbcc1c-4921-43e7-943c-623cc4427a21
       Content-Length:
       - '4131'
       Connection:
@@ -1476,10 +1476,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:24:02.211911", "expires":
-        "2019-01-03T20:24:02Z", "id": "16cc83a75a124ad497ac48bff0e612f8", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:55:31.613716", "expires":
+        "2019-01-04T17:55:31Z", "id": "3fb757d9734548aeb0377fbb170635c8", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["snbWUkO2TGSoGAzEkNB1qw"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["hwR7dewfS_OUbyZPYOgvhg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -1523,7 +1523,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:02 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:31 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1541,13 +1541,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:24:02 GMT
+      - Fri, 04 Jan 2019 16:55:31 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-df1be95c-5cd6-42d4-97cc-d1bcdc0882ed
+      - req-8b05ce3e-b49a-46d6-964d-0bf45db86066
       Content-Length:
       - '4118'
       Connection:
@@ -1556,10 +1556,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:24:02.399638", "expires":
-        "2019-01-03T20:24:02Z", "id": "ac30330fb1484449ba39ca12a35e7a60", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:55:31.796494", "expires":
+        "2019-01-04T17:55:31Z", "id": "4835c6c1d1004ff5a8aa0a087e9955e7", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["3_jFyN2iTYK_TMysKZHVqA"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["isWTvQVzRK6B22jzVWIN8g"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -1603,7 +1603,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:02 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:31 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images?limit=1000
@@ -1618,7 +1618,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9c10175393634da6bef5aa07939e70dc
+      - 2ca1134cef1f4e54bb27e66eba4056ab
   response:
     status:
       code: 200
@@ -1629,9 +1629,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-dd0320fe-9b96-4b90-8085-e5859b08bdf6
+      - req-9e87a141-a644-494c-aefe-8482135f5b24
       Date:
-      - Thu, 03 Jan 2019 19:24:02 GMT
+      - Fri, 04 Jan 2019 16:55:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -1673,7 +1673,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:02 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:32 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images?limit=1000&marker=bb799f70-5e02-461b-8324-17ee88259c7b
@@ -1688,7 +1688,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9c10175393634da6bef5aa07939e70dc
+      - 2ca1134cef1f4e54bb27e66eba4056ab
   response:
     status:
       code: 200
@@ -1699,14 +1699,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-2e52a593-53e4-4ee8-aad5-bf21969bacf1
+      - req-32a5f98d-2e5e-4d56-a04b-763793cd7503
       Date:
-      - Thu, 03 Jan 2019 19:24:02 GMT
+      - Fri, 04 Jan 2019 16:55:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:02 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:32 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images?limit=1000
@@ -1721,7 +1721,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 16cc83a75a124ad497ac48bff0e612f8
+      - 3fb757d9734548aeb0377fbb170635c8
   response:
     status:
       code: 200
@@ -1732,9 +1732,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-7911b036-881a-4928-97c0-f7348bbee19c
+      - req-1b42c92a-0d2f-401b-b3ed-b5860615d0e0
       Date:
-      - Thu, 03 Jan 2019 19:24:03 GMT
+      - Fri, 04 Jan 2019 16:55:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -1776,7 +1776,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:03 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:32 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images?limit=1000&marker=bb799f70-5e02-461b-8324-17ee88259c7b
@@ -1791,7 +1791,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 16cc83a75a124ad497ac48bff0e612f8
+      - 3fb757d9734548aeb0377fbb170635c8
   response:
     status:
       code: 200
@@ -1802,14 +1802,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-a77db18b-ae90-4218-b2fe-e5c1d565e3fc
+      - req-4515b0e9-a99f-4ace-8b9c-0cf6cd6547d6
       Date:
-      - Thu, 03 Jan 2019 19:24:03 GMT
+      - Fri, 04 Jan 2019 16:55:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:03 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:32 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images?limit=1000
@@ -1824,7 +1824,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f8a97a3e800b49b1a4829795b8a62ae1
+      - 94c7246b751247e1a23803290b85486f
   response:
     status:
       code: 200
@@ -1835,9 +1835,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-36d108bb-e921-4b72-b159-4e06f929cd91
+      - req-20b1aba3-3120-4b75-b9e0-aaf5365db2e8
       Date:
-      - Thu, 03 Jan 2019 19:24:03 GMT
+      - Fri, 04 Jan 2019 16:55:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -1879,7 +1879,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:03 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:32 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images?limit=1000&marker=bb799f70-5e02-461b-8324-17ee88259c7b
@@ -1894,7 +1894,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f8a97a3e800b49b1a4829795b8a62ae1
+      - 94c7246b751247e1a23803290b85486f
   response:
     status:
       code: 200
@@ -1905,14 +1905,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-49e79b86-3868-4340-aacb-19f1cfab59fd
+      - req-99f31bc1-a681-4f3d-9927-09d627e973b0
       Date:
-      - Thu, 03 Jan 2019 19:24:03 GMT
+      - Fri, 04 Jan 2019 16:55:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:03 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:32 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images?limit=1000
@@ -1927,7 +1927,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ac30330fb1484449ba39ca12a35e7a60
+      - 4835c6c1d1004ff5a8aa0a087e9955e7
   response:
     status:
       code: 200
@@ -1938,9 +1938,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-89f3a01d-9f8c-4271-87cc-874d1e2a778a
+      - req-9e37d906-7dc3-483b-b62a-3d4464d7ec0b
       Date:
-      - Thu, 03 Jan 2019 19:24:03 GMT
+      - Fri, 04 Jan 2019 16:55:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -1982,7 +1982,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:03 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:32 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images?limit=1000&marker=bb799f70-5e02-461b-8324-17ee88259c7b
@@ -1997,7 +1997,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ac30330fb1484449ba39ca12a35e7a60
+      - 4835c6c1d1004ff5a8aa0a087e9955e7
   response:
     status:
       code: 200
@@ -2008,14 +2008,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-b86a2fa7-65f7-4f4a-a58e-f175cf32094b
+      - req-3c27629e-4d85-4386-abe9-99eecd78a07a
       Date:
-      - Thu, 03 Jan 2019 19:24:03 GMT
+      - Fri, 04 Jan 2019 16:55:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:03 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:33 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-keypairs?limit=1000
@@ -2030,7 +2030,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c821165ce6754779b0b6073410f07e17
+      - 75da2323456849fda593bc809361b6d2
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2043,9 +2043,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-5c9ba181-9a22-470a-a20b-6bf02f7c08f4
+      - req-45f4ec78-53bf-4ce6-871d-f8c8bf023704
       Date:
-      - Thu, 03 Jan 2019 19:24:03 GMT
+      - Fri, 04 Jan 2019 16:55:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -2055,7 +2055,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:03 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:33 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -2070,7 +2070,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c821165ce6754779b0b6073410f07e17
+      - 75da2323456849fda593bc809361b6d2
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2083,9 +2083,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-d7374e46-4750-4334-bbcd-c4f8751c2ec0
+      - req-93ac40ea-6ed3-4d63-9592-5bf4734f36fd
       Date:
-      - Thu, 03 Jan 2019 19:24:04 GMT
+      - Fri, 04 Jan 2019 16:55:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -2095,7 +2095,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:04 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:33 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8/os-keypairs?limit=1000
@@ -2110,7 +2110,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 65cefc2443fb41ee8f90bb86b17d574c
+      - e0da2087300843a3bb44437fb2e7e6b3
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2123,9 +2123,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-992384b5-eb61-45f2-8239-122478e813f7
+      - req-f6772ab1-0eac-4cb1-8385-37e470532d71
       Date:
-      - Thu, 03 Jan 2019 19:24:04 GMT
+      - Fri, 04 Jan 2019 16:55:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -2135,7 +2135,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:04 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:33 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -2150,7 +2150,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 65cefc2443fb41ee8f90bb86b17d574c
+      - e0da2087300843a3bb44437fb2e7e6b3
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2163,9 +2163,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-51074007-5d48-4421-8af5-d7ebdb72c002
+      - req-e0ebd5cf-a1d5-495e-8de8-455f37b1ea67
       Date:
-      - Thu, 03 Jan 2019 19:24:04 GMT
+      - Fri, 04 Jan 2019 16:55:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -2175,7 +2175,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:04 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:33 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-keypairs?limit=1000
@@ -2190,7 +2190,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b01fd47331c64b49b3f5ac4abdf92277
+      - 19ec8e33c03e44058f7aad942b071b6b
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2203,9 +2203,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-604b94e5-798d-4432-b85a-c60852deb307
+      - req-37fce829-17fa-42c6-8007-60dfd9e1bf59
       Date:
-      - Thu, 03 Jan 2019 19:24:04 GMT
+      - Fri, 04 Jan 2019 16:55:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -2215,7 +2215,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:04 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:33 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -2230,7 +2230,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b01fd47331c64b49b3f5ac4abdf92277
+      - 19ec8e33c03e44058f7aad942b071b6b
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2243,9 +2243,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-b2c93e96-f004-4809-b0cb-884cc7bda9e8
+      - req-458ec18e-9cf2-4d44-b2de-2dd1acb2781e
       Date:
-      - Thu, 03 Jan 2019 19:24:04 GMT
+      - Fri, 04 Jan 2019 16:55:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -2255,7 +2255,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:04 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:33 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608/os-keypairs?limit=1000
@@ -2270,7 +2270,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 822b1453956942e4a678a1e94da08f25
+      - a1dd59a73f4c44eba8a5d8b7ac2b5c17
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2283,9 +2283,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-ae4098c6-56b2-4dc2-9380-eb30ecc9be8c
+      - req-2dec817e-c9be-4e29-b5da-2e3cec45ffc2
       Date:
-      - Thu, 03 Jan 2019 19:24:04 GMT
+      - Fri, 04 Jan 2019 16:55:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -2295,7 +2295,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:04 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:33 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -2310,7 +2310,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 822b1453956942e4a678a1e94da08f25
+      - a1dd59a73f4c44eba8a5d8b7ac2b5c17
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2323,9 +2323,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-e3543367-7397-4b6a-b767-65a85bfa0b70
+      - req-48cec1c5-6f89-4219-938f-a3fc9acfce7a
       Date:
-      - Thu, 03 Jan 2019 19:24:04 GMT
+      - Fri, 04 Jan 2019 16:55:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -2335,7 +2335,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:04 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:34 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -2353,13 +2353,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:24:04 GMT
+      - Fri, 04 Jan 2019 16:55:34 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-8b4c4d93-a640-47a9-9cdc-ee802e13725a
+      - req-2de5cbcb-6cba-4002-bcd8-53a5281219f9
       Content-Length:
       - '4170'
       Connection:
@@ -2368,10 +2368,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:24:04.862698", "expires":
-        "2019-01-03T20:24:04Z", "id": "c379cc27d7374fd884f50bd2056010d9", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:55:34.199252", "expires":
+        "2019-01-04T17:55:34Z", "id": "a0c43bc99d00451e89da9ef5f67e7e39", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["nC15Whz7SRylxkv1kpLUPA"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["HxLGOiwGSTCvVT911AgVfg"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -2416,7 +2416,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:04 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:34 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -2434,13 +2434,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:24:05 GMT
+      - Fri, 04 Jan 2019 16:55:34 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-eb5bf816-83ee-436d-879a-35b47f50f5d7
+      - req-5d17003e-47cc-4d8a-8bbe-c1774869d4f3
       Content-Length:
       - '4117'
       Connection:
@@ -2449,10 +2449,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:24:05.066378", "expires":
-        "2019-01-03T20:24:05Z", "id": "bdce2632f1b54b789cc8dfbf8d451a4a", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:55:34.396340", "expires":
+        "2019-01-04T17:55:34Z", "id": "29cc022a09bf47d2b35cefd0e6c26659", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["igAh6RiqS8KyNNPkC2BTEA"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["-VfXonXcQe6uevqDAom3Ww"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -2496,7 +2496,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:05 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:34 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -2514,13 +2514,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:24:05 GMT
+      - Fri, 04 Jan 2019 16:55:34 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-e88de9a5-9e51-4fe7-b4ac-da0514ac8359
+      - req-554d4551-fb53-4d30-b2b4-bdb0b87d0faa
       Content-Length:
       - '4131'
       Connection:
@@ -2529,10 +2529,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:24:05.269269", "expires":
-        "2019-01-03T20:24:05Z", "id": "9c7190a890d14c9c8e81338af1ef4ab7", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:55:34.600671", "expires":
+        "2019-01-04T17:55:34Z", "id": "a5ea4e2707fd44a59cc23e46fa125e95", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["MbMVBuRnQ--UGpmAufPTEw"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["NGtxrsuRS8SdkZKmrAufKQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -2576,7 +2576,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:05 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:34 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -2594,13 +2594,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:24:05 GMT
+      - Fri, 04 Jan 2019 16:55:34 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-e644f197-50e8-416e-afc9-7dd3892fd6bc
+      - req-8ebd7761-23dc-4ff9-a39d-14dd86549d70
       Content-Length:
       - '4118'
       Connection:
@@ -2609,10 +2609,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:24:05.457723", "expires":
-        "2019-01-03T20:24:05Z", "id": "1825395372274b3e924ffe759a0c26af", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:55:34.808321", "expires":
+        "2019-01-04T17:55:34Z", "id": "b33f527f61f84c88add9b23b910c60cc", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["_w1GTVmSRDGpzg9LnhKPMg"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["VVD0vzsfRqi5vfdMf1ruSg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -2656,7 +2656,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:05 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:34 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks?limit=1000&show_nested=true
@@ -2671,7 +2671,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bdce2632f1b54b789cc8dfbf8d451a4a
+      - 29cc022a09bf47d2b35cefd0e6c26659
   response:
     status:
       code: 200
@@ -2682,9 +2682,9 @@ http_interactions:
       Content-Length:
       - '2559'
       X-Openstack-Request-Id:
-      - req-ccef80f6-1303-4929-9dd4-5d596d7c9277
+      - req-3da1a0e9-77a9-49ba-9c43-3a170e2e7ad1
       Date:
-      - Thu, 03 Jan 2019 19:24:05 GMT
+      - Fri, 04 Jan 2019 16:55:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": [{"description": "Heat WordPress template to support F20,
@@ -2718,7 +2718,7 @@ http_interactions:
         "rel": "self"}], "updated_time": null, "stack_owner": null, "stack_status":
         "CREATE_COMPLETE", "id": "091e1e54-e01c-4ec5-a0ab-b00bee4d425c"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:05 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:35 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks?limit=1000&marker=091e1e54-e01c-4ec5-a0ab-b00bee4d425c&show_nested=true
@@ -2733,7 +2733,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bdce2632f1b54b789cc8dfbf8d451a4a
+      - 29cc022a09bf47d2b35cefd0e6c26659
   response:
     status:
       code: 200
@@ -2744,14 +2744,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-ff944bd0-ed68-4ce1-bba7-ae82ed5e6554
+      - req-dd24e8f2-5c71-4d09-95d6-d8d343f5c555
       Date:
-      - Thu, 03 Jan 2019 19:24:05 GMT
+      - Fri, 04 Jan 2019 16:55:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:05 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:35 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/b458a5c25c3749758f4c0661940b3ba8/stacks?limit=1000&show_nested=true
@@ -2766,7 +2766,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9c7190a890d14c9c8e81338af1ef4ab7
+      - a5ea4e2707fd44a59cc23e46fa125e95
   response:
     status:
       code: 200
@@ -2777,14 +2777,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-59d2bd36-5a9f-44b6-a411-0f52a2a91543
+      - req-e4433915-583c-4518-990e-6cef139f93e8
       Date:
-      - Thu, 03 Jan 2019 19:24:05 GMT
+      - Fri, 04 Jan 2019 16:55:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:06 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:35 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/e54e5c3c19e34720b05661f2ea1ea00a/stacks?limit=1000&show_nested=true
@@ -2799,7 +2799,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c379cc27d7374fd884f50bd2056010d9
+      - a0c43bc99d00451e89da9ef5f67e7e39
   response:
     status:
       code: 200
@@ -2810,14 +2810,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-a86a3b6d-6335-46a5-b88c-6ad277c8f532
+      - req-70a4c4d7-58d2-4edc-85c0-622b34c5b8f6
       Date:
-      - Thu, 03 Jan 2019 19:24:06 GMT
+      - Fri, 04 Jan 2019 16:55:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:06 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:35 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/e8f744b1fc6a487681d35fb275252608/stacks?limit=1000&show_nested=true
@@ -2832,7 +2832,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1825395372274b3e924ffe759a0c26af
+      - b33f527f61f84c88add9b23b910c60cc
   response:
     status:
       code: 200
@@ -2843,14 +2843,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-ea7a52fd-20bd-4ec1-88f4-5028e2f57de3
+      - req-a0bd663a-4def-45a2-b0c0-8b0763b36f7e
       Date:
-      - Thu, 03 Jan 2019 19:24:06 GMT
+      - Fri, 04 Jan 2019 16:55:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:06 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:35 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack3/45d2af82-eff9-4483-a1f0-f19c44d96146
@@ -2865,7 +2865,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bdce2632f1b54b789cc8dfbf8d451a4a
+      - 29cc022a09bf47d2b35cefd0e6c26659
   response:
     status:
       code: 200
@@ -2876,9 +2876,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-91dc30a4-496c-4612-b5d8-b98d0fb1794a
+      - req-21811ad5-f052-42a8-a3fd-70f9b7394870
       Date:
-      - Thu, 03 Jan 2019 19:24:06 GMT
+      - Fri, 04 Jan 2019 16:55:36 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -2905,7 +2905,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:06 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:36 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack2/4cf24b12-29fc-4529-a8ed-6b079dea7c17
@@ -2920,7 +2920,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bdce2632f1b54b789cc8dfbf8d451a4a
+      - 29cc022a09bf47d2b35cefd0e6c26659
   response:
     status:
       code: 200
@@ -2931,9 +2931,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-c8d33c21-4163-4ede-9aa2-69462962d3e6
+      - req-02c2b11d-7bec-4c84-aa9f-85b1cd93fa69
       Date:
-      - Thu, 03 Jan 2019 19:24:07 GMT
+      - Fri, 04 Jan 2019 16:55:36 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -2960,7 +2960,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:07 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:36 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c
@@ -2975,7 +2975,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bdce2632f1b54b789cc8dfbf8d451a4a
+      - 29cc022a09bf47d2b35cefd0e6c26659
   response:
     status:
       code: 200
@@ -2986,9 +2986,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-27c815ec-7262-42ff-b9c8-0edf16dca9cd
+      - req-7a8a8f4d-3c1a-43a4-9b0c-762fa3234069
       Date:
-      - Thu, 03 Jan 2019 19:24:07 GMT
+      - Fri, 04 Jan 2019 16:55:36 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -3015,7 +3015,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:07 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:36 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack3/45d2af82-eff9-4483-a1f0-f19c44d96146/template
@@ -3030,7 +3030,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bdce2632f1b54b789cc8dfbf8d451a4a
+      - 29cc022a09bf47d2b35cefd0e6c26659
   response:
     status:
       code: 200
@@ -3041,9 +3041,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-d0c809ca-d86b-4605-bf2a-84e987e97535
+      - req-cea54961-7d90-4494-89ee-8543b597f11a
       Date:
-      - Thu, 03 Jan 2019 19:24:07 GMT
+      - Fri, 04 Jan 2019 16:55:36 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -3099,7 +3099,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:07 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:36 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack3/45d2af82-eff9-4483-a1f0-f19c44d96146/resources
@@ -3114,7 +3114,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bdce2632f1b54b789cc8dfbf8d451a4a
+      - 29cc022a09bf47d2b35cefd0e6c26659
   response:
     status:
       code: 200
@@ -3125,9 +3125,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-9c70c511-4c7f-44a8-b86b-3eb6914f79be
+      - req-94259d66-9ea6-4bcd-acd3-3f440a0bf9ea
       Date:
-      - Thu, 03 Jan 2019 19:24:07 GMT
+      - Fri, 04 Jan 2019 16:55:36 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -3139,7 +3139,7 @@ http_interactions:
         changed", "physical_resource_id": "aa5907f3-8209-4dd0-b3ef-600431d85bac",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:07 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:37 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/detail?limit=1000
@@ -3154,7 +3154,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c821165ce6754779b0b6073410f07e17
+      - 75da2323456849fda593bc809361b6d2
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3167,9 +3167,9 @@ http_interactions:
       Content-Length:
       - '3981'
       X-Compute-Request-Id:
-      - req-48dd052c-4ac4-4f91-9c6f-c861f6b5fb7a
+      - req-e23af33a-b53f-4ec6-a245-46e09f82d17d
       Date:
-      - Thu, 03 Jan 2019 19:24:08 GMT
+      - Fri, 04 Jan 2019 16:55:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/detail?limit=1000&marker=96fef14f-5338-4d58-8b89-58b627b27b9b",
@@ -3215,7 +3215,7 @@ http_interactions:
         [], "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:08 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:37 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/detail?limit=1000&marker=96fef14f-5338-4d58-8b89-58b627b27b9b
@@ -3230,7 +3230,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c821165ce6754779b0b6073410f07e17
+      - 75da2323456849fda593bc809361b6d2
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3243,9 +3243,9 @@ http_interactions:
       Content-Length:
       - '4045'
       X-Compute-Request-Id:
-      - req-b31456be-1066-4135-93ea-160677d4cbd4
+      - req-e7657c98-4d44-4474-a9f6-d1c2ea2705b0
       Date:
-      - Thu, 03 Jan 2019 19:24:08 GMT
+      - Fri, 04 Jan 2019 16:55:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/detail?limit=1000&marker=ca1fc357-ee31-45e9-a38d-98723d6c8876",
@@ -3291,7 +3291,7 @@ http_interactions:
         [], "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 3, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:08 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:37 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/detail?limit=1000&marker=ca1fc357-ee31-45e9-a38d-98723d6c8876
@@ -3306,7 +3306,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c821165ce6754779b0b6073410f07e17
+      - 75da2323456849fda593bc809361b6d2
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3319,9 +3319,9 @@ http_interactions:
       Content-Length:
       - '4127'
       X-Compute-Request-Id:
-      - req-83531cab-ce08-4efc-8812-ec883990b4dd
+      - req-b675f4c7-4aac-49d3-8a84-a70c2756bf06
       Date:
-      - Thu, 03 Jan 2019 19:24:08 GMT
+      - Fri, 04 Jan 2019 16:55:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/detail?limit=1000&marker=ca4f3a16-bae3-4407-83e9-f77b28af0f2b",
@@ -3369,7 +3369,7 @@ http_interactions:
         "", "progress": 0, "OS-EXT-STS:power_state": 1, "config_drive": "", "metadata":
         {}}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:08 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:37 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/detail?limit=1000&marker=ca4f3a16-bae3-4407-83e9-f77b28af0f2b
@@ -3384,7 +3384,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c821165ce6754779b0b6073410f07e17
+      - 75da2323456849fda593bc809361b6d2
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3397,9 +3397,9 @@ http_interactions:
       Content-Length:
       - '3796'
       X-Compute-Request-Id:
-      - req-a324fd3a-6028-45f2-b135-1e47d2eb0b60
+      - req-655649c4-2331-4320-afcd-7777129bfef4
       Date:
-      - Thu, 03 Jan 2019 19:24:08 GMT
+      - Fri, 04 Jan 2019 16:55:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/detail?limit=1000&marker=aa5907f3-8209-4dd0-b3ef-600431d85bac",
@@ -3441,7 +3441,7 @@ http_interactions:
         "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:09 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:38 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/detail?limit=1000&marker=aa5907f3-8209-4dd0-b3ef-600431d85bac
@@ -3456,7 +3456,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c821165ce6754779b0b6073410f07e17
+      - 75da2323456849fda593bc809361b6d2
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3469,9 +3469,9 @@ http_interactions:
       Content-Length:
       - '1816'
       X-Compute-Request-Id:
-      - req-c011f6d1-8094-453c-be15-400b59bbadb6
+      - req-08b3b030-b516-4a07-9ccf-6e0a51cf752f
       Date:
-      - Thu, 03 Jan 2019 19:24:09 GMT
+      - Fri, 04 Jan 2019 16:55:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": [{"status": "SHUTOFF", "updated": "2018-01-17T14:49:17Z",
@@ -3494,7 +3494,7 @@ http_interactions:
         "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:09 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:38 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8/servers/detail?limit=1000
@@ -3509,7 +3509,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 65cefc2443fb41ee8f90bb86b17d574c
+      - e0da2087300843a3bb44437fb2e7e6b3
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3522,14 +3522,14 @@ http_interactions:
       Content-Length:
       - '15'
       X-Compute-Request-Id:
-      - req-f6b6e3f9-5f79-4eee-872c-9891bfe6450e
+      - req-578de1fb-85d2-4f51-a2d5-fdd506371397
       Date:
-      - Thu, 03 Jan 2019 19:24:09 GMT
+      - Fri, 04 Jan 2019 16:55:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:09 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:38 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?limit=1000
@@ -3544,7 +3544,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b01fd47331c64b49b3f5ac4abdf92277
+      - 19ec8e33c03e44058f7aad942b071b6b
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3557,14 +3557,14 @@ http_interactions:
       Content-Length:
       - '15'
       X-Compute-Request-Id:
-      - req-b9109055-2cc4-45d9-b77d-821c5fa8a3f6
+      - req-58587f53-5365-418f-8981-706fd6162e24
       Date:
-      - Thu, 03 Jan 2019 19:24:09 GMT
+      - Fri, 04 Jan 2019 16:55:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:09 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:38 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608/servers/detail?limit=1000
@@ -3579,7 +3579,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 822b1453956942e4a678a1e94da08f25
+      - a1dd59a73f4c44eba8a5d8b7ac2b5c17
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3592,14 +3592,14 @@ http_interactions:
       Content-Length:
       - '15'
       X-Compute-Request-Id:
-      - req-6363d7cf-3e4c-4dd2-96c7-c2f85171feaa
+      - req-a9877dc0-1085-44da-967b-8cdb0dafbd01
       Date:
-      - Thu, 03 Jan 2019 19:24:09 GMT
+      - Fri, 04 Jan 2019 16:55:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:09 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:38 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack2/4cf24b12-29fc-4529-a8ed-6b079dea7c17/template
@@ -3614,7 +3614,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bdce2632f1b54b789cc8dfbf8d451a4a
+      - 29cc022a09bf47d2b35cefd0e6c26659
   response:
     status:
       code: 200
@@ -3625,9 +3625,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-729eb485-2740-41e3-9c84-dae8a743498e
+      - req-a40d20de-d624-4b1f-83f4-e6e1020fbcce
       Date:
-      - Thu, 03 Jan 2019 19:24:09 GMT
+      - Fri, 04 Jan 2019 16:55:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -3683,7 +3683,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:09 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:38 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack2/4cf24b12-29fc-4529-a8ed-6b079dea7c17/resources
@@ -3698,7 +3698,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bdce2632f1b54b789cc8dfbf8d451a4a
+      - 29cc022a09bf47d2b35cefd0e6c26659
   response:
     status:
       code: 200
@@ -3709,9 +3709,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-87220bd8-4ce3-4cc6-b7ba-583af3a663dd
+      - req-a551eed0-9ac8-48c3-a0e5-600fdd9feca1
       Date:
-      - Thu, 03 Jan 2019 19:24:09 GMT
+      - Fri, 04 Jan 2019 16:55:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -3723,7 +3723,7 @@ http_interactions:
         changed", "physical_resource_id": "219a737c-b4ad-430d-944a-a92a4834b12d",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:09 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:39 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c/template
@@ -3738,7 +3738,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bdce2632f1b54b789cc8dfbf8d451a4a
+      - 29cc022a09bf47d2b35cefd0e6c26659
   response:
     status:
       code: 200
@@ -3749,9 +3749,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-21c3d560-1578-4419-b43b-28ca39f00538
+      - req-da54f750-1ef5-4b4d-b696-0961f78a0144
       Date:
-      - Thu, 03 Jan 2019 19:24:10 GMT
+      - Fri, 04 Jan 2019 16:55:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -3807,7 +3807,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:10 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:39 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c/resources
@@ -3822,7 +3822,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bdce2632f1b54b789cc8dfbf8d451a4a
+      - 29cc022a09bf47d2b35cefd0e6c26659
   response:
     status:
       code: 200
@@ -3833,9 +3833,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-df604806-5fb3-4c27-af7a-6b32d8b7d3fa
+      - req-1269a30e-b4a9-4c53-a4bf-6de88230484f
       Date:
-      - Thu, 03 Jan 2019 19:24:10 GMT
+      - Fri, 04 Jan 2019 16:55:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -3847,7 +3847,7 @@ http_interactions:
         changed", "physical_resource_id": "b686353f-0da0-48bf-bc35-8ea411a67dfd",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:10 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:39 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a//os-quota-sets/69f8f7205ade4aa59084c32c83e60b5a
@@ -3862,7 +3862,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c821165ce6754779b0b6073410f07e17
+      - 75da2323456849fda593bc809361b6d2
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3875,9 +3875,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-2f7e8de0-717b-4e77-a11e-b2bf2e87236a
+      - req-1e09e59c-a17d-4e24-9cd0-02a12fa2d2f9
       Date:
-      - Thu, 03 Jan 2019 19:24:10 GMT
+      - Fri, 04 Jan 2019 16:55:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -3886,7 +3886,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:10 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:39 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8//os-quota-sets/b458a5c25c3749758f4c0661940b3ba8
@@ -3901,7 +3901,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 65cefc2443fb41ee8f90bb86b17d574c
+      - e0da2087300843a3bb44437fb2e7e6b3
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3914,9 +3914,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-e48ca7dc-2ed2-4121-8d3b-ab0734640f72
+      - req-9e1a7b3b-0d06-459f-9142-17a2bb6badd2
       Date:
-      - Thu, 03 Jan 2019 19:24:10 GMT
+      - Fri, 04 Jan 2019 16:55:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -3925,7 +3925,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:10 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:39 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a//os-quota-sets/e54e5c3c19e34720b05661f2ea1ea00a
@@ -3940,7 +3940,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b01fd47331c64b49b3f5ac4abdf92277
+      - 19ec8e33c03e44058f7aad942b071b6b
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3953,9 +3953,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-51e995aa-1740-4418-a7da-e73c2ee6e2f9
+      - req-3ffc2f6a-2ee8-46cd-ab23-c7799ea311c9
       Date:
-      - Thu, 03 Jan 2019 19:24:10 GMT
+      - Fri, 04 Jan 2019 16:55:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -3964,7 +3964,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:10 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:39 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608//os-quota-sets/e8f744b1fc6a487681d35fb275252608
@@ -3979,7 +3979,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 822b1453956942e4a678a1e94da08f25
+      - a1dd59a73f4c44eba8a5d8b7ac2b5c17
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3992,9 +3992,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-13ade34b-252d-4c50-8b17-9148899eb831
+      - req-a116c897-85c0-4955-b69d-53e118c1e42a
       Date:
-      - Thu, 03 Jan 2019 19:24:10 GMT
+      - Fri, 04 Jan 2019 16:55:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -4003,7 +4003,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:10 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:39 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4021,13 +4021,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:24:10 GMT
+      - Fri, 04 Jan 2019 16:55:39 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-5560bd65-d374-4b00-8781-da1dbd85baab
+      - req-c4683476-0630-4fc6-80ae-fbb82b6cebe2
       Content-Length:
       - '4117'
       Connection:
@@ -4036,10 +4036,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:24:10.719311", "expires":
-        "2019-01-03T20:24:10Z", "id": "99906174ab5a4d67a4689177c26b0d37", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:55:39.801736", "expires":
+        "2019-01-04T17:55:39Z", "id": "74caaef0bbef41b39023507f9e49ec84", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["49hSecwIQnC5QPvjgTM7dg"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["CHzhonWZRieAx6r4cGo8lQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -4083,7 +4083,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:10 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:39 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4101,13 +4101,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:24:10 GMT
+      - Fri, 04 Jan 2019 16:55:39 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-e6579c8c-e41e-4d2d-b427-bd81381498c9
+      - req-aa256569-3971-46cc-9308-4a8c1de42f85
       Content-Length:
       - '4131'
       Connection:
@@ -4116,10 +4116,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:24:10.920223", "expires":
-        "2019-01-03T20:24:10Z", "id": "9427799b72c245909d61117527d8def4", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:55:39.994187", "expires":
+        "2019-01-04T17:55:39Z", "id": "e98d2ce934704013806e8a3756948b1b", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["ycSh-z7vRwGvCHPcp9Mnnw"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["P9PZTOi5RtKkBvPXQlifOA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -4163,7 +4163,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:10 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:40 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4181,13 +4181,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:24:11 GMT
+      - Fri, 04 Jan 2019 16:55:40 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-878a380d-6999-4e08-90b4-2a9523a2f310
+      - req-d67802b5-30f5-4ac0-80ad-cc21f166ec8a
       Content-Length:
       - '4118'
       Connection:
@@ -4196,10 +4196,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:24:11.109489", "expires":
-        "2019-01-03T20:24:11Z", "id": "1527b646aa2341b28f791dfc31ec511b", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:55:40.227286", "expires":
+        "2019-01-04T17:55:40Z", "id": "f5fa421d5c2a42ed98b29320f8e1b4fc", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["N5RkO_ojRUm13WgSQD4KHg"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["cPxK_KNWQk2SyzJsQ6eBZA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -4243,7 +4243,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:11 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:40 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a//os-quota-sets/69f8f7205ade4aa59084c32c83e60b5a
@@ -4258,22 +4258,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 99906174ab5a4d67a4689177c26b0d37
+      - 74caaef0bbef41b39023507f9e49ec84
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-4d2ae1e5-3338-47d9-9855-07626fee1c84
+      - req-33ee8377-db86-42ea-aa4b-55ee02f0f086
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-4d2ae1e5-3338-47d9-9855-07626fee1c84
+      - req-33ee8377-db86-42ea-aa4b-55ee02f0f086
       Date:
-      - Thu, 03 Jan 2019 19:24:11 GMT
+      - Fri, 04 Jan 2019 16:55:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -4283,7 +4283,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "69f8f7205ade4aa59084c32c83e60b5a"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:11 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:40 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8//os-quota-sets/b458a5c25c3749758f4c0661940b3ba8
@@ -4298,22 +4298,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9427799b72c245909d61117527d8def4
+      - e98d2ce934704013806e8a3756948b1b
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-40ad9d3c-47c3-4ed9-bbc2-e806ae6c92f2
+      - req-5da2e5f5-0291-41f1-8e0a-200839bcfa28
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-40ad9d3c-47c3-4ed9-bbc2-e806ae6c92f2
+      - req-5da2e5f5-0291-41f1-8e0a-200839bcfa28
       Date:
-      - Thu, 03 Jan 2019 19:24:11 GMT
+      - Fri, 04 Jan 2019 16:55:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -4323,7 +4323,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "b458a5c25c3749758f4c0661940b3ba8"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:11 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:40 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a//os-quota-sets/e54e5c3c19e34720b05661f2ea1ea00a
@@ -4338,22 +4338,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9cb8a4edcc494b91bab973cff4f04e11
+      - 941b81cd623d4d87a6c1ad2bc9340889
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-02a75a02-4321-47a2-a2ed-5e1e8277785b
+      - req-6f9b3789-49c2-42a7-8cbb-b24c86913fad
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-02a75a02-4321-47a2-a2ed-5e1e8277785b
+      - req-6f9b3789-49c2-42a7-8cbb-b24c86913fad
       Date:
-      - Thu, 03 Jan 2019 19:24:12 GMT
+      - Fri, 04 Jan 2019 16:55:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -4363,7 +4363,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "e54e5c3c19e34720b05661f2ea1ea00a"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:12 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:41 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608//os-quota-sets/e8f744b1fc6a487681d35fb275252608
@@ -4378,22 +4378,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1527b646aa2341b28f791dfc31ec511b
+      - f5fa421d5c2a42ed98b29320f8e1b4fc
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-0471d0e8-7067-4e8d-a516-7190560933fc
+      - req-9349b881-924b-4b39-a5e9-87e403fb0855
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-0471d0e8-7067-4e8d-a516-7190560933fc
+      - req-9349b881-924b-4b39-a5e9-87e403fb0855
       Date:
-      - Thu, 03 Jan 2019 19:24:12 GMT
+      - Fri, 04 Jan 2019 16:55:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -4403,7 +4403,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "e8f744b1fc6a487681d35fb275252608"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:12 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:41 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4421,13 +4421,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:24:12 GMT
+      - Fri, 04 Jan 2019 16:55:41 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-cbf41a26-429a-4d16-8cb6-31c2bd8ca3d9
+      - req-cbea3e73-57c1-45d4-8971-d66ed8f13121
       Content-Length:
       - '4170'
       Connection:
@@ -4436,10 +4436,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:24:12.539614", "expires":
-        "2019-01-03T20:24:12Z", "id": "069b490a73f84870a2ce6428ef19cc16", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:55:41.615553", "expires":
+        "2019-01-04T17:55:41Z", "id": "75baecd086cf4464925bf28eb11acf7c", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["tn1TWuPUReaUnnz9OTnDeQ"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["CdX0T8vuQoi2eCSR4WwXbA"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -4484,7 +4484,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:12 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:41 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4502,13 +4502,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:24:12 GMT
+      - Fri, 04 Jan 2019 16:55:41 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-776fe6f9-a91d-4c04-a697-db780f64d91d
+      - req-82173f8b-aeb1-45f9-9f02-3fdc1bc23442
       Content-Length:
       - '4117'
       Connection:
@@ -4517,10 +4517,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:24:12.729413", "expires":
-        "2019-01-03T20:24:12Z", "id": "8b570d310e6b48a690af07634141092b", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:55:41.809767", "expires":
+        "2019-01-04T17:55:41Z", "id": "f64fccf2a4144d119ad89c0e9c12d32e", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["Uc1rbyhqSBerekv7R6uLzg"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["ZWp1eYEzRfSlSsNRZL2dKw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -4564,7 +4564,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:12 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:41 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4582,13 +4582,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:24:12 GMT
+      - Fri, 04 Jan 2019 16:55:41 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-a9f0fa79-82d6-479d-9ef0-537d90c62fc7
+      - req-c3868e05-1b79-485e-8d65-d0675f7b5589
       Content-Length:
       - '4131'
       Connection:
@@ -4597,10 +4597,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:24:12.917686", "expires":
-        "2019-01-03T20:24:12Z", "id": "e935954558ad4c4a9cff36ae2a393128", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:55:41.995497", "expires":
+        "2019-01-04T17:55:41Z", "id": "bc70897fd88a4958b788a3f9e8dc20aa", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["yPiZCijkRv6rxuDwy6zmdw"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["1dX282xCSQe-SCaDbMn2xw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -4644,7 +4644,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:12 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:42 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4662,13 +4662,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:24:13 GMT
+      - Fri, 04 Jan 2019 16:55:42 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-8a9aac86-3619-4d22-8a49-611d6eefa966
+      - req-861a697f-8c97-4a28-9765-bfb4b513a482
       Content-Length:
       - '4118'
       Connection:
@@ -4677,10 +4677,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:24:13.105253", "expires":
-        "2019-01-03T20:24:13Z", "id": "cda6495e40ef4ab2adeed978579aebb4", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:55:42.212986", "expires":
+        "2019-01-04T17:55:42Z", "id": "3fa70d7aeff7489a8a72775ea8c0ad4e", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["BRUP8ae_Re2igZ4h9mKtaQ"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["0Fx5fUEUSFiXRniK0nVp-g"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -4724,7 +4724,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:13 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:42 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0//quotas/69f8f7205ade4aa59084c32c83e60b5a
@@ -4739,7 +4739,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8b570d310e6b48a690af07634141092b
+      - f64fccf2a4144d119ad89c0e9c12d32e
   response:
     status:
       code: 200
@@ -4750,16 +4750,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-e3e858ba-99b8-4343-8ab3-c896801ed992
+      - req-30df4ff9-0a33-40ef-b2ef-2e387b23b7d9
       Date:
-      - Thu, 03 Jan 2019 19:24:13 GMT
+      - Fri, 04 Jan 2019 16:55:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 20, "network": 20, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:13 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:42 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0//quotas/b458a5c25c3749758f4c0661940b3ba8
@@ -4774,7 +4774,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e935954558ad4c4a9cff36ae2a393128
+      - bc70897fd88a4958b788a3f9e8dc20aa
   response:
     status:
       code: 200
@@ -4785,16 +4785,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-6c26bd9d-b2bd-41da-a59c-b0b4b8fdccc8
+      - req-47ff9957-5add-4386-8f21-bcacf980a722
       Date:
-      - Thu, 03 Jan 2019 19:24:13 GMT
+      - Fri, 04 Jan 2019 16:55:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:13 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:42 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0//quotas/e54e5c3c19e34720b05661f2ea1ea00a
@@ -4809,7 +4809,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '069b490a73f84870a2ce6428ef19cc16'
+      - 75baecd086cf4464925bf28eb11acf7c
   response:
     status:
       code: 200
@@ -4820,16 +4820,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-a30d3e80-6d5d-4694-a448-2b37c919b6f5
+      - req-be870686-c279-4846-89cd-8b9cabfcb36d
       Date:
-      - Thu, 03 Jan 2019 19:24:13 GMT
+      - Fri, 04 Jan 2019 16:55:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:13 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:42 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0//quotas/e8f744b1fc6a487681d35fb275252608
@@ -4844,7 +4844,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cda6495e40ef4ab2adeed978579aebb4
+      - 3fa70d7aeff7489a8a72775ea8c0ad4e
   response:
     status:
       code: 200
@@ -4855,16 +4855,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-8c8b8e39-ce42-4855-870b-7ebd577bf8b6
+      - req-47b6a5d2-fd64-4ee7-bc4d-4eed97bfd8dc
       Date:
-      - Thu, 03 Jan 2019 19:24:13 GMT
+      - Fri, 04 Jan 2019 16:55:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:13 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:42 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/4bb36934-fd61-4a19-ab9d-28fbbda0c7f0/os-volume_attachments
@@ -4879,7 +4879,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c821165ce6754779b0b6073410f07e17
+      - 75da2323456849fda593bc809361b6d2
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4892,15 +4892,15 @@ http_interactions:
       Content-Length:
       - '197'
       X-Compute-Request-Id:
-      - req-b85b7b15-3141-4193-9b3d-0b8642de4fa1
+      - req-954dcf76-6be5-4051-980b-399bbe871298
       Date:
-      - Thu, 03 Jan 2019 19:24:13 GMT
+      - Fri, 04 Jan 2019 16:55:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumeAttachments": [{"device": "/dev/vda", "serverId": "4bb36934-fd61-4a19-ab9d-28fbbda0c7f0",
         "id": "b124469d-a857-4b39-abe9-d0e63985f834", "volumeId": "b124469d-a857-4b39-abe9-d0e63985f834"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:13 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:43 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/ca4f3a16-bae3-4407-83e9-f77b28af0f2b/os-volume_attachments
@@ -4915,7 +4915,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c821165ce6754779b0b6073410f07e17
+      - 75da2323456849fda593bc809361b6d2
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4928,15 +4928,15 @@ http_interactions:
       Content-Length:
       - '197'
       X-Compute-Request-Id:
-      - req-0008572a-9dcf-4bfc-89c5-82396cbbc43d
+      - req-cc0e8114-5ca6-4cbf-88d1-1d044a440f1e
       Date:
-      - Thu, 03 Jan 2019 19:24:14 GMT
+      - Fri, 04 Jan 2019 16:55:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumeAttachments": [{"device": "/dev/vdd", "serverId": "ca4f3a16-bae3-4407-83e9-f77b28af0f2b",
         "id": "0a55c0d5-c780-4e7d-9d09-47f5520c7448", "volumeId": "0a55c0d5-c780-4e7d-9d09-47f5520c7448"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:14 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:43 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4954,13 +4954,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:24:14 GMT
+      - Fri, 04 Jan 2019 16:55:43 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-49630e92-7c42-49b3-995a-65c8da94a95a
+      - req-77394436-bca3-42b4-a823-d73882801e98
       Content-Length:
       - '4170'
       Connection:
@@ -4969,10 +4969,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:24:14.369077", "expires":
-        "2019-01-03T20:24:14Z", "id": "1cd302a9b9e74ca7b40b64bf43d087db", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:55:43.307367", "expires":
+        "2019-01-04T17:55:43Z", "id": "0f5dd58f2f924c6c868d88d41ae8c531", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["VswCR29HQoCEXQ8T2zdq9w"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["sQ2rXTskTP2tRIIonxGg2Q"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -5017,7 +5017,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:14 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:43 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -5035,13 +5035,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:24:14 GMT
+      - Fri, 04 Jan 2019 16:55:43 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-ba6eb713-c795-4ee2-bfc0-ae2afee82b80
+      - req-d7a9d214-f77a-4070-b81e-1aa933353d36
       Content-Length:
       - '4170'
       Connection:
@@ -5050,10 +5050,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:24:14.558659", "expires":
-        "2019-01-03T20:24:14Z", "id": "3cc57e2519b54213a8690bc3fd4a9912", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:55:43.496490", "expires":
+        "2019-01-04T17:55:43Z", "id": "65401e48762d474494c7cfe847560f0d", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["kzj2VhEZTtODW1mHy7jekw"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["7Ne3FPQiQQKu3Zk7QwN7UA"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -5098,7 +5098,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:14 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:43 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-aggregates
@@ -5113,7 +5113,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b01fd47331c64b49b3f5ac4abdf92277
+      - 19ec8e33c03e44058f7aad942b071b6b
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5126,14 +5126,14 @@ http_interactions:
       Content-Length:
       - '18'
       X-Compute-Request-Id:
-      - req-caa8c2f1-6065-4606-8e7c-b53e3b970f49
+      - req-9110cee6-2305-4583-9345-8d46ebac840a
       Date:
-      - Thu, 03 Jan 2019 19:24:14 GMT
+      - Fri, 04 Jan 2019 16:55:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"aggregates": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:14 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:43 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&status=available
@@ -5148,22 +5148,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 99906174ab5a4d67a4689177c26b0d37
+      - 74caaef0bbef41b39023507f9e49ec84
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-0deb092c-aca3-4875-8d4d-3997c15a5bfd
+      - req-a25ad108-8db8-4a3e-b5e4-7345a15a1c98
       Content-Type:
       - application/json
       Content-Length:
       - '2723'
       X-Openstack-Request-Id:
-      - req-0deb092c-aca3-4875-8d4d-3997c15a5bfd
+      - req-a25ad108-8db8-4a3e-b5e4-7345a15a1c98
       Date:
-      - Thu, 03 Jan 2019 19:24:14 GMT
+      - Fri, 04 Jan 2019 16:55:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&status=available&marker=9bb99818-b339-4e31-b87f-e4181ec48acd",
@@ -5196,7 +5196,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-4", "bootable": "true", "created_at":
         "2016-11-11T13:49:53.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:14 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:43 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=9bb99818-b339-4e31-b87f-e4181ec48acd&status=available
@@ -5211,22 +5211,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 99906174ab5a4d67a4689177c26b0d37
+      - 74caaef0bbef41b39023507f9e49ec84
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-634b2c59-5a53-4e5c-8405-031587883d35
+      - req-a88901d7-f330-49c9-89dd-d041f27105f0
       Content-Type:
       - application/json
       Content-Length:
       - '1180'
       X-Openstack-Request-Id:
-      - req-634b2c59-5a53-4e5c-8405-031587883d35
+      - req-a88901d7-f330-49c9-89dd-d041f27105f0
       Date:
-      - Thu, 03 Jan 2019 19:24:15 GMT
+      - Fri, 04 Jan 2019 16:55:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": [{"migration_status": null, "attachments": [], "links":
@@ -5243,7 +5243,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-FromSnapshot", "bootable": "false", "created_at":
         "2016-11-11T13:49:26.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:15 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:43 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/volumes/detail?limit=1000&status=available
@@ -5258,27 +5258,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9427799b72c245909d61117527d8def4
+      - e98d2ce934704013806e8a3756948b1b
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-cf87a61f-9ad8-48a1-8673-e0e9cc1f779d
+      - req-156f1491-e905-4e9c-a8f7-f9880dd5350a
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-cf87a61f-9ad8-48a1-8673-e0e9cc1f779d
+      - req-156f1491-e905-4e9c-a8f7-f9880dd5350a
       Date:
-      - Thu, 03 Jan 2019 19:24:15 GMT
+      - Fri, 04 Jan 2019 16:55:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:15 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:44 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/volumes/detail?limit=1000&status=available
@@ -5293,27 +5293,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9cb8a4edcc494b91bab973cff4f04e11
+      - 941b81cd623d4d87a6c1ad2bc9340889
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-4e0755cf-7cf1-47f5-be95-6598f117a5f9
+      - req-7208e32c-9d4f-47c9-a0e3-1eec77682847
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-4e0755cf-7cf1-47f5-be95-6598f117a5f9
+      - req-7208e32c-9d4f-47c9-a0e3-1eec77682847
       Date:
-      - Thu, 03 Jan 2019 19:24:15 GMT
+      - Fri, 04 Jan 2019 16:55:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:15 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:44 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/volumes/detail?limit=1000&status=available
@@ -5328,27 +5328,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1527b646aa2341b28f791dfc31ec511b
+      - f5fa421d5c2a42ed98b29320f8e1b4fc
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-e44b8fda-8f81-41c7-949a-d6c3eda668b8
+      - req-3af744b3-8fc9-4edf-b2c8-1706705677d1
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-e44b8fda-8f81-41c7-949a-d6c3eda668b8
+      - req-3af744b3-8fc9-4edf-b2c8-1706705677d1
       Date:
-      - Thu, 03 Jan 2019 19:24:15 GMT
+      - Fri, 04 Jan 2019 16:55:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:15 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:44 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail
@@ -5363,22 +5363,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 99906174ab5a4d67a4689177c26b0d37
+      - 74caaef0bbef41b39023507f9e49ec84
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-7678fdba-2f11-4ded-b973-4108a17a90d0
+      - req-ee74f2bf-7f99-47da-bb89-2db147cb3755
       Content-Type:
       - application/json
       Content-Length:
       - '1053'
       X-Openstack-Request-Id:
-      - req-7678fdba-2f11-4ded-b973-4108a17a90d0
+      - req-ee74f2bf-7f99-47da-bb89-2db147cb3755
       Date:
-      - Thu, 03 Jan 2019 19:24:15 GMT
+      - Fri, 04 Jan 2019 16:55:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?marker=76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
@@ -5393,7 +5393,7 @@ http_interactions:
         "created_at": "2016-11-11T13:49:36.000000", "size": 1, "id": "76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:15 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:44 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?limit=1000&status=available
@@ -5408,22 +5408,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 99906174ab5a4d67a4689177c26b0d37
+      - 74caaef0bbef41b39023507f9e49ec84
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-762e44d0-135b-4777-b7a1-f86b28bbd0d3
+      - req-664d6c55-8464-40d7-9c96-b2d3d6e17860
       Content-Type:
       - application/json
       Content-Length:
       - '1081'
       X-Openstack-Request-Id:
-      - req-762e44d0-135b-4777-b7a1-f86b28bbd0d3
+      - req-664d6c55-8464-40d7-9c96-b2d3d6e17860
       Date:
-      - Thu, 03 Jan 2019 19:24:15 GMT
+      - Fri, 04 Jan 2019 16:55:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?limit=1000&status=available&marker=76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
@@ -5438,7 +5438,7 @@ http_interactions:
         "created_at": "2016-11-11T13:49:36.000000", "size": 1, "id": "76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:15 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:44 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/snapshots/detail
@@ -5453,27 +5453,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9427799b72c245909d61117527d8def4
+      - e98d2ce934704013806e8a3756948b1b
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-3e499c6d-e841-43d3-8908-1565e9d1acb1
+      - req-8e0b296b-a259-47e7-b420-896138434139
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-3e499c6d-e841-43d3-8908-1565e9d1acb1
+      - req-8e0b296b-a259-47e7-b420-896138434139
       Date:
-      - Thu, 03 Jan 2019 19:24:15 GMT
+      - Fri, 04 Jan 2019 16:55:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:15 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:44 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/snapshots/detail?limit=1000&status=available
@@ -5488,27 +5488,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9427799b72c245909d61117527d8def4
+      - e98d2ce934704013806e8a3756948b1b
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-31c84ae5-8b08-49ca-8828-7414c8e2ecb8
+      - req-ea7e1723-9aae-4457-ab71-1a72483ce3e5
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-31c84ae5-8b08-49ca-8828-7414c8e2ecb8
+      - req-ea7e1723-9aae-4457-ab71-1a72483ce3e5
       Date:
-      - Thu, 03 Jan 2019 19:24:15 GMT
+      - Fri, 04 Jan 2019 16:55:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:15 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:44 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/snapshots/detail
@@ -5523,27 +5523,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9cb8a4edcc494b91bab973cff4f04e11
+      - 941b81cd623d4d87a6c1ad2bc9340889
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-804d97db-5124-4092-a4e5-5ae405af32d8
+      - req-fbf7f72e-0756-44dd-8a9c-fd665f01e49c
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-804d97db-5124-4092-a4e5-5ae405af32d8
+      - req-fbf7f72e-0756-44dd-8a9c-fd665f01e49c
       Date:
-      - Thu, 03 Jan 2019 19:24:16 GMT
+      - Fri, 04 Jan 2019 16:55:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:16 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:45 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/snapshots/detail?limit=1000&status=available
@@ -5558,27 +5558,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9cb8a4edcc494b91bab973cff4f04e11
+      - 941b81cd623d4d87a6c1ad2bc9340889
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-abf31680-b50b-47f4-806c-7981f5c6dd3f
+      - req-cd01b2a5-593c-4433-8a55-55c93d11a20a
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-abf31680-b50b-47f4-806c-7981f5c6dd3f
+      - req-cd01b2a5-593c-4433-8a55-55c93d11a20a
       Date:
-      - Thu, 03 Jan 2019 19:24:16 GMT
+      - Fri, 04 Jan 2019 16:55:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:16 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:45 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/snapshots/detail
@@ -5593,27 +5593,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1527b646aa2341b28f791dfc31ec511b
+      - f5fa421d5c2a42ed98b29320f8e1b4fc
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-60582ec9-506f-41da-9129-9a9ceecd6800
+      - req-aba13f4c-4ec4-44dd-b005-3bb2a3a5b284
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-60582ec9-506f-41da-9129-9a9ceecd6800
+      - req-aba13f4c-4ec4-44dd-b005-3bb2a3a5b284
       Date:
-      - Thu, 03 Jan 2019 19:24:16 GMT
+      - Fri, 04 Jan 2019 16:55:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:16 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:45 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/snapshots/detail?limit=1000&status=available
@@ -5628,27 +5628,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1527b646aa2341b28f791dfc31ec511b
+      - f5fa421d5c2a42ed98b29320f8e1b4fc
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-935f8238-2b69-4f2c-9ef4-5db6a95cfa5c
+      - req-30a4c0c5-9f61-49a7-bc2f-435ad2b2118e
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-935f8238-2b69-4f2c-9ef4-5db6a95cfa5c
+      - req-30a4c0c5-9f61-49a7-bc2f-435ad2b2118e
       Date:
-      - Thu, 03 Jan 2019 19:24:16 GMT
+      - Fri, 04 Jan 2019 16:55:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:16 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:45 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000
@@ -5663,22 +5663,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 99906174ab5a4d67a4689177c26b0d37
+      - 74caaef0bbef41b39023507f9e49ec84
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-1eec8026-6155-4b90-b55c-7ea53d988a39
+      - req-f4e14be7-860c-42dc-b5af-08963eec785a
       Content-Type:
       - application/json
       Content-Length:
       - '2706'
       X-Openstack-Request-Id:
-      - req-1eec8026-6155-4b90-b55c-7ea53d988a39
+      - req-f4e14be7-860c-42dc-b5af-08963eec785a
       Date:
-      - Thu, 03 Jan 2019 19:24:16 GMT
+      - Fri, 04 Jan 2019 16:55:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=9bb99818-b339-4e31-b87f-e4181ec48acd",
@@ -5711,7 +5711,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-4", "bootable": "true", "created_at":
         "2016-11-11T13:49:53.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:16 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:45 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=9bb99818-b339-4e31-b87f-e4181ec48acd
@@ -5726,22 +5726,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 99906174ab5a4d67a4689177c26b0d37
+      - 74caaef0bbef41b39023507f9e49ec84
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-8176b2ff-c658-4406-996f-27dbafed31dd
+      - req-92bd5a74-8683-4374-9368-3499fe70f76a
       Content-Type:
       - application/json
       Content-Length:
       - '3284'
       X-Openstack-Request-Id:
-      - req-8176b2ff-c658-4406-996f-27dbafed31dd
+      - req-92bd5a74-8683-4374-9368-3499fe70f76a
       Date:
-      - Thu, 03 Jan 2019 19:24:16 GMT
+      - Fri, 04 Jan 2019 16:55:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=2c774148-c11a-434c-aabb-7fa9c82c37ce",
@@ -5782,7 +5782,7 @@ http_interactions:
         "name": "EmsRefreshSpec-Volume-2", "bootable": "false", "created_at": "2016-11-11T13:49:43.000000",
         "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:16 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:45 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=2c774148-c11a-434c-aabb-7fa9c82c37ce
@@ -5797,22 +5797,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 99906174ab5a4d67a4689177c26b0d37
+      - 74caaef0bbef41b39023507f9e49ec84
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-9db485de-c321-4ea2-aefc-3d83fc2f91ef
+      - req-9b2d4629-4f67-4de6-8dc0-845f08537fae
       Content-Type:
       - application/json
       Content-Length:
       - '2753'
       X-Openstack-Request-Id:
-      - req-9db485de-c321-4ea2-aefc-3d83fc2f91ef
+      - req-9b2d4629-4f67-4de6-8dc0-845f08537fae
       Date:
-      - Thu, 03 Jan 2019 19:24:16 GMT
+      - Fri, 04 Jan 2019 16:55:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=0a55c0d5-c780-4e7d-9d09-47f5520c7448",
@@ -5846,7 +5846,7 @@ http_interactions:
         "bootable": "false", "created_at": "2016-11-11T13:49:20.000000", "volume_type":
         "iscsi"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:16 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:45 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=0a55c0d5-c780-4e7d-9d09-47f5520c7448
@@ -5861,27 +5861,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 99906174ab5a4d67a4689177c26b0d37
+      - 74caaef0bbef41b39023507f9e49ec84
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-b35d7322-4e8f-488f-99a1-d6178ce6b7d8
+      - req-3d70729c-89c8-46fa-964c-30b3ecbf63c0
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-b35d7322-4e8f-488f-99a1-d6178ce6b7d8
+      - req-3d70729c-89c8-46fa-964c-30b3ecbf63c0
       Date:
-      - Thu, 03 Jan 2019 19:24:16 GMT
+      - Fri, 04 Jan 2019 16:55:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:17 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:45 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/volumes/detail?limit=1000
@@ -5896,27 +5896,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9427799b72c245909d61117527d8def4
+      - e98d2ce934704013806e8a3756948b1b
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-93ff2162-aa76-478e-9a33-8167f41384d7
+      - req-009d0142-381e-4ccb-b1c7-242532917e75
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-93ff2162-aa76-478e-9a33-8167f41384d7
+      - req-009d0142-381e-4ccb-b1c7-242532917e75
       Date:
-      - Thu, 03 Jan 2019 19:24:17 GMT
+      - Fri, 04 Jan 2019 16:55:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:17 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:46 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/volumes/detail?limit=1000
@@ -5931,27 +5931,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9cb8a4edcc494b91bab973cff4f04e11
+      - 941b81cd623d4d87a6c1ad2bc9340889
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-65e9c9d1-faff-4b1e-bbbf-675b0084ec9c
+      - req-ace3b3d8-d5ab-496d-8f9c-c59735f51eb5
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-65e9c9d1-faff-4b1e-bbbf-675b0084ec9c
+      - req-ace3b3d8-d5ab-496d-8f9c-c59735f51eb5
       Date:
-      - Thu, 03 Jan 2019 19:24:17 GMT
+      - Fri, 04 Jan 2019 16:55:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:17 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:46 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/volumes/detail?limit=1000
@@ -5966,27 +5966,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1527b646aa2341b28f791dfc31ec511b
+      - f5fa421d5c2a42ed98b29320f8e1b4fc
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-a9a4e9f9-b806-48db-a881-a7e43a971fb3
+      - req-9964d4b4-ef8d-4a3a-bb0f-c9c0337abfb9
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-a9a4e9f9-b806-48db-a881-a7e43a971fb3
+      - req-9964d4b4-ef8d-4a3a-bb0f-c9c0337abfb9
       Date:
-      - Thu, 03 Jan 2019 19:24:17 GMT
+      - Fri, 04 Jan 2019 16:55:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:17 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:46 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -6004,13 +6004,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:24:18 GMT
+      - Fri, 04 Jan 2019 16:55:47 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-01a80fd9-ce21-48d6-b004-e5c81df4af83
+      - req-375b94a9-b447-41d4-bb69-0f031baecfd4
       Content-Length:
       - '4170'
       Connection:
@@ -6019,10 +6019,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:24:18.708505", "expires":
-        "2019-01-03T20:24:18Z", "id": "a8a8a9e19a714bdb981c71b69915314b", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:55:47.425168", "expires":
+        "2019-01-04T17:55:47Z", "id": "6db6245333184e888c1a15aaec6c3e19", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["uRTaBPMlSOi5lu9lgAImQg"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["P2G_X46bTc2OfDrSGD6G0g"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -6067,7 +6067,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:18 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:47 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -6085,13 +6085,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:24:18 GMT
+      - Fri, 04 Jan 2019 16:55:47 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-e3abdecf-b29a-4424-ba11-0192df34e552
+      - req-9439db03-7578-4d18-ae7e-53e8223832a2
       Content-Length:
       - '4170'
       Connection:
@@ -6100,10 +6100,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:24:18.907259", "expires":
-        "2019-01-03T20:24:18Z", "id": "0ee91777873a42a49cc8b224c747ba97", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:55:47.611683", "expires":
+        "2019-01-04T17:55:47Z", "id": "2802704833334270a23874f85015b87c", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["gj2uhB2lRUCzUKGW411T7Q"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["L2PXhi46SW2WAXJTM4aFUA"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -6148,7 +6148,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:18 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:47 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/networks
@@ -6163,7 +6163,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0ee91777873a42a49cc8b224c747ba97
+      - 2802704833334270a23874f85015b87c
   response:
     status:
       code: 200
@@ -6174,27 +6174,12 @@ http_interactions:
       Content-Length:
       - '5330'
       X-Openstack-Request-Id:
-      - req-b49cf446-cda3-4894-a3d4-35080113a0bd
+      - req-4d1373f1-7d9f-456d-b946-d10199d14695
       Date:
-      - Thu, 03 Jan 2019 19:24:19 GMT
+      - Fri, 04 Jan 2019 16:55:47 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"networks": [{"status": "ACTIVE", "subnets": ["bb23bb48-804d-4416-bac3-231db23841e8"],
-        "name": "EmsRefreshSpec-NetworkPrivate_2", "provider:physical_network": null,
-        "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
-        0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
-        "id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "provider:segmentation_id":
-        53}, {"status": "ACTIVE", "subnets": ["841b5584-f86f-4abd-9bc2-f445b8bc860b",
-        "39628ee0-d5ff-4a88-ae66-80442e5feefd"], "name": "EmsRefreshSpec-NetworkPrivate_30",
-        "provider:physical_network": null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
-        "vxlan", "id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "provider:segmentation_id":
-        79}, {"status": "ACTIVE", "subnets": ["edfcb49b-e917-4897-b8ae-859ef3dae2de",
-        "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4"], "name": "EmsRefreshSpec-IsolatedNetworkPrivate_2",
-        "provider:physical_network": null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
-        "vxlan", "id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "provider:segmentation_id":
-        57}, {"status": "ACTIVE", "subnets": ["33da95a6-bded-44d8-be36-6cc97f3d72bd"],
+      string: '{"networks": [{"status": "ACTIVE", "subnets": ["33da95a6-bded-44d8-be36-6cc97f3d72bd"],
         "name": "EmsRefreshSpec-NetworkPublic", "provider:physical_network": "public_net_0",
         "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
         0, "router:external": true, "shared": false, "provider:network_type": "flat",
@@ -6204,7 +6189,12 @@ http_interactions:
         "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
         0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
         "id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "provider:segmentation_id":
-        98}, {"status": "ACTIVE", "subnets": ["82ca5926-43cb-4312-a23f-727d5c0f5bae"],
+        98}, {"status": "ACTIVE", "subnets": ["826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
+        "edfcb49b-e917-4897-b8ae-859ef3dae2de"], "name": "EmsRefreshSpec-IsolatedNetworkPrivate_2",
+        "provider:physical_network": null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
+        "vxlan", "id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "provider:segmentation_id":
+        57}, {"status": "ACTIVE", "subnets": ["82ca5926-43cb-4312-a23f-727d5c0f5bae"],
         "name": "EmsRefreshSpec-NetworkPrivate_3", "provider:physical_network": null,
         "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
         0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
@@ -6239,14 +6229,24 @@ http_interactions:
         null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
         "vxlan", "id": "560b4210-2b5a-4439-8d24-203e09478f48", "provider:segmentation_id":
-        54}, {"status": "ACTIVE", "subnets": ["104c081f-97dd-42b7-8930-98abbd015c74",
-        "d53802a5-f0f6-48ba-9207-dbd9b13acac3"], "name": "EmsRefreshSpec-NetworkPrivate",
+        54}, {"status": "ACTIVE", "subnets": ["bb23bb48-804d-4416-bac3-231db23841e8"],
+        "name": "EmsRefreshSpec-NetworkPrivate_2", "provider:physical_network": null,
+        "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
+        0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
+        "id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "provider:segmentation_id":
+        53}, {"status": "ACTIVE", "subnets": ["841b5584-f86f-4abd-9bc2-f445b8bc860b",
+        "39628ee0-d5ff-4a88-ae66-80442e5feefd"], "name": "EmsRefreshSpec-NetworkPrivate_30",
+        "provider:physical_network": null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
+        "vxlan", "id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "provider:segmentation_id":
+        79}, {"status": "ACTIVE", "subnets": ["d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "104c081f-97dd-42b7-8930-98abbd015c74"], "name": "EmsRefreshSpec-NetworkPrivate",
         "provider:physical_network": null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
         "vxlan", "id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "provider:segmentation_id":
         14}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:19 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:47 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -6264,13 +6264,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:24:19 GMT
+      - Fri, 04 Jan 2019 16:55:47 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-5231f85c-eeae-48f4-8cff-d0b272fdbac9
+      - req-4203e789-0ddb-43c8-b6df-d9f5e3f0688b
       Content-Length:
       - '4170'
       Connection:
@@ -6279,10 +6279,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:24:19.294570", "expires":
-        "2019-01-03T20:24:19Z", "id": "7a52df75b51b4899bf2178f75cbcdd4e", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:55:48.001354", "expires":
+        "2019-01-04T17:55:47Z", "id": "99bea9cbb6f044e69c86f67d4916849f", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["aMKX_2bTSsWc3-xdB25qRg"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["GvOjW4fSQUCkRKDY9J0wGQ"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -6327,7 +6327,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:19 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:48 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -6345,13 +6345,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:24:19 GMT
+      - Fri, 04 Jan 2019 16:55:48 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-ec268643-2fa4-4703-891b-ea2547eca303
+      - req-7e863daa-e798-4645-9363-df13e3989ee6
       Content-Length:
       - '370'
       Connection:
@@ -6360,13 +6360,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:24:19.453638", "expires":
-        "2019-01-03T20:24:19Z", "id": "75a5e14249c74f348243b5a3ec52f9d5", "audit_ids":
-        ["Qe-L29BuTVKrk4hFWevkpQ"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:55:48.172075", "expires":
+        "2019-01-04T17:55:48Z", "id": "909d51eb14e641e9b06902ca1f168bce", "audit_ids":
+        ["crDKKWmyTB6ywfht0IKnsA"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:19 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:48 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -6381,20 +6381,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 75a5e14249c74f348243b5a3ec52f9d5
+      - 909d51eb14e641e9b06902ca1f168bce
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:24:19 GMT
+      - Fri, 04 Jan 2019 16:55:48 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-f2c38e91-01e4-4ace-8921-31538b772fca
+      - req-e3a4da4b-46d2-44b9-91c7-2e259a6f78cc
       Content-Length:
       - '500'
       Connection:
@@ -6411,7 +6411,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:19 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:48 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -6429,13 +6429,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:24:19 GMT
+      - Fri, 04 Jan 2019 16:55:48 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-00b9fec6-d859-442a-bb9f-3eae6cb48baf
+      - req-2313dae7-f424-4f63-b5ad-e7d6c75ce261
       Content-Length:
       - '4117'
       Connection:
@@ -6444,10 +6444,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:24:19.787111", "expires":
-        "2019-01-03T20:24:19Z", "id": "cd8ee43b56424231b08f24fdfb2d6af9", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:55:48.499537", "expires":
+        "2019-01-04T17:55:48Z", "id": "ac4a5cc50a1b4867b79b4ceb1f688327", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["s1H13Bx5RfqTgUp3LdjU_w"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["mv9SocCERkKH_6hvw1DFUA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -6491,7 +6491,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:19 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:48 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -6509,13 +6509,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:24:19 GMT
+      - Fri, 04 Jan 2019 16:55:48 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-a58cbd09-365c-416c-b6f6-5bb4e6bdcd3b
+      - req-40371e25-27d6-48e5-b245-0ff63feeec8f
       Content-Length:
       - '4131'
       Connection:
@@ -6524,10 +6524,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:24:19.976710", "expires":
-        "2019-01-03T20:24:19Z", "id": "d04ba49036a34327bf7b5a54c2eb3119", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:55:48.686535", "expires":
+        "2019-01-04T17:55:48Z", "id": "0689aa86f62a46748e1dcfed11a631b2", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["v860HKqTTlSOAeuHpuEeXQ"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["Un5nqOmQSryGqi769cWLyw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -6571,7 +6571,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:20 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:48 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -6589,13 +6589,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:24:20 GMT
+      - Fri, 04 Jan 2019 16:55:48 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-9127dff7-b053-46a4-87e7-370d08ac3c35
+      - req-c3c15ccd-d40c-4bb1-beb4-0e2ed01727ce
       Content-Length:
       - '4118'
       Connection:
@@ -6604,10 +6604,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:24:20.167843", "expires":
-        "2019-01-03T20:24:20Z", "id": "7144505ed7754402bd51a55bdb3d24ca", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:55:48.882223", "expires":
+        "2019-01-04T17:55:48Z", "id": "6c994873b6a54caeb22be402fa5033fe", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["tIvBajwYTni6NJGB_dCUJQ"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["_sgR2Y-NSeKVBGhLeAQKZw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -6651,7 +6651,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:20 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:48 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks?limit=1000&show_nested=true
@@ -6666,7 +6666,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cd8ee43b56424231b08f24fdfb2d6af9
+      - ac4a5cc50a1b4867b79b4ceb1f688327
   response:
     status:
       code: 200
@@ -6677,9 +6677,9 @@ http_interactions:
       Content-Length:
       - '2559'
       X-Openstack-Request-Id:
-      - req-1f6df150-1a4d-4380-ad86-0b06414a29ad
+      - req-ee6fc00f-d9bf-463c-ac42-717726c4d338
       Date:
-      - Thu, 03 Jan 2019 19:24:20 GMT
+      - Fri, 04 Jan 2019 16:55:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": [{"description": "Heat WordPress template to support F20,
@@ -6713,7 +6713,7 @@ http_interactions:
         "rel": "self"}], "updated_time": null, "stack_owner": null, "stack_status":
         "CREATE_COMPLETE", "id": "091e1e54-e01c-4ec5-a0ab-b00bee4d425c"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:20 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:49 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks?limit=1000&marker=091e1e54-e01c-4ec5-a0ab-b00bee4d425c&show_nested=true
@@ -6728,7 +6728,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cd8ee43b56424231b08f24fdfb2d6af9
+      - ac4a5cc50a1b4867b79b4ceb1f688327
   response:
     status:
       code: 200
@@ -6739,14 +6739,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-5b86747f-5a17-4211-83e7-5dd7756dd37d
+      - req-73dca5ff-5131-40fa-8aad-a436bb018ed4
       Date:
-      - Thu, 03 Jan 2019 19:24:20 GMT
+      - Fri, 04 Jan 2019 16:55:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:20 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:49 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/b458a5c25c3749758f4c0661940b3ba8/stacks?limit=1000&show_nested=true
@@ -6761,7 +6761,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d04ba49036a34327bf7b5a54c2eb3119
+      - '0689aa86f62a46748e1dcfed11a631b2'
   response:
     status:
       code: 200
@@ -6772,14 +6772,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-0b5b6e86-e5c6-4229-a6eb-2fe4f7497bb4
+      - req-94412488-1879-4476-bcc6-24cddf03564f
       Date:
-      - Thu, 03 Jan 2019 19:24:20 GMT
+      - Fri, 04 Jan 2019 16:55:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:20 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:49 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/e54e5c3c19e34720b05661f2ea1ea00a/stacks?limit=1000&show_nested=true
@@ -6794,7 +6794,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7a52df75b51b4899bf2178f75cbcdd4e
+      - 99bea9cbb6f044e69c86f67d4916849f
   response:
     status:
       code: 200
@@ -6805,14 +6805,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-796612c1-1c35-450b-9c71-e0eefde08f84
+      - req-c7b7903e-f0d0-44f6-9a45-131c7e6dcbfc
       Date:
-      - Thu, 03 Jan 2019 19:24:20 GMT
+      - Fri, 04 Jan 2019 16:55:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:20 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:49 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/e8f744b1fc6a487681d35fb275252608/stacks?limit=1000&show_nested=true
@@ -6827,7 +6827,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7144505ed7754402bd51a55bdb3d24ca
+      - 6c994873b6a54caeb22be402fa5033fe
   response:
     status:
       code: 200
@@ -6838,14 +6838,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-28251d4b-4a70-494e-8653-d9175307ed8d
+      - req-4dadd70d-ddca-47e4-a446-7cf5fff7ca75
       Date:
-      - Thu, 03 Jan 2019 19:24:20 GMT
+      - Fri, 04 Jan 2019 16:55:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:21 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:49 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack3/45d2af82-eff9-4483-a1f0-f19c44d96146
@@ -6860,7 +6860,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cd8ee43b56424231b08f24fdfb2d6af9
+      - ac4a5cc50a1b4867b79b4ceb1f688327
   response:
     status:
       code: 200
@@ -6871,9 +6871,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-fb01d61d-6b32-4d32-9702-6c5481cf9e15
+      - req-6f5be464-a910-48a2-9de6-bf8341c02d82
       Date:
-      - Thu, 03 Jan 2019 19:24:21 GMT
+      - Fri, 04 Jan 2019 16:55:50 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -6900,7 +6900,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:21 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:50 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack2/4cf24b12-29fc-4529-a8ed-6b079dea7c17
@@ -6915,7 +6915,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cd8ee43b56424231b08f24fdfb2d6af9
+      - ac4a5cc50a1b4867b79b4ceb1f688327
   response:
     status:
       code: 200
@@ -6926,9 +6926,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-5febce4c-8fa3-4ea7-92d6-556b8be1887e
+      - req-8bac010f-04ff-49a8-bb0e-162b2e766b3c
       Date:
-      - Thu, 03 Jan 2019 19:24:21 GMT
+      - Fri, 04 Jan 2019 16:55:50 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -6955,7 +6955,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:21 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:50 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c
@@ -6970,7 +6970,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cd8ee43b56424231b08f24fdfb2d6af9
+      - ac4a5cc50a1b4867b79b4ceb1f688327
   response:
     status:
       code: 200
@@ -6981,9 +6981,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-a33cc07e-4516-4611-a761-3300629bc900
+      - req-8e2b7314-abd1-4e71-bc26-b6e042452694
       Date:
-      - Thu, 03 Jan 2019 19:24:22 GMT
+      - Fri, 04 Jan 2019 16:55:50 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -7010,7 +7010,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:22 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:50 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack3/45d2af82-eff9-4483-a1f0-f19c44d96146/resources
@@ -7025,7 +7025,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cd8ee43b56424231b08f24fdfb2d6af9
+      - ac4a5cc50a1b4867b79b4ceb1f688327
   response:
     status:
       code: 200
@@ -7036,9 +7036,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-1ff23c27-773a-4387-92e5-be3c5c80f479
+      - req-6815daa3-a2ac-438f-9485-5742e232bf2c
       Date:
-      - Thu, 03 Jan 2019 19:24:22 GMT
+      - Fri, 04 Jan 2019 16:55:50 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -7050,7 +7050,7 @@ http_interactions:
         changed", "physical_resource_id": "aa5907f3-8209-4dd0-b3ef-600431d85bac",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:22 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:50 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack2/4cf24b12-29fc-4529-a8ed-6b079dea7c17/resources
@@ -7065,7 +7065,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cd8ee43b56424231b08f24fdfb2d6af9
+      - ac4a5cc50a1b4867b79b4ceb1f688327
   response:
     status:
       code: 200
@@ -7076,9 +7076,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-0a0f2f00-9d02-441e-9595-75c6244832b3
+      - req-eba5d909-47fb-40b0-91ab-bbae9237e489
       Date:
-      - Thu, 03 Jan 2019 19:24:22 GMT
+      - Fri, 04 Jan 2019 16:55:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -7090,7 +7090,7 @@ http_interactions:
         changed", "physical_resource_id": "219a737c-b4ad-430d-944a-a92a4834b12d",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:22 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:51 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c/resources
@@ -7105,7 +7105,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cd8ee43b56424231b08f24fdfb2d6af9
+      - ac4a5cc50a1b4867b79b4ceb1f688327
   response:
     status:
       code: 200
@@ -7116,9 +7116,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-6bcfb92f-7f48-47d6-8869-89f10a46bc10
+      - req-3cf848b3-be73-4e34-883b-3af1aae566d2
       Date:
-      - Thu, 03 Jan 2019 19:24:22 GMT
+      - Fri, 04 Jan 2019 16:55:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -7130,7 +7130,7 @@ http_interactions:
         changed", "physical_resource_id": "b686353f-0da0-48bf-bc35-8ea411a67dfd",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:22 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:51 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -7148,13 +7148,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:24:22 GMT
+      - Fri, 04 Jan 2019 16:55:51 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-db5854ac-f2c9-4be5-b329-f12e373370fe
+      - req-d0e3fd13-17ee-4cc6-97ca-c3c2f9150769
       Content-Length:
       - '4117'
       Connection:
@@ -7163,10 +7163,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:24:22.606322", "expires":
-        "2019-01-03T20:24:22Z", "id": "061cb9867d58495cad14ad0a3986a7c4", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:55:51.334651", "expires":
+        "2019-01-04T17:55:51Z", "id": "8ec1c3ea3f0841b3bc9c89c3ff168073", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["caMBIiAtStaWt47wkVZJGA"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["bEgddaICTEiglDWatbX0sQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -7210,7 +7210,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:22 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:51 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -7228,13 +7228,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:24:22 GMT
+      - Fri, 04 Jan 2019 16:55:51 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-a9c12807-e0ff-42f3-b185-5bea10c8308f
+      - req-f94a3d36-8b72-49bd-b0d0-fca068f2e1ef
       Content-Length:
       - '4131'
       Connection:
@@ -7243,10 +7243,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:24:22.801967", "expires":
-        "2019-01-03T20:24:22Z", "id": "07bef5ece26c41439e67edcf599c90d9", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:55:51.533483", "expires":
+        "2019-01-04T17:55:51Z", "id": "98b261a1565d42ae8972f9d334e48fe2", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["nD2waNruTty8II_-1Tn2Bg"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["Po1QBkgTRdyZ7rbWw7m51Q"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -7290,7 +7290,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:22 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:51 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -7308,13 +7308,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:24:22 GMT
+      - Fri, 04 Jan 2019 16:55:51 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-e2d3f4a5-3438-4324-8b4d-059e60805b90
+      - req-3aac9bd1-956e-4b83-b69a-ebf19feca6d3
       Content-Length:
       - '4118'
       Connection:
@@ -7323,10 +7323,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:24:22.993430", "expires":
-        "2019-01-03T20:24:22Z", "id": "39c2a1897c01403db03778d390a2a878", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:55:51.723121", "expires":
+        "2019-01-04T17:55:51Z", "id": "2df0fd7f3fd04ca59d53952db3d21bff", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["BjE3Hw-yRyquRWVx2h9Pig"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["c2Qg9fCcQgmnDaN-D2GLXQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -7370,7 +7370,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:23 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:51 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -7385,7 +7385,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 061cb9867d58495cad14ad0a3986a7c4
+      - 8ec1c3ea3f0841b3bc9c89c3ff168073
   response:
     status:
       code: 200
@@ -7396,141 +7396,9 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-8dd5b1f0-8ca9-4f56-9308-e39574d429ad
+      - req-42f3391e-fcb9-4d91-a745-b99ecdf7624f
       Date:
-      - Thu, 03 Jan 2019 19:24:23 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
-        true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:23 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 061cb9867d58495cad14ad0a3986a7c4
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-ec0e119d-5bad-4c2c-9556-b11d4029cd94
-      Date:
-      - Thu, 03 Jan 2019 19:24:23 GMT
+      - Fri, 04 Jan 2019 16:55:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
@@ -7634,7 +7502,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:23 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:51 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
@@ -7649,7 +7517,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 061cb9867d58495cad14ad0a3986a7c4
+      - 8ec1c3ea3f0841b3bc9c89c3ff168073
   response:
     status:
       code: 200
@@ -7660,405 +7528,9 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-322c8740-db81-415d-ae78-81beee52bdd7
+      - req-fb0ca5e1-872a-4235-b48d-3da6e680cf27
       Date:
-      - Thu, 03 Jan 2019 19:24:23 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
-        true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:23 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 061cb9867d58495cad14ad0a3986a7c4
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-0b6a5771-184f-4c02-8c1b-27a728364a2c
-      Date:
-      - Thu, 03 Jan 2019 19:24:23 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
-        true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:23 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 07bef5ece26c41439e67edcf599c90d9
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-452a48f7-1611-4829-888c-23dc5631db0f
-      Date:
-      - Thu, 03 Jan 2019 19:24:24 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
-        true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:24 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 07bef5ece26c41439e67edcf599c90d9
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-b34bbbf3-ce4d-4f40-91ed-0dff20c0b071
-      Date:
-      - Thu, 03 Jan 2019 19:24:24 GMT
+      - Fri, 04 Jan 2019 16:55:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
@@ -8162,271 +7634,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:24 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 07bef5ece26c41439e67edcf599c90d9
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-9fcd5be8-cb08-41cd-bdff-f719df586a43
-      Date:
-      - Thu, 03 Jan 2019 19:24:24 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
-        true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:24 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 07bef5ece26c41439e67edcf599c90d9
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-7260077a-3fbb-422a-93d6-c80663bb96c1
-      Date:
-      - Thu, 03 Jan 2019 19:24:24 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
-        true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:24 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:52 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -8441,7 +7649,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0ee91777873a42a49cc8b224c747ba97
+      - 98b261a1565d42ae8972f9d334e48fe2
   response:
     status:
       code: 200
@@ -8452,273 +7660,9 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-ff209ba7-0a1c-472f-b0c8-07c66a9c4e96
+      - req-f3fda376-3bd0-4dac-b6b3-4b0e566677c7
       Date:
-      - Thu, 03 Jan 2019 19:24:24 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
-        true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:24 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 0ee91777873a42a49cc8b224c747ba97
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-9b98f7db-1f6c-47ce-9ac9-8a6f57b82710
-      Date:
-      - Thu, 03 Jan 2019 19:24:24 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
-        true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:25 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 39c2a1897c01403db03778d390a2a878
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-70d86029-23d1-4ef3-adec-fd9ca5e5c26e
-      Date:
-      - Thu, 03 Jan 2019 19:24:25 GMT
+      - Fri, 04 Jan 2019 16:55:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
@@ -8822,7 +7766,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:25 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:52 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
@@ -8837,7 +7781,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 39c2a1897c01403db03778d390a2a878
+      - 98b261a1565d42ae8972f9d334e48fe2
   response:
     status:
       code: 200
@@ -8848,19 +7792,541 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-963294a9-0c1a-4f6b-8cc2-f3252b3577c4
+      - req-c473c15a-1196-4428-8d67-09f915e2d803
       Date:
-      - Thu, 03 Jan 2019 19:24:25 GMT
+      - Fri, 04 Jan 2019 16:55:52 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
-        true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
         "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
         "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Fri, 04 Jan 2019 16:55:52 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 2802704833334270a23874f85015b87c
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-4172a88b-f65a-45d5-9b45-dee5d6dee801
+      Date:
+      - Fri, 04 Jan 2019 16:55:52 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Fri, 04 Jan 2019 16:55:52 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 2802704833334270a23874f85015b87c
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-440603fe-027f-4f33-a5cc-b040354cbd0b
+      Date:
+      - Fri, 04 Jan 2019 16:55:52 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Fri, 04 Jan 2019 16:55:52 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 2df0fd7f3fd04ca59d53952db3d21bff
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-bef82a56-10fe-42d8-b547-1357fd44d5d3
+      Date:
+      - Fri, 04 Jan 2019 16:55:53 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Fri, 04 Jan 2019 16:55:53 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 2df0fd7f3fd04ca59d53952db3d21bff
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-91e5d8d9-d1d2-4822-b33b-c3e7cfc007a8
+      Date:
+      - Fri, 04 Jan 2019 16:55:53 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp":
+        true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
@@ -8941,6 +8407,12 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
         "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
         "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
@@ -8954,7 +8426,7 @@ http_interactions:
         4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
         "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:25 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:53 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
@@ -8969,7 +8441,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 39c2a1897c01403db03778d390a2a878
+      - 2df0fd7f3fd04ca59d53952db3d21bff
   response:
     status:
       code: 200
@@ -8980,19 +8452,145 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-839805db-161a-4566-adc6-9ec4a86ce08b
+      - req-c30ed7ae-3de4-462a-bf58-f59e78f33ddd
       Date:
-      - Thu, 03 Jan 2019 19:24:25 GMT
+      - Fri, 04 Jan 2019 16:55:53 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
-        true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
         "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
         "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Fri, 04 Jan 2019 16:55:53 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 2df0fd7f3fd04ca59d53952db3d21bff
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-b319096c-8ef3-49bd-8427-585359eca7f9
+      Date:
+      - Fri, 04 Jan 2019 16:55:53 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp":
+        true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
@@ -9073,6 +8671,12 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
         "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
         "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
@@ -9086,7 +8690,271 @@ http_interactions:
         4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
         "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:25 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:53 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 2df0fd7f3fd04ca59d53952db3d21bff
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-8da03b05-cdf4-49ac-8bb2-50f88986e1bb
+      Date:
+      - Fri, 04 Jan 2019 16:55:53 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Fri, 04 Jan 2019 16:55:53 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 2df0fd7f3fd04ca59d53952db3d21bff
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-27ba9530-84c4-4f81-b494-660502cf80f0
+      Date:
+      - Fri, 04 Jan 2019 16:55:53 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Fri, 04 Jan 2019 16:55:54 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?limit=1000
@@ -9101,7 +8969,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 061cb9867d58495cad14ad0a3986a7c4
+      - 8ec1c3ea3f0841b3bc9c89c3ff168073
   response:
     status:
       code: 200
@@ -9112,9 +8980,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-377b5df0-c7a0-4fbf-aa9a-b5dbe176d659
+      - req-4adb92e4-08b9-4686-8398-59723f112cac
       Date:
-      - Thu, 03 Jan 2019 19:24:25 GMT
+      - Fri, 04 Jan 2019 16:55:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -9156,7 +9024,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:25 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:54 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?limit=1000&marker=ee601a91-f6ac-4a46-a599-87cfd83094a3
@@ -9171,7 +9039,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 061cb9867d58495cad14ad0a3986a7c4
+      - 8ec1c3ea3f0841b3bc9c89c3ff168073
   response:
     status:
       code: 200
@@ -9182,9 +9050,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-7fbc82fd-dc4a-4dc3-92be-93ab2a4b1fc5
+      - req-30f69c87-3e0e-4183-944e-466ca65cbc19
       Date:
-      - Thu, 03 Jan 2019 19:24:25 GMT
+      - Fri, 04 Jan 2019 16:55:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -9226,7 +9094,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:25 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:54 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?limit=1000
@@ -9241,7 +9109,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 07bef5ece26c41439e67edcf599c90d9
+      - 98b261a1565d42ae8972f9d334e48fe2
   response:
     status:
       code: 200
@@ -9252,9 +9120,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-dc58678e-a136-4337-9d4c-9ec218a6c3f7
+      - req-b582937a-3611-4486-ab8b-5313e72edbfd
       Date:
-      - Thu, 03 Jan 2019 19:24:25 GMT
+      - Fri, 04 Jan 2019 16:55:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -9296,7 +9164,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:25 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:54 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?limit=1000&marker=ee601a91-f6ac-4a46-a599-87cfd83094a3
@@ -9311,7 +9179,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 07bef5ece26c41439e67edcf599c90d9
+      - 98b261a1565d42ae8972f9d334e48fe2
   response:
     status:
       code: 200
@@ -9322,9 +9190,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-eff0ac5b-1890-4b7d-ac0a-1be2b5e72080
+      - req-3f0e96b2-ee76-46f4-8605-a0a9f89a9011
       Date:
-      - Thu, 03 Jan 2019 19:24:26 GMT
+      - Fri, 04 Jan 2019 16:55:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -9366,7 +9234,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:26 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:54 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?limit=1000
@@ -9381,7 +9249,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0ee91777873a42a49cc8b224c747ba97
+      - 2802704833334270a23874f85015b87c
   response:
     status:
       code: 200
@@ -9392,9 +9260,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-abd4ca16-9e67-48d7-9809-1c84a850016f
+      - req-de2fc741-60fe-4200-b9fe-52c46df4df82
       Date:
-      - Thu, 03 Jan 2019 19:24:26 GMT
+      - Fri, 04 Jan 2019 16:55:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -9436,7 +9304,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:26 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:54 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?limit=1000&marker=ee601a91-f6ac-4a46-a599-87cfd83094a3
@@ -9451,7 +9319,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0ee91777873a42a49cc8b224c747ba97
+      - 2802704833334270a23874f85015b87c
   response:
     status:
       code: 200
@@ -9462,9 +9330,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-46521b2d-3110-4e68-857e-9e6b49f820f7
+      - req-0ba19c0d-aa5a-4be6-b1a2-041e98307a56
       Date:
-      - Thu, 03 Jan 2019 19:24:26 GMT
+      - Fri, 04 Jan 2019 16:55:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -9506,7 +9374,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:26 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:54 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?limit=1000
@@ -9521,7 +9389,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 39c2a1897c01403db03778d390a2a878
+      - 2df0fd7f3fd04ca59d53952db3d21bff
   response:
     status:
       code: 200
@@ -9532,9 +9400,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-d6d94f2d-2076-4771-ae85-9a7706625657
+      - req-35f0b617-f23e-4b49-9609-ae0f12416454
       Date:
-      - Thu, 03 Jan 2019 19:24:26 GMT
+      - Fri, 04 Jan 2019 16:55:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -9576,7 +9444,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:26 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:54 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?limit=1000&marker=ee601a91-f6ac-4a46-a599-87cfd83094a3
@@ -9591,7 +9459,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 39c2a1897c01403db03778d390a2a878
+      - 2df0fd7f3fd04ca59d53952db3d21bff
   response:
     status:
       code: 200
@@ -9602,9 +9470,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-158fb4d8-7bba-42c6-993b-7bc2ded64b96
+      - req-186b2a95-6b71-4389-b624-0e4323c9047e
       Date:
-      - Thu, 03 Jan 2019 19:24:26 GMT
+      - Fri, 04 Jan 2019 16:55:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -9646,7 +9514,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:26 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:55 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?limit=1000
@@ -9661,7 +9529,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 061cb9867d58495cad14ad0a3986a7c4
+      - 8ec1c3ea3f0841b3bc9c89c3ff168073
   response:
     status:
       code: 200
@@ -9672,9 +9540,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-f875782f-37a6-4d4d-84b6-3dd017a1a9df
+      - req-164b392b-bb98-45e9-ad4c-ef2747cf7b5f
       Date:
-      - Thu, 03 Jan 2019 19:24:26 GMT
+      - Fri, 04 Jan 2019 16:55:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -10077,7 +9945,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:26 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:55 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?limit=1000&marker=dee8791c-23b3-4e65-846d-49aeaba18036
@@ -10092,7 +9960,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 061cb9867d58495cad14ad0a3986a7c4
+      - 8ec1c3ea3f0841b3bc9c89c3ff168073
   response:
     status:
       code: 200
@@ -10103,9 +9971,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-d88fea50-6e7a-4fa4-b02e-55a9796533a8
+      - req-9902f91e-dc7d-42dd-a067-3d6ce2747f23
       Date:
-      - Thu, 03 Jan 2019 19:24:26 GMT
+      - Fri, 04 Jan 2019 16:55:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -10508,7 +10376,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:26 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:55 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?limit=1000
@@ -10523,7 +10391,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 07bef5ece26c41439e67edcf599c90d9
+      - 98b261a1565d42ae8972f9d334e48fe2
   response:
     status:
       code: 200
@@ -10534,9 +10402,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-02df3a90-0bac-4436-bf34-bfd0e6491d8c
+      - req-69739c33-cf24-45db-9af0-db4bd737afb5
       Date:
-      - Thu, 03 Jan 2019 19:24:26 GMT
+      - Fri, 04 Jan 2019 16:55:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -10939,7 +10807,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:27 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:55 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?limit=1000&marker=dee8791c-23b3-4e65-846d-49aeaba18036
@@ -10954,7 +10822,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 07bef5ece26c41439e67edcf599c90d9
+      - 98b261a1565d42ae8972f9d334e48fe2
   response:
     status:
       code: 200
@@ -10965,9 +10833,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-9c2c28fb-23de-4657-bdb0-3d96de46969f
+      - req-42602ca7-44ca-4501-b739-a705fbe64e6b
       Date:
-      - Thu, 03 Jan 2019 19:24:27 GMT
+      - Fri, 04 Jan 2019 16:55:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -11370,7 +11238,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:27 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:55 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?limit=1000
@@ -11385,7 +11253,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0ee91777873a42a49cc8b224c747ba97
+      - 2802704833334270a23874f85015b87c
   response:
     status:
       code: 200
@@ -11396,9 +11264,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-a1440854-3663-4a2c-b71f-5dd7c7156543
+      - req-87d5d113-78db-410b-abac-f22d19345ce0
       Date:
-      - Thu, 03 Jan 2019 19:24:27 GMT
+      - Fri, 04 Jan 2019 16:55:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -11801,7 +11669,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:27 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:56 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?limit=1000&marker=dee8791c-23b3-4e65-846d-49aeaba18036
@@ -11816,7 +11684,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0ee91777873a42a49cc8b224c747ba97
+      - 2802704833334270a23874f85015b87c
   response:
     status:
       code: 200
@@ -11827,9 +11695,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-873cb9ca-352e-41b4-a7f6-c5c3026ea684
+      - req-800a2c84-d1b1-4f75-8fb3-b6785c4e7254
       Date:
-      - Thu, 03 Jan 2019 19:24:27 GMT
+      - Fri, 04 Jan 2019 16:55:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -12232,7 +12100,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:27 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:56 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?limit=1000
@@ -12247,7 +12115,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 39c2a1897c01403db03778d390a2a878
+      - 2df0fd7f3fd04ca59d53952db3d21bff
   response:
     status:
       code: 200
@@ -12258,9 +12126,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-75f444ed-d757-4f06-8a35-f01b71d81566
+      - req-12cf1141-33fe-47b9-ad9e-c5d0514a2fb9
       Date:
-      - Thu, 03 Jan 2019 19:24:27 GMT
+      - Fri, 04 Jan 2019 16:55:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -12663,7 +12531,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:27 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:56 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?limit=1000&marker=dee8791c-23b3-4e65-846d-49aeaba18036
@@ -12678,7 +12546,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 39c2a1897c01403db03778d390a2a878
+      - 2df0fd7f3fd04ca59d53952db3d21bff
   response:
     status:
       code: 200
@@ -12689,9 +12557,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-4004ae83-40ed-4b6b-b059-21b982de97cb
+      - req-ea6ecf97-2088-43a2-b610-f7a37acbd9bd
       Date:
-      - Thu, 03 Jan 2019 19:24:27 GMT
+      - Fri, 04 Jan 2019 16:55:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -13094,7 +12962,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:28 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:56 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?limit=1000
@@ -13109,7 +12977,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 061cb9867d58495cad14ad0a3986a7c4
+      - 8ec1c3ea3f0841b3bc9c89c3ff168073
   response:
     status:
       code: 200
@@ -13120,9 +12988,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-a4004ecf-4461-4772-a844-49218d44b108
+      - req-b1e58062-87de-4fe2-964a-c69e9a568968
       Date:
-      - Thu, 03 Jan 2019 19:24:28 GMT
+      - Fri, 04 Jan 2019 16:55:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -13154,7 +13022,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:28 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:57 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?limit=1000&marker=a41c036a-c34e-454b-851d-5eefd03888cb
@@ -13169,7 +13037,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 061cb9867d58495cad14ad0a3986a7c4
+      - 8ec1c3ea3f0841b3bc9c89c3ff168073
   response:
     status:
       code: 200
@@ -13180,9 +13048,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-ddf14cf5-d46e-44a9-b955-bca965d1103f
+      - req-652dac46-dc9a-4392-a84d-4b5d283ec339
       Date:
-      - Thu, 03 Jan 2019 19:24:28 GMT
+      - Fri, 04 Jan 2019 16:55:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -13214,7 +13082,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:28 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:57 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?limit=1000
@@ -13229,7 +13097,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 07bef5ece26c41439e67edcf599c90d9
+      - 98b261a1565d42ae8972f9d334e48fe2
   response:
     status:
       code: 200
@@ -13240,9 +13108,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-3d249d72-ce29-4a1d-94d1-dbce622a4cb5
+      - req-ff2eef0b-9caa-42cf-ba62-e2c0d829b3d2
       Date:
-      - Thu, 03 Jan 2019 19:24:28 GMT
+      - Fri, 04 Jan 2019 16:55:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -13274,7 +13142,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:28 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:57 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?limit=1000&marker=a41c036a-c34e-454b-851d-5eefd03888cb
@@ -13289,7 +13157,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 07bef5ece26c41439e67edcf599c90d9
+      - 98b261a1565d42ae8972f9d334e48fe2
   response:
     status:
       code: 200
@@ -13300,9 +13168,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-1519012b-38bb-4363-8cfe-12629926f6a4
+      - req-c341efb0-fdda-4fda-94af-be461e7ba499
       Date:
-      - Thu, 03 Jan 2019 19:24:28 GMT
+      - Fri, 04 Jan 2019 16:55:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -13334,7 +13202,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:28 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:57 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?limit=1000
@@ -13349,7 +13217,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0ee91777873a42a49cc8b224c747ba97
+      - 2802704833334270a23874f85015b87c
   response:
     status:
       code: 200
@@ -13360,9 +13228,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-1e6b2e86-7b54-49a5-a714-133a6f7841f2
+      - req-1af00f8a-cb8e-4345-af01-196c05b4c4d1
       Date:
-      - Thu, 03 Jan 2019 19:24:28 GMT
+      - Fri, 04 Jan 2019 16:55:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -13394,7 +13262,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:28 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:57 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?limit=1000&marker=a41c036a-c34e-454b-851d-5eefd03888cb
@@ -13409,7 +13277,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0ee91777873a42a49cc8b224c747ba97
+      - 2802704833334270a23874f85015b87c
   response:
     status:
       code: 200
@@ -13420,9 +13288,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-1d0589ba-9767-4880-b081-8d48ba71a11c
+      - req-da50ba74-eb30-42d1-b3f9-037e6f266d2a
       Date:
-      - Thu, 03 Jan 2019 19:24:28 GMT
+      - Fri, 04 Jan 2019 16:55:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -13454,7 +13322,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:28 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:57 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?limit=1000
@@ -13469,7 +13337,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 39c2a1897c01403db03778d390a2a878
+      - 2df0fd7f3fd04ca59d53952db3d21bff
   response:
     status:
       code: 200
@@ -13480,9 +13348,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-25421dc9-c94c-4306-9c2f-04067b79a9b7
+      - req-9f4cd33f-7715-40cf-b83c-900da4eb89c3
       Date:
-      - Thu, 03 Jan 2019 19:24:28 GMT
+      - Fri, 04 Jan 2019 16:55:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -13514,7 +13382,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:28 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:57 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?limit=1000&marker=a41c036a-c34e-454b-851d-5eefd03888cb
@@ -13529,7 +13397,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 39c2a1897c01403db03778d390a2a878
+      - 2df0fd7f3fd04ca59d53952db3d21bff
   response:
     status:
       code: 200
@@ -13540,9 +13408,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-173d7ba6-a562-4a3a-95df-d605e637ed83
+      - req-483074d6-5d40-4e97-8bce-b915fc68105f
       Date:
-      - Thu, 03 Jan 2019 19:24:29 GMT
+      - Fri, 04 Jan 2019 16:55:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -13574,7 +13442,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:29 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:58 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000
@@ -13589,7 +13457,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 061cb9867d58495cad14ad0a3986a7c4
+      - 8ec1c3ea3f0841b3bc9c89c3ff168073
   response:
     status:
       code: 200
@@ -13600,9 +13468,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-680448f3-eb27-4bd3-ac69-65dafd080551
+      - req-4118acd4-e7b3-4e73-a9b8-fa4d91f0261f
       Date:
-      - Thu, 03 Jan 2019 19:24:29 GMT
+      - Fri, 04 Jan 2019 16:55:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef",
@@ -13644,7 +13512,7 @@ http_interactions:
         null, "port_range_min": null, "id": "ff24dfac-169a-4238-b78b-ed1536a0bf06",
         "security_group_id": "5b2b42a6-1271-4c4a-b062-8e8ba299acef"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:29 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:58 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef
@@ -13659,7 +13527,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 061cb9867d58495cad14ad0a3986a7c4
+      - 8ec1c3ea3f0841b3bc9c89c3ff168073
   response:
     status:
       code: 200
@@ -13670,9 +13538,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-8d96b258-5946-4bf3-80fd-f2581ff207e8
+      - req-ddbfefbb-e912-490c-b632-9cce44eb18ba
       Date:
-      - Thu, 03 Jan 2019 19:24:29 GMT
+      - Fri, 04 Jan 2019 16:55:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab",
@@ -13715,7 +13583,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "c06c0e71-2c18-43a9-ace9-91242f0251e2",
         "security_group_id": "98bfc20c-a897-42c5-b33c-f0d8317667ab"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:29 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:58 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab
@@ -13730,7 +13598,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 061cb9867d58495cad14ad0a3986a7c4
+      - 8ec1c3ea3f0841b3bc9c89c3ff168073
   response:
     status:
       code: 200
@@ -13741,9 +13609,9 @@ http_interactions:
       Content-Length:
       - '2717'
       X-Openstack-Request-Id:
-      - req-273b0972-50ec-4186-855f-42e04a215738
+      - req-1d9ede4e-e9ec-4339-adfe-53793e8abd44
       Date:
-      - Thu, 03 Jan 2019 19:24:29 GMT
+      - Fri, 04 Jan 2019 16:55:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4",
@@ -13778,7 +13646,7 @@ http_interactions:
         null, "port_range_min": null, "id": "75924ebc-4758-4042-ad04-4ef3c9189098",
         "security_group_id": "e4836528-d0df-425e-a117-ae8ec6f356d4"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:29 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:58 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4
@@ -13793,7 +13661,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 061cb9867d58495cad14ad0a3986a7c4
+      - 8ec1c3ea3f0841b3bc9c89c3ff168073
   response:
     status:
       code: 200
@@ -13804,9 +13672,9 @@ http_interactions:
       Content-Length:
       - '7080'
       X-Openstack-Request-Id:
-      - req-d9e91889-22f6-4c4d-b29c-f00e33f6c3a1
+      - req-4f4cb79e-e380-45b8-ba44-4fa33c11d434
       Date:
-      - Thu, 03 Jan 2019 19:24:29 GMT
+      - Fri, 04 Jan 2019 16:55:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=fd147cb7-7456-43d9-a01f-c06e21b4e6fb&page_reverse=True",
@@ -13893,7 +13761,7 @@ http_interactions:
         "port_range_max": 80, "port_range_min": 80, "id": "f79f0e32-b186-4778-952e-20827a60ef73",
         "security_group_id": "fd147cb7-7456-43d9-a01f-c06e21b4e6fb"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:29 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:58 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000
@@ -13908,7 +13776,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 07bef5ece26c41439e67edcf599c90d9
+      - 98b261a1565d42ae8972f9d334e48fe2
   response:
     status:
       code: 200
@@ -13919,9 +13787,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-509cd1bc-92ba-4516-a350-5a847b38ead6
+      - req-db01a6af-4bce-46a6-bde7-5c3d3259bf28
       Date:
-      - Thu, 03 Jan 2019 19:24:29 GMT
+      - Fri, 04 Jan 2019 16:55:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef",
@@ -13963,7 +13831,7 @@ http_interactions:
         null, "port_range_min": null, "id": "ff24dfac-169a-4238-b78b-ed1536a0bf06",
         "security_group_id": "5b2b42a6-1271-4c4a-b062-8e8ba299acef"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:29 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:58 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef
@@ -13978,7 +13846,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 07bef5ece26c41439e67edcf599c90d9
+      - 98b261a1565d42ae8972f9d334e48fe2
   response:
     status:
       code: 200
@@ -13989,9 +13857,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-8d456b48-bfc9-45f9-9f26-d99059183446
+      - req-b022860c-9327-4adf-bc52-29665ac18f35
       Date:
-      - Thu, 03 Jan 2019 19:24:29 GMT
+      - Fri, 04 Jan 2019 16:55:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab",
@@ -14034,7 +13902,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "c06c0e71-2c18-43a9-ace9-91242f0251e2",
         "security_group_id": "98bfc20c-a897-42c5-b33c-f0d8317667ab"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:29 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:58 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab
@@ -14049,7 +13917,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 07bef5ece26c41439e67edcf599c90d9
+      - 98b261a1565d42ae8972f9d334e48fe2
   response:
     status:
       code: 200
@@ -14060,9 +13928,9 @@ http_interactions:
       Content-Length:
       - '2717'
       X-Openstack-Request-Id:
-      - req-9d5883d5-e675-42df-a815-28e4fcc360c9
+      - req-72991d01-29a4-4ced-b41e-0dfda512a516
       Date:
-      - Thu, 03 Jan 2019 19:24:29 GMT
+      - Fri, 04 Jan 2019 16:55:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4",
@@ -14097,7 +13965,7 @@ http_interactions:
         null, "port_range_min": null, "id": "75924ebc-4758-4042-ad04-4ef3c9189098",
         "security_group_id": "e4836528-d0df-425e-a117-ae8ec6f356d4"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:29 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:58 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4
@@ -14112,7 +13980,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 07bef5ece26c41439e67edcf599c90d9
+      - 98b261a1565d42ae8972f9d334e48fe2
   response:
     status:
       code: 200
@@ -14123,9 +13991,9 @@ http_interactions:
       Content-Length:
       - '7080'
       X-Openstack-Request-Id:
-      - req-9f3b0315-ae38-4b1d-9c95-d243ed81a6fd
+      - req-c6ca3716-dc62-4a65-afac-25181fbf3238
       Date:
-      - Thu, 03 Jan 2019 19:24:30 GMT
+      - Fri, 04 Jan 2019 16:55:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=fd147cb7-7456-43d9-a01f-c06e21b4e6fb&page_reverse=True",
@@ -14212,7 +14080,7 @@ http_interactions:
         "port_range_max": 80, "port_range_min": 80, "id": "f79f0e32-b186-4778-952e-20827a60ef73",
         "security_group_id": "fd147cb7-7456-43d9-a01f-c06e21b4e6fb"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:30 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:58 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000
@@ -14227,7 +14095,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0ee91777873a42a49cc8b224c747ba97
+      - 2802704833334270a23874f85015b87c
   response:
     status:
       code: 200
@@ -14238,9 +14106,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-ac7e9d16-29bf-455c-be67-d4c2bfebc08b
+      - req-5dde707c-cc1d-4533-8318-6f5d60635f86
       Date:
-      - Thu, 03 Jan 2019 19:24:30 GMT
+      - Fri, 04 Jan 2019 16:55:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef",
@@ -14282,7 +14150,7 @@ http_interactions:
         null, "port_range_min": null, "id": "ff24dfac-169a-4238-b78b-ed1536a0bf06",
         "security_group_id": "5b2b42a6-1271-4c4a-b062-8e8ba299acef"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:30 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:59 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef
@@ -14297,7 +14165,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0ee91777873a42a49cc8b224c747ba97
+      - 2802704833334270a23874f85015b87c
   response:
     status:
       code: 200
@@ -14308,9 +14176,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-8f1c00e5-fd94-4b11-9725-923a1d6616de
+      - req-d7366b59-d8f6-414a-8bf3-476160b3744f
       Date:
-      - Thu, 03 Jan 2019 19:24:30 GMT
+      - Fri, 04 Jan 2019 16:55:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab",
@@ -14353,7 +14221,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "c06c0e71-2c18-43a9-ace9-91242f0251e2",
         "security_group_id": "98bfc20c-a897-42c5-b33c-f0d8317667ab"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:30 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:59 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab
@@ -14368,7 +14236,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0ee91777873a42a49cc8b224c747ba97
+      - 2802704833334270a23874f85015b87c
   response:
     status:
       code: 200
@@ -14379,9 +14247,9 @@ http_interactions:
       Content-Length:
       - '2717'
       X-Openstack-Request-Id:
-      - req-17eb0cd7-3c35-40e7-b24b-a37949380c8c
+      - req-b6f0c3cf-7a90-4053-b936-33aa81c02944
       Date:
-      - Thu, 03 Jan 2019 19:24:30 GMT
+      - Fri, 04 Jan 2019 16:55:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4",
@@ -14416,7 +14284,7 @@ http_interactions:
         null, "port_range_min": null, "id": "75924ebc-4758-4042-ad04-4ef3c9189098",
         "security_group_id": "e4836528-d0df-425e-a117-ae8ec6f356d4"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:30 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:59 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4
@@ -14431,7 +14299,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0ee91777873a42a49cc8b224c747ba97
+      - 2802704833334270a23874f85015b87c
   response:
     status:
       code: 200
@@ -14442,9 +14310,9 @@ http_interactions:
       Content-Length:
       - '7080'
       X-Openstack-Request-Id:
-      - req-76300522-ae2c-4bdf-a27f-31046e448797
+      - req-f45cb8de-022a-4e2f-8cd7-80c3ffba2595
       Date:
-      - Thu, 03 Jan 2019 19:24:30 GMT
+      - Fri, 04 Jan 2019 16:55:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=fd147cb7-7456-43d9-a01f-c06e21b4e6fb&page_reverse=True",
@@ -14531,7 +14399,7 @@ http_interactions:
         "port_range_max": 80, "port_range_min": 80, "id": "f79f0e32-b186-4778-952e-20827a60ef73",
         "security_group_id": "fd147cb7-7456-43d9-a01f-c06e21b4e6fb"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:30 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:59 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000
@@ -14546,7 +14414,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 39c2a1897c01403db03778d390a2a878
+      - 2df0fd7f3fd04ca59d53952db3d21bff
   response:
     status:
       code: 200
@@ -14557,9 +14425,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-812345c9-f1ac-48e5-b147-fe7fc419589c
+      - req-10779516-35bf-4a56-8711-32632b9e6172
       Date:
-      - Thu, 03 Jan 2019 19:24:30 GMT
+      - Fri, 04 Jan 2019 16:55:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef",
@@ -14601,7 +14469,7 @@ http_interactions:
         null, "port_range_min": null, "id": "ff24dfac-169a-4238-b78b-ed1536a0bf06",
         "security_group_id": "5b2b42a6-1271-4c4a-b062-8e8ba299acef"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:30 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:59 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef
@@ -14616,7 +14484,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 39c2a1897c01403db03778d390a2a878
+      - 2df0fd7f3fd04ca59d53952db3d21bff
   response:
     status:
       code: 200
@@ -14627,9 +14495,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-0d3e7eed-bbbe-4268-a83a-46ac086dc99b
+      - req-1b2f5fa3-fbe9-4ae8-8726-26454d5cdb64
       Date:
-      - Thu, 03 Jan 2019 19:24:30 GMT
+      - Fri, 04 Jan 2019 16:55:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab",
@@ -14672,7 +14540,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "c06c0e71-2c18-43a9-ace9-91242f0251e2",
         "security_group_id": "98bfc20c-a897-42c5-b33c-f0d8317667ab"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:30 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:59 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab
@@ -14687,7 +14555,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 39c2a1897c01403db03778d390a2a878
+      - 2df0fd7f3fd04ca59d53952db3d21bff
   response:
     status:
       code: 200
@@ -14698,9 +14566,9 @@ http_interactions:
       Content-Length:
       - '2717'
       X-Openstack-Request-Id:
-      - req-70999949-278f-4a40-b3b5-9d6a82c308e0
+      - req-97b5ceb5-3e1d-428a-8384-ef8fe55606a4
       Date:
-      - Thu, 03 Jan 2019 19:24:30 GMT
+      - Fri, 04 Jan 2019 16:55:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4",
@@ -14735,7 +14603,7 @@ http_interactions:
         null, "port_range_min": null, "id": "75924ebc-4758-4042-ad04-4ef3c9189098",
         "security_group_id": "e4836528-d0df-425e-a117-ae8ec6f356d4"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:30 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:59 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4
@@ -14750,7 +14618,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 39c2a1897c01403db03778d390a2a878
+      - 2df0fd7f3fd04ca59d53952db3d21bff
   response:
     status:
       code: 200
@@ -14761,9 +14629,9 @@ http_interactions:
       Content-Length:
       - '7080'
       X-Openstack-Request-Id:
-      - req-9697bbe8-6999-4028-915d-9f105da0264a
+      - req-768da367-dc3f-4beb-b738-49ff6b971366
       Date:
-      - Thu, 03 Jan 2019 19:24:30 GMT
+      - Fri, 04 Jan 2019 16:55:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=fd147cb7-7456-43d9-a01f-c06e21b4e6fb&page_reverse=True",
@@ -14850,7 +14718,7 @@ http_interactions:
         "port_range_max": 80, "port_range_min": 80, "id": "f79f0e32-b186-4778-952e-20827a60ef73",
         "security_group_id": "fd147cb7-7456-43d9-a01f-c06e21b4e6fb"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:30 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:59 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -14868,13 +14736,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:24:31 GMT
+      - Fri, 04 Jan 2019 16:56:00 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-1cfce9e5-0459-4c7d-bfbf-5b416dabcefb
+      - req-cf8c15f2-118d-4704-977f-57bcce7d68e5
       Content-Length:
       - '4170'
       Connection:
@@ -14883,10 +14751,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:24:31.581068", "expires":
-        "2019-01-03T20:24:31Z", "id": "8ff8b7625e124f8db463270aea22f234", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:56:00.481053", "expires":
+        "2019-01-04T17:56:00Z", "id": "bc97a0fb6552477483ef809373584405", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["Qp7YGGkiSw-pZishosLZUw"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["fw4NlW6fQ1GWYfvYioMt5w"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -14931,7 +14799,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:31 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:00 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -14949,13 +14817,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:24:31 GMT
+      - Fri, 04 Jan 2019 16:56:00 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-563f3f51-8fd3-4c5e-bf0a-56ebd83927f8
+      - req-ce5f8c8e-f6c8-4045-8a80-18d94a82522d
       Content-Length:
       - '4170'
       Connection:
@@ -14964,10 +14832,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:24:31.783413", "expires":
-        "2019-01-03T20:24:31Z", "id": "ad7cf13a24244202928a81a5603fe03a", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:56:00.670074", "expires":
+        "2019-01-04T17:56:00Z", "id": "c63ea27018ad450c9e646f1f3c44a93b", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["flFykQN7Sd6yPBBXRe-5hw"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["sgch48yqSSCTiWtu1Xs_PQ"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -15012,7 +14880,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:31 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:00 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -15030,13 +14898,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:24:31 GMT
+      - Fri, 04 Jan 2019 16:56:00 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-fc91c66b-c6a8-4ea3-a921-6e7a7bcc704a
+      - req-020f1f6b-65f9-4dc6-b2c0-8aedb74e1286
       Content-Length:
       - '370'
       Connection:
@@ -15045,13 +14913,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:24:31.943469", "expires":
-        "2019-01-03T20:24:31Z", "id": "b3bdf66d03ad42feb07197ccbddb86f5", "audit_ids":
-        ["MwJxCGjZTk6sUvKadvx-4A"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:56:00.830308", "expires":
+        "2019-01-04T17:56:00Z", "id": "4cb8436bad4d46769f3fbbf49a9d5c24", "audit_ids":
+        ["Cl13Hop1T5e2G97EoqTDog"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:31 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:00 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -15066,20 +14934,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b3bdf66d03ad42feb07197ccbddb86f5
+      - 4cb8436bad4d46769f3fbbf49a9d5c24
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:24:32 GMT
+      - Fri, 04 Jan 2019 16:56:00 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-b382c9c0-ed59-481f-9621-22961abafc8e
+      - req-a2722f5d-c348-4f7e-a093-d0d800dcbb6e
       Content-Length:
       - '500'
       Connection:
@@ -15096,7 +14964,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:32 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:00 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -15114,13 +14982,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:24:32 GMT
+      - Fri, 04 Jan 2019 16:56:01 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-ba3b9d84-e67e-4364-95e0-b334d43dc018
+      - req-256cb653-6aa7-492c-9ea9-98d5b8563b14
       Content-Length:
       - '4117'
       Connection:
@@ -15129,10 +14997,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:24:32.265411", "expires":
-        "2019-01-03T20:24:32Z", "id": "102755e8c3494490862be05b7b333b51", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:56:01.151857", "expires":
+        "2019-01-04T17:56:01Z", "id": "0b24083d77004fe89f45fe810280a97d", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["rN9t6K4xQa-p7cWHwfpG7g"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["HTRhAruEQ1erjR2Q0VnjtA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -15176,7 +15044,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:32 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:01 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -15194,13 +15062,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:24:32 GMT
+      - Fri, 04 Jan 2019 16:56:01 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-6f245f86-21c5-400d-8577-71e2ab3dfb91
+      - req-9f9cf6a2-e7e6-40ce-b418-be122cc314a9
       Content-Length:
       - '4131'
       Connection:
@@ -15209,10 +15077,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:24:32.455143", "expires":
-        "2019-01-03T20:24:32Z", "id": "43ac45aa302247de92b0c8cee154d908", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:56:01.334270", "expires":
+        "2019-01-04T17:56:01Z", "id": "f2fceda5cae04a948c500cbda85dbb9e", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["8aNXV42FReO0euyZwCf69A"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["N9F3eN7PReyeBMgV5VY_Yg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -15256,7 +15124,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:32 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:01 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -15274,13 +15142,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:24:32 GMT
+      - Fri, 04 Jan 2019 16:56:01 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-228f4c59-ce16-41a0-8599-4249fdb1885f
+      - req-70edfc66-4a14-4c24-8dbf-661381630a21
       Content-Length:
       - '4118'
       Connection:
@@ -15289,10 +15157,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:24:32.644975", "expires":
-        "2019-01-03T20:24:32Z", "id": "203faa2c82c147d5a5d1d420c8d04f1d", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:56:01.520664", "expires":
+        "2019-01-04T17:56:01Z", "id": "b018b81b93604396bf6cca5d266bb6ba", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["8yu2F9nQQsi_nb4e2y6XAg"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["wSUojwr0SpCJHIofqk9EVw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -15336,7 +15204,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:32 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:01 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000
@@ -15351,22 +15219,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 102755e8c3494490862be05b7b333b51
+      - 0b24083d77004fe89f45fe810280a97d
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-fa951b67-55ee-48c8-bf3e-d971592c80b9
+      - req-40517677-721d-4974-889c-c07101a6ab9e
       Content-Type:
       - application/json
       Content-Length:
       - '2706'
       X-Openstack-Request-Id:
-      - req-fa951b67-55ee-48c8-bf3e-d971592c80b9
+      - req-40517677-721d-4974-889c-c07101a6ab9e
       Date:
-      - Thu, 03 Jan 2019 19:24:32 GMT
+      - Fri, 04 Jan 2019 16:56:01 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=9bb99818-b339-4e31-b87f-e4181ec48acd",
@@ -15399,7 +15267,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-4", "bootable": "true", "created_at":
         "2016-11-11T13:49:53.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:32 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:01 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=9bb99818-b339-4e31-b87f-e4181ec48acd
@@ -15414,22 +15282,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 102755e8c3494490862be05b7b333b51
+      - 0b24083d77004fe89f45fe810280a97d
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-547d3bbf-ee87-43ea-b85c-efa9c043b59d
+      - req-7920b6df-0913-4cfd-8a4d-2002749905ea
       Content-Type:
       - application/json
       Content-Length:
       - '3284'
       X-Openstack-Request-Id:
-      - req-547d3bbf-ee87-43ea-b85c-efa9c043b59d
+      - req-7920b6df-0913-4cfd-8a4d-2002749905ea
       Date:
-      - Thu, 03 Jan 2019 19:24:33 GMT
+      - Fri, 04 Jan 2019 16:56:01 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=2c774148-c11a-434c-aabb-7fa9c82c37ce",
@@ -15470,7 +15338,7 @@ http_interactions:
         "name": "EmsRefreshSpec-Volume-2", "bootable": "false", "created_at": "2016-11-11T13:49:43.000000",
         "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:33 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:01 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=2c774148-c11a-434c-aabb-7fa9c82c37ce
@@ -15485,22 +15353,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 102755e8c3494490862be05b7b333b51
+      - 0b24083d77004fe89f45fe810280a97d
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-1f8e5950-f12b-43a3-b0fc-731cb8040cae
+      - req-462c3d4a-4113-47cf-9351-7752a534b059
       Content-Type:
       - application/json
       Content-Length:
       - '2753'
       X-Openstack-Request-Id:
-      - req-1f8e5950-f12b-43a3-b0fc-731cb8040cae
+      - req-462c3d4a-4113-47cf-9351-7752a534b059
       Date:
-      - Thu, 03 Jan 2019 19:24:33 GMT
+      - Fri, 04 Jan 2019 16:56:02 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=0a55c0d5-c780-4e7d-9d09-47f5520c7448",
@@ -15534,7 +15402,7 @@ http_interactions:
         "bootable": "false", "created_at": "2016-11-11T13:49:20.000000", "volume_type":
         "iscsi"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:33 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:02 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=0a55c0d5-c780-4e7d-9d09-47f5520c7448
@@ -15549,27 +15417,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 102755e8c3494490862be05b7b333b51
+      - 0b24083d77004fe89f45fe810280a97d
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-e68c043b-45f3-489d-9302-b6e79089af14
+      - req-9b78ddb7-5556-4513-9234-28ab69418c71
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-e68c043b-45f3-489d-9302-b6e79089af14
+      - req-9b78ddb7-5556-4513-9234-28ab69418c71
       Date:
-      - Thu, 03 Jan 2019 19:24:33 GMT
+      - Fri, 04 Jan 2019 16:56:02 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:33 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:02 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/volumes/detail?limit=1000
@@ -15584,27 +15452,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 43ac45aa302247de92b0c8cee154d908
+      - f2fceda5cae04a948c500cbda85dbb9e
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-1bf87bce-3203-41b9-8ac7-880daaa73da8
+      - req-d74b512e-274a-42d8-9b7c-78b683458132
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-1bf87bce-3203-41b9-8ac7-880daaa73da8
+      - req-d74b512e-274a-42d8-9b7c-78b683458132
       Date:
-      - Thu, 03 Jan 2019 19:24:33 GMT
+      - Fri, 04 Jan 2019 16:56:02 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:33 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:02 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/volumes/detail?limit=1000
@@ -15619,27 +15487,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ad7cf13a24244202928a81a5603fe03a
+      - c63ea27018ad450c9e646f1f3c44a93b
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-29111d50-f0b1-4b22-a8fb-e1b9dd185814
+      - req-ecff3e52-7647-44ad-8cfd-2c04d77ddc86
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-29111d50-f0b1-4b22-a8fb-e1b9dd185814
+      - req-ecff3e52-7647-44ad-8cfd-2c04d77ddc86
       Date:
-      - Thu, 03 Jan 2019 19:24:33 GMT
+      - Fri, 04 Jan 2019 16:56:02 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:33 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:02 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/volumes/detail?limit=1000
@@ -15654,27 +15522,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 203faa2c82c147d5a5d1d420c8d04f1d
+      - b018b81b93604396bf6cca5d266bb6ba
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-7bdaf689-15d6-4cd8-9c81-10c9517f542f
+      - req-bb90746a-de17-4aad-86e2-0a5be029e920
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-7bdaf689-15d6-4cd8-9c81-10c9517f542f
+      - req-bb90746a-de17-4aad-86e2-0a5be029e920
       Date:
-      - Thu, 03 Jan 2019 19:24:34 GMT
+      - Fri, 04 Jan 2019 16:56:02 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:34 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:02 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail
@@ -15689,22 +15557,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 102755e8c3494490862be05b7b333b51
+      - 0b24083d77004fe89f45fe810280a97d
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-471681ba-1793-49eb-9647-af8eec740fb2
+      - req-8dc962db-ef28-4664-97e1-8a5770dbe9e2
       Content-Type:
       - application/json
       Content-Length:
       - '1053'
       X-Openstack-Request-Id:
-      - req-471681ba-1793-49eb-9647-af8eec740fb2
+      - req-8dc962db-ef28-4664-97e1-8a5770dbe9e2
       Date:
-      - Thu, 03 Jan 2019 19:24:34 GMT
+      - Fri, 04 Jan 2019 16:56:02 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?marker=76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
@@ -15719,7 +15587,7 @@ http_interactions:
         "created_at": "2016-11-11T13:49:36.000000", "size": 1, "id": "76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:34 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:02 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?limit=1000
@@ -15734,22 +15602,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 102755e8c3494490862be05b7b333b51
+      - 0b24083d77004fe89f45fe810280a97d
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-8761b285-6386-4113-a0c1-4dc73fbaed32
+      - req-e4ead233-373e-43ca-9de1-354f5f5c1cf6
       Content-Type:
       - application/json
       Content-Length:
       - '1064'
       X-Openstack-Request-Id:
-      - req-8761b285-6386-4113-a0c1-4dc73fbaed32
+      - req-e4ead233-373e-43ca-9de1-354f5f5c1cf6
       Date:
-      - Thu, 03 Jan 2019 19:24:34 GMT
+      - Fri, 04 Jan 2019 16:56:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?limit=1000&marker=76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
@@ -15764,7 +15632,7 @@ http_interactions:
         "created_at": "2016-11-11T13:49:36.000000", "size": 1, "id": "76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:34 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:03 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/snapshots/detail
@@ -15779,27 +15647,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 43ac45aa302247de92b0c8cee154d908
+      - f2fceda5cae04a948c500cbda85dbb9e
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-bc0eb8de-7ebe-4fc7-9f3b-a63b6b1334c3
+      - req-230ee1b1-a09f-4bbc-9710-cd2375b8b58b
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-bc0eb8de-7ebe-4fc7-9f3b-a63b6b1334c3
+      - req-230ee1b1-a09f-4bbc-9710-cd2375b8b58b
       Date:
-      - Thu, 03 Jan 2019 19:24:34 GMT
+      - Fri, 04 Jan 2019 16:56:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:34 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:03 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/snapshots/detail?limit=1000
@@ -15814,27 +15682,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 43ac45aa302247de92b0c8cee154d908
+      - f2fceda5cae04a948c500cbda85dbb9e
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-819671c5-9304-49cc-a68d-a1cc287529c6
+      - req-dd0b4497-f5fa-4caf-9f0f-d0788d701f25
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-819671c5-9304-49cc-a68d-a1cc287529c6
+      - req-dd0b4497-f5fa-4caf-9f0f-d0788d701f25
       Date:
-      - Thu, 03 Jan 2019 19:24:34 GMT
+      - Fri, 04 Jan 2019 16:56:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:34 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:03 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/snapshots/detail
@@ -15849,27 +15717,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ad7cf13a24244202928a81a5603fe03a
+      - c63ea27018ad450c9e646f1f3c44a93b
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-5a7c0392-1a6f-4af3-9ad8-ec7abfb02aba
+      - req-574ec68e-ba4a-4686-8093-047f6f0e0330
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-5a7c0392-1a6f-4af3-9ad8-ec7abfb02aba
+      - req-574ec68e-ba4a-4686-8093-047f6f0e0330
       Date:
-      - Thu, 03 Jan 2019 19:24:35 GMT
+      - Fri, 04 Jan 2019 16:56:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:35 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:03 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/snapshots/detail?limit=1000
@@ -15884,27 +15752,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ad7cf13a24244202928a81a5603fe03a
+      - c63ea27018ad450c9e646f1f3c44a93b
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-4f3f19de-2fa2-434c-880a-1f6ff701c531
+      - req-9bac8ec0-72e5-4769-b85b-c530c7c65b43
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-4f3f19de-2fa2-434c-880a-1f6ff701c531
+      - req-9bac8ec0-72e5-4769-b85b-c530c7c65b43
       Date:
-      - Thu, 03 Jan 2019 19:24:35 GMT
+      - Fri, 04 Jan 2019 16:56:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:35 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:03 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/snapshots/detail
@@ -15919,27 +15787,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 203faa2c82c147d5a5d1d420c8d04f1d
+      - b018b81b93604396bf6cca5d266bb6ba
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-6117fa25-296c-44ea-ac10-e5ffb538d5e3
+      - req-5decc930-82dd-4f85-97a1-a2508ac4b730
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-6117fa25-296c-44ea-ac10-e5ffb538d5e3
+      - req-5decc930-82dd-4f85-97a1-a2508ac4b730
       Date:
-      - Thu, 03 Jan 2019 19:24:35 GMT
+      - Fri, 04 Jan 2019 16:56:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:35 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:04 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/snapshots/detail?limit=1000
@@ -15954,27 +15822,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 203faa2c82c147d5a5d1d420c8d04f1d
+      - b018b81b93604396bf6cca5d266bb6ba
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-d2112ec2-a40e-4fc9-b71e-cb614f5ecbbb
+      - req-13cc1c55-428b-49a4-af34-5c6917003595
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-d2112ec2-a40e-4fc9-b71e-cb614f5ecbbb
+      - req-13cc1c55-428b-49a4-af34-5c6917003595
       Date:
-      - Thu, 03 Jan 2019 19:24:35 GMT
+      - Fri, 04 Jan 2019 16:56:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:35 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:04 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/backups/detail
@@ -15989,27 +15857,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 102755e8c3494490862be05b7b333b51
+      - 0b24083d77004fe89f45fe810280a97d
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-cafdb340-ac6d-4327-bb1b-7b4fd43c4646
+      - req-2711d8f4-7ea5-40ef-a8b2-ae45a9f4bf77
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-cafdb340-ac6d-4327-bb1b-7b4fd43c4646
+      - req-2711d8f4-7ea5-40ef-a8b2-ae45a9f4bf77
       Date:
-      - Thu, 03 Jan 2019 19:24:35 GMT
+      - Fri, 04 Jan 2019 16:56:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:35 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:04 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/backups/detail?limit=1000
@@ -16024,27 +15892,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 102755e8c3494490862be05b7b333b51
+      - 0b24083d77004fe89f45fe810280a97d
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-294f40d0-f107-4046-989b-ccc1c7589560
+      - req-a1240da2-3fa8-441a-abe0-923b2f2c1d3e
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-294f40d0-f107-4046-989b-ccc1c7589560
+      - req-a1240da2-3fa8-441a-abe0-923b2f2c1d3e
       Date:
-      - Thu, 03 Jan 2019 19:24:35 GMT
+      - Fri, 04 Jan 2019 16:56:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:35 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:05 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/backups/detail
@@ -16059,27 +15927,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 43ac45aa302247de92b0c8cee154d908
+      - f2fceda5cae04a948c500cbda85dbb9e
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-e4ed7712-37d3-4ca2-a76d-86853c7bf847
+      - req-7dcc9384-a0ee-4258-8b18-206736485248
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-e4ed7712-37d3-4ca2-a76d-86853c7bf847
+      - req-7dcc9384-a0ee-4258-8b18-206736485248
       Date:
-      - Thu, 03 Jan 2019 19:24:35 GMT
+      - Fri, 04 Jan 2019 16:56:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:35 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:05 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/backups/detail?limit=1000
@@ -16094,27 +15962,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 43ac45aa302247de92b0c8cee154d908
+      - f2fceda5cae04a948c500cbda85dbb9e
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-c9752d2f-b6e1-438e-9d88-0e3886ce39ef
+      - req-518ca2b5-6398-43c1-ae7d-997f817057fe
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-c9752d2f-b6e1-438e-9d88-0e3886ce39ef
+      - req-518ca2b5-6398-43c1-ae7d-997f817057fe
       Date:
-      - Thu, 03 Jan 2019 19:24:35 GMT
+      - Fri, 04 Jan 2019 16:56:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:35 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:05 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/backups/detail
@@ -16129,27 +15997,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ad7cf13a24244202928a81a5603fe03a
+      - c63ea27018ad450c9e646f1f3c44a93b
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-2a80687e-a9fe-4a31-a779-aa62eeda33b1
+      - req-ded59351-1061-4cc1-a416-adc93b9a15db
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-2a80687e-a9fe-4a31-a779-aa62eeda33b1
+      - req-ded59351-1061-4cc1-a416-adc93b9a15db
       Date:
-      - Thu, 03 Jan 2019 19:24:36 GMT
+      - Fri, 04 Jan 2019 16:56:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:36 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:05 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/backups/detail?limit=1000
@@ -16164,27 +16032,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ad7cf13a24244202928a81a5603fe03a
+      - c63ea27018ad450c9e646f1f3c44a93b
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-d070aa88-27ec-420b-b6af-f910e0f52db7
+      - req-97628657-2954-4620-bfc3-b40ff07c0727
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-d070aa88-27ec-420b-b6af-f910e0f52db7
+      - req-97628657-2954-4620-bfc3-b40ff07c0727
       Date:
-      - Thu, 03 Jan 2019 19:24:36 GMT
+      - Fri, 04 Jan 2019 16:56:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:36 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:05 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/backups/detail
@@ -16199,27 +16067,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 203faa2c82c147d5a5d1d420c8d04f1d
+      - b018b81b93604396bf6cca5d266bb6ba
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-c03695ef-ca89-4c82-b995-06b2fb966c94
+      - req-cda36b3c-d064-47c2-bc71-ff4a36c8ebd0
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-c03695ef-ca89-4c82-b995-06b2fb966c94
+      - req-cda36b3c-d064-47c2-bc71-ff4a36c8ebd0
       Date:
-      - Thu, 03 Jan 2019 19:24:36 GMT
+      - Fri, 04 Jan 2019 16:56:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:36 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:05 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/backups/detail?limit=1000
@@ -16234,27 +16102,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 203faa2c82c147d5a5d1d420c8d04f1d
+      - b018b81b93604396bf6cca5d266bb6ba
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-5ac9369a-b8cf-4c28-90de-a75789717c8e
+      - req-517a6b98-5442-4103-9292-53a5c1f37526
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-5ac9369a-b8cf-4c28-90de-a75789717c8e
+      - req-517a6b98-5442-4103-9292-53a5c1f37526
       Date:
-      - Thu, 03 Jan 2019 19:24:36 GMT
+      - Fri, 04 Jan 2019 16:56:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:36 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:05 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/types?limit=1000
@@ -16269,22 +16137,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 102755e8c3494490862be05b7b333b51
+      - 0b24083d77004fe89f45fe810280a97d
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-62eb2d80-86bb-4488-abc1-ef98b03c34d6
+      - req-05f8b8ab-3def-417b-985a-7fdf236b82a0
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-62eb2d80-86bb-4488-abc1-ef98b03c34d6
+      - req-05f8b8ab-3def-417b-985a-7fdf236b82a0
       Date:
-      - Thu, 03 Jan 2019 19:24:36 GMT
+      - Fri, 04 Jan 2019 16:56:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -16296,7 +16164,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:36 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:05 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/types?limit=1000&marker=0d07f8c3-f295-48c7-b632-6b7d8bd860eb
@@ -16311,22 +16179,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 102755e8c3494490862be05b7b333b51
+      - 0b24083d77004fe89f45fe810280a97d
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-b38daba4-ddc3-4f6e-afe1-2568af9638a7
+      - req-d6357e66-be86-48bf-9f77-814a6f47a5aa
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-b38daba4-ddc3-4f6e-afe1-2568af9638a7
+      - req-d6357e66-be86-48bf-9f77-814a6f47a5aa
       Date:
-      - Thu, 03 Jan 2019 19:24:37 GMT
+      - Fri, 04 Jan 2019 16:56:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -16338,7 +16206,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:37 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:05 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/types?limit=1000
@@ -16353,22 +16221,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 43ac45aa302247de92b0c8cee154d908
+      - f2fceda5cae04a948c500cbda85dbb9e
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-63998345-859d-417e-9ed3-3fe917d265f5
+      - req-d66bff0c-4764-4f13-8640-459dd2f75510
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-63998345-859d-417e-9ed3-3fe917d265f5
+      - req-d66bff0c-4764-4f13-8640-459dd2f75510
       Date:
-      - Thu, 03 Jan 2019 19:24:37 GMT
+      - Fri, 04 Jan 2019 16:56:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -16380,7 +16248,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:37 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:06 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/types?limit=1000&marker=0d07f8c3-f295-48c7-b632-6b7d8bd860eb
@@ -16395,22 +16263,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 43ac45aa302247de92b0c8cee154d908
+      - f2fceda5cae04a948c500cbda85dbb9e
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-fc2692ef-dbd5-4e4a-aca1-a1791d7d89c5
+      - req-e6716d39-4bcb-4288-8722-935a4826f288
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-fc2692ef-dbd5-4e4a-aca1-a1791d7d89c5
+      - req-e6716d39-4bcb-4288-8722-935a4826f288
       Date:
-      - Thu, 03 Jan 2019 19:24:37 GMT
+      - Fri, 04 Jan 2019 16:56:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -16422,7 +16290,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:37 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:06 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/types?limit=1000
@@ -16437,22 +16305,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ad7cf13a24244202928a81a5603fe03a
+      - c63ea27018ad450c9e646f1f3c44a93b
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-49517546-45a8-4719-bf2c-ef6a61fd5ab6
+      - req-26d9948b-2e68-42ce-ad5c-1ace3973ead2
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-49517546-45a8-4719-bf2c-ef6a61fd5ab6
+      - req-26d9948b-2e68-42ce-ad5c-1ace3973ead2
       Date:
-      - Thu, 03 Jan 2019 19:24:37 GMT
+      - Fri, 04 Jan 2019 16:56:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -16464,7 +16332,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:37 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:06 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/types?limit=1000&marker=0d07f8c3-f295-48c7-b632-6b7d8bd860eb
@@ -16479,22 +16347,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ad7cf13a24244202928a81a5603fe03a
+      - c63ea27018ad450c9e646f1f3c44a93b
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-50e5e2cf-bf09-4007-ab70-b89a3fa33240
+      - req-1c8e81dd-2400-4f47-aa7e-7647aab0e605
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-50e5e2cf-bf09-4007-ab70-b89a3fa33240
+      - req-1c8e81dd-2400-4f47-aa7e-7647aab0e605
       Date:
-      - Thu, 03 Jan 2019 19:24:37 GMT
+      - Fri, 04 Jan 2019 16:56:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -16506,7 +16374,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:37 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:06 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/types?limit=1000
@@ -16521,22 +16389,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 203faa2c82c147d5a5d1d420c8d04f1d
+      - b018b81b93604396bf6cca5d266bb6ba
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-d59cc920-ec8f-40f3-a2f7-f512f452a684
+      - req-0cbaaed9-bf91-4d4f-8184-503eec9fa940
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-d59cc920-ec8f-40f3-a2f7-f512f452a684
+      - req-0cbaaed9-bf91-4d4f-8184-503eec9fa940
       Date:
-      - Thu, 03 Jan 2019 19:24:37 GMT
+      - Fri, 04 Jan 2019 16:56:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -16548,7 +16416,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:37 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:06 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/types?limit=1000&marker=0d07f8c3-f295-48c7-b632-6b7d8bd860eb
@@ -16563,22 +16431,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 203faa2c82c147d5a5d1d420c8d04f1d
+      - b018b81b93604396bf6cca5d266bb6ba
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-f2d8a06b-c894-4410-8e56-b583f67ca7e8
+      - req-44911d87-0137-4639-b402-a7949f885350
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-f2d8a06b-c894-4410-8e56-b583f67ca7e8
+      - req-44911d87-0137-4639-b402-a7949f885350
       Date:
-      - Thu, 03 Jan 2019 19:24:37 GMT
+      - Fri, 04 Jan 2019 16:56:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -16590,7 +16458,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:37 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:06 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -16608,13 +16476,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:24:38 GMT
+      - Fri, 04 Jan 2019 16:56:06 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-cdc625b3-00ca-43da-a91e-6251b662b4e0
+      - req-8ff0b7fe-ecbd-4b30-92b7-c208ce4b4954
       Content-Length:
       - '4170'
       Connection:
@@ -16623,10 +16491,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:24:38.971764", "expires":
-        "2019-01-03T20:24:38Z", "id": "f99224c1d85f486a94e29544b47769c0", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:56:06.853001", "expires":
+        "2019-01-04T17:56:06Z", "id": "cbb30971448b43c1a428889248174b5f", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["G-qwdD3jRkyhfaDBAzTUKg"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["bnj78FtrT26nKoMkFVq7qQ"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -16671,7 +16539,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:38 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:06 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -16689,13 +16557,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:24:39 GMT
+      - Fri, 04 Jan 2019 16:56:06 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-da2b4fa2-8bd4-4a02-8a7f-cfe51ece1183
+      - req-466f6c2b-60dc-4a00-8f59-58ed5acb8971
       Content-Length:
       - '4170'
       Connection:
@@ -16704,10 +16572,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:24:39.171297", "expires":
-        "2019-01-03T20:24:39Z", "id": "7dd4e106a63e49258f39a74c09ac476d", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:56:07.050483", "expires":
+        "2019-01-04T17:56:07Z", "id": "1fc83c7124aa49b2a21f5cdd27056706", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["YmxHL9T3RzudQABaCCY6Nw"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["khgf7nAmRwWwNstxfKwcGQ"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -16752,7 +16620,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:39 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:07 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -16770,13 +16638,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:24:39 GMT
+      - Fri, 04 Jan 2019 16:56:07 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-41ee0fc6-ee04-4ead-84f7-98bd9906a414
+      - req-155e9b00-6abb-43c0-b883-f0e7f90062bc
       Content-Length:
       - '370'
       Connection:
@@ -16785,13 +16653,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:24:39.334884", "expires":
-        "2019-01-03T20:24:39Z", "id": "17a228a51b5244ad8e5edad441772004", "audit_ids":
-        ["OGSwQ7gHRbiXueuqCBemuw"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:56:07.216737", "expires":
+        "2019-01-04T17:56:07Z", "id": "b96d179ba55b47cc95d9f26718d5b677", "audit_ids":
+        ["avcCCEONRXuD0b_L53dTCw"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:39 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:07 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -16806,20 +16674,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 17a228a51b5244ad8e5edad441772004
+      - b96d179ba55b47cc95d9f26718d5b677
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:24:39 GMT
+      - Fri, 04 Jan 2019 16:56:07 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-b4718401-0b8a-4813-8ab2-361cd08f87af
+      - req-feb1d9cf-8f8b-4b04-b71f-605675a264ca
       Content-Length:
       - '500'
       Connection:
@@ -16836,7 +16704,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:39 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:07 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -16854,13 +16722,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:24:39 GMT
+      - Fri, 04 Jan 2019 16:56:07 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-fc3b0d7d-03c2-408c-857d-2f3ce1b4c510
+      - req-49bf7f5b-acd1-4a38-b14b-1438f5ea2055
       Content-Length:
       - '4117'
       Connection:
@@ -16869,10 +16737,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:24:39.675847", "expires":
-        "2019-01-03T20:24:39Z", "id": "ec14b0330d9e485f955a3fd2243c0007", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:56:07.543636", "expires":
+        "2019-01-04T17:56:07Z", "id": "f7f5f9d0d3374ae9973416561cc5a7da", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["zxTL8xLhQ5-7XsIQqBS5ig"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["pSvPxvIlQJu0OfSsr-_lnw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -16916,7 +16784,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:39 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:07 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -16934,13 +16802,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:24:39 GMT
+      - Fri, 04 Jan 2019 16:56:07 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-bcdb0ade-6233-4096-9e9f-b4d87143a99d
+      - req-d5a2ebf2-0e6a-4169-8c2d-b8909b2532ff
       Content-Length:
       - '4131'
       Connection:
@@ -16949,10 +16817,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:24:39.869821", "expires":
-        "2019-01-03T20:24:39Z", "id": "b3e508ddad874d0aa6a1b859328567ac", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:56:07.748195", "expires":
+        "2019-01-04T17:56:07Z", "id": "2780594b41714f3596da0158593d29b6", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["ppA4FTAHQjq23CYYvzraVQ"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["qygTzDvXQJGP48YPpfK3kw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -16996,7 +16864,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:39 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:07 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -17014,13 +16882,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:24:40 GMT
+      - Fri, 04 Jan 2019 16:56:07 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-aea1b879-3300-4e2c-8ae1-19091e084c7d
+      - req-01969f11-de0a-4c62-b232-d3e95ac32d38
       Content-Length:
       - '4118'
       Connection:
@@ -17029,10 +16897,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:24:40.066704", "expires":
-        "2019-01-03T20:24:40Z", "id": "af201ab4eb5c46b693689c66f0dbd317", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:56:07.949158", "expires":
+        "2019-01-04T17:56:07Z", "id": "1647b36ae94e4c789f51023a20e614b8", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["iIiu25d9T06EjxZbYWJ-6A"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["77EXmQkKQY-VdZmw_9FfzQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -17076,7 +16944,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:40 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:07 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/?format=json&limit=1000
@@ -17091,7 +16959,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ec14b0330d9e485f955a3fd2243c0007
+      - f7f5f9d0d3374ae9973416561cc5a7da
   response:
     status:
       code: 200
@@ -17120,15 +16988,15 @@ http_interactions:
       X-Account-Project-Domain-Id:
       - default
       X-Trans-Id:
-      - txa2965c7b8ed447b1af58f-005c2e6178
+      - tx0b3f07c89eeb4176b7306-005c2f9028
       Date:
-      - Thu, 03 Jan 2019 19:24:40 GMT
+      - Fri, 04 Jan 2019 16:56:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '[{"count": 3, "bytes": 33, "name": "dir_1"}, {"count": 0, "bytes":
         0, "name": "dir_2"}, {"count": 0, "bytes": 0, "name": "dir_3"}]'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:40 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:08 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/?format=json&limit=1000&marker=dir_3
@@ -17143,7 +17011,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ec14b0330d9e485f955a3fd2243c0007
+      - f7f5f9d0d3374ae9973416561cc5a7da
   response:
     status:
       code: 200
@@ -17172,14 +17040,14 @@ http_interactions:
       X-Account-Project-Domain-Id:
       - default
       X-Trans-Id:
-      - tx228b2b8bebdf4d42a81dd-005c2e6178
+      - txdae5eb771dc54ab58003b-005c2f9028
       Date:
-      - Thu, 03 Jan 2019 19:24:40 GMT
+      - Fri, 04 Jan 2019 16:56:08 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:40 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:08 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_b458a5c25c3749758f4c0661940b3ba8/?format=json&limit=1000
@@ -17194,7 +17062,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b3e508ddad874d0aa6a1b859328567ac
+      - 2780594b41714f3596da0158593d29b6
   response:
     status:
       code: 200
@@ -17207,22 +17075,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1546543480.48015'
+      - '1546620968.38285'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1546543480.48015'
+      - '1546620968.38285'
       X-Trans-Id:
-      - txaeab5ef5fdf841a8a698b-005c2e6178
+      - txd7ef286315ac4afd8fa9a-005c2f9028
       Date:
-      - Thu, 03 Jan 2019 19:24:40 GMT
+      - Fri, 04 Jan 2019 16:56:08 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:40 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:08 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_e54e5c3c19e34720b05661f2ea1ea00a/?format=json&limit=1000
@@ -17237,7 +17105,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7dd4e106a63e49258f39a74c09ac476d
+      - 1fc83c7124aa49b2a21f5cdd27056706
   response:
     status:
       code: 200
@@ -17250,22 +17118,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1546543480.63608'
+      - '1546620968.54586'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1546543480.63608'
+      - '1546620968.54586'
       X-Trans-Id:
-      - tx8cc9ea984fe04169962ab-005c2e6178
+      - txd285153f15974e739bba9-005c2f9028
       Date:
-      - Thu, 03 Jan 2019 19:24:40 GMT
+      - Fri, 04 Jan 2019 16:56:08 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:40 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:08 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_e8f744b1fc6a487681d35fb275252608/?format=json&limit=1000
@@ -17280,7 +17148,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - af201ab4eb5c46b693689c66f0dbd317
+      - 1647b36ae94e4c789f51023a20e614b8
   response:
     status:
       code: 200
@@ -17293,22 +17161,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1546543481.07404'
+      - '1546620968.70672'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1546543481.07404'
+      - '1546620968.70672'
       X-Trans-Id:
-      - tx5724a822222e4302a4c06-005c2e6179
+      - tx22ca206521934df7b83f3-005c2f9028
       Date:
-      - Thu, 03 Jan 2019 19:24:41 GMT
+      - Fri, 04 Jan 2019 16:56:08 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:41 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:08 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/dir_1?format=json
@@ -17323,7 +17191,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ec14b0330d9e485f955a3fd2243c0007
+      - f7f5f9d0d3374ae9973416561cc5a7da
   response:
     status:
       code: 200
@@ -17344,9 +17212,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - tx0fd3ccc73a564d66a1140-005c2e6179
+      - tx7d3a5f73936340aab8d3a-005c2f9028
       Date:
-      - Thu, 03 Jan 2019 19:24:41 GMT
+      - Fri, 04 Jan 2019 16:56:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '[{"hash": "61257bf228e2f6802a196c9a460d19a8", "last_modified": "2016-11-11T13:50:03.869630",
@@ -17356,7 +17224,7 @@ http_interactions:
         {"hash": "1727a9b61bddf85bbe7a5710c9f45691", "last_modified": "2016-11-11T13:50:04.495640",
         "bytes": 11, "name": "file_3", "content_type": "application/octet-stream"}]'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:41 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:08 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/dir_2?format=json
@@ -17371,7 +17239,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ec14b0330d9e485f955a3fd2243c0007
+      - f7f5f9d0d3374ae9973416561cc5a7da
   response:
     status:
       code: 200
@@ -17392,14 +17260,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - tx7caefcccf2774c1a81ee6-005c2e6179
+      - tx6572b3f187454cc187edb-005c2f9028
       Date:
-      - Thu, 03 Jan 2019 19:24:41 GMT
+      - Fri, 04 Jan 2019 16:56:08 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:41 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:08 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/dir_3?format=json
@@ -17414,7 +17282,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ec14b0330d9e485f955a3fd2243c0007
+      - f7f5f9d0d3374ae9973416561cc5a7da
   response:
     status:
       code: 200
@@ -17435,12 +17303,12 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - tx0326bd75392d4114bee05-005c2e6179
+      - tx9f9d06df8c3b47f98e9c7-005c2f9029
       Date:
-      - Thu, 03 Jan 2019 19:24:41 GMT
+      - Fri, 04 Jan 2019 16:56:09 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:41 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:09 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_fast_refresh.yml
+++ b/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_fast_refresh.yml
@@ -17,13 +17,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:24:49 GMT
+      - Fri, 04 Jan 2019 16:58:31 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-e40717e6-85be-4fa5-acb7-a0c2e37c2546
+      - req-7a3dacce-e095-4830-aecb-1e3ab6e5c230
       Content-Length:
       - '4170'
       Connection:
@@ -32,10 +32,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:24:49.405423", "expires":
-        "2019-01-03T20:24:49Z", "id": "9b5f200f76804d219b5b0536a6a565b8", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:58:31.312711", "expires":
+        "2019-01-04T17:58:31Z", "id": "8c6415af41b54322a94c3692fa0be73f", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["SDdRudlaTZ6hHidoXdI8rw"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["4kbISKbuSxaZhoVb2TTqsw"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -80,7 +80,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:49 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:31 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -95,7 +95,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9b5f200f76804d219b5b0536a6a565b8
+      - 8c6415af41b54322a94c3692fa0be73f
   response:
     status:
       code: 200
@@ -106,7 +106,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Thu, 03 Jan 2019 19:24:49 GMT
+      - Fri, 04 Jan 2019 16:58:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -115,7 +115,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:49 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:31 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-availability-zone
@@ -130,7 +130,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9b5f200f76804d219b5b0536a6a565b8
+      - 8c6415af41b54322a94c3692fa0be73f
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -143,15 +143,15 @@ http_interactions:
       Content-Length:
       - '97'
       X-Compute-Request-Id:
-      - req-8700aa9e-8d0a-4188-8d5b-ea9779985bf9
+      - req-fc8b5978-b116-4f3c-b8bb-797c50d00053
       Date:
-      - Thu, 03 Jan 2019 19:24:49 GMT
+      - Fri, 04 Jan 2019 16:58:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"availabilityZoneInfo": [{"zoneState": {"available": true}, "hosts":
         null, "zoneName": "nova"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:49 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:31 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -169,13 +169,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:24:49 GMT
+      - Fri, 04 Jan 2019 16:58:31 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-d638694a-a54d-44de-9bf3-3feaa2f92376
+      - req-43f8c38c-55fe-4ebf-9dcc-d9c6f8975482
       Content-Length:
       - '4170'
       Connection:
@@ -184,10 +184,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:24:49.878850", "expires":
-        "2019-01-03T20:24:49Z", "id": "577b5d80c48d4aaab2fca6cf735de7be", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:58:31.770469", "expires":
+        "2019-01-04T17:58:31Z", "id": "0c0bd64dc23542379847ee56e26f0b04", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["7EZJMJEtTYqLmIdO-f4ZdA"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["YJJyKQ9ATqKMvzBj53FoRg"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -232,7 +232,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:49 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:31 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-availability-zone.json
@@ -247,28 +247,28 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 577b5d80c48d4aaab2fca6cf735de7be
+      - 0c0bd64dc23542379847ee56e26f0b04
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-09e1f507-0dfa-40fa-bdc1-fa8ee2e76a9b
+      - req-a5cd5c2f-b395-44fc-814e-88736c4feb8d
       Content-Type:
       - application/json
       Content-Length:
       - '82'
       X-Openstack-Request-Id:
-      - req-09e1f507-0dfa-40fa-bdc1-fa8ee2e76a9b
+      - req-a5cd5c2f-b395-44fc-814e-88736c4feb8d
       Date:
-      - Thu, 03 Jan 2019 19:24:50 GMT
+      - Fri, 04 Jan 2019 16:58:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"availabilityZoneInfo": [{"zoneState": {"available": true}, "zoneName":
         "nova"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:50 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:31 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-services?all_tenants=True&limit=1000
@@ -283,7 +283,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9b5f200f76804d219b5b0536a6a565b8
+      - 8c6415af41b54322a94c3692fa0be73f
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -296,26 +296,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-07315d11-f1b6-480e-a68a-82cbd9dbb5f6
+      - req-45ee124b-0ec3-4348-bf2c-658f6ecdeb18
       Date:
-      - Thu, 03 Jan 2019 19:24:50 GMT
+      - Fri, 04 Jan 2019 16:58:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-01-03T19:24:45.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-01-04T16:58:28.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2019-01-03T19:24:43.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2019-01-04T16:58:27.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-01-03T19:24:45.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-01-04T16:58:28.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2019-01-03T19:24:49.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2019-01-04T16:58:22.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2019-01-03T19:24:48.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2019-01-04T16:58:22.000000"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:50 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:32 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-services?all_tenants=True&limit=1000&marker=5
@@ -330,7 +330,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9b5f200f76804d219b5b0536a6a565b8
+      - 8c6415af41b54322a94c3692fa0be73f
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -343,26 +343,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-50e75d9e-4e0b-4798-95ac-9f03887780ee
+      - req-48aa770e-1c5c-4165-969e-78294daf1e89
       Date:
-      - Thu, 03 Jan 2019 19:24:50 GMT
+      - Fri, 04 Jan 2019 16:58:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-01-03T19:24:45.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-01-04T16:58:28.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2019-01-03T19:24:43.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2019-01-04T16:58:27.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-01-03T19:24:45.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-01-04T16:58:28.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2019-01-03T19:24:49.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2019-01-04T16:58:22.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2019-01-03T19:24:48.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2019-01-04T16:58:22.000000"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:50 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:32 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000
@@ -377,7 +377,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9b5f200f76804d219b5b0536a6a565b8
+      - 8c6415af41b54322a94c3692fa0be73f
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -390,9 +390,9 @@ http_interactions:
       Content-Length:
       - '1010'
       X-Compute-Request-Id:
-      - req-61970acc-f21c-4785-8bfb-4b318b818236
+      - req-d3cc1118-d135-4865-957d-ea67de2e180f
       Date:
-      - Thu, 03 Jan 2019 19:24:50 GMT
+      - Fri, 04 Jan 2019 16:58:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.tiny", "links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/1",
@@ -406,7 +406,7 @@ http_interactions:
         0, "disk": 20, "id": "2"}], "flavors_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=2",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:50 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:32 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=2
@@ -421,7 +421,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9b5f200f76804d219b5b0536a6a565b8
+      - 8c6415af41b54322a94c3692fa0be73f
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -434,9 +434,9 @@ http_interactions:
       Content-Length:
       - '1014'
       X-Compute-Request-Id:
-      - req-35f34fe9-866b-42d5-b931-037389aa30ef
+      - req-9cb58d63-f27a-4066-8d83-f98d91dbd1e4
       Date:
-      - Thu, 03 Jan 2019 19:24:50 GMT
+      - Fri, 04 Jan 2019 16:58:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.medium", "links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/3",
@@ -450,7 +450,7 @@ http_interactions:
         0, "disk": 80, "id": "4"}], "flavors_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=4",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:50 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:32 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=4
@@ -465,7 +465,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9b5f200f76804d219b5b0536a6a565b8
+      - 8c6415af41b54322a94c3692fa0be73f
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -478,9 +478,9 @@ http_interactions:
       Content-Length:
       - '1026'
       X-Compute-Request-Id:
-      - req-31bd6245-5c38-4f1b-81e0-d46ca76bb0da
+      - req-39c3d745-0fed-4f58-b64c-f74307c08fd7
       Date:
-      - Thu, 03 Jan 2019 19:24:50 GMT
+      - Fri, 04 Jan 2019 16:58:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.xlarge", "links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/5",
@@ -495,7 +495,7 @@ http_interactions:
         1, "disk": 1, "id": "6"}], "flavors_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=6",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:50 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:32 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=6
@@ -510,7 +510,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9b5f200f76804d219b5b0536a6a565b8
+      - 8c6415af41b54322a94c3692fa0be73f
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -523,9 +523,9 @@ http_interactions:
       Content-Length:
       - '448'
       X-Compute-Request-Id:
-      - req-0e222319-6787-47f7-96f8-a3c60c5190fb
+      - req-1805f90e-7015-47e2-acf6-889e9830564b
       Date:
-      - Thu, 03 Jan 2019 19:24:50 GMT
+      - Fri, 04 Jan 2019 16:58:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.ems_refresh_spec_private", "links": [{"href":
@@ -535,7 +535,7 @@ http_interactions:
         8, "swap": "", "os-flavor-access:is_public": false, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         0, "disk": 160, "id": "7"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:50 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:32 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -553,13 +553,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:24:50 GMT
+      - Fri, 04 Jan 2019 16:58:32 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-3075e234-f044-4c29-ab9f-64a9f39aa790
+      - req-67e4e331-1631-4daa-bf7d-efa903d9585d
       Content-Length:
       - '370'
       Connection:
@@ -568,13 +568,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:24:50.925058", "expires":
-        "2019-01-03T20:24:50Z", "id": "5257092219334613813b9ef784669e8a", "audit_ids":
-        ["7M1qGWrfSZSRfC-GInGlQw"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:58:32.761528", "expires":
+        "2019-01-04T17:58:32Z", "id": "cd86ff385b934f95afbd4596da9acc2c", "audit_ids":
+        ["vLkuFVu0RceuKd57BOLfyQ"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:50 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:32 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -589,20 +589,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5257092219334613813b9ef784669e8a
+      - cd86ff385b934f95afbd4596da9acc2c
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:24:51 GMT
+      - Fri, 04 Jan 2019 16:58:32 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-608eb85a-dbe1-47f4-8fed-ee4f214ecee4
+      - req-5f2d71f2-9bee-45e7-85f6-5de84b940d03
       Content-Length:
       - '500'
       Connection:
@@ -619,7 +619,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:51 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:32 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/7/os-flavor-access
@@ -634,7 +634,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9b5f200f76804d219b5b0536a6a565b8
+      - 8c6415af41b54322a94c3692fa0be73f
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -647,15 +647,15 @@ http_interactions:
       Content-Length:
       - '88'
       X-Compute-Request-Id:
-      - req-3310c64e-c923-45c5-b3b2-c345933f228f
+      - req-bdc71da9-b24a-4a2c-a50c-5ba5e08090cb
       Date:
-      - Thu, 03 Jan 2019 19:24:51 GMT
+      - Fri, 04 Jan 2019 16:58:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavor_access": [{"tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "flavor_id": "7"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:51 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:33 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -673,13 +673,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:24:51 GMT
+      - Fri, 04 Jan 2019 16:58:33 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-50e9b03e-d3d8-4ce6-b058-ebafa271e1a0
+      - req-59674a45-6439-40ba-9b96-03be215dc9ce
       Content-Length:
       - '4170'
       Connection:
@@ -688,10 +688,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:24:51.358513", "expires":
-        "2019-01-03T20:24:51Z", "id": "d82f76cb02a9447bab9e1425da5361e9", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:58:33.268046", "expires":
+        "2019-01-04T17:58:33Z", "id": "d4feafaba1a84cf1bfa231708c233bee", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["nsuUq9JFQzCS7O7sen2C1Q"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["YUS1Yx9WTfeMtXfQ5MzmgQ"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -736,7 +736,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:51 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:33 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images
@@ -751,7 +751,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d82f76cb02a9447bab9e1425da5361e9
+      - d4feafaba1a84cf1bfa231708c233bee
   response:
     status:
       code: 200
@@ -762,9 +762,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-8c3bc72d-27f6-4d93-a393-8f3118cad8c8
+      - req-35e350df-92b4-4064-809d-0dbc69322801
       Date:
-      - Thu, 03 Jan 2019 19:24:51 GMT
+      - Fri, 04 Jan 2019 16:58:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -806,7 +806,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images"}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:51 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:33 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images?marker=bb799f70-5e02-461b-8324-17ee88259c7b
@@ -821,7 +821,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d82f76cb02a9447bab9e1425da5361e9
+      - d4feafaba1a84cf1bfa231708c233bee
   response:
     status:
       code: 200
@@ -832,14 +832,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-71940c9c-170e-450b-8288-972a9ff45fa2
+      - req-5b064b80-e179-40b7-9d06-13cb0f56b6f5
       Date:
-      - Thu, 03 Jan 2019 19:24:51 GMT
+      - Fri, 04 Jan 2019 16:58:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images"}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:51 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:33 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-keypairs?all_tenants=True&limit=1000
@@ -854,7 +854,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9b5f200f76804d219b5b0536a6a565b8
+      - 8c6415af41b54322a94c3692fa0be73f
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -867,9 +867,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-932bf0f6-f8d2-4dec-992b-9f4f4f3c2029
+      - req-8e41c74b-bad5-49d2-9da5-1c5973b4af4b
       Date:
-      - Thu, 03 Jan 2019 19:24:51 GMT
+      - Fri, 04 Jan 2019 16:58:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -879,7 +879,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:51 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:33 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-keypairs?all_tenants=True&limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -894,7 +894,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9b5f200f76804d219b5b0536a6a565b8
+      - 8c6415af41b54322a94c3692fa0be73f
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -907,9 +907,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-7d292ed1-5a08-4115-b24a-58af0b76468a
+      - req-98b8276d-11b2-477f-9e79-a3b027ede193
       Date:
-      - Thu, 03 Jan 2019 19:24:51 GMT
+      - Fri, 04 Jan 2019 16:58:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -919,7 +919,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:51 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:33 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -937,13 +937,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:24:52 GMT
+      - Fri, 04 Jan 2019 16:58:33 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-9c35627c-7681-4318-b769-45916ab773af
+      - req-895cf24c-2bc7-4fb6-9d04-fc953377c707
       Content-Length:
       - '4170'
       Connection:
@@ -952,10 +952,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:24:52.060601", "expires":
-        "2019-01-03T20:24:52Z", "id": "fc54b3c7ed8d4a1a8443536fb223d3d3", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:58:33.947658", "expires":
+        "2019-01-04T17:58:33Z", "id": "35159f2b5cbf4aae993600c25ab6b35a", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["foSPULJjRay7Yg7M2ubTIg"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["CoaVylz9Su-SwC0zgKnroA"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -1000,7 +1000,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:52 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:33 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1018,13 +1018,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:24:52 GMT
+      - Fri, 04 Jan 2019 16:58:34 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-936412f7-fea3-4366-8f5a-f2e97c02695d
+      - req-5302e0a5-ce31-48d4-8006-e5776a724999
       Content-Length:
       - '4117'
       Connection:
@@ -1033,10 +1033,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:24:52.251219", "expires":
-        "2019-01-03T20:24:52Z", "id": "14fb0884cc25472e947e6629b2cc1aaa", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:58:34.135159", "expires":
+        "2019-01-04T17:58:34Z", "id": "cbe0fe7131ad43ab9559ae4b105ead85", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["fuC5zr0nSw6v8mD2ti33gw"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["rp5sgdLsRdqc4FDRHBq45g"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -1080,7 +1080,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:52 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:34 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1098,13 +1098,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:24:52 GMT
+      - Fri, 04 Jan 2019 16:58:34 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-d0a1ffa8-5ec0-438a-9a69-20aba653ec63
+      - req-fdef10bf-c9e6-49c0-9dda-a5594d3b1117
       Content-Length:
       - '4131'
       Connection:
@@ -1113,10 +1113,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:24:52.439998", "expires":
-        "2019-01-03T20:24:52Z", "id": "bfad6cca850d491c9c1f497d7b2a6257", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:58:34.326803", "expires":
+        "2019-01-04T17:58:34Z", "id": "a9e6cee413cd43c4b735dd73d931abe2", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["Ls6D-NuaRee1cTmJz9eiFw"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["QOk9LiaRQO2mNyGdU6GH_Q"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -1160,7 +1160,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:52 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:34 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1178,13 +1178,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:24:52 GMT
+      - Fri, 04 Jan 2019 16:58:34 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-4d7ae8d1-efde-4454-9bb5-5772dc901d22
+      - req-b56e89a8-d508-4be3-a2ee-39ea94cf9115
       Content-Length:
       - '4118'
       Connection:
@@ -1193,10 +1193,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:24:52.676745", "expires":
-        "2019-01-03T20:24:52Z", "id": "4b1915689cfe4fbaac10433feefc1d76", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:58:34.517811", "expires":
+        "2019-01-04T17:58:34Z", "id": "1d265931f9c94d07bd42ef8308382538", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["3-_e_UvfSKy1H3vScHGfRg"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["KuF4gT76QpalCS2lUxm4fg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -1240,7 +1240,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:52 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:34 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks?limit=1000&show_nested=true
@@ -1255,7 +1255,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 14fb0884cc25472e947e6629b2cc1aaa
+      - cbe0fe7131ad43ab9559ae4b105ead85
   response:
     status:
       code: 200
@@ -1266,9 +1266,9 @@ http_interactions:
       Content-Length:
       - '2559'
       X-Openstack-Request-Id:
-      - req-6c7fb0e7-771e-4c51-ba45-7c95f70fe26d
+      - req-f53f10db-3a16-4832-89c4-d529f26b35dd
       Date:
-      - Thu, 03 Jan 2019 19:24:52 GMT
+      - Fri, 04 Jan 2019 16:58:34 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": [{"description": "Heat WordPress template to support F20,
@@ -1302,7 +1302,7 @@ http_interactions:
         "rel": "self"}], "updated_time": null, "stack_owner": null, "stack_status":
         "CREATE_COMPLETE", "id": "091e1e54-e01c-4ec5-a0ab-b00bee4d425c"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:52 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:34 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks?limit=1000&marker=091e1e54-e01c-4ec5-a0ab-b00bee4d425c&show_nested=true
@@ -1317,7 +1317,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 14fb0884cc25472e947e6629b2cc1aaa
+      - cbe0fe7131ad43ab9559ae4b105ead85
   response:
     status:
       code: 200
@@ -1328,14 +1328,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-6db1d6ea-5663-4f79-a398-9126e7da7204
+      - req-1a926ca0-15c3-4e61-a45e-26eb301baef4
       Date:
-      - Thu, 03 Jan 2019 19:24:52 GMT
+      - Fri, 04 Jan 2019 16:58:34 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:53 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:34 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/b458a5c25c3749758f4c0661940b3ba8/stacks?limit=1000&show_nested=true
@@ -1350,7 +1350,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bfad6cca850d491c9c1f497d7b2a6257
+      - a9e6cee413cd43c4b735dd73d931abe2
   response:
     status:
       code: 200
@@ -1361,14 +1361,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-3b4a3885-199e-424c-adf6-b08bd9973fa5
+      - req-ce219c64-ccad-4d77-8901-37f22df177df
       Date:
-      - Thu, 03 Jan 2019 19:24:53 GMT
+      - Fri, 04 Jan 2019 16:58:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:53 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:35 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/e54e5c3c19e34720b05661f2ea1ea00a/stacks?limit=1000&show_nested=true
@@ -1383,7 +1383,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fc54b3c7ed8d4a1a8443536fb223d3d3
+      - 35159f2b5cbf4aae993600c25ab6b35a
   response:
     status:
       code: 200
@@ -1394,14 +1394,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-0c33bfad-538a-4c15-9e88-435e6eb86fe5
+      - req-e14c4bda-0f36-45a5-9bb1-277c71c8d222
       Date:
-      - Thu, 03 Jan 2019 19:24:53 GMT
+      - Fri, 04 Jan 2019 16:58:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:53 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:35 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/e8f744b1fc6a487681d35fb275252608/stacks?limit=1000&show_nested=true
@@ -1416,7 +1416,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4b1915689cfe4fbaac10433feefc1d76
+      - 1d265931f9c94d07bd42ef8308382538
   response:
     status:
       code: 200
@@ -1427,14 +1427,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-1d769d2e-d05d-4708-ad8a-ba17f6612507
+      - req-56c20ff5-991d-4e67-8817-77665c3c4ccd
       Date:
-      - Thu, 03 Jan 2019 19:24:53 GMT
+      - Fri, 04 Jan 2019 16:58:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:53 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:35 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack3/45d2af82-eff9-4483-a1f0-f19c44d96146
@@ -1449,7 +1449,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 14fb0884cc25472e947e6629b2cc1aaa
+      - cbe0fe7131ad43ab9559ae4b105ead85
   response:
     status:
       code: 200
@@ -1460,9 +1460,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-5afb63e2-1446-4d2f-ab90-00138f5dc77c
+      - req-ba1f3886-0831-4ec2-91de-d5e6e6b611f3
       Date:
-      - Thu, 03 Jan 2019 19:24:53 GMT
+      - Fri, 04 Jan 2019 16:58:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -1489,7 +1489,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:53 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:35 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack2/4cf24b12-29fc-4529-a8ed-6b079dea7c17
@@ -1504,7 +1504,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 14fb0884cc25472e947e6629b2cc1aaa
+      - cbe0fe7131ad43ab9559ae4b105ead85
   response:
     status:
       code: 200
@@ -1515,9 +1515,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-987c33b0-486c-4bfd-baf3-73d03bdfa5ea
+      - req-3fa87463-3d25-4942-9989-638947a5a3a6
       Date:
-      - Thu, 03 Jan 2019 19:24:54 GMT
+      - Fri, 04 Jan 2019 16:58:36 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -1544,7 +1544,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:54 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:36 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c
@@ -1559,7 +1559,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 14fb0884cc25472e947e6629b2cc1aaa
+      - cbe0fe7131ad43ab9559ae4b105ead85
   response:
     status:
       code: 200
@@ -1570,9 +1570,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-4109cae8-7b51-44be-bf9f-9e0318872e8b
+      - req-52074262-7c4b-4d9e-8df1-c3a9bb3d2d3b
       Date:
-      - Thu, 03 Jan 2019 19:24:54 GMT
+      - Fri, 04 Jan 2019 16:58:36 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -1599,7 +1599,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:54 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:36 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack3/45d2af82-eff9-4483-a1f0-f19c44d96146/template
@@ -1614,7 +1614,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 14fb0884cc25472e947e6629b2cc1aaa
+      - cbe0fe7131ad43ab9559ae4b105ead85
   response:
     status:
       code: 200
@@ -1625,9 +1625,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-233b5c2b-bcfe-4b08-81bd-9ccfccef5939
+      - req-97a433f7-ab2b-4888-a1cd-e79a36e367b0
       Date:
-      - Thu, 03 Jan 2019 19:24:54 GMT
+      - Fri, 04 Jan 2019 16:58:36 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -1683,7 +1683,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:54 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:36 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack3/45d2af82-eff9-4483-a1f0-f19c44d96146/resources
@@ -1698,7 +1698,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 14fb0884cc25472e947e6629b2cc1aaa
+      - cbe0fe7131ad43ab9559ae4b105ead85
   response:
     status:
       code: 200
@@ -1709,9 +1709,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-a0e2efd2-04cf-471e-a73a-e2c270a49a4c
+      - req-543bab85-9203-4465-9519-b122a5d742b4
       Date:
-      - Thu, 03 Jan 2019 19:24:54 GMT
+      - Fri, 04 Jan 2019 16:58:36 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -1723,7 +1723,7 @@ http_interactions:
         changed", "physical_resource_id": "aa5907f3-8209-4dd0-b3ef-600431d85bac",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:54 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:36 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?all_tenants=True&limit=1000
@@ -1738,7 +1738,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9b5f200f76804d219b5b0536a6a565b8
+      - 8c6415af41b54322a94c3692fa0be73f
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1751,9 +1751,9 @@ http_interactions:
       Content-Length:
       - '3998'
       X-Compute-Request-Id:
-      - req-699cfb94-b1cd-4072-a88a-965bf7438c9d
+      - req-47bb6b74-1143-4adf-bc7a-0a9323974bd5
       Date:
-      - Thu, 03 Jan 2019 19:24:55 GMT
+      - Fri, 04 Jan 2019 16:58:36 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?all_tenants=True&limit=1000&marker=96fef14f-5338-4d58-8b89-58b627b27b9b",
@@ -1799,7 +1799,7 @@ http_interactions:
         [], "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:55 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:36 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?all_tenants=True&limit=1000&marker=96fef14f-5338-4d58-8b89-58b627b27b9b
@@ -1814,7 +1814,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9b5f200f76804d219b5b0536a6a565b8
+      - 8c6415af41b54322a94c3692fa0be73f
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1827,9 +1827,9 @@ http_interactions:
       Content-Length:
       - '4062'
       X-Compute-Request-Id:
-      - req-a70f72be-4ceb-473f-a7f9-f3268f7df889
+      - req-3f2675e9-7cee-4cab-9886-72763126b5cc
       Date:
-      - Thu, 03 Jan 2019 19:24:55 GMT
+      - Fri, 04 Jan 2019 16:58:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?all_tenants=True&limit=1000&marker=ca1fc357-ee31-45e9-a38d-98723d6c8876",
@@ -1875,7 +1875,7 @@ http_interactions:
         [], "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 3, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:55 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:37 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?all_tenants=True&limit=1000&marker=ca1fc357-ee31-45e9-a38d-98723d6c8876
@@ -1890,7 +1890,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9b5f200f76804d219b5b0536a6a565b8
+      - 8c6415af41b54322a94c3692fa0be73f
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1903,9 +1903,9 @@ http_interactions:
       Content-Length:
       - '4144'
       X-Compute-Request-Id:
-      - req-984b2b6f-507f-4c9a-a867-ed182bbde6e3
+      - req-da46205f-74c1-4a84-b5a4-11905cd7431e
       Date:
-      - Thu, 03 Jan 2019 19:24:55 GMT
+      - Fri, 04 Jan 2019 16:58:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?all_tenants=True&limit=1000&marker=ca4f3a16-bae3-4407-83e9-f77b28af0f2b",
@@ -1953,7 +1953,7 @@ http_interactions:
         "", "progress": 0, "OS-EXT-STS:power_state": 1, "config_drive": "", "metadata":
         {}}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:55 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:37 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?all_tenants=True&limit=1000&marker=ca4f3a16-bae3-4407-83e9-f77b28af0f2b
@@ -1968,7 +1968,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9b5f200f76804d219b5b0536a6a565b8
+      - 8c6415af41b54322a94c3692fa0be73f
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1981,9 +1981,9 @@ http_interactions:
       Content-Length:
       - '3813'
       X-Compute-Request-Id:
-      - req-5b5f36ac-0465-4cf5-abfe-57415f50cf6a
+      - req-ba196bcb-e15c-47b1-982c-fe75040dfa82
       Date:
-      - Thu, 03 Jan 2019 19:24:55 GMT
+      - Fri, 04 Jan 2019 16:58:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?all_tenants=True&limit=1000&marker=aa5907f3-8209-4dd0-b3ef-600431d85bac",
@@ -2025,7 +2025,7 @@ http_interactions:
         "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:55 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:38 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?all_tenants=True&limit=1000&marker=aa5907f3-8209-4dd0-b3ef-600431d85bac
@@ -2040,7 +2040,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9b5f200f76804d219b5b0536a6a565b8
+      - 8c6415af41b54322a94c3692fa0be73f
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2053,9 +2053,9 @@ http_interactions:
       Content-Length:
       - '1816'
       X-Compute-Request-Id:
-      - req-52480364-c59d-45ec-bf73-d378a719c91a
+      - req-5c0d7ed5-cb4a-4500-9a5b-e64819d2868c
       Date:
-      - Thu, 03 Jan 2019 19:24:56 GMT
+      - Fri, 04 Jan 2019 16:58:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": [{"status": "SHUTOFF", "updated": "2018-01-17T14:49:17Z",
@@ -2078,7 +2078,7 @@ http_interactions:
         "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:56 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:39 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack2/4cf24b12-29fc-4529-a8ed-6b079dea7c17/template
@@ -2093,7 +2093,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 14fb0884cc25472e947e6629b2cc1aaa
+      - cbe0fe7131ad43ab9559ae4b105ead85
   response:
     status:
       code: 200
@@ -2104,9 +2104,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-a5d0d115-93ec-4d0f-b70f-1856d3d1e46a
+      - req-8faa5427-227d-400f-9ca5-86de00108941
       Date:
-      - Thu, 03 Jan 2019 19:24:56 GMT
+      - Fri, 04 Jan 2019 16:58:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -2162,7 +2162,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:56 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:39 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack2/4cf24b12-29fc-4529-a8ed-6b079dea7c17/resources
@@ -2177,7 +2177,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 14fb0884cc25472e947e6629b2cc1aaa
+      - cbe0fe7131ad43ab9559ae4b105ead85
   response:
     status:
       code: 200
@@ -2188,9 +2188,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-af7eca7e-e679-4d5c-92b9-641d205c1cc8
+      - req-1644b6be-0300-49c3-bd19-43549e476d15
       Date:
-      - Thu, 03 Jan 2019 19:24:56 GMT
+      - Fri, 04 Jan 2019 16:58:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -2202,7 +2202,7 @@ http_interactions:
         changed", "physical_resource_id": "219a737c-b4ad-430d-944a-a92a4834b12d",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:56 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:39 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c/template
@@ -2217,7 +2217,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 14fb0884cc25472e947e6629b2cc1aaa
+      - cbe0fe7131ad43ab9559ae4b105ead85
   response:
     status:
       code: 200
@@ -2228,9 +2228,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-088dc75b-eb64-44c6-aeed-c1fe001ecf81
+      - req-9d3268b3-9286-46e4-8216-b91d47e966fa
       Date:
-      - Thu, 03 Jan 2019 19:24:56 GMT
+      - Fri, 04 Jan 2019 16:58:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -2286,7 +2286,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:56 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:39 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c/resources
@@ -2301,7 +2301,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 14fb0884cc25472e947e6629b2cc1aaa
+      - cbe0fe7131ad43ab9559ae4b105ead85
   response:
     status:
       code: 200
@@ -2312,9 +2312,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-833a06ac-bc82-406f-b478-faa5417b6828
+      - req-1fef4084-2be2-410e-a64b-295e33f9149a
       Date:
-      - Thu, 03 Jan 2019 19:24:56 GMT
+      - Fri, 04 Jan 2019 16:58:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -2326,7 +2326,7 @@ http_interactions:
         changed", "physical_resource_id": "b686353f-0da0-48bf-bc35-8ea411a67dfd",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:56 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:39 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -2344,13 +2344,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:24:56 GMT
+      - Fri, 04 Jan 2019 16:58:39 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-a8997896-c77b-461c-a936-957bc6282adb
+      - req-b6f39604-9bd2-401d-b7af-4c3c81213acd
       Content-Length:
       - '4117'
       Connection:
@@ -2359,10 +2359,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:24:56.863017", "expires":
-        "2019-01-03T20:24:56Z", "id": "cc504228f2b54cd18ef3565bd497ae3a", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:58:39.858317", "expires":
+        "2019-01-04T17:58:39Z", "id": "64f9b4f966e24f9a8191d2ead8f39751", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["oNXmOawCQ5eM0SHIQTFKGA"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["kz-qfJQ1Rk-3juszrhoEag"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -2406,7 +2406,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:56 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:39 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -2421,7 +2421,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cc504228f2b54cd18ef3565bd497ae3a
+      - 64f9b4f966e24f9a8191d2ead8f39751
   response:
     status:
       code: 200
@@ -2432,7 +2432,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Thu, 03 Jan 2019 19:24:56 GMT
+      - Fri, 04 Jan 2019 16:58:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -2441,7 +2441,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:56 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:39 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -2459,13 +2459,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:24:57 GMT
+      - Fri, 04 Jan 2019 16:58:40 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-aca90944-3393-45da-a371-507dd08aabf0
+      - req-b2326600-27a7-410c-9710-057986f2aa08
       Content-Length:
       - '4131'
       Connection:
@@ -2474,10 +2474,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:24:57.142592", "expires":
-        "2019-01-03T20:24:57Z", "id": "edc460bbd6bd4666b8e61aefa0517875", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:58:40.136758", "expires":
+        "2019-01-04T17:58:40Z", "id": "2e6eae2b5f66441aa3a0223b742f8957", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["INExaStPQQyfDLe25rmh4g"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["2oebpkPnQ9yOjz6MpZiO0g"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -2521,7 +2521,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:57 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:40 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -2536,7 +2536,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - edc460bbd6bd4666b8e61aefa0517875
+      - 2e6eae2b5f66441aa3a0223b742f8957
   response:
     status:
       code: 200
@@ -2547,7 +2547,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Thu, 03 Jan 2019 19:24:57 GMT
+      - Fri, 04 Jan 2019 16:58:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -2556,7 +2556,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:57 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:40 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -2574,13 +2574,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:24:57 GMT
+      - Fri, 04 Jan 2019 16:58:40 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-100aa7b2-6c86-4d66-8b80-5e53044647a3
+      - req-66ad95fa-f246-4bb3-8bb1-ccd2c3778a4c
       Content-Length:
       - '4118'
       Connection:
@@ -2589,10 +2589,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:24:57.414609", "expires":
-        "2019-01-03T20:24:57Z", "id": "9a6c77d715f04814beb8090563b515aa", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:58:40.409741", "expires":
+        "2019-01-04T17:58:40Z", "id": "4b77ade8728e452a9ff1325222bef256", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["TyiP3MbKSoGgs1Gv92Hu9w"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["tApWiJ0pQE-cxGD9AmQ97w"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -2636,7 +2636,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:57 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:40 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -2651,7 +2651,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9a6c77d715f04814beb8090563b515aa
+      - 4b77ade8728e452a9ff1325222bef256
   response:
     status:
       code: 200
@@ -2662,7 +2662,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Thu, 03 Jan 2019 19:24:57 GMT
+      - Fri, 04 Jan 2019 16:58:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -2671,7 +2671,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:57 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:40 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a//os-quota-sets/69f8f7205ade4aa59084c32c83e60b5a
@@ -2686,7 +2686,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cc504228f2b54cd18ef3565bd497ae3a
+      - 64f9b4f966e24f9a8191d2ead8f39751
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2699,9 +2699,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-26ae56b3-0b05-4832-9e05-bade3bf80a66
+      - req-c8c2af79-2f1a-4f23-8725-905b0a8127fa
       Date:
-      - Thu, 03 Jan 2019 19:24:57 GMT
+      - Fri, 04 Jan 2019 16:58:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -2710,7 +2710,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:57 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:40 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8//os-quota-sets/b458a5c25c3749758f4c0661940b3ba8
@@ -2725,7 +2725,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - edc460bbd6bd4666b8e61aefa0517875
+      - 2e6eae2b5f66441aa3a0223b742f8957
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2738,9 +2738,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-1dad7723-f1fb-45f9-9e6c-fd828c4ce042
+      - req-72ecdd46-e56c-4459-9c76-38d32b3435cc
       Date:
-      - Thu, 03 Jan 2019 19:24:57 GMT
+      - Fri, 04 Jan 2019 16:58:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -2749,7 +2749,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:57 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:40 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a//os-quota-sets/e54e5c3c19e34720b05661f2ea1ea00a
@@ -2764,7 +2764,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9b5f200f76804d219b5b0536a6a565b8
+      - 8c6415af41b54322a94c3692fa0be73f
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2777,9 +2777,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-d9b010d0-dc25-4d5f-8f22-7bae242a1e4d
+      - req-a7679069-d3c8-4e49-b0f5-cfd933c0110f
       Date:
-      - Thu, 03 Jan 2019 19:24:57 GMT
+      - Fri, 04 Jan 2019 16:58:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -2788,7 +2788,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:57 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:40 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608//os-quota-sets/e8f744b1fc6a487681d35fb275252608
@@ -2803,7 +2803,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9a6c77d715f04814beb8090563b515aa
+      - 4b77ade8728e452a9ff1325222bef256
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2816,9 +2816,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-c1cad4c0-0702-4c95-95a9-f9c94f5138cb
+      - req-4d103bec-fc59-48f9-a5f6-2ae34d27b825
       Date:
-      - Thu, 03 Jan 2019 19:24:58 GMT
+      - Fri, 04 Jan 2019 16:58:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -2827,7 +2827,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:58 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:41 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -2845,13 +2845,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:24:58 GMT
+      - Fri, 04 Jan 2019 16:58:41 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-78417d93-dba2-49f6-90ae-7804bd4bfae5
+      - req-27eeb21b-00ec-4b77-9a15-3f08c3ec0c74
       Content-Length:
       - '4117'
       Connection:
@@ -2860,10 +2860,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:24:58.267778", "expires":
-        "2019-01-03T20:24:58Z", "id": "91049a2e17f4454ba5fedd20ca6982f7", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:58:41.276804", "expires":
+        "2019-01-04T17:58:41Z", "id": "92fcaaeb96554837a529d227733b4209", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["DCT99WfjSii0CPUgFyLndA"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["R-SnWcxeTz6RKIzt6e0SpA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -2907,7 +2907,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:58 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:41 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -2925,13 +2925,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:24:58 GMT
+      - Fri, 04 Jan 2019 16:58:41 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-0991b089-7649-450f-8915-702c164d54dd
+      - req-3c0f6d90-9092-46e2-847a-36df25f0da4e
       Content-Length:
       - '4131'
       Connection:
@@ -2940,10 +2940,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:24:58.452287", "expires":
-        "2019-01-03T20:24:58Z", "id": "7cfc4b12da6a42f48a313d2d5cf50597", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:58:41.468668", "expires":
+        "2019-01-04T17:58:41Z", "id": "0a6a159b357b4aa1ab637e5c848ac4de", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["O_Sh9skHSmaWeaW8FYRICA"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["TlLkH70JRIeaL7VE19Bddg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -2987,7 +2987,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:58 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:41 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -3005,13 +3005,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:24:58 GMT
+      - Fri, 04 Jan 2019 16:58:41 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-8cd6548d-6b32-4d76-af4c-e68417aea915
+      - req-bc290ef2-ced2-4c9f-90be-c27a90ca7798
       Content-Length:
       - '4118'
       Connection:
@@ -3020,10 +3020,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:24:58.649242", "expires":
-        "2019-01-03T20:24:58Z", "id": "bdcf2517ccfb49979f78b646abada3e3", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:58:41.656205", "expires":
+        "2019-01-04T17:58:41Z", "id": "7a3be9cc01b84abe94224f25aa3f049f", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["tEoGNI0yRO2pU5G6vPLIgQ"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["ceFj8PNsTHGRAtBSSPWeUQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -3067,7 +3067,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:58 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:41 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a//os-quota-sets/69f8f7205ade4aa59084c32c83e60b5a
@@ -3082,22 +3082,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 91049a2e17f4454ba5fedd20ca6982f7
+      - 92fcaaeb96554837a529d227733b4209
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-281dccdb-e10f-4df2-828c-492dc16e9466
+      - req-d45cb992-cfa6-477e-9cf0-66f1703733b7
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-281dccdb-e10f-4df2-828c-492dc16e9466
+      - req-d45cb992-cfa6-477e-9cf0-66f1703733b7
       Date:
-      - Thu, 03 Jan 2019 19:24:58 GMT
+      - Fri, 04 Jan 2019 16:58:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -3107,7 +3107,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "69f8f7205ade4aa59084c32c83e60b5a"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:58 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:41 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8//os-quota-sets/b458a5c25c3749758f4c0661940b3ba8
@@ -3122,22 +3122,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7cfc4b12da6a42f48a313d2d5cf50597
+      - 0a6a159b357b4aa1ab637e5c848ac4de
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-f6f2e915-b922-4599-9d0d-af54adacb9b6
+      - req-bc6f9db7-7508-4c1e-8743-ea73158f6b88
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-f6f2e915-b922-4599-9d0d-af54adacb9b6
+      - req-bc6f9db7-7508-4c1e-8743-ea73158f6b88
       Date:
-      - Thu, 03 Jan 2019 19:24:59 GMT
+      - Fri, 04 Jan 2019 16:58:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -3147,7 +3147,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "b458a5c25c3749758f4c0661940b3ba8"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:59 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:42 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a//os-quota-sets/e54e5c3c19e34720b05661f2ea1ea00a
@@ -3162,22 +3162,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 577b5d80c48d4aaab2fca6cf735de7be
+      - 0c0bd64dc23542379847ee56e26f0b04
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-39b6016f-2f4a-4ec6-af94-440a4e60e35e
+      - req-f0b34d69-b573-41fa-9af6-9d6acf0fdf3f
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-39b6016f-2f4a-4ec6-af94-440a4e60e35e
+      - req-f0b34d69-b573-41fa-9af6-9d6acf0fdf3f
       Date:
-      - Thu, 03 Jan 2019 19:24:59 GMT
+      - Fri, 04 Jan 2019 16:58:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -3187,7 +3187,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "e54e5c3c19e34720b05661f2ea1ea00a"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:59 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:42 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608//os-quota-sets/e8f744b1fc6a487681d35fb275252608
@@ -3202,22 +3202,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bdcf2517ccfb49979f78b646abada3e3
+      - 7a3be9cc01b84abe94224f25aa3f049f
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-e214615e-6d0f-459a-873e-2bc90a33a96f
+      - req-dd93aded-4678-45cd-97b3-99286119efb2
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-e214615e-6d0f-459a-873e-2bc90a33a96f
+      - req-dd93aded-4678-45cd-97b3-99286119efb2
       Date:
-      - Thu, 03 Jan 2019 19:24:59 GMT
+      - Fri, 04 Jan 2019 16:58:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -3227,7 +3227,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "e8f744b1fc6a487681d35fb275252608"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:24:59 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:42 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -3245,13 +3245,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:24:59 GMT
+      - Fri, 04 Jan 2019 16:58:43 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-d51838b3-86e1-4da7-aab3-fce444966186
+      - req-11a20b2f-0f4e-48df-a287-ea2aad9f83bf
       Content-Length:
       - '4170'
       Connection:
@@ -3260,10 +3260,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:24:59.976428", "expires":
-        "2019-01-03T20:24:59Z", "id": "c4151e45c4194c09ba34d7c7e8951a6a", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:58:43.078448", "expires":
+        "2019-01-04T17:58:43Z", "id": "b4f63c4e68b74aa78e7ffdca366f0c04", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["8EkVwyHeS-KRVVe7-C2fmw"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["ekt3gUrNQ5Cm8usPxkv1fw"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -3308,7 +3308,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:00 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:43 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -3326,13 +3326,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:25:00 GMT
+      - Fri, 04 Jan 2019 16:58:43 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-edf4ed78-53ad-4823-ab63-cc8456b40e02
+      - req-ceae25e9-7165-4e0b-9dd0-d404cc7eee30
       Content-Length:
       - '4117'
       Connection:
@@ -3341,10 +3341,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:25:00.168803", "expires":
-        "2019-01-03T20:25:00Z", "id": "e2f46462411d4ea594300d808dff72ab", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:58:43.262596", "expires":
+        "2019-01-04T17:58:43Z", "id": "4f11968b66b74dc7af05d08b26144b01", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["-87KdiigRMeFSkApRzCk3A"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["FKJHQqzLQ2GrO1o3C0-o-g"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -3388,7 +3388,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:00 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:43 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -3406,13 +3406,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:25:00 GMT
+      - Fri, 04 Jan 2019 16:58:43 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-e1213870-8d2e-4a2c-8fb5-72f53ebf0309
+      - req-ea564e43-50d5-4eeb-b0b3-7e36ab0f3338
       Content-Length:
       - '4131'
       Connection:
@@ -3421,10 +3421,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:25:00.366001", "expires":
-        "2019-01-03T20:25:00Z", "id": "deb4b3994d744cbd80813d4838e6f396", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:58:43.457819", "expires":
+        "2019-01-04T17:58:43Z", "id": "bda1353ee82347b9b6fae689c43df547", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["MsXV6qtCSda3nNNPaA-3hg"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["DOiOOfjRRfao14lPSfIiHg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -3468,7 +3468,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:00 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:43 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -3486,13 +3486,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:25:00 GMT
+      - Fri, 04 Jan 2019 16:58:43 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-292827b7-7d38-41f3-976a-6a202563957e
+      - req-1ded16ed-fdf6-4b8d-ae66-4668d6f2a42f
       Content-Length:
       - '4118'
       Connection:
@@ -3501,10 +3501,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:25:00.563703", "expires":
-        "2019-01-03T20:25:00Z", "id": "744d29a4630d482cb3f6a1575d8e150e", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:58:43.651236", "expires":
+        "2019-01-04T17:58:43Z", "id": "63f857d43381443e9009383a19ae2748", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["6vwNAkHISReAgqA2X5bmSA"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["LGjkBMUOQIiu9BvuP5Ep4w"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -3548,7 +3548,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:00 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:43 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0//quotas/69f8f7205ade4aa59084c32c83e60b5a
@@ -3563,7 +3563,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e2f46462411d4ea594300d808dff72ab
+      - 4f11968b66b74dc7af05d08b26144b01
   response:
     status:
       code: 200
@@ -3574,16 +3574,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-f902e2a7-5c7d-4e8f-8645-64ea585aa3d6
+      - req-eeb8eafa-3f2a-4f63-b218-4a987ca9b21e
       Date:
-      - Thu, 03 Jan 2019 19:25:00 GMT
+      - Fri, 04 Jan 2019 16:58:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 20, "network": 20, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:00 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:43 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0//quotas/b458a5c25c3749758f4c0661940b3ba8
@@ -3598,7 +3598,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - deb4b3994d744cbd80813d4838e6f396
+      - bda1353ee82347b9b6fae689c43df547
   response:
     status:
       code: 200
@@ -3609,16 +3609,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-57dffe30-4926-4f8e-9394-434e756fe748
+      - req-0756c767-6377-4566-af55-6b72cfae8585
       Date:
-      - Thu, 03 Jan 2019 19:25:00 GMT
+      - Fri, 04 Jan 2019 16:58:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:00 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:43 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0//quotas/e54e5c3c19e34720b05661f2ea1ea00a
@@ -3633,7 +3633,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c4151e45c4194c09ba34d7c7e8951a6a
+      - b4f63c4e68b74aa78e7ffdca366f0c04
   response:
     status:
       code: 200
@@ -3644,16 +3644,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-cbb3e845-c3b2-40ee-be7f-be2ab80b04c0
+      - req-d7346b9e-61db-4653-b22a-828696f8595e
       Date:
-      - Thu, 03 Jan 2019 19:25:01 GMT
+      - Fri, 04 Jan 2019 16:58:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:01 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:44 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0//quotas/e8f744b1fc6a487681d35fb275252608
@@ -3668,7 +3668,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 744d29a4630d482cb3f6a1575d8e150e
+      - 63f857d43381443e9009383a19ae2748
   response:
     status:
       code: 200
@@ -3679,16 +3679,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-8b13964b-c411-40f9-9f55-d5b9d33d33e9
+      - req-91bc3f30-6eb8-4516-bb5a-f4baa279fcbc
       Date:
-      - Thu, 03 Jan 2019 19:25:01 GMT
+      - Fri, 04 Jan 2019 16:58:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:01 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:44 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/4bb36934-fd61-4a19-ab9d-28fbbda0c7f0/os-volume_attachments
@@ -3703,7 +3703,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9b5f200f76804d219b5b0536a6a565b8
+      - 8c6415af41b54322a94c3692fa0be73f
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3716,15 +3716,15 @@ http_interactions:
       Content-Length:
       - '197'
       X-Compute-Request-Id:
-      - req-92510308-f6e9-4a95-b0ba-a5b24ad2a6cf
+      - req-c198e9b1-22bd-419c-b2b8-5287139ca27f
       Date:
-      - Thu, 03 Jan 2019 19:25:01 GMT
+      - Fri, 04 Jan 2019 16:58:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumeAttachments": [{"device": "/dev/vda", "serverId": "4bb36934-fd61-4a19-ab9d-28fbbda0c7f0",
         "id": "b124469d-a857-4b39-abe9-d0e63985f834", "volumeId": "b124469d-a857-4b39-abe9-d0e63985f834"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:01 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:44 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/ca4f3a16-bae3-4407-83e9-f77b28af0f2b/os-volume_attachments
@@ -3739,7 +3739,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9b5f200f76804d219b5b0536a6a565b8
+      - 8c6415af41b54322a94c3692fa0be73f
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3752,15 +3752,15 @@ http_interactions:
       Content-Length:
       - '197'
       X-Compute-Request-Id:
-      - req-040fbb22-322e-4d75-8d93-2992c036306b
+      - req-4729f2ae-8afc-4869-abc1-3e192eaad665
       Date:
-      - Thu, 03 Jan 2019 19:25:01 GMT
+      - Fri, 04 Jan 2019 16:58:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumeAttachments": [{"device": "/dev/vdd", "serverId": "ca4f3a16-bae3-4407-83e9-f77b28af0f2b",
         "id": "0a55c0d5-c780-4e7d-9d09-47f5520c7448", "volumeId": "0a55c0d5-c780-4e7d-9d09-47f5520c7448"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:01 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:44 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -3778,13 +3778,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:25:01 GMT
+      - Fri, 04 Jan 2019 16:58:44 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-2097a5a7-b241-4563-9d3c-7a34177ce6fd
+      - req-24660a37-1050-4349-836f-a5ba1b2ba8e4
       Content-Length:
       - '4170'
       Connection:
@@ -3793,10 +3793,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:25:01.652309", "expires":
-        "2019-01-03T20:25:01Z", "id": "2eadf69d182d4aa28e00d5d3170d28f6", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:58:44.762653", "expires":
+        "2019-01-04T17:58:44Z", "id": "f65efac3c2304569af347db0528fbb99", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["9MiYOIGuSKmhwUi68ajGjA"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["zk6g72pMTUi9vGuR3LZ6Mw"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -3841,7 +3841,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:01 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:44 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -3859,13 +3859,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:25:01 GMT
+      - Fri, 04 Jan 2019 16:58:44 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-2040a689-d9f1-47eb-ad1c-4b330b3e71e7
+      - req-353e5ce8-daab-4230-86c2-3ab7b3c9dfa2
       Content-Length:
       - '4170'
       Connection:
@@ -3874,10 +3874,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:25:01.854401", "expires":
-        "2019-01-03T20:25:01Z", "id": "39f59230809541aca0432d942e7368db", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:58:44.951980", "expires":
+        "2019-01-04T17:58:44Z", "id": "539ed077ced44aa3b215d364e4ee15fd", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["btK8rUbhSjefle8ujydjhA"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["S3Au9r1CSF2jBwg2h1q2aw"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -3922,7 +3922,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:01 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:44 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-aggregates
@@ -3937,7 +3937,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9b5f200f76804d219b5b0536a6a565b8
+      - 8c6415af41b54322a94c3692fa0be73f
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3950,14 +3950,14 @@ http_interactions:
       Content-Length:
       - '18'
       X-Compute-Request-Id:
-      - req-e33f1387-6153-4b99-af15-f9436a0e0f18
+      - req-f563383b-bacb-482b-b8d1-d2a6c61ce01d
       Date:
-      - Thu, 03 Jan 2019 19:25:01 GMT
+      - Fri, 04 Jan 2019 16:58:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"aggregates": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:01 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:45 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/volumes/detail?all_tenants=True&limit=1000&status=available
@@ -3972,22 +3972,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 577b5d80c48d4aaab2fca6cf735de7be
+      - 0c0bd64dc23542379847ee56e26f0b04
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-fc7f61fe-c25a-4e24-b087-81edbff587da
+      - req-35f8da7a-782a-4e73-9dd2-ba120f340a9d
       Content-Type:
       - application/json
       Content-Length:
       - '2740'
       X-Openstack-Request-Id:
-      - req-fc7f61fe-c25a-4e24-b087-81edbff587da
+      - req-35f8da7a-782a-4e73-9dd2-ba120f340a9d
       Date:
-      - Thu, 03 Jan 2019 19:25:02 GMT
+      - Fri, 04 Jan 2019 16:58:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/volumes/detail?all_tenants=True&limit=1000&status=available&marker=9bb99818-b339-4e31-b87f-e4181ec48acd",
@@ -4020,7 +4020,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-4", "bootable": "true", "created_at":
         "2016-11-11T13:49:53.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:02 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:45 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/volumes/detail?all_tenants=True&limit=1000&marker=9bb99818-b339-4e31-b87f-e4181ec48acd&status=available
@@ -4035,22 +4035,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 577b5d80c48d4aaab2fca6cf735de7be
+      - 0c0bd64dc23542379847ee56e26f0b04
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-0edfe755-dd53-4e7e-be0b-39d38c0eb69b
+      - req-4ff5f642-a04e-4614-95a0-24f072178914
       Content-Type:
       - application/json
       Content-Length:
       - '1180'
       X-Openstack-Request-Id:
-      - req-0edfe755-dd53-4e7e-be0b-39d38c0eb69b
+      - req-4ff5f642-a04e-4614-95a0-24f072178914
       Date:
-      - Thu, 03 Jan 2019 19:25:02 GMT
+      - Fri, 04 Jan 2019 16:58:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": [{"migration_status": null, "attachments": [], "links":
@@ -4067,7 +4067,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-FromSnapshot", "bootable": "false", "created_at":
         "2016-11-11T13:49:26.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:02 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:45 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/snapshots/detail
@@ -4082,27 +4082,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 577b5d80c48d4aaab2fca6cf735de7be
+      - 0c0bd64dc23542379847ee56e26f0b04
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-ad29a6ca-92bc-4a4c-a482-4ce57e7f4f8e
+      - req-83b29936-32b7-4a65-9cc9-eac728673b2d
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-ad29a6ca-92bc-4a4c-a482-4ce57e7f4f8e
+      - req-83b29936-32b7-4a65-9cc9-eac728673b2d
       Date:
-      - Thu, 03 Jan 2019 19:25:02 GMT
+      - Fri, 04 Jan 2019 16:58:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:02 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:45 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/snapshots/detail?all_tenants=True&limit=1000&status=available
@@ -4117,22 +4117,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 577b5d80c48d4aaab2fca6cf735de7be
+      - 0c0bd64dc23542379847ee56e26f0b04
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-4b5d9e19-ff71-473b-a125-ff60b89989d9
+      - req-73650d79-4b19-43fa-a374-b087f7dd7fdb
       Content-Type:
       - application/json
       Content-Length:
       - '1098'
       X-Openstack-Request-Id:
-      - req-4b5d9e19-ff71-473b-a125-ff60b89989d9
+      - req-73650d79-4b19-43fa-a374-b087f7dd7fdb
       Date:
-      - Thu, 03 Jan 2019 19:25:02 GMT
+      - Fri, 04 Jan 2019 16:58:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/snapshots/detail?all_tenants=True&limit=1000&status=available&marker=76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
@@ -4147,7 +4147,7 @@ http_interactions:
         "created_at": "2016-11-11T13:49:36.000000", "size": 1, "id": "76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:02 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:45 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/volumes/detail?all_tenants=True&limit=1000
@@ -4162,22 +4162,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 577b5d80c48d4aaab2fca6cf735de7be
+      - 0c0bd64dc23542379847ee56e26f0b04
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-6bb4dafc-038d-4419-9b18-7207bf497a92
+      - req-9ce3eca4-16f4-4be8-8016-00c0bc49773a
       Content-Type:
       - application/json
       Content-Length:
       - '2723'
       X-Openstack-Request-Id:
-      - req-6bb4dafc-038d-4419-9b18-7207bf497a92
+      - req-9ce3eca4-16f4-4be8-8016-00c0bc49773a
       Date:
-      - Thu, 03 Jan 2019 19:25:02 GMT
+      - Fri, 04 Jan 2019 16:58:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/volumes/detail?all_tenants=True&limit=1000&marker=9bb99818-b339-4e31-b87f-e4181ec48acd",
@@ -4210,7 +4210,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-4", "bootable": "true", "created_at":
         "2016-11-11T13:49:53.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:02 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:45 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/volumes/detail?all_tenants=True&limit=1000&marker=9bb99818-b339-4e31-b87f-e4181ec48acd
@@ -4225,22 +4225,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 577b5d80c48d4aaab2fca6cf735de7be
+      - 0c0bd64dc23542379847ee56e26f0b04
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-3a589c9d-dcdc-4432-a153-6102e5164860
+      - req-48ffaef0-88e4-4bc8-b1d8-c11a5761f833
       Content-Type:
       - application/json
       Content-Length:
       - '3301'
       X-Openstack-Request-Id:
-      - req-3a589c9d-dcdc-4432-a153-6102e5164860
+      - req-48ffaef0-88e4-4bc8-b1d8-c11a5761f833
       Date:
-      - Thu, 03 Jan 2019 19:25:02 GMT
+      - Fri, 04 Jan 2019 16:58:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/volumes/detail?all_tenants=True&limit=1000&marker=2c774148-c11a-434c-aabb-7fa9c82c37ce",
@@ -4281,7 +4281,7 @@ http_interactions:
         "name": "EmsRefreshSpec-Volume-2", "bootable": "false", "created_at": "2016-11-11T13:49:43.000000",
         "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:02 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:45 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/volumes/detail?all_tenants=True&limit=1000&marker=2c774148-c11a-434c-aabb-7fa9c82c37ce
@@ -4296,22 +4296,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 577b5d80c48d4aaab2fca6cf735de7be
+      - 0c0bd64dc23542379847ee56e26f0b04
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-807a2b8c-75b7-462e-ab8f-693f3a11bc8e
+      - req-5d0d2dcb-12e3-425b-82b5-65f34b99c30e
       Content-Type:
       - application/json
       Content-Length:
       - '2770'
       X-Openstack-Request-Id:
-      - req-807a2b8c-75b7-462e-ab8f-693f3a11bc8e
+      - req-5d0d2dcb-12e3-425b-82b5-65f34b99c30e
       Date:
-      - Thu, 03 Jan 2019 19:25:02 GMT
+      - Fri, 04 Jan 2019 16:58:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/volumes/detail?all_tenants=True&limit=1000&marker=0a55c0d5-c780-4e7d-9d09-47f5520c7448",
@@ -4345,7 +4345,7 @@ http_interactions:
         "bootable": "false", "created_at": "2016-11-11T13:49:20.000000", "volume_type":
         "iscsi"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:03 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:46 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/volumes/detail?all_tenants=True&limit=1000&marker=0a55c0d5-c780-4e7d-9d09-47f5520c7448
@@ -4360,27 +4360,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 577b5d80c48d4aaab2fca6cf735de7be
+      - 0c0bd64dc23542379847ee56e26f0b04
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-23020550-a5ad-46a7-951b-36c9b56b1c5c
+      - req-6269e11b-1151-4938-a86b-6b3952208598
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-23020550-a5ad-46a7-951b-36c9b56b1c5c
+      - req-6269e11b-1151-4938-a86b-6b3952208598
       Date:
-      - Thu, 03 Jan 2019 19:25:03 GMT
+      - Fri, 04 Jan 2019 16:58:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:03 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:46 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4398,13 +4398,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:25:04 GMT
+      - Fri, 04 Jan 2019 16:58:47 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-54b50a2c-bff1-4da9-a79b-8b08d4c4d29a
+      - req-62c8ac55-4aed-40e1-ab00-ea710ab01dca
       Content-Length:
       - '4170'
       Connection:
@@ -4413,10 +4413,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:25:04.433182", "expires":
-        "2019-01-03T20:25:04Z", "id": "6cbf1fe38c4448ed9c0349c7d717bdc1", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:58:47.428793", "expires":
+        "2019-01-04T17:58:47Z", "id": "33b91785aee24707b13ff92be9fb2b80", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["59KN_YVdRwi4ZHm69tVz9g"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["KepuSPdYQr2mYwB3rVyMpw"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -4461,7 +4461,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:04 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:47 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4479,13 +4479,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:25:04 GMT
+      - Fri, 04 Jan 2019 16:58:47 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-3b8b1580-04c0-4ab6-85e0-e31c49d28d99
+      - req-64d49539-d682-4351-861f-536ce810344f
       Content-Length:
       - '4170'
       Connection:
@@ -4494,10 +4494,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:25:04.630480", "expires":
-        "2019-01-03T20:25:04Z", "id": "5e991131873d4f658a0604fd1dd269ad", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:58:47.617603", "expires":
+        "2019-01-04T17:58:47Z", "id": "ace7f7ecede64cc2ad7fd7e8566f4e06", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["5B0FrehGTNSsREdslhvbjw"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["IcHr_KeCTZuxCiKrO4NhPQ"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -4542,7 +4542,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:04 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:47 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/networks
@@ -4557,7 +4557,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5e991131873d4f658a0604fd1dd269ad
+      - ace7f7ecede64cc2ad7fd7e8566f4e06
   response:
     status:
       code: 200
@@ -4568,17 +4568,12 @@ http_interactions:
       Content-Length:
       - '5330'
       X-Openstack-Request-Id:
-      - req-29681807-cc7f-4e09-9c0d-6456583663ea
+      - req-1ad2b6ab-7db5-432f-a106-ab4e1b619de4
       Date:
-      - Thu, 03 Jan 2019 19:25:04 GMT
+      - Fri, 04 Jan 2019 16:58:47 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"networks": [{"status": "ACTIVE", "subnets": ["bb23bb48-804d-4416-bac3-231db23841e8"],
-        "name": "EmsRefreshSpec-NetworkPrivate_2", "provider:physical_network": null,
-        "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
-        0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
-        "id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "provider:segmentation_id":
-        53}, {"status": "ACTIVE", "subnets": ["841b5584-f86f-4abd-9bc2-f445b8bc860b",
+      string: '{"networks": [{"status": "ACTIVE", "subnets": ["841b5584-f86f-4abd-9bc2-f445b8bc860b",
         "39628ee0-d5ff-4a88-ae66-80442e5feefd"], "name": "EmsRefreshSpec-NetworkPrivate_30",
         "provider:physical_network": null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
@@ -4633,14 +4628,19 @@ http_interactions:
         null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
         "vxlan", "id": "560b4210-2b5a-4439-8d24-203e09478f48", "provider:segmentation_id":
-        54}, {"status": "ACTIVE", "subnets": ["104c081f-97dd-42b7-8930-98abbd015c74",
+        54}, {"status": "ACTIVE", "subnets": ["bb23bb48-804d-4416-bac3-231db23841e8"],
+        "name": "EmsRefreshSpec-NetworkPrivate_2", "provider:physical_network": null,
+        "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
+        0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
+        "id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "provider:segmentation_id":
+        53}, {"status": "ACTIVE", "subnets": ["104c081f-97dd-42b7-8930-98abbd015c74",
         "d53802a5-f0f6-48ba-9207-dbd9b13acac3"], "name": "EmsRefreshSpec-NetworkPrivate",
         "provider:physical_network": null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
         "vxlan", "id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "provider:segmentation_id":
         14}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:04 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:47 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4658,13 +4658,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:25:04 GMT
+      - Fri, 04 Jan 2019 16:58:47 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-ec0f6472-8655-4c88-a968-70db28a127a7
+      - req-df389851-381e-4d47-ad74-9b48f8b19c60
       Content-Length:
       - '4170'
       Connection:
@@ -4673,10 +4673,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:25:05.017095", "expires":
-        "2019-01-03T20:25:04Z", "id": "7797882ca58140fa90546a8f5587fc42", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:58:48.022635", "expires":
+        "2019-01-04T17:58:48Z", "id": "52b6278e537b4d01a454424f18cb6e67", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["ZYJXWYJgSTeYiTIUTTFqFA"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["k0phmXNoQaKIzdjbRfhaxg"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -4721,7 +4721,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:05 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:48 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4739,13 +4739,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:25:05 GMT
+      - Fri, 04 Jan 2019 16:58:48 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-3195997e-821d-44c9-b6a2-df5a8b8f0e4a
+      - req-02836a27-72e5-46c4-be4a-e5b87e00a49f
       Content-Length:
       - '370'
       Connection:
@@ -4754,13 +4754,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:25:05.189818", "expires":
-        "2019-01-03T20:25:05Z", "id": "38e6babe3f92434abcd0bc34d5167160", "audit_ids":
-        ["ijEebUg1RaOFiuWk3B4bQw"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:58:48.206286", "expires":
+        "2019-01-04T17:58:48Z", "id": "51f17535dae341d99ac1e0e10aa79c1c", "audit_ids":
+        ["AmwLlRlJSty1X5PhogOUZw"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:05 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:48 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -4775,20 +4775,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 38e6babe3f92434abcd0bc34d5167160
+      - 51f17535dae341d99ac1e0e10aa79c1c
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:25:05 GMT
+      - Fri, 04 Jan 2019 16:58:48 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-2da8b9e1-108c-4c8f-a9cc-84421cc9c1b7
+      - req-045d32b7-4dcf-4acf-a3bf-7b3212de04f7
       Content-Length:
       - '500'
       Connection:
@@ -4805,7 +4805,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:05 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:48 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4823,13 +4823,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:25:05 GMT
+      - Fri, 04 Jan 2019 16:58:48 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-522c5fcd-371e-46ac-a6e1-0c1a54e30f3f
+      - req-72bc35de-7624-47ab-8524-78df0db8a8c1
       Content-Length:
       - '4117'
       Connection:
@@ -4838,10 +4838,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:25:05.549301", "expires":
-        "2019-01-03T20:25:05Z", "id": "9b569ea76e2a4b8d99bbcb684d62caee", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:58:48.529456", "expires":
+        "2019-01-04T17:58:48Z", "id": "513d20adb26a42b89a05488cebcc5acf", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["kmJpaBsYTUu302-HtxcFzQ"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["lNh0mCCvS9GcA3OvFr6Zww"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -4885,7 +4885,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:05 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:48 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4903,13 +4903,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:25:05 GMT
+      - Fri, 04 Jan 2019 16:58:48 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-4b077db3-7b15-4afe-9961-ca4424f7e8ac
+      - req-fb33e736-274c-4173-b2f0-48c158d50175
       Content-Length:
       - '4131'
       Connection:
@@ -4918,10 +4918,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:25:05.736880", "expires":
-        "2019-01-03T20:25:05Z", "id": "a336bc2836c74abdb1ba0e3e4890ee10", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:58:48.720001", "expires":
+        "2019-01-04T17:58:48Z", "id": "a46e64ada48743a3bff91232bb792b15", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["q9F_AjTOQjqzAbB9-sN2Sg"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["ATMg_7ZzRvqBmjqLLu7xcg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -4965,7 +4965,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:05 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:48 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4983,13 +4983,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:25:05 GMT
+      - Fri, 04 Jan 2019 16:58:48 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-c7c74b6d-3a7b-4c7a-aebb-c20a2ecc911f
+      - req-98971620-27ec-4098-a411-96db7b91a5d4
       Content-Length:
       - '4118'
       Connection:
@@ -4998,10 +4998,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:25:05.919286", "expires":
-        "2019-01-03T20:25:05Z", "id": "a4da268d82c44ccd93dfc90ac1ad598b", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:58:48.908410", "expires":
+        "2019-01-04T17:58:48Z", "id": "1c18b144f6964e1ba1c2695bee4b712a", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["JIAHSO_bToOS_UYaxmK-2w"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["AYPp273YQcyrP8lYQO9zlw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -5045,7 +5045,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:05 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:48 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks?limit=1000&show_nested=true
@@ -5060,7 +5060,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9b569ea76e2a4b8d99bbcb684d62caee
+      - 513d20adb26a42b89a05488cebcc5acf
   response:
     status:
       code: 200
@@ -5071,9 +5071,9 @@ http_interactions:
       Content-Length:
       - '2559'
       X-Openstack-Request-Id:
-      - req-077f898e-f88a-4507-8c5c-64f1ddcf1131
+      - req-f39d034d-5721-4c2a-9bfa-cbb82f95bd58
       Date:
-      - Thu, 03 Jan 2019 19:25:06 GMT
+      - Fri, 04 Jan 2019 16:58:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": [{"description": "Heat WordPress template to support F20,
@@ -5107,7 +5107,7 @@ http_interactions:
         "rel": "self"}], "updated_time": null, "stack_owner": null, "stack_status":
         "CREATE_COMPLETE", "id": "091e1e54-e01c-4ec5-a0ab-b00bee4d425c"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:06 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:49 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks?limit=1000&marker=091e1e54-e01c-4ec5-a0ab-b00bee4d425c&show_nested=true
@@ -5122,7 +5122,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9b569ea76e2a4b8d99bbcb684d62caee
+      - 513d20adb26a42b89a05488cebcc5acf
   response:
     status:
       code: 200
@@ -5133,14 +5133,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-4226d06c-b97f-4a28-907a-3fa259382d71
+      - req-d8c88f63-db18-4077-8cc1-899f7aff1ce3
       Date:
-      - Thu, 03 Jan 2019 19:25:06 GMT
+      - Fri, 04 Jan 2019 16:58:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:06 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:49 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/b458a5c25c3749758f4c0661940b3ba8/stacks?limit=1000&show_nested=true
@@ -5155,7 +5155,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a336bc2836c74abdb1ba0e3e4890ee10
+      - a46e64ada48743a3bff91232bb792b15
   response:
     status:
       code: 200
@@ -5166,14 +5166,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-b060a0eb-cad0-4893-837d-abcaff4cd5c2
+      - req-71fb74ef-6651-494c-899a-0758e749433b
       Date:
-      - Thu, 03 Jan 2019 19:25:06 GMT
+      - Fri, 04 Jan 2019 16:58:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:06 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:49 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/e54e5c3c19e34720b05661f2ea1ea00a/stacks?limit=1000&show_nested=true
@@ -5188,7 +5188,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7797882ca58140fa90546a8f5587fc42
+      - 52b6278e537b4d01a454424f18cb6e67
   response:
     status:
       code: 200
@@ -5199,14 +5199,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-bb0e3d4c-6608-4a6c-8ec0-8c1917bd3720
+      - req-749bb713-c1a1-4984-a8b1-4dbb46b10860
       Date:
-      - Thu, 03 Jan 2019 19:25:06 GMT
+      - Fri, 04 Jan 2019 16:58:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:06 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:49 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/e8f744b1fc6a487681d35fb275252608/stacks?limit=1000&show_nested=true
@@ -5221,7 +5221,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a4da268d82c44ccd93dfc90ac1ad598b
+      - 1c18b144f6964e1ba1c2695bee4b712a
   response:
     status:
       code: 200
@@ -5232,14 +5232,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-52f160b8-e6bc-4dd4-bb60-1a71d003ddab
+      - req-89c5ee89-bd20-4414-aed1-f1324747639c
       Date:
-      - Thu, 03 Jan 2019 19:25:06 GMT
+      - Fri, 04 Jan 2019 16:58:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:06 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:49 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack3/45d2af82-eff9-4483-a1f0-f19c44d96146
@@ -5254,7 +5254,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9b569ea76e2a4b8d99bbcb684d62caee
+      - 513d20adb26a42b89a05488cebcc5acf
   response:
     status:
       code: 200
@@ -5265,9 +5265,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-7a0abad7-a99e-4a61-a744-135494dc938a
+      - req-5b8aed12-40c7-4bf1-92eb-318ffa138376
       Date:
-      - Thu, 03 Jan 2019 19:25:07 GMT
+      - Fri, 04 Jan 2019 16:58:50 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -5294,7 +5294,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:07 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:50 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack2/4cf24b12-29fc-4529-a8ed-6b079dea7c17
@@ -5309,7 +5309,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9b569ea76e2a4b8d99bbcb684d62caee
+      - 513d20adb26a42b89a05488cebcc5acf
   response:
     status:
       code: 200
@@ -5320,9 +5320,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-793fd9a1-714b-426b-8ca5-04838de5a9b3
+      - req-14c12807-b71d-4d5c-8a4d-3b13fd19fb64
       Date:
-      - Thu, 03 Jan 2019 19:25:07 GMT
+      - Fri, 04 Jan 2019 16:58:50 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -5349,7 +5349,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:07 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:50 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c
@@ -5364,7 +5364,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9b569ea76e2a4b8d99bbcb684d62caee
+      - 513d20adb26a42b89a05488cebcc5acf
   response:
     status:
       code: 200
@@ -5375,9 +5375,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-fe1b16be-75fe-4e0a-ac9a-5116c6d476e3
+      - req-0e06659d-079a-4e18-af7b-bd8f8994b5be
       Date:
-      - Thu, 03 Jan 2019 19:25:07 GMT
+      - Fri, 04 Jan 2019 16:58:50 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -5404,7 +5404,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:07 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:50 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack3/45d2af82-eff9-4483-a1f0-f19c44d96146/resources
@@ -5419,7 +5419,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9b569ea76e2a4b8d99bbcb684d62caee
+      - 513d20adb26a42b89a05488cebcc5acf
   response:
     status:
       code: 200
@@ -5430,9 +5430,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-3822dfca-33e3-49bf-ac2c-4e4cd3fb9a5c
+      - req-55df4a58-f387-49c9-861a-65da8d13d0da
       Date:
-      - Thu, 03 Jan 2019 19:25:08 GMT
+      - Fri, 04 Jan 2019 16:58:50 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -5444,7 +5444,7 @@ http_interactions:
         changed", "physical_resource_id": "aa5907f3-8209-4dd0-b3ef-600431d85bac",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:08 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:50 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack2/4cf24b12-29fc-4529-a8ed-6b079dea7c17/resources
@@ -5459,7 +5459,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9b569ea76e2a4b8d99bbcb684d62caee
+      - 513d20adb26a42b89a05488cebcc5acf
   response:
     status:
       code: 200
@@ -5470,9 +5470,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-5c6f1535-3ab4-4393-a891-366638d1026e
+      - req-e9bfad92-c672-489b-b1ff-cf19dd93b700
       Date:
-      - Thu, 03 Jan 2019 19:25:08 GMT
+      - Fri, 04 Jan 2019 16:58:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -5484,7 +5484,7 @@ http_interactions:
         changed", "physical_resource_id": "219a737c-b4ad-430d-944a-a92a4834b12d",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:08 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:51 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c/resources
@@ -5499,7 +5499,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9b569ea76e2a4b8d99bbcb684d62caee
+      - 513d20adb26a42b89a05488cebcc5acf
   response:
     status:
       code: 200
@@ -5510,9 +5510,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-2090d1d7-028a-409a-96cd-0882eeac0fd8
+      - req-b195d172-35c1-41d2-97b4-b57aaab8968b
       Date:
-      - Thu, 03 Jan 2019 19:25:08 GMT
+      - Fri, 04 Jan 2019 16:58:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -5524,7 +5524,7 @@ http_interactions:
         changed", "physical_resource_id": "b686353f-0da0-48bf-bc35-8ea411a67dfd",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:08 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:51 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?all_tenants=True&limit=1000
@@ -5539,7 +5539,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5e991131873d4f658a0604fd1dd269ad
+      - ace7f7ecede64cc2ad7fd7e8566f4e06
   response:
     status:
       code: 200
@@ -5550,19 +5550,13 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-bf51585e-6b3d-4df3-99bf-3cfee74a0cfc
+      - req-e2c5e13e-a603-48fc-a3b3-1cf16e5d078d
       Date:
-      - Thu, 03 Jan 2019 19:25:08 GMT
+      - Fri, 04 Jan 2019 16:58:51 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
-        true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp":
+        true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
@@ -5643,6 +5637,12 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
         "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
         "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
@@ -5656,7 +5656,7 @@ http_interactions:
         4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
         "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:08 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:51 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?all_tenants=True&limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
@@ -5671,7 +5671,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5e991131873d4f658a0604fd1dd269ad
+      - ace7f7ecede64cc2ad7fd7e8566f4e06
   response:
     status:
       code: 200
@@ -5682,12 +5682,29 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-af4858c5-2aa5-4288-b96c-8abef7cc2de8
+      - req-489d7453-b26c-4dab-948e-388274f663bf
       Date:
-      - Thu, 03 Jan 2019 19:25:08 GMT
+      - Fri, 04 Jan 2019 16:58:51 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
@@ -5758,155 +5775,6 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
         "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:08 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?all_tenants=True&limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 5e991131873d4f658a0604fd1dd269ad
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-9780a897-e062-4491-9bbb-f1e38dd2e922
-      Date:
-      - Thu, 03 Jan 2019 19:25:08 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
-        true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
         "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
@@ -5920,403 +5788,7 @@ http_interactions:
         4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
         "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:08 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?all_tenants=True&limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 5e991131873d4f658a0604fd1dd269ad
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-2b3eeeec-cb60-4de2-92dc-8ac79dc2c674
-      Date:
-      - Thu, 03 Jan 2019 19:25:09 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:09 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?all_tenants=True&limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 5e991131873d4f658a0604fd1dd269ad
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-95776768-0ea1-4aba-9189-ebc100218c07
-      Date:
-      - Thu, 03 Jan 2019 19:25:09 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
-        true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:09 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?all_tenants=True&limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 5e991131873d4f658a0604fd1dd269ad
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-30b095aa-cb5e-4bdb-b2ac-7d34bd19b7a3
-      Date:
-      - Thu, 03 Jan 2019 19:25:09 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
-        true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:09 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:51 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?all_tenants=True&limit=1000
@@ -6331,7 +5803,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5e991131873d4f658a0604fd1dd269ad
+      - ace7f7ecede64cc2ad7fd7e8566f4e06
   response:
     status:
       code: 200
@@ -6342,9 +5814,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-04761175-c29e-492a-adda-05981aa753cb
+      - req-5aeb94a7-c9c8-46de-a003-4a17cdf59912
       Date:
-      - Thu, 03 Jan 2019 19:25:09 GMT
+      - Fri, 04 Jan 2019 16:58:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -6386,7 +5858,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:09 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:51 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?all_tenants=True&limit=1000&marker=ee601a91-f6ac-4a46-a599-87cfd83094a3
@@ -6401,7 +5873,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5e991131873d4f658a0604fd1dd269ad
+      - ace7f7ecede64cc2ad7fd7e8566f4e06
   response:
     status:
       code: 200
@@ -6412,9 +5884,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-e6543e7f-08bf-48e8-b08a-9358b6eb218d
+      - req-fea9ab82-03b3-4d52-9511-5a265231fba6
       Date:
-      - Thu, 03 Jan 2019 19:25:09 GMT
+      - Fri, 04 Jan 2019 16:58:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -6456,7 +5928,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:09 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:51 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?all_tenants=True&limit=1000
@@ -6471,7 +5943,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5e991131873d4f658a0604fd1dd269ad
+      - ace7f7ecede64cc2ad7fd7e8566f4e06
   response:
     status:
       code: 200
@@ -6482,9 +5954,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-95e512f8-7353-4200-a1be-8aa340ee4e86
+      - req-07f86337-5ee4-4cd3-8fee-32c108e7a634
       Date:
-      - Thu, 03 Jan 2019 19:25:09 GMT
+      - Fri, 04 Jan 2019 16:58:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -6887,7 +6359,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:09 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:51 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?all_tenants=True&limit=1000&marker=dee8791c-23b3-4e65-846d-49aeaba18036
@@ -6902,7 +6374,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5e991131873d4f658a0604fd1dd269ad
+      - ace7f7ecede64cc2ad7fd7e8566f4e06
   response:
     status:
       code: 200
@@ -6913,9 +6385,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-0f078e6c-b0ca-4b5a-aa40-4afea295af4f
+      - req-a965ca6f-467b-4ed8-aaef-30aa7e331a4e
       Date:
-      - Thu, 03 Jan 2019 19:25:10 GMT
+      - Fri, 04 Jan 2019 16:58:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -7318,7 +6790,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:10 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:52 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?all_tenants=True&limit=1000
@@ -7333,7 +6805,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5e991131873d4f658a0604fd1dd269ad
+      - ace7f7ecede64cc2ad7fd7e8566f4e06
   response:
     status:
       code: 200
@@ -7344,9 +6816,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-257b59cd-4874-43d2-a6d7-bbcc5e9047e2
+      - req-8f54683f-ba22-484c-8b0d-1e02f04816c8
       Date:
-      - Thu, 03 Jan 2019 19:25:10 GMT
+      - Fri, 04 Jan 2019 16:58:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -7378,7 +6850,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:10 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:52 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?all_tenants=True&limit=1000&marker=a41c036a-c34e-454b-851d-5eefd03888cb
@@ -7393,7 +6865,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5e991131873d4f658a0604fd1dd269ad
+      - ace7f7ecede64cc2ad7fd7e8566f4e06
   response:
     status:
       code: 200
@@ -7404,9 +6876,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-5733c510-05cf-4fce-bb1a-7720c3c4210b
+      - req-15cba771-c0bb-49bd-933e-000d7967b4ca
       Date:
-      - Thu, 03 Jan 2019 19:25:10 GMT
+      - Fri, 04 Jan 2019 16:58:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -7438,7 +6910,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:10 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:52 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?all_tenants=True&limit=1000
@@ -7453,7 +6925,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5e991131873d4f658a0604fd1dd269ad
+      - ace7f7ecede64cc2ad7fd7e8566f4e06
   response:
     status:
       code: 200
@@ -7464,9 +6936,9 @@ http_interactions:
       Content-Length:
       - '3418'
       X-Openstack-Request-Id:
-      - req-98d5f81f-ffbc-4a67-9b60-1ee7c521f3d4
+      - req-82c2804d-31e3-42ab-a6b7-b341a421da6f
       Date:
-      - Thu, 03 Jan 2019 19:25:10 GMT
+      - Fri, 04 Jan 2019 16:58:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef",
@@ -7508,7 +6980,7 @@ http_interactions:
         null, "port_range_min": null, "id": "ff24dfac-169a-4238-b78b-ed1536a0bf06",
         "security_group_id": "5b2b42a6-1271-4c4a-b062-8e8ba299acef"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:10 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:52 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef
@@ -7523,7 +6995,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5e991131873d4f658a0604fd1dd269ad
+      - ace7f7ecede64cc2ad7fd7e8566f4e06
   response:
     status:
       code: 200
@@ -7534,9 +7006,9 @@ http_interactions:
       Content-Length:
       - '3418'
       X-Openstack-Request-Id:
-      - req-67065f3f-2f82-4bf2-b76e-d29c051dc4fd
+      - req-7d53a417-448b-4eb2-9632-9f643f4c27a5
       Date:
-      - Thu, 03 Jan 2019 19:25:10 GMT
+      - Fri, 04 Jan 2019 16:58:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab",
@@ -7579,7 +7051,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "c06c0e71-2c18-43a9-ace9-91242f0251e2",
         "security_group_id": "98bfc20c-a897-42c5-b33c-f0d8317667ab"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:10 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:52 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab
@@ -7594,7 +7066,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5e991131873d4f658a0604fd1dd269ad
+      - ace7f7ecede64cc2ad7fd7e8566f4e06
   response:
     status:
       code: 200
@@ -7605,9 +7077,9 @@ http_interactions:
       Content-Length:
       - '2751'
       X-Openstack-Request-Id:
-      - req-4e25020d-cdee-42d0-a147-e4a363bab1b1
+      - req-c598c281-6e25-47c8-b046-65bc7824df44
       Date:
-      - Thu, 03 Jan 2019 19:25:10 GMT
+      - Fri, 04 Jan 2019 16:58:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4",
@@ -7642,7 +7114,7 @@ http_interactions:
         null, "port_range_min": null, "id": "75924ebc-4758-4042-ad04-4ef3c9189098",
         "security_group_id": "e4836528-d0df-425e-a117-ae8ec6f356d4"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:10 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:52 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4
@@ -7657,7 +7129,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5e991131873d4f658a0604fd1dd269ad
+      - ace7f7ecede64cc2ad7fd7e8566f4e06
   response:
     status:
       code: 200
@@ -7668,9 +7140,9 @@ http_interactions:
       Content-Length:
       - '7097'
       X-Openstack-Request-Id:
-      - req-7cc94190-40c0-47f5-8006-c38eda1854a4
+      - req-b37bfc7d-b48a-47f0-b264-f568744c0a87
       Date:
-      - Thu, 03 Jan 2019 19:25:10 GMT
+      - Fri, 04 Jan 2019 16:58:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=fd147cb7-7456-43d9-a01f-c06e21b4e6fb&page_reverse=True",
@@ -7757,7 +7229,7 @@ http_interactions:
         "port_range_max": 80, "port_range_min": 80, "id": "f79f0e32-b186-4778-952e-20827a60ef73",
         "security_group_id": "fd147cb7-7456-43d9-a01f-c06e21b4e6fb"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:10 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:52 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -7775,13 +7247,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:25:11 GMT
+      - Fri, 04 Jan 2019 16:58:53 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-69968fc8-16c1-49ad-a6f1-fd79c8456807
+      - req-55a1257e-98f3-4319-a955-205cb6046c46
       Content-Length:
       - '4170'
       Connection:
@@ -7790,10 +7262,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:25:11.430665", "expires":
-        "2019-01-03T20:25:11Z", "id": "de0379c7a14445a38d4c975d6e1665de", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:58:53.467673", "expires":
+        "2019-01-04T17:58:53Z", "id": "23e6311467134ec39d9e41a9ac314042", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["IHijQDluR2KFKDGl8pdKPw"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["etC3noDdQkuu7coJAfd5XA"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -7838,7 +7310,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:11 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:53 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -7856,13 +7328,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:25:11 GMT
+      - Fri, 04 Jan 2019 16:58:53 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-92878724-72dd-4edf-85f5-8f8daabee67d
+      - req-cc8052d0-4270-4886-a97d-073321d398a3
       Content-Length:
       - '4170'
       Connection:
@@ -7871,10 +7343,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:25:11.615735", "expires":
-        "2019-01-03T20:25:11Z", "id": "fb20a73508394f1dbe2400774bbcc58c", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:58:53.654438", "expires":
+        "2019-01-04T17:58:53Z", "id": "584b92f417d14289ad1db4fc5733779f", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["3hr-pK7ERxCIL-a6XoBUDg"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["hdrxq_xpTTSfa_kgDApQNw"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -7919,7 +7391,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:11 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:53 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -7937,13 +7409,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:25:11 GMT
+      - Fri, 04 Jan 2019 16:58:53 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-2dc20c89-5820-4b85-a474-348ee36553fc
+      - req-f54c6df1-ed7d-4ae8-8cf1-bf505349b57f
       Content-Length:
       - '370'
       Connection:
@@ -7952,13 +7424,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:25:11.775805", "expires":
-        "2019-01-03T20:25:11Z", "id": "feb3d13ce4fa4eb4b3db442d606db0d8", "audit_ids":
-        ["pzulV-KzRU-ztAfhTp1Z6w"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:58:53.817950", "expires":
+        "2019-01-04T17:58:53Z", "id": "999c6236ee31440aaa201e397db9a4fe", "audit_ids":
+        ["1b9iOx_lQm-drm41uQZVqA"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:11 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:53 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -7973,20 +7445,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - feb3d13ce4fa4eb4b3db442d606db0d8
+      - 999c6236ee31440aaa201e397db9a4fe
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:25:11 GMT
+      - Fri, 04 Jan 2019 16:58:53 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-06a6a750-a155-492b-834a-a239857beedf
+      - req-6a3277be-ab43-4c3a-9504-02344b759b96
       Content-Length:
       - '500'
       Connection:
@@ -8003,7 +7475,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:11 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:53 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -8021,13 +7493,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:25:12 GMT
+      - Fri, 04 Jan 2019 16:58:54 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-1f11ec82-90e1-4ec3-a63e-36c09135ffec
+      - req-22f05da7-614b-4df7-8fc5-e0b9b81469c8
       Content-Length:
       - '4117'
       Connection:
@@ -8036,10 +7508,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:25:12.104311", "expires":
-        "2019-01-03T20:25:12Z", "id": "39f1aa505b064f258c18e8bd7bf90070", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:58:54.142464", "expires":
+        "2019-01-04T17:58:54Z", "id": "0575070beee64f56a243295b4483a987", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["wNtlJEYMRWW-ntCUdO_iEw"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["dCA4s3CdSZqN7WI8jdhvzA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -8083,7 +7555,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:12 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:54 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -8101,13 +7573,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:25:12 GMT
+      - Fri, 04 Jan 2019 16:58:54 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-cfd393cf-d190-4f42-882c-1a40eb73a240
+      - req-33f1b3ea-46f4-4752-9ef4-35d7e1e1eb6d
       Content-Length:
       - '4131'
       Connection:
@@ -8116,10 +7588,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:25:12.293463", "expires":
-        "2019-01-03T20:25:12Z", "id": "e7de7ab4872a4460a668314098f08978", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:58:54.330956", "expires":
+        "2019-01-04T17:58:54Z", "id": "153cf123695746d685bd99221f90f185", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["IEARRXINR2a9BaCiwYhLuw"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["LevppcvkQ9eXlLJdUFypWQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -8163,7 +7635,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:12 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:54 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -8181,13 +7653,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:25:12 GMT
+      - Fri, 04 Jan 2019 16:58:54 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-6822c0fb-63d5-4f4d-99fc-581294af87b4
+      - req-8698add1-c04e-47ac-b9b8-c250a0501c5b
       Content-Length:
       - '4118'
       Connection:
@@ -8196,10 +7668,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:25:12.485317", "expires":
-        "2019-01-03T20:25:12Z", "id": "4b2e8d3e5e0a4337a88846582a883479", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:58:54.513656", "expires":
+        "2019-01-04T17:58:54Z", "id": "111d7137b1a448efbe2553f1f1e895cd", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["idQBv6g9TOG47pj6sJ_S5w"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["QGGu56i2QNSsNr0UCmrcQQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -8243,7 +7715,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:12 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:54 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000
@@ -8258,22 +7730,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 39f1aa505b064f258c18e8bd7bf90070
+      - 0575070beee64f56a243295b4483a987
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-42857a26-136c-4098-b907-ed3f59ea50ca
+      - req-df98edf5-0886-4c5e-ba2c-3da08e74e7f1
       Content-Type:
       - application/json
       Content-Length:
       - '2706'
       X-Openstack-Request-Id:
-      - req-42857a26-136c-4098-b907-ed3f59ea50ca
+      - req-df98edf5-0886-4c5e-ba2c-3da08e74e7f1
       Date:
-      - Thu, 03 Jan 2019 19:25:12 GMT
+      - Fri, 04 Jan 2019 16:58:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=9bb99818-b339-4e31-b87f-e4181ec48acd",
@@ -8306,7 +7778,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-4", "bootable": "true", "created_at":
         "2016-11-11T13:49:53.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:12 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:54 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=9bb99818-b339-4e31-b87f-e4181ec48acd
@@ -8321,22 +7793,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 39f1aa505b064f258c18e8bd7bf90070
+      - 0575070beee64f56a243295b4483a987
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-438a5e4f-526a-4306-bc90-f9d3b712f29f
+      - req-293c2b75-5e13-480c-9955-706b78beb609
       Content-Type:
       - application/json
       Content-Length:
       - '3284'
       X-Openstack-Request-Id:
-      - req-438a5e4f-526a-4306-bc90-f9d3b712f29f
+      - req-293c2b75-5e13-480c-9955-706b78beb609
       Date:
-      - Thu, 03 Jan 2019 19:25:12 GMT
+      - Fri, 04 Jan 2019 16:58:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=2c774148-c11a-434c-aabb-7fa9c82c37ce",
@@ -8377,7 +7849,7 @@ http_interactions:
         "name": "EmsRefreshSpec-Volume-2", "bootable": "false", "created_at": "2016-11-11T13:49:43.000000",
         "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:12 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:54 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=2c774148-c11a-434c-aabb-7fa9c82c37ce
@@ -8392,22 +7864,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 39f1aa505b064f258c18e8bd7bf90070
+      - 0575070beee64f56a243295b4483a987
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-8b69d067-fea3-46dd-8019-46cb1a10ba4b
+      - req-21daebd5-81e7-4635-8eee-8a0cdc3797c5
       Content-Type:
       - application/json
       Content-Length:
       - '2753'
       X-Openstack-Request-Id:
-      - req-8b69d067-fea3-46dd-8019-46cb1a10ba4b
+      - req-21daebd5-81e7-4635-8eee-8a0cdc3797c5
       Date:
-      - Thu, 03 Jan 2019 19:25:13 GMT
+      - Fri, 04 Jan 2019 16:58:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=0a55c0d5-c780-4e7d-9d09-47f5520c7448",
@@ -8441,7 +7913,7 @@ http_interactions:
         "bootable": "false", "created_at": "2016-11-11T13:49:20.000000", "volume_type":
         "iscsi"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:13 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:55 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=0a55c0d5-c780-4e7d-9d09-47f5520c7448
@@ -8456,27 +7928,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 39f1aa505b064f258c18e8bd7bf90070
+      - 0575070beee64f56a243295b4483a987
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-2efcc247-e4a3-4854-a247-045aae9b8898
+      - req-101ed809-ae8b-4e71-8326-695d7f812c88
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-2efcc247-e4a3-4854-a247-045aae9b8898
+      - req-101ed809-ae8b-4e71-8326-695d7f812c88
       Date:
-      - Thu, 03 Jan 2019 19:25:13 GMT
+      - Fri, 04 Jan 2019 16:58:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:13 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:55 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/volumes/detail?limit=1000
@@ -8491,27 +7963,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e7de7ab4872a4460a668314098f08978
+      - 153cf123695746d685bd99221f90f185
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-a0ee00dc-027e-4940-8454-6ee1426bdfd4
+      - req-94a563de-02bc-4985-a7a0-ba19a6ec1950
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-a0ee00dc-027e-4940-8454-6ee1426bdfd4
+      - req-94a563de-02bc-4985-a7a0-ba19a6ec1950
       Date:
-      - Thu, 03 Jan 2019 19:25:13 GMT
+      - Fri, 04 Jan 2019 16:58:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:13 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:55 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/volumes/detail?limit=1000
@@ -8526,27 +7998,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fb20a73508394f1dbe2400774bbcc58c
+      - 584b92f417d14289ad1db4fc5733779f
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-5e393e5b-d0d1-4c36-a607-51f6409c0ab5
+      - req-962ceece-4079-4da5-a839-d1bccffcf18a
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-5e393e5b-d0d1-4c36-a607-51f6409c0ab5
+      - req-962ceece-4079-4da5-a839-d1bccffcf18a
       Date:
-      - Thu, 03 Jan 2019 19:25:13 GMT
+      - Fri, 04 Jan 2019 16:58:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:13 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:55 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/volumes/detail?limit=1000
@@ -8561,27 +8033,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4b2e8d3e5e0a4337a88846582a883479
+      - 111d7137b1a448efbe2553f1f1e895cd
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-6a58e5c5-8cfb-4c88-9d38-1617025e0c87
+      - req-6701e2fc-38a5-4bb1-955c-62a42e0337ea
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-6a58e5c5-8cfb-4c88-9d38-1617025e0c87
+      - req-6701e2fc-38a5-4bb1-955c-62a42e0337ea
       Date:
-      - Thu, 03 Jan 2019 19:25:13 GMT
+      - Fri, 04 Jan 2019 16:58:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:13 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:55 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail
@@ -8596,22 +8068,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 39f1aa505b064f258c18e8bd7bf90070
+      - 0575070beee64f56a243295b4483a987
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-bd04b900-2e31-498a-a1af-64cd83451f8c
+      - req-0ae3908d-2331-434c-97b0-9784c5dd2964
       Content-Type:
       - application/json
       Content-Length:
       - '1053'
       X-Openstack-Request-Id:
-      - req-bd04b900-2e31-498a-a1af-64cd83451f8c
+      - req-0ae3908d-2331-434c-97b0-9784c5dd2964
       Date:
-      - Thu, 03 Jan 2019 19:25:13 GMT
+      - Fri, 04 Jan 2019 16:58:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?marker=76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
@@ -8626,7 +8098,7 @@ http_interactions:
         "created_at": "2016-11-11T13:49:36.000000", "size": 1, "id": "76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:13 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:55 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?limit=1000
@@ -8641,22 +8113,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 39f1aa505b064f258c18e8bd7bf90070
+      - 0575070beee64f56a243295b4483a987
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-3f520317-6fad-4309-95d1-b4a084951b8c
+      - req-ede2a120-7eda-4a97-b896-4859fbd795a8
       Content-Type:
       - application/json
       Content-Length:
       - '1064'
       X-Openstack-Request-Id:
-      - req-3f520317-6fad-4309-95d1-b4a084951b8c
+      - req-ede2a120-7eda-4a97-b896-4859fbd795a8
       Date:
-      - Thu, 03 Jan 2019 19:25:14 GMT
+      - Fri, 04 Jan 2019 16:58:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?limit=1000&marker=76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
@@ -8671,7 +8143,7 @@ http_interactions:
         "created_at": "2016-11-11T13:49:36.000000", "size": 1, "id": "76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:14 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:55 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/snapshots/detail
@@ -8686,27 +8158,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e7de7ab4872a4460a668314098f08978
+      - 153cf123695746d685bd99221f90f185
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-6b2d120b-8291-4e8d-931b-b4cb429397a8
+      - req-d9140a54-0c37-4821-bbc0-6da09d6dbc34
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-6b2d120b-8291-4e8d-931b-b4cb429397a8
+      - req-d9140a54-0c37-4821-bbc0-6da09d6dbc34
       Date:
-      - Thu, 03 Jan 2019 19:25:14 GMT
+      - Fri, 04 Jan 2019 16:58:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:14 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:56 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/snapshots/detail?limit=1000
@@ -8721,27 +8193,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e7de7ab4872a4460a668314098f08978
+      - 153cf123695746d685bd99221f90f185
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-c37d892b-ffdf-45b7-b71a-1f304d19a517
+      - req-07ab7695-1d91-428f-b96b-36b5c9d12ac7
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-c37d892b-ffdf-45b7-b71a-1f304d19a517
+      - req-07ab7695-1d91-428f-b96b-36b5c9d12ac7
       Date:
-      - Thu, 03 Jan 2019 19:25:14 GMT
+      - Fri, 04 Jan 2019 16:58:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:14 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:56 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/snapshots/detail
@@ -8756,27 +8228,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fb20a73508394f1dbe2400774bbcc58c
+      - 584b92f417d14289ad1db4fc5733779f
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-e8378616-a934-4703-a16e-bb18a3105086
+      - req-02b69da6-538a-41df-b5e1-acd5ac3586f8
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-e8378616-a934-4703-a16e-bb18a3105086
+      - req-02b69da6-538a-41df-b5e1-acd5ac3586f8
       Date:
-      - Thu, 03 Jan 2019 19:25:14 GMT
+      - Fri, 04 Jan 2019 16:58:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:14 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:56 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/snapshots/detail?limit=1000
@@ -8791,27 +8263,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fb20a73508394f1dbe2400774bbcc58c
+      - 584b92f417d14289ad1db4fc5733779f
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-3048ce0f-cd36-41bc-a1fe-9c58e28038c7
+      - req-eed4becb-e852-44c9-b2ff-0ec9e1b2ec8d
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-3048ce0f-cd36-41bc-a1fe-9c58e28038c7
+      - req-eed4becb-e852-44c9-b2ff-0ec9e1b2ec8d
       Date:
-      - Thu, 03 Jan 2019 19:25:14 GMT
+      - Fri, 04 Jan 2019 16:58:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:14 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:56 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/snapshots/detail
@@ -8826,27 +8298,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4b2e8d3e5e0a4337a88846582a883479
+      - 111d7137b1a448efbe2553f1f1e895cd
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-3fb7eb3c-887e-4ff1-8e20-bc723c25eec2
+      - req-948a7686-f4c8-4156-ac49-67eac2ffbdec
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-3fb7eb3c-887e-4ff1-8e20-bc723c25eec2
+      - req-948a7686-f4c8-4156-ac49-67eac2ffbdec
       Date:
-      - Thu, 03 Jan 2019 19:25:14 GMT
+      - Fri, 04 Jan 2019 16:58:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:14 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:56 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/snapshots/detail?limit=1000
@@ -8861,27 +8333,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4b2e8d3e5e0a4337a88846582a883479
+      - 111d7137b1a448efbe2553f1f1e895cd
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-f7b2b425-1fa2-4d33-a4fc-9ad0a5b381de
+      - req-738b9af2-3308-426a-ae1f-1f9ac9541d5a
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-f7b2b425-1fa2-4d33-a4fc-9ad0a5b381de
+      - req-738b9af2-3308-426a-ae1f-1f9ac9541d5a
       Date:
-      - Thu, 03 Jan 2019 19:25:14 GMT
+      - Fri, 04 Jan 2019 16:58:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:14 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:56 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/backups/detail
@@ -8896,27 +8368,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 39f1aa505b064f258c18e8bd7bf90070
+      - 0575070beee64f56a243295b4483a987
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-319f32fc-2645-44d2-b7d2-1d3440e6c3a9
+      - req-18e34229-9d58-4bbb-a7cb-42e50c1ef667
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-319f32fc-2645-44d2-b7d2-1d3440e6c3a9
+      - req-18e34229-9d58-4bbb-a7cb-42e50c1ef667
       Date:
-      - Thu, 03 Jan 2019 19:25:14 GMT
+      - Fri, 04 Jan 2019 16:58:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:14 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:56 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/backups/detail?limit=1000
@@ -8931,27 +8403,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 39f1aa505b064f258c18e8bd7bf90070
+      - 0575070beee64f56a243295b4483a987
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-710e9716-aa38-47ab-972a-742021b1f6bb
+      - req-e56ff635-c7dd-4dab-a0db-d6510d136445
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-710e9716-aa38-47ab-972a-742021b1f6bb
+      - req-e56ff635-c7dd-4dab-a0db-d6510d136445
       Date:
-      - Thu, 03 Jan 2019 19:25:14 GMT
+      - Fri, 04 Jan 2019 16:58:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:14 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:56 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/backups/detail
@@ -8966,27 +8438,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e7de7ab4872a4460a668314098f08978
+      - 153cf123695746d685bd99221f90f185
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-d2eabf28-cc04-4b1b-b13a-9d7135a04c84
+      - req-1e9bc0f0-ef12-4ebf-ac08-aba3a7fd4726
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-d2eabf28-cc04-4b1b-b13a-9d7135a04c84
+      - req-1e9bc0f0-ef12-4ebf-ac08-aba3a7fd4726
       Date:
-      - Thu, 03 Jan 2019 19:25:14 GMT
+      - Fri, 04 Jan 2019 16:58:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:15 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:57 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/backups/detail?limit=1000
@@ -9001,27 +8473,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e7de7ab4872a4460a668314098f08978
+      - 153cf123695746d685bd99221f90f185
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-a0c15b2d-4438-48d4-82a6-34c9ed99a646
+      - req-23147545-de08-493b-8e35-f6af04741748
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-a0c15b2d-4438-48d4-82a6-34c9ed99a646
+      - req-23147545-de08-493b-8e35-f6af04741748
       Date:
-      - Thu, 03 Jan 2019 19:25:15 GMT
+      - Fri, 04 Jan 2019 16:58:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:15 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:57 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/backups/detail
@@ -9036,27 +8508,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fb20a73508394f1dbe2400774bbcc58c
+      - 584b92f417d14289ad1db4fc5733779f
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-9406e2d9-0c48-499c-9735-f3bd96c6b7d4
+      - req-a08413c1-7ed4-4cc3-8736-97f0e8958413
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-9406e2d9-0c48-499c-9735-f3bd96c6b7d4
+      - req-a08413c1-7ed4-4cc3-8736-97f0e8958413
       Date:
-      - Thu, 03 Jan 2019 19:25:15 GMT
+      - Fri, 04 Jan 2019 16:58:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:15 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:57 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/backups/detail?limit=1000
@@ -9071,27 +8543,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fb20a73508394f1dbe2400774bbcc58c
+      - 584b92f417d14289ad1db4fc5733779f
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-a679aa67-c7b7-4a79-ba19-6dd6cf410c9a
+      - req-204146af-2cc9-40e2-b693-69bf6482ae0d
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-a679aa67-c7b7-4a79-ba19-6dd6cf410c9a
+      - req-204146af-2cc9-40e2-b693-69bf6482ae0d
       Date:
-      - Thu, 03 Jan 2019 19:25:15 GMT
+      - Fri, 04 Jan 2019 16:58:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:15 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:57 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/backups/detail
@@ -9106,27 +8578,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4b2e8d3e5e0a4337a88846582a883479
+      - 111d7137b1a448efbe2553f1f1e895cd
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-8dbf503f-f2ba-47f7-a68c-ebe9bf8b6131
+      - req-21c92497-9c2f-4031-b261-9b6a9784ac7a
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-8dbf503f-f2ba-47f7-a68c-ebe9bf8b6131
+      - req-21c92497-9c2f-4031-b261-9b6a9784ac7a
       Date:
-      - Thu, 03 Jan 2019 19:25:15 GMT
+      - Fri, 04 Jan 2019 16:58:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:15 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:57 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/backups/detail?limit=1000
@@ -9141,27 +8613,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4b2e8d3e5e0a4337a88846582a883479
+      - 111d7137b1a448efbe2553f1f1e895cd
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-ea9894d9-aab9-4e15-b547-2d08247f11ed
+      - req-80e79fb9-6a59-496e-99cb-f7205dd2b946
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-ea9894d9-aab9-4e15-b547-2d08247f11ed
+      - req-80e79fb9-6a59-496e-99cb-f7205dd2b946
       Date:
-      - Thu, 03 Jan 2019 19:25:15 GMT
+      - Fri, 04 Jan 2019 16:58:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:15 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:57 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/types?limit=1000
@@ -9176,22 +8648,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 39f1aa505b064f258c18e8bd7bf90070
+      - 0575070beee64f56a243295b4483a987
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-cf777e0f-0e37-4b0b-8a90-3dbb2d456738
+      - req-258913a8-4248-461a-b5e0-b66f44694bed
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-cf777e0f-0e37-4b0b-8a90-3dbb2d456738
+      - req-258913a8-4248-461a-b5e0-b66f44694bed
       Date:
-      - Thu, 03 Jan 2019 19:25:15 GMT
+      - Fri, 04 Jan 2019 16:58:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -9203,7 +8675,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:15 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:57 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/types?limit=1000&marker=0d07f8c3-f295-48c7-b632-6b7d8bd860eb
@@ -9218,22 +8690,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 39f1aa505b064f258c18e8bd7bf90070
+      - 0575070beee64f56a243295b4483a987
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-829a9cc8-883c-4df4-a517-7609411790cc
+      - req-4ef5fa8d-cb0f-43b2-a4fc-9505fbe017d6
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-829a9cc8-883c-4df4-a517-7609411790cc
+      - req-4ef5fa8d-cb0f-43b2-a4fc-9505fbe017d6
       Date:
-      - Thu, 03 Jan 2019 19:25:15 GMT
+      - Fri, 04 Jan 2019 16:58:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -9245,7 +8717,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:15 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:57 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/types?limit=1000
@@ -9260,22 +8732,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e7de7ab4872a4460a668314098f08978
+      - 153cf123695746d685bd99221f90f185
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-e205774b-5ff9-4504-a6f3-fb6a012c00d4
+      - req-98f32de5-0d83-4763-90ba-8fa45358bac4
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-e205774b-5ff9-4504-a6f3-fb6a012c00d4
+      - req-98f32de5-0d83-4763-90ba-8fa45358bac4
       Date:
-      - Thu, 03 Jan 2019 19:25:15 GMT
+      - Fri, 04 Jan 2019 16:58:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -9287,7 +8759,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:15 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:57 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/types?limit=1000&marker=0d07f8c3-f295-48c7-b632-6b7d8bd860eb
@@ -9302,22 +8774,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e7de7ab4872a4460a668314098f08978
+      - 153cf123695746d685bd99221f90f185
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-fda3345f-89c2-41dc-81a4-232b745eda6f
+      - req-be2f7380-126b-46ad-9804-1ea60eef99e2
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-fda3345f-89c2-41dc-81a4-232b745eda6f
+      - req-be2f7380-126b-46ad-9804-1ea60eef99e2
       Date:
-      - Thu, 03 Jan 2019 19:25:15 GMT
+      - Fri, 04 Jan 2019 16:58:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -9329,7 +8801,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:15 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:57 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/types?limit=1000
@@ -9344,22 +8816,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fb20a73508394f1dbe2400774bbcc58c
+      - 584b92f417d14289ad1db4fc5733779f
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-cbd6400e-2e4c-4e64-a363-cbb08b82fb22
+      - req-aa12e60a-69ae-460c-b1bb-bb26b87edcf4
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-cbd6400e-2e4c-4e64-a363-cbb08b82fb22
+      - req-aa12e60a-69ae-460c-b1bb-bb26b87edcf4
       Date:
-      - Thu, 03 Jan 2019 19:25:16 GMT
+      - Fri, 04 Jan 2019 16:58:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -9371,7 +8843,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:16 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:58 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/types?limit=1000&marker=0d07f8c3-f295-48c7-b632-6b7d8bd860eb
@@ -9386,22 +8858,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fb20a73508394f1dbe2400774bbcc58c
+      - 584b92f417d14289ad1db4fc5733779f
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-eb24ca8e-d140-4252-ae3d-1d88c0cd5b56
+      - req-0e9db3ae-f975-475a-888b-ded9d66fbb1a
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-eb24ca8e-d140-4252-ae3d-1d88c0cd5b56
+      - req-0e9db3ae-f975-475a-888b-ded9d66fbb1a
       Date:
-      - Thu, 03 Jan 2019 19:25:16 GMT
+      - Fri, 04 Jan 2019 16:58:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -9413,7 +8885,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:16 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:58 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/types?limit=1000
@@ -9428,22 +8900,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4b2e8d3e5e0a4337a88846582a883479
+      - 111d7137b1a448efbe2553f1f1e895cd
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-f3bae7f9-72ba-4a84-ada9-b81e32b42962
+      - req-020b84b2-098a-4bda-b171-5a645c2b2478
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-f3bae7f9-72ba-4a84-ada9-b81e32b42962
+      - req-020b84b2-098a-4bda-b171-5a645c2b2478
       Date:
-      - Thu, 03 Jan 2019 19:25:16 GMT
+      - Fri, 04 Jan 2019 16:58:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -9455,7 +8927,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:16 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:58 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/types?limit=1000&marker=0d07f8c3-f295-48c7-b632-6b7d8bd860eb
@@ -9470,22 +8942,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4b2e8d3e5e0a4337a88846582a883479
+      - 111d7137b1a448efbe2553f1f1e895cd
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-91f60802-4a56-4e0b-949f-10136d47c957
+      - req-9823ac22-9e0b-4a88-a1bb-83fa0102600d
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-91f60802-4a56-4e0b-949f-10136d47c957
+      - req-9823ac22-9e0b-4a88-a1bb-83fa0102600d
       Date:
-      - Thu, 03 Jan 2019 19:25:16 GMT
+      - Fri, 04 Jan 2019 16:58:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -9497,7 +8969,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:16 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:58 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -9515,13 +8987,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:25:16 GMT
+      - Fri, 04 Jan 2019 16:58:58 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-1712c0c6-75a6-4146-b1a5-4860dcadd618
+      - req-c0155f53-3f8b-48d1-8c13-5c997d0fa03e
       Content-Length:
       - '4170'
       Connection:
@@ -9530,10 +9002,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:25:16.686323", "expires":
-        "2019-01-03T20:25:16Z", "id": "1d1300b39f6847998e58520805471f3c", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:58:58.636730", "expires":
+        "2019-01-04T17:58:58Z", "id": "a8ed4df21de043b58a76412cd5253086", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["NKpyhd-1Sze39AjD_PUteA"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["9Zpi_yz5S462nDki1XgCEQ"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -9578,7 +9050,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:16 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:58 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -9596,13 +9068,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:25:16 GMT
+      - Fri, 04 Jan 2019 16:58:58 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-0cc5d94d-5f21-4357-9d26-860f2291455d
+      - req-d5c8dc6e-6cff-487b-8af4-1e440a324620
       Content-Length:
       - '4170'
       Connection:
@@ -9611,10 +9083,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:25:16.903969", "expires":
-        "2019-01-03T20:25:16Z", "id": "3900521501c8450a9d73fd3c65e3d5fe", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:58:58.831521", "expires":
+        "2019-01-04T17:58:58Z", "id": "9fb7e4a8fec845b4ac6df703d5d879dd", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["pG52M6zQTciwlGXm4Da_HQ"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["PaczM0OyRbe8f9bBaY9Jyw"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -9659,7 +9131,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:16 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:58 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -9677,13 +9149,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:25:17 GMT
+      - Fri, 04 Jan 2019 16:58:58 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-cb59f27e-608f-46e0-a750-898fd4aba19a
+      - req-f5a07a8e-4f51-41f9-adb6-d05972da14d2
       Content-Length:
       - '370'
       Connection:
@@ -9692,13 +9164,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:25:17.084682", "expires":
-        "2019-01-03T20:25:17Z", "id": "66b94db8fe1149b7bd3e016b4b320b82", "audit_ids":
-        ["6D2p_NsrR3uC1vO4R3ePtw"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:58:58.992420", "expires":
+        "2019-01-04T17:58:58Z", "id": "62e928754b164c9f94e094634bbd6e1e", "audit_ids":
+        ["VI6Vb0eBR8O_3XGYaywITg"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:17 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:59 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -9713,20 +9185,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 66b94db8fe1149b7bd3e016b4b320b82
+      - 62e928754b164c9f94e094634bbd6e1e
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:25:17 GMT
+      - Fri, 04 Jan 2019 16:58:59 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-2c324d9e-ead7-4fa0-aa4c-0b596374260f
+      - req-e077f1ff-0212-4d0e-ab75-25f9ba0dd56d
       Content-Length:
       - '500'
       Connection:
@@ -9743,7 +9215,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:17 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:59 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -9761,13 +9233,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:25:17 GMT
+      - Fri, 04 Jan 2019 16:58:59 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-22b2e34a-9694-4ac1-baef-56065bcb0ddd
+      - req-b47e8622-64ea-4458-bed3-0db1cdc88cea
       Content-Length:
       - '4117'
       Connection:
@@ -9776,10 +9248,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:25:17.433515", "expires":
-        "2019-01-03T20:25:17Z", "id": "983ff650e40f4e8985c46170312f5eac", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:58:59.318064", "expires":
+        "2019-01-04T17:58:59Z", "id": "7411ad84cc5d48b9a1a18df7c2380be2", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["a1lK-ZNcQrOLrGRiM2GMVw"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["K3p5A9D5Raqbxf_Ah24Zrg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -9823,7 +9295,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:17 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:59 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -9841,13 +9313,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:25:17 GMT
+      - Fri, 04 Jan 2019 16:58:59 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-68d3d7a7-07ea-45bc-8761-aeca6c0f11f8
+      - req-893373e1-d8b7-4463-b091-06d3065852df
       Content-Length:
       - '4131'
       Connection:
@@ -9856,10 +9328,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:25:17.629778", "expires":
-        "2019-01-03T20:25:17Z", "id": "d5183867944f4ceebcfbd21906609026", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:58:59.512053", "expires":
+        "2019-01-04T17:58:59Z", "id": "d583fa619613428495042481d5265bc1", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["GCTMNG5eQAyl0nZWTxU8yw"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["_vEHuWmhSRGD2T16Y-7V4w"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -9903,7 +9375,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:17 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:59 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -9921,13 +9393,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:25:17 GMT
+      - Fri, 04 Jan 2019 16:58:59 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-7ddf8e8b-abeb-485b-8fd4-0305359dd041
+      - req-794f8996-adfc-4f4a-9ab0-3984fc89421c
       Content-Length:
       - '4118'
       Connection:
@@ -9936,10 +9408,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:25:17.828562", "expires":
-        "2019-01-03T20:25:17Z", "id": "be1c4b689ddc4ba1bd08134592898f9d", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:58:59.717137", "expires":
+        "2019-01-04T17:58:59Z", "id": "8a7de5ed28754cbb95c2d9889fc8bbbc", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["XPgoLXNgQn2PpGJ4tPLUOw"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["k07A9TP1SpGoPwKc-ShEzw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -9983,7 +9455,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:17 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:59 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/?format=json&limit=1000
@@ -9998,7 +9470,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 983ff650e40f4e8985c46170312f5eac
+      - 7411ad84cc5d48b9a1a18df7c2380be2
   response:
     status:
       code: 200
@@ -10027,15 +9499,15 @@ http_interactions:
       X-Account-Project-Domain-Id:
       - default
       X-Trans-Id:
-      - txec52635438ee4ae49422e-005c2e619d
+      - txa2564065c33f47b590f45-005c2f90d3
       Date:
-      - Thu, 03 Jan 2019 19:25:17 GMT
+      - Fri, 04 Jan 2019 16:58:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '[{"count": 3, "bytes": 33, "name": "dir_1"}, {"count": 0, "bytes":
         0, "name": "dir_2"}, {"count": 0, "bytes": 0, "name": "dir_3"}]'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:18 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:59 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/?format=json&limit=1000&marker=dir_3
@@ -10050,7 +9522,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 983ff650e40f4e8985c46170312f5eac
+      - 7411ad84cc5d48b9a1a18df7c2380be2
   response:
     status:
       code: 200
@@ -10079,14 +9551,14 @@ http_interactions:
       X-Account-Project-Domain-Id:
       - default
       X-Trans-Id:
-      - tx3e97b8b2b0f1436791dbc-005c2e619e
+      - tx5dcb0f4d52d046b681bfa-005c2f90d3
       Date:
-      - Thu, 03 Jan 2019 19:25:18 GMT
+      - Fri, 04 Jan 2019 16:58:59 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:18 GMT
+  recorded_at: Fri, 04 Jan 2019 16:59:00 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_b458a5c25c3749758f4c0661940b3ba8/?format=json&limit=1000
@@ -10101,7 +9573,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d5183867944f4ceebcfbd21906609026
+      - d583fa619613428495042481d5265bc1
   response:
     status:
       code: 200
@@ -10114,22 +9586,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1546543518.23497'
+      - '1546621140.13911'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1546543518.23497'
+      - '1546621140.13911'
       X-Trans-Id:
-      - txa5b3a0ef34da4b42b71c7-005c2e619e
+      - txf339f56c0fa34f99a6207-005c2f90d4
       Date:
-      - Thu, 03 Jan 2019 19:25:18 GMT
+      - Fri, 04 Jan 2019 16:59:00 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:18 GMT
+  recorded_at: Fri, 04 Jan 2019 16:59:00 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_e54e5c3c19e34720b05661f2ea1ea00a/?format=json&limit=1000
@@ -10144,7 +9616,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3900521501c8450a9d73fd3c65e3d5fe
+      - 9fb7e4a8fec845b4ac6df703d5d879dd
   response:
     status:
       code: 200
@@ -10157,22 +9629,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1546543518.38557'
+      - '1546621140.31864'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1546543518.38557'
+      - '1546621140.31864'
       X-Trans-Id:
-      - tx62856415e4984ce482d73-005c2e619e
+      - txe79dd4673dbb408db95d4-005c2f90d4
       Date:
-      - Thu, 03 Jan 2019 19:25:18 GMT
+      - Fri, 04 Jan 2019 16:59:00 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:18 GMT
+  recorded_at: Fri, 04 Jan 2019 16:59:00 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_e8f744b1fc6a487681d35fb275252608/?format=json&limit=1000
@@ -10187,7 +9659,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - be1c4b689ddc4ba1bd08134592898f9d
+      - 8a7de5ed28754cbb95c2d9889fc8bbbc
   response:
     status:
       code: 200
@@ -10200,22 +9672,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1546543518.54610'
+      - '1546621140.46731'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1546543518.54610'
+      - '1546621140.46731'
       X-Trans-Id:
-      - txcce0c66de8d742a5bfb54-005c2e619e
+      - txa048045fcbc44bf686f68-005c2f90d4
       Date:
-      - Thu, 03 Jan 2019 19:25:18 GMT
+      - Fri, 04 Jan 2019 16:59:00 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:18 GMT
+  recorded_at: Fri, 04 Jan 2019 16:59:00 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/dir_1?format=json
@@ -10230,7 +9702,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 983ff650e40f4e8985c46170312f5eac
+      - 7411ad84cc5d48b9a1a18df7c2380be2
   response:
     status:
       code: 200
@@ -10251,9 +9723,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - txb2207666d5964305b49b2-005c2e619e
+      - tx4c2b80f4df724a809dcf2-005c2f90d4
       Date:
-      - Thu, 03 Jan 2019 19:25:18 GMT
+      - Fri, 04 Jan 2019 16:59:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '[{"hash": "61257bf228e2f6802a196c9a460d19a8", "last_modified": "2016-11-11T13:50:03.869630",
@@ -10263,7 +9735,7 @@ http_interactions:
         {"hash": "1727a9b61bddf85bbe7a5710c9f45691", "last_modified": "2016-11-11T13:50:04.495640",
         "bytes": 11, "name": "file_3", "content_type": "application/octet-stream"}]'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:18 GMT
+  recorded_at: Fri, 04 Jan 2019 16:59:00 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/dir_2?format=json
@@ -10278,7 +9750,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 983ff650e40f4e8985c46170312f5eac
+      - 7411ad84cc5d48b9a1a18df7c2380be2
   response:
     status:
       code: 200
@@ -10299,14 +9771,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - txd5080c8307404e4a879a5-005c2e619e
+      - txebec98f5162b437e80f18-005c2f90d4
       Date:
-      - Thu, 03 Jan 2019 19:25:18 GMT
+      - Fri, 04 Jan 2019 16:59:00 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:18 GMT
+  recorded_at: Fri, 04 Jan 2019 16:59:00 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/dir_3?format=json
@@ -10321,7 +9793,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 983ff650e40f4e8985c46170312f5eac
+      - 7411ad84cc5d48b9a1a18df7c2380be2
   response:
     status:
       code: 200
@@ -10342,12 +9814,12 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - txe681befa23bd4932bfbff-005c2e619e
+      - txe2e612fd75f346039d4e1-005c2f90d4
       Date:
-      - Thu, 03 Jan 2019 19:25:18 GMT
+      - Fri, 04 Jan 2019 16:59:00 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:18 GMT
+  recorded_at: Fri, 04 Jan 2019 16:59:00 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_keystone_v3.yml
+++ b/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_keystone_v3.yml
@@ -17,15 +17,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:27:37 GMT
+      - Fri, 04 Jan 2019 16:52:49 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 3709877b1e3a4eab97644519936f64ac
+      - 67233fa9000c437c9d6364f35a546600
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-92b7c2e3-b84e-4c37-b425-75afc250e97e
+      - req-63edf170-f532-4f9a-9b5a-a313584702d3
       Content-Length:
       - '7311'
       Connection:
@@ -37,7 +37,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2019-01-03T20:27:37.187554Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2019-01-04T17:52:49.149493Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -116,10 +116,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["DRecsxYzSwGvNOVRZccZ3A"],
-        "issued_at": "2019-01-03T19:27:37.187573Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["G9ls17YqS9ioyzsAEWNdUA"],
+        "issued_at": "2019-01-04T16:52:49.149517Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:37 GMT
+  recorded_at: Fri, 04 Jan 2019 16:52:49 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -134,7 +134,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3709877b1e3a4eab97644519936f64ac
+      - 67233fa9000c437c9d6364f35a546600
   response:
     status:
       code: 200
@@ -145,7 +145,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Thu, 03 Jan 2019 19:27:37 GMT
+      - Fri, 04 Jan 2019 16:52:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -154,7 +154,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:37 GMT
+  recorded_at: Fri, 04 Jan 2019 16:52:49 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-availability-zone
@@ -169,7 +169,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3709877b1e3a4eab97644519936f64ac
+      - 67233fa9000c437c9d6364f35a546600
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -182,15 +182,15 @@ http_interactions:
       Content-Length:
       - '97'
       X-Compute-Request-Id:
-      - req-f75f2ad5-1174-474d-b5f3-bf6564518839
+      - req-3e9b30f7-bcd3-4899-9eef-3afe8a597499
       Date:
-      - Thu, 03 Jan 2019 19:27:37 GMT
+      - Fri, 04 Jan 2019 16:52:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"availabilityZoneInfo": [{"zoneState": {"available": true}, "hosts":
         null, "zoneName": "nova"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:37 GMT
+  recorded_at: Fri, 04 Jan 2019 16:52:49 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -208,15 +208,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:27:37 GMT
+      - Fri, 04 Jan 2019 16:52:49 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 5bc11c8dda904e298ff9a1f80d667acb
+      - f242ad24b5ea4e5f965fed56419cf25b
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-d74aa4e2-5742-4001-9138-359b649d6bf1
+      - req-ba55af49-2fb8-4eb5-8666-13fe43f9a55f
       Content-Length:
       - '7311'
       Connection:
@@ -228,7 +228,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2019-01-03T20:27:37.613002Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2019-01-04T17:52:49.793086Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -307,10 +307,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["1f5st_y5Q6KrAeZ5getS9w"],
-        "issued_at": "2019-01-03T19:27:37.613040Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Pt92G9diSP6Brf7QeCaADA"],
+        "issued_at": "2019-01-04T16:52:49.793107Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:37 GMT
+  recorded_at: Fri, 04 Jan 2019 16:52:49 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/os-availability-zone.json
@@ -325,28 +325,28 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5bc11c8dda904e298ff9a1f80d667acb
+      - f242ad24b5ea4e5f965fed56419cf25b
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-d9c0474e-5baf-43bd-8c13-a2a5f694bb4a
+      - req-e01ab1be-36ce-479f-ab67-20c2509caace
       Content-Type:
       - application/json
       Content-Length:
       - '82'
       X-Openstack-Request-Id:
-      - req-d9c0474e-5baf-43bd-8c13-a2a5f694bb4a
+      - req-e01ab1be-36ce-479f-ab67-20c2509caace
       Date:
-      - Thu, 03 Jan 2019 19:27:37 GMT
+      - Fri, 04 Jan 2019 16:52:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"availabilityZoneInfo": [{"zoneState": {"available": true}, "zoneName":
         "nova"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:37 GMT
+  recorded_at: Fri, 04 Jan 2019 16:52:49 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -364,15 +364,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:27:37 GMT
+      - Fri, 04 Jan 2019 16:52:50 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 4a66a0ef9c1c4834a4c6e6f107032ccb
+      - c984d81de311418faa68e46c9c9546e5
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-aa603b29-dadd-4626-86ac-16306953db1d
+      - req-7d624097-ed08-4b99-a0e1-0349572a7262
       Content-Length:
       - '297'
       Connection:
@@ -381,12 +381,12 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"token": {"methods": ["password"], "expires_at": "2019-01-03T20:27:37.913363Z",
+      string: '{"token": {"methods": ["password"], "expires_at": "2019-01-04T17:52:50.264286Z",
         "extras": {}, "user": {"domain": {"id": "default", "name": "Default"}, "id":
-        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["PcSKlFcsQrCFm82FCzCPCw"],
-        "issued_at": "2019-01-03T19:27:37.913381Z"}}'
+        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["nnxubp-GSEq6jdBgvrh8rQ"],
+        "issued_at": "2019-01-04T16:52:50.264307Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:37 GMT
+  recorded_at: Fri, 04 Jan 2019 16:52:50 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects?domain_id=default
@@ -401,20 +401,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4a66a0ef9c1c4834a4c6e6f107032ccb
+      - c984d81de311418faa68e46c9c9546e5
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:27:38 GMT
+      - Fri, 04 Jan 2019 16:52:50 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-17b86716-f93e-4680-aee8-1862b45b6a31
+      - req-19dc23d1-3845-4b3a-8d28-085cd3dd042d
       Content-Length:
       - '2475'
       Connection:
@@ -447,7 +447,7 @@ http_interactions:
         "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
         "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:38 GMT
+  recorded_at: Fri, 04 Jan 2019 16:52:50 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -465,15 +465,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:27:38 GMT
+      - Fri, 04 Jan 2019 16:52:50 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 654ef627e4b8456b9c86cd14fe4ce9f4
+      - a3dba1b2b9834ce4b9caa20427196f3f
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-a03d4a5c-510d-43b7-a560-355c62960fe7
+      - req-1db0d482-70f3-4658-bcf9-7da8d973bf5b
       Content-Length:
       - '7278'
       Connection:
@@ -485,7 +485,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:27:38.253848Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:52:50.609995Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -564,10 +564,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["NbHEULLpRriS_xX5bHc0HA"],
-        "issued_at": "2019-01-03T19:27:38.253867Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["P3CYAGBPS9Ch8dKE64b7Ug"],
+        "issued_at": "2019-01-04T16:52:50.610028Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:38 GMT
+  recorded_at: Fri, 04 Jan 2019 16:52:50 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -582,7 +582,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 654ef627e4b8456b9c86cd14fe4ce9f4
+      - a3dba1b2b9834ce4b9caa20427196f3f
   response:
     status:
       code: 200
@@ -593,7 +593,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Thu, 03 Jan 2019 19:27:38 GMT
+      - Fri, 04 Jan 2019 16:52:50 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -602,7 +602,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:38 GMT
+  recorded_at: Fri, 04 Jan 2019 16:52:50 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -620,15 +620,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:27:38 GMT
+      - Fri, 04 Jan 2019 16:52:50 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - aefaf05b99744a83b823ee109916244a
+      - 75446880ba2e4189986da3671c19cf8c
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-476174a9-86d7-4f6d-9f86-2b4f221b8e9f
+      - req-a3998829-65f2-427c-bec8-53294ae09cbc
       Content-Length:
       - '7278'
       Connection:
@@ -640,7 +640,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:27:38.551316Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:52:50.927524Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -719,10 +719,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["MArh6O_DT_q6pjDNj-d1-A"],
-        "issued_at": "2019-01-03T19:27:38.551334Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["N6hyAKBFRfSQAyLpTuDtFw"],
+        "issued_at": "2019-01-04T16:52:50.927550Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:38 GMT
+  recorded_at: Fri, 04 Jan 2019 16:52:50 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -737,7 +737,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - aefaf05b99744a83b823ee109916244a
+      - 75446880ba2e4189986da3671c19cf8c
   response:
     status:
       code: 200
@@ -748,7 +748,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Thu, 03 Jan 2019 19:27:38 GMT
+      - Fri, 04 Jan 2019 16:52:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -757,7 +757,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:38 GMT
+  recorded_at: Fri, 04 Jan 2019 16:52:51 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -775,15 +775,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:27:38 GMT
+      - Fri, 04 Jan 2019 16:52:51 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - e35cba3cf22b4803a0aedc4da241c8f0
+      - 2f1de41faa384c5a9965f645e639128c
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-4b59f853-0e79-479e-8659-a080f81982ee
+      - req-539fdcce-c8bc-42e5-b098-a47282e4ae37
       Content-Length:
       - '7264'
       Connection:
@@ -795,7 +795,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:27:38.847744Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:52:51.226583Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -874,10 +874,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["gsqaIF-wQJyt3YVZm0Ig7Q"],
-        "issued_at": "2019-01-03T19:27:38.847775Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["SnY8CduTRPWOVGcqhV8ZkA"],
+        "issued_at": "2019-01-04T16:52:51.226611Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:38 GMT
+  recorded_at: Fri, 04 Jan 2019 16:52:51 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -892,7 +892,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e35cba3cf22b4803a0aedc4da241c8f0
+      - 2f1de41faa384c5a9965f645e639128c
   response:
     status:
       code: 200
@@ -903,7 +903,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Thu, 03 Jan 2019 19:27:38 GMT
+      - Fri, 04 Jan 2019 16:52:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -912,7 +912,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:38 GMT
+  recorded_at: Fri, 04 Jan 2019 16:52:51 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -930,15 +930,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:27:39 GMT
+      - Fri, 04 Jan 2019 16:52:51 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - f2f6be8d940f45d7a9e16841bf8a42e2
+      - 100edbe9bd6c4ca5b01f6fdb0e3eab6e
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-26e1a691-d981-4a05-86ea-7e245c90d587
+      - req-d28a727a-2c2a-4b8f-a7d5-ec9ae773f2a1
       Content-Length:
       - '7278'
       Connection:
@@ -950,7 +950,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:27:39.131547Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:52:51.531252Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -1029,10 +1029,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["SF4Ozq2HTw-rpexgiU7xCA"],
-        "issued_at": "2019-01-03T19:27:39.131565Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Pg20WdQIRRyQesBVx7sxrg"],
+        "issued_at": "2019-01-04T16:52:51.531274Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:39 GMT
+  recorded_at: Fri, 04 Jan 2019 16:52:51 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -1047,7 +1047,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f2f6be8d940f45d7a9e16841bf8a42e2
+      - 100edbe9bd6c4ca5b01f6fdb0e3eab6e
   response:
     status:
       code: 200
@@ -1058,7 +1058,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Thu, 03 Jan 2019 19:27:39 GMT
+      - Fri, 04 Jan 2019 16:52:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -1067,7 +1067,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:39 GMT
+  recorded_at: Fri, 04 Jan 2019 16:52:51 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -1085,15 +1085,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:27:39 GMT
+      - Fri, 04 Jan 2019 16:52:51 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - c582350c8c88431b8628509dd43449be
+      - 29995e284e9a457b9b9327dec05d8fdf
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-94b8ed0f-3f91-4e32-851a-54be10ef8da6
+      - req-30372392-6f8f-4b84-a02f-b3846b07ac0c
       Content-Length:
       - '7265'
       Connection:
@@ -1105,7 +1105,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:27:39.413232Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:52:51.842190Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -1184,10 +1184,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["rGMUBxe_RNuZXckSduY0gQ"],
-        "issued_at": "2019-01-03T19:27:39.413250Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["WOrwpihZSbGF4wl0_sVhrQ"],
+        "issued_at": "2019-01-04T16:52:51.842213Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:39 GMT
+  recorded_at: Fri, 04 Jan 2019 16:52:51 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -1202,7 +1202,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c582350c8c88431b8628509dd43449be
+      - 29995e284e9a457b9b9327dec05d8fdf
   response:
     status:
       code: 200
@@ -1213,7 +1213,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Thu, 03 Jan 2019 19:27:39 GMT
+      - Fri, 04 Jan 2019 16:52:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -1222,7 +1222,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:39 GMT
+  recorded_at: Fri, 04 Jan 2019 16:52:51 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -1240,15 +1240,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:27:39 GMT
+      - Fri, 04 Jan 2019 16:52:52 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 7255979f42234e738a4f26b6c49aec2b
+      - e709285606e54fd88109676cad5a9182
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-9b501ce5-ce70-4c0f-93fb-87bcde6bcb1a
+      - req-b94c5b1b-5497-4089-9073-5abfac49a032
       Content-Length:
       - '7278'
       Connection:
@@ -1260,7 +1260,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:27:39.699566Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:52:52.140240Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -1339,10 +1339,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["nKn64dO5RDyAVbg_zw-FMg"],
-        "issued_at": "2019-01-03T19:27:39.699585Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["rm_ZBANfQWi7xOUsqWCmLA"],
+        "issued_at": "2019-01-04T16:52:52.140263Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:39 GMT
+  recorded_at: Fri, 04 Jan 2019 16:52:52 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -1357,7 +1357,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7255979f42234e738a4f26b6c49aec2b
+      - e709285606e54fd88109676cad5a9182
   response:
     status:
       code: 200
@@ -1368,7 +1368,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Thu, 03 Jan 2019 19:27:39 GMT
+      - Fri, 04 Jan 2019 16:52:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -1377,7 +1377,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:39 GMT
+  recorded_at: Fri, 04 Jan 2019 16:52:52 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3/os-services?limit=1000
@@ -1392,7 +1392,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 654ef627e4b8456b9c86cd14fe4ce9f4
+      - a3dba1b2b9834ce4b9caa20427196f3f
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1405,26 +1405,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-cab05805-4e76-4785-9392-92c0773d1ae3
+      - req-3c834e41-6764-4eb0-8ee5-9ee6cfcef3fa
       Date:
-      - Thu, 03 Jan 2019 19:27:39 GMT
+      - Fri, 04 Jan 2019 16:52:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-01-03T19:27:38.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-01-04T16:52:50.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2019-01-03T19:27:33.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2019-01-04T16:52:45.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-01-03T19:27:35.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-01-04T16:52:48.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 5, "updated_at":
-        "2019-01-03T19:27:37.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2019-01-04T16:52:50.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2019-01-03T19:27:31.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2019-01-04T16:52:44.000000"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:39 GMT
+  recorded_at: Fri, 04 Jan 2019 16:52:52 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3/os-services?limit=1000&marker=6
@@ -1439,7 +1439,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 654ef627e4b8456b9c86cd14fe4ce9f4
+      - a3dba1b2b9834ce4b9caa20427196f3f
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1452,26 +1452,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-ebdd18b7-f0e0-44a7-aa01-1cff3db48089
+      - req-12739af3-0e78-4475-bb23-1a33c19f31ef
       Date:
-      - Thu, 03 Jan 2019 19:27:40 GMT
+      - Fri, 04 Jan 2019 16:52:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-01-03T19:27:38.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-01-04T16:52:50.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2019-01-03T19:27:33.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2019-01-04T16:52:45.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-01-03T19:27:35.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-01-04T16:52:48.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 5, "updated_at":
-        "2019-01-03T19:27:37.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2019-01-04T16:52:50.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2019-01-03T19:27:31.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2019-01-04T16:52:44.000000"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:40 GMT
+  recorded_at: Fri, 04 Jan 2019 16:52:52 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/28db8f69ba9e4305b7fad82da4c86e74/os-services?limit=1000
@@ -1486,7 +1486,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - aefaf05b99744a83b823ee109916244a
+      - 75446880ba2e4189986da3671c19cf8c
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1499,26 +1499,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-9cd990d9-2075-4bb0-9697-fe06bea2160a
+      - req-62fba0b9-2258-40e9-ad57-6c56d38d3ddd
       Date:
-      - Thu, 03 Jan 2019 19:27:40 GMT
+      - Fri, 04 Jan 2019 16:52:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-01-03T19:27:38.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-01-04T16:52:50.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2019-01-03T19:27:33.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2019-01-04T16:52:45.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-01-03T19:27:35.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-01-04T16:52:48.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 5, "updated_at":
-        "2019-01-03T19:27:37.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2019-01-04T16:52:50.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2019-01-03T19:27:31.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2019-01-04T16:52:44.000000"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:40 GMT
+  recorded_at: Fri, 04 Jan 2019 16:52:52 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/28db8f69ba9e4305b7fad82da4c86e74/os-services?limit=1000&marker=6
@@ -1533,7 +1533,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - aefaf05b99744a83b823ee109916244a
+      - 75446880ba2e4189986da3671c19cf8c
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1546,26 +1546,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-641a0a80-3c71-42e4-bea1-6deacf08a200
+      - req-1fba9349-5824-4bbb-9b0b-414256c02820
       Date:
-      - Thu, 03 Jan 2019 19:27:40 GMT
+      - Fri, 04 Jan 2019 16:52:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-01-03T19:27:38.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-01-04T16:52:50.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2019-01-03T19:27:33.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2019-01-04T16:52:45.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-01-03T19:27:35.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-01-04T16:52:48.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 5, "updated_at":
-        "2019-01-03T19:27:37.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2019-01-04T16:52:50.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2019-01-03T19:27:31.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2019-01-04T16:52:44.000000"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:40 GMT
+  recorded_at: Fri, 04 Jan 2019 16:52:52 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/os-services?limit=1000
@@ -1580,7 +1580,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e35cba3cf22b4803a0aedc4da241c8f0
+      - 2f1de41faa384c5a9965f645e639128c
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1593,26 +1593,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-038783cc-7b10-4dc4-9210-8bb302a7d948
+      - req-401ea6fd-f21a-47a0-985c-d09613de2cfd
       Date:
-      - Thu, 03 Jan 2019 19:27:40 GMT
+      - Fri, 04 Jan 2019 16:52:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-01-03T19:27:38.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-01-04T16:52:50.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2019-01-03T19:27:33.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2019-01-04T16:52:45.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-01-03T19:27:35.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-01-04T16:52:48.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 5, "updated_at":
-        "2019-01-03T19:27:37.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2019-01-04T16:52:50.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2019-01-03T19:27:31.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2019-01-04T16:52:44.000000"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:40 GMT
+  recorded_at: Fri, 04 Jan 2019 16:52:52 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/os-services?limit=1000&marker=6
@@ -1627,7 +1627,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e35cba3cf22b4803a0aedc4da241c8f0
+      - 2f1de41faa384c5a9965f645e639128c
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1640,26 +1640,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-ff8ae79f-bbf3-4e1d-90f8-45d5e677cf2a
+      - req-4869adfc-f009-40b9-9d13-856b8e328755
       Date:
-      - Thu, 03 Jan 2019 19:27:40 GMT
+      - Fri, 04 Jan 2019 16:52:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-01-03T19:27:38.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-01-04T16:52:50.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2019-01-03T19:27:33.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2019-01-04T16:52:45.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-01-03T19:27:35.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-01-04T16:52:48.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 5, "updated_at":
-        "2019-01-03T19:27:37.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2019-01-04T16:52:50.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2019-01-03T19:27:31.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2019-01-04T16:52:44.000000"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:40 GMT
+  recorded_at: Fri, 04 Jan 2019 16:52:53 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/52c452d7763a4295950527948232a3e5/os-services?limit=1000
@@ -1674,7 +1674,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f2f6be8d940f45d7a9e16841bf8a42e2
+      - 100edbe9bd6c4ca5b01f6fdb0e3eab6e
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1687,26 +1687,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-a38e577a-154c-409d-9d09-7b69179ae8d8
+      - req-aeffe868-2443-4ece-9614-0abe9048fafe
       Date:
-      - Thu, 03 Jan 2019 19:27:40 GMT
+      - Fri, 04 Jan 2019 16:52:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-01-03T19:27:38.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-01-04T16:52:50.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2019-01-03T19:27:33.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2019-01-04T16:52:45.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-01-03T19:27:35.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-01-04T16:52:48.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 5, "updated_at":
-        "2019-01-03T19:27:37.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2019-01-04T16:52:50.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2019-01-03T19:27:31.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2019-01-04T16:52:44.000000"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:40 GMT
+  recorded_at: Fri, 04 Jan 2019 16:52:53 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/52c452d7763a4295950527948232a3e5/os-services?limit=1000&marker=6
@@ -1721,7 +1721,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f2f6be8d940f45d7a9e16841bf8a42e2
+      - 100edbe9bd6c4ca5b01f6fdb0e3eab6e
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1734,26 +1734,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-83f09ed3-a15e-40cf-a32b-e2e51b0d4482
+      - req-b531a380-6500-4a6e-8835-75e68201740b
       Date:
-      - Thu, 03 Jan 2019 19:27:40 GMT
+      - Fri, 04 Jan 2019 16:52:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-01-03T19:27:38.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-01-04T16:52:50.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2019-01-03T19:27:33.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2019-01-04T16:52:45.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-01-03T19:27:35.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-01-04T16:52:48.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 5, "updated_at":
-        "2019-01-03T19:27:37.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2019-01-04T16:52:50.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2019-01-03T19:27:31.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2019-01-04T16:52:44.000000"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:40 GMT
+  recorded_at: Fri, 04 Jan 2019 16:52:53 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-services?limit=1000
@@ -1768,7 +1768,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3709877b1e3a4eab97644519936f64ac
+      - 67233fa9000c437c9d6364f35a546600
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1781,26 +1781,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-99dc2734-cfae-48d3-85cd-4027e67a86b6
+      - req-6c648261-2100-44d6-834e-f9a8b98b51b9
       Date:
-      - Thu, 03 Jan 2019 19:27:40 GMT
+      - Fri, 04 Jan 2019 16:52:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-01-03T19:27:38.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-01-04T16:52:50.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2019-01-03T19:27:33.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2019-01-04T16:52:45.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-01-03T19:27:35.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-01-04T16:52:48.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 5, "updated_at":
-        "2019-01-03T19:27:37.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2019-01-04T16:52:50.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2019-01-03T19:27:31.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2019-01-04T16:52:44.000000"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:40 GMT
+  recorded_at: Fri, 04 Jan 2019 16:52:53 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-services?limit=1000&marker=6
@@ -1815,7 +1815,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3709877b1e3a4eab97644519936f64ac
+      - 67233fa9000c437c9d6364f35a546600
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1828,26 +1828,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-7d90c0f7-ef53-4b18-ace5-9f552467c7c9
+      - req-a5365c65-9d7f-4f67-8efa-fc928fc3df58
       Date:
-      - Thu, 03 Jan 2019 19:27:41 GMT
+      - Fri, 04 Jan 2019 16:52:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-01-03T19:27:38.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-01-04T16:52:50.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2019-01-03T19:27:33.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2019-01-04T16:52:45.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-01-03T19:27:35.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-01-04T16:52:48.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 5, "updated_at":
-        "2019-01-03T19:27:37.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2019-01-04T16:52:50.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2019-01-03T19:27:31.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2019-01-04T16:52:44.000000"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:41 GMT
+  recorded_at: Fri, 04 Jan 2019 16:52:53 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/d09cbe26295d47ff848ea73c74264e23/os-services?limit=1000
@@ -1862,7 +1862,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c582350c8c88431b8628509dd43449be
+      - 29995e284e9a457b9b9327dec05d8fdf
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1875,26 +1875,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-3a90e75e-5c7b-4c9e-a734-fe3d0ee15ec1
+      - req-f92c5980-a326-4d44-8e98-341fd0876c48
       Date:
-      - Thu, 03 Jan 2019 19:27:41 GMT
+      - Fri, 04 Jan 2019 16:52:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-01-03T19:27:38.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-01-04T16:52:50.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2019-01-03T19:27:33.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2019-01-04T16:52:45.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-01-03T19:27:35.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-01-04T16:52:48.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 5, "updated_at":
-        "2019-01-03T19:27:37.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2019-01-04T16:52:50.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2019-01-03T19:27:31.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2019-01-04T16:52:44.000000"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:41 GMT
+  recorded_at: Fri, 04 Jan 2019 16:52:53 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/d09cbe26295d47ff848ea73c74264e23/os-services?limit=1000&marker=6
@@ -1909,7 +1909,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c582350c8c88431b8628509dd43449be
+      - 29995e284e9a457b9b9327dec05d8fdf
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1922,26 +1922,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-585137f4-6f76-4322-b13d-a90d590d4a23
+      - req-32bd1e9e-adfe-46b8-99f8-98db2eb05769
       Date:
-      - Thu, 03 Jan 2019 19:27:41 GMT
+      - Fri, 04 Jan 2019 16:52:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-01-03T19:27:38.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-01-04T16:52:50.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2019-01-03T19:27:33.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2019-01-04T16:52:45.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-01-03T19:27:35.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-01-04T16:52:48.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 5, "updated_at":
-        "2019-01-03T19:27:37.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2019-01-04T16:52:50.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2019-01-03T19:27:31.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2019-01-04T16:52:44.000000"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:41 GMT
+  recorded_at: Fri, 04 Jan 2019 16:52:53 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/os-services?limit=1000
@@ -1956,7 +1956,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7255979f42234e738a4f26b6c49aec2b
+      - e709285606e54fd88109676cad5a9182
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1969,26 +1969,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-165c91fc-0ced-4ab0-8618-a84efd4e0bcd
+      - req-f7d69a5a-4090-49ad-bd34-f47da65d714a
       Date:
-      - Thu, 03 Jan 2019 19:27:41 GMT
+      - Fri, 04 Jan 2019 16:52:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-01-03T19:27:38.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-01-04T16:52:50.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2019-01-03T19:27:33.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2019-01-04T16:52:45.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-01-03T19:27:35.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-01-04T16:52:48.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 5, "updated_at":
-        "2019-01-03T19:27:37.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2019-01-04T16:52:50.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2019-01-03T19:27:31.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2019-01-04T16:52:44.000000"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:41 GMT
+  recorded_at: Fri, 04 Jan 2019 16:52:53 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/os-services?limit=1000&marker=6
@@ -2003,7 +2003,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7255979f42234e738a4f26b6c49aec2b
+      - e709285606e54fd88109676cad5a9182
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2016,26 +2016,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-49aa672e-4354-4eac-988d-46785e5937aa
+      - req-b9e899a5-a739-4859-b0e4-1461829ba7e0
       Date:
-      - Thu, 03 Jan 2019 19:27:41 GMT
+      - Fri, 04 Jan 2019 16:52:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-01-03T19:27:38.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-01-04T16:52:50.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2019-01-03T19:27:33.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2019-01-04T16:52:45.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-01-03T19:27:35.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-01-04T16:52:48.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 5, "updated_at":
-        "2019-01-03T19:27:37.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2019-01-04T16:52:50.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2019-01-03T19:27:31.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2019-01-04T16:52:44.000000"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:41 GMT
+  recorded_at: Fri, 04 Jan 2019 16:52:54 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000
@@ -2050,7 +2050,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3709877b1e3a4eab97644519936f64ac
+      - 67233fa9000c437c9d6364f35a546600
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2063,9 +2063,9 @@ http_interactions:
       Content-Length:
       - '1010'
       X-Compute-Request-Id:
-      - req-f5f16392-f440-4fcd-97ea-ae3a86b11f1d
+      - req-dfba9c64-bd71-4262-8bdb-69cdd445d325
       Date:
-      - Thu, 03 Jan 2019 19:27:41 GMT
+      - Fri, 04 Jan 2019 16:52:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.tiny", "links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/1",
@@ -2079,7 +2079,7 @@ http_interactions:
         0, "disk": 20, "id": "2"}], "flavors_links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=2",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:41 GMT
+  recorded_at: Fri, 04 Jan 2019 16:52:54 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=2
@@ -2094,7 +2094,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3709877b1e3a4eab97644519936f64ac
+      - 67233fa9000c437c9d6364f35a546600
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2107,9 +2107,9 @@ http_interactions:
       Content-Length:
       - '1014'
       X-Compute-Request-Id:
-      - req-cd4a31ea-76fb-4804-8888-331ac527ad6d
+      - req-dc746525-bead-4332-9afa-46868c3829a2
       Date:
-      - Thu, 03 Jan 2019 19:27:41 GMT
+      - Fri, 04 Jan 2019 16:52:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.medium", "links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/3",
@@ -2123,7 +2123,7 @@ http_interactions:
         0, "disk": 80, "id": "4"}], "flavors_links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=4",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:41 GMT
+  recorded_at: Fri, 04 Jan 2019 16:52:54 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=4
@@ -2138,7 +2138,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3709877b1e3a4eab97644519936f64ac
+      - 67233fa9000c437c9d6364f35a546600
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2151,9 +2151,9 @@ http_interactions:
       Content-Length:
       - '1026'
       X-Compute-Request-Id:
-      - req-6ac25e96-4fd0-498e-a30f-53cf28ce42d4
+      - req-3df3fe18-20df-4947-beff-0d55e745ea15
       Date:
-      - Thu, 03 Jan 2019 19:27:41 GMT
+      - Fri, 04 Jan 2019 16:52:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.xlarge", "links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/5",
@@ -2168,7 +2168,7 @@ http_interactions:
         1, "disk": 1, "id": "6"}], "flavors_links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=6",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:41 GMT
+  recorded_at: Fri, 04 Jan 2019 16:52:54 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=6
@@ -2183,7 +2183,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3709877b1e3a4eab97644519936f64ac
+      - 67233fa9000c437c9d6364f35a546600
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2196,9 +2196,9 @@ http_interactions:
       Content-Length:
       - '448'
       X-Compute-Request-Id:
-      - req-a452c238-20b7-4fde-805c-b304cf8517de
+      - req-56d41529-cd3a-4942-a730-642d30c750bd
       Date:
-      - Thu, 03 Jan 2019 19:27:41 GMT
+      - Fri, 04 Jan 2019 16:52:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.ems_refresh_spec_private", "links": [{"href":
@@ -2208,7 +2208,7 @@ http_interactions:
         8, "swap": "", "os-flavor-access:is_public": false, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         0, "disk": 160, "id": "7"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:41 GMT
+  recorded_at: Fri, 04 Jan 2019 16:52:54 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/7/os-flavor-access
@@ -2223,7 +2223,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3709877b1e3a4eab97644519936f64ac
+      - 67233fa9000c437c9d6364f35a546600
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2236,15 +2236,15 @@ http_interactions:
       Content-Length:
       - '88'
       X-Compute-Request-Id:
-      - req-3d6a23d1-ef37-4883-90fe-d650b5cee81d
+      - req-95053040-e041-498c-80d4-034aaa600f7d
       Date:
-      - Thu, 03 Jan 2019 19:27:42 GMT
+      - Fri, 04 Jan 2019 16:52:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavor_access": [{"tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "flavor_id": "7"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:42 GMT
+  recorded_at: Fri, 04 Jan 2019 16:52:54 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -2262,15 +2262,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:27:42 GMT
+      - Fri, 04 Jan 2019 16:52:54 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - e2dcd0a437a849919f062b9f0b1fb6f1
+      - 8db5e36c34e340feb6056100f3ff6716
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-5bdca437-bb28-4044-b0b3-dfaea7ce9a6f
+      - req-73f4a36d-6daa-451b-8acc-c72d7b8fa0f1
       Content-Length:
       - '7311'
       Connection:
@@ -2282,7 +2282,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2019-01-03T20:27:42.227270Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2019-01-04T17:52:54.801144Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -2361,10 +2361,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["adB3QUFsQw-wiRDsQjInNw"],
-        "issued_at": "2019-01-03T19:27:42.227290Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["zzxx7cShQw2pdO39JNN2vQ"],
+        "issued_at": "2019-01-04T16:52:54.801171Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:42 GMT
+  recorded_at: Fri, 04 Jan 2019 16:52:54 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -2382,15 +2382,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:27:42 GMT
+      - Fri, 04 Jan 2019 16:52:54 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 3e4c19942d4c483ca89e78031294cca9
+      - 2fae9c28bcd24f71a81178b1c594e33f
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-496e63c2-d074-4339-a207-1db94c6c8b86
+      - req-25eb7ecd-613e-46cd-9f7b-9443482480e2
       Content-Length:
       - '7278'
       Connection:
@@ -2402,7 +2402,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:27:42.428193Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:52:55.060082Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -2481,10 +2481,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["2xiqyrObTzq4LQP9WR4WQQ"],
-        "issued_at": "2019-01-03T19:27:42.428210Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["x70odmtwRIWrB8V2Iu5lag"],
+        "issued_at": "2019-01-04T16:52:55.060104Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:42 GMT
+  recorded_at: Fri, 04 Jan 2019 16:52:55 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -2502,15 +2502,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:27:42 GMT
+      - Fri, 04 Jan 2019 16:52:55 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - d553f887af5b471eb7db3ef86c204858
+      - 42c5918e3f554969a2e597f46faa1dda
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-51a56390-1427-4621-a64a-221008860d22
+      - req-3dc67903-c186-4e21-baa1-4a706c6e5bf3
       Content-Length:
       - '7278'
       Connection:
@@ -2522,7 +2522,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:27:42.629705Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:52:55.272490Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -2601,10 +2601,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["aq5ct51cRhGKAFiYKro_Pg"],
-        "issued_at": "2019-01-03T19:27:42.629722Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["UYm9m3wETr2VNzJ9pSG6BA"],
+        "issued_at": "2019-01-04T16:52:55.272512Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:42 GMT
+  recorded_at: Fri, 04 Jan 2019 16:52:55 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -2622,15 +2622,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:27:42 GMT
+      - Fri, 04 Jan 2019 16:52:55 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 8e73180a119341988ce72ebdbba78309
+      - 5fd9bc851f6b49ffbf6260f0e0d991a0
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-8b80a63d-1e65-4af1-ad34-4e7800bc267c
+      - req-468e6bae-290b-4427-a094-19963ee03e3f
       Content-Length:
       - '7264'
       Connection:
@@ -2642,7 +2642,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:27:42.834360Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:52:55.485543Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -2721,10 +2721,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["TzQiBLiQRaKzyetCZMuqFg"],
-        "issued_at": "2019-01-03T19:27:42.834379Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Avj_trMXQoqCws4x488zOA"],
+        "issued_at": "2019-01-04T16:52:55.485566Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:42 GMT
+  recorded_at: Fri, 04 Jan 2019 16:52:55 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -2742,15 +2742,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:27:42 GMT
+      - Fri, 04 Jan 2019 16:52:55 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 9e848315961c4580925ec619f99e1caf
+      - 8a4ae6b6e5f84ce79272cb41755a8115
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-3a83134a-491f-4324-a610-7afdc8c8150e
+      - req-4dde06bb-d206-40af-b9cc-9a7355049476
       Content-Length:
       - '7278'
       Connection:
@@ -2762,7 +2762,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:27:43.034748Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:52:55.698153Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -2841,10 +2841,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["LsTurjm9THKIWNg3KNOpgQ"],
-        "issued_at": "2019-01-03T19:27:43.034776Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["NyUMkoMPT7uDHiD3rBSlcg"],
+        "issued_at": "2019-01-04T16:52:55.698176Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:43 GMT
+  recorded_at: Fri, 04 Jan 2019 16:52:55 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -2862,15 +2862,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:27:43 GMT
+      - Fri, 04 Jan 2019 16:52:55 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 2b6e685aba7648de89b8f8e37193b06f
+      - 37b949f4c3ef46d687c80f5b1092442c
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-226f8f4d-20e9-4405-854d-db9fb9ff26ef
+      - req-89b8cc9d-5e57-4f1c-96da-571f85603160
       Content-Length:
       - '7265'
       Connection:
@@ -2882,7 +2882,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:27:43.237012Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:52:55.908690Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -2961,10 +2961,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["zYsUObC7RMefse1DCccDgA"],
-        "issued_at": "2019-01-03T19:27:43.237029Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Y5Zb43xeSaijWVrFgAEtZw"],
+        "issued_at": "2019-01-04T16:52:55.908713Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:43 GMT
+  recorded_at: Fri, 04 Jan 2019 16:52:55 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -2982,15 +2982,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:27:43 GMT
+      - Fri, 04 Jan 2019 16:52:56 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - f1f4a851beb64693960c643f6c066743
+      - 227ace59082f4e579949cc74f09753a2
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-55b1eee6-d555-4779-9697-9788cb044602
+      - req-df09ba0e-020d-47d6-8193-c5198cf19bc3
       Content-Length:
       - '7278'
       Connection:
@@ -3002,7 +3002,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:27:43.680006Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:52:56.118477Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -3081,10 +3081,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["oNxfW-7uRbaM9XwzOAdxtA"],
-        "issued_at": "2019-01-03T19:27:43.680024Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["JWLkQxR6RZCl9Jzr_pekhg"],
+        "issued_at": "2019-01-04T16:52:56.118499Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:43 GMT
+  recorded_at: Fri, 04 Jan 2019 16:52:56 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images?limit=1000
@@ -3099,7 +3099,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3e4c19942d4c483ca89e78031294cca9
+      - 2fae9c28bcd24f71a81178b1c594e33f
   response:
     status:
       code: 200
@@ -3110,9 +3110,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-1765d381-6c38-4382-8290-d1cd95fcbd3c
+      - req-fd0ceac3-72e1-4fd1-91c0-6412920d6a33
       Date:
-      - Thu, 03 Jan 2019 19:27:43 GMT
+      - Fri, 04 Jan 2019 16:52:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -3154,7 +3154,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:43 GMT
+  recorded_at: Fri, 04 Jan 2019 16:52:56 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images?limit=1000&marker=b672acdb-654b-41d7-963c-44a0349bd285
@@ -3169,7 +3169,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3e4c19942d4c483ca89e78031294cca9
+      - 2fae9c28bcd24f71a81178b1c594e33f
   response:
     status:
       code: 200
@@ -3180,14 +3180,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-b874c22c-1b1b-4221-9132-dd24cab4fe78
+      - req-4545dc17-3a28-4f6c-a9f2-754e6403b9e9
       Date:
-      - Thu, 03 Jan 2019 19:27:43 GMT
+      - Fri, 04 Jan 2019 16:52:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:43 GMT
+  recorded_at: Fri, 04 Jan 2019 16:52:56 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images?limit=1000
@@ -3202,7 +3202,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d553f887af5b471eb7db3ef86c204858
+      - 42c5918e3f554969a2e597f46faa1dda
   response:
     status:
       code: 200
@@ -3213,9 +3213,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-e7062109-bd0d-493c-89ef-63e8420b2e33
+      - req-e20791d6-b5c0-4983-b549-0defa9b2290a
       Date:
-      - Thu, 03 Jan 2019 19:27:44 GMT
+      - Fri, 04 Jan 2019 16:52:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -3257,7 +3257,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:44 GMT
+  recorded_at: Fri, 04 Jan 2019 16:52:56 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images?limit=1000&marker=b672acdb-654b-41d7-963c-44a0349bd285
@@ -3272,7 +3272,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d553f887af5b471eb7db3ef86c204858
+      - 42c5918e3f554969a2e597f46faa1dda
   response:
     status:
       code: 200
@@ -3283,14 +3283,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-5bfbd3f6-7b2f-4495-a1b8-ff2d9e220d76
+      - req-2862bba7-51ff-4f24-a28a-74d9db0a225c
       Date:
-      - Thu, 03 Jan 2019 19:27:44 GMT
+      - Fri, 04 Jan 2019 16:52:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:44 GMT
+  recorded_at: Fri, 04 Jan 2019 16:52:56 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images?limit=1000
@@ -3305,7 +3305,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8e73180a119341988ce72ebdbba78309
+      - 5fd9bc851f6b49ffbf6260f0e0d991a0
   response:
     status:
       code: 200
@@ -3316,9 +3316,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-1ad6a414-d562-4601-b090-3a2c355ecf99
+      - req-14ad6ec9-66db-4801-b84a-02ad4f732220
       Date:
-      - Thu, 03 Jan 2019 19:27:44 GMT
+      - Fri, 04 Jan 2019 16:52:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -3360,7 +3360,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:44 GMT
+  recorded_at: Fri, 04 Jan 2019 16:52:56 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images?limit=1000&marker=b672acdb-654b-41d7-963c-44a0349bd285
@@ -3375,7 +3375,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8e73180a119341988ce72ebdbba78309
+      - 5fd9bc851f6b49ffbf6260f0e0d991a0
   response:
     status:
       code: 200
@@ -3386,14 +3386,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-cd9d34ad-a6e9-4b80-a6c6-0a18abf9d567
+      - req-5fa1208a-22b4-4f71-91f3-33fb1d55bc59
       Date:
-      - Thu, 03 Jan 2019 19:27:44 GMT
+      - Fri, 04 Jan 2019 16:52:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:44 GMT
+  recorded_at: Fri, 04 Jan 2019 16:52:56 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images?limit=1000
@@ -3408,7 +3408,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9e848315961c4580925ec619f99e1caf
+      - 8a4ae6b6e5f84ce79272cb41755a8115
   response:
     status:
       code: 200
@@ -3419,9 +3419,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-2a3cce14-30df-4905-ade5-b19b1a2989c2
+      - req-efd49134-1314-4fd4-ad5b-c141dbdbded4
       Date:
-      - Thu, 03 Jan 2019 19:27:44 GMT
+      - Fri, 04 Jan 2019 16:52:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -3463,7 +3463,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:44 GMT
+  recorded_at: Fri, 04 Jan 2019 16:52:57 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images?limit=1000&marker=b672acdb-654b-41d7-963c-44a0349bd285
@@ -3478,7 +3478,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9e848315961c4580925ec619f99e1caf
+      - 8a4ae6b6e5f84ce79272cb41755a8115
   response:
     status:
       code: 200
@@ -3489,14 +3489,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-c6c19a77-dabd-4ca5-8411-05eb30558e0e
+      - req-543e26f7-0905-40ed-a641-cb72c8c56f9b
       Date:
-      - Thu, 03 Jan 2019 19:27:44 GMT
+      - Fri, 04 Jan 2019 16:52:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:44 GMT
+  recorded_at: Fri, 04 Jan 2019 16:52:57 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images?limit=1000
@@ -3511,7 +3511,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e2dcd0a437a849919f062b9f0b1fb6f1
+      - 8db5e36c34e340feb6056100f3ff6716
   response:
     status:
       code: 200
@@ -3522,9 +3522,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-e5135876-60bb-4354-956f-d2b14b484b7c
+      - req-b833150b-3c70-41e6-bb38-66578e3ffae9
       Date:
-      - Thu, 03 Jan 2019 19:27:44 GMT
+      - Fri, 04 Jan 2019 16:52:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -3566,7 +3566,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:44 GMT
+  recorded_at: Fri, 04 Jan 2019 16:52:57 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images?limit=1000&marker=b672acdb-654b-41d7-963c-44a0349bd285
@@ -3581,7 +3581,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e2dcd0a437a849919f062b9f0b1fb6f1
+      - 8db5e36c34e340feb6056100f3ff6716
   response:
     status:
       code: 200
@@ -3592,14 +3592,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-c97d5851-6b63-4d5e-acec-2812e8ee1bfd
+      - req-9b60acde-ace0-46d0-ab23-d027201bd8c6
       Date:
-      - Thu, 03 Jan 2019 19:27:45 GMT
+      - Fri, 04 Jan 2019 16:52:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:45 GMT
+  recorded_at: Fri, 04 Jan 2019 16:52:57 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images?limit=1000
@@ -3614,7 +3614,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2b6e685aba7648de89b8f8e37193b06f
+      - 37b949f4c3ef46d687c80f5b1092442c
   response:
     status:
       code: 200
@@ -3625,9 +3625,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-b01a14bc-3d6b-43c6-9409-4321ec8b9516
+      - req-e853f0e5-3b15-4950-9bfb-76c89a5dd1a3
       Date:
-      - Thu, 03 Jan 2019 19:27:45 GMT
+      - Fri, 04 Jan 2019 16:52:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -3669,7 +3669,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:45 GMT
+  recorded_at: Fri, 04 Jan 2019 16:52:57 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images?limit=1000&marker=b672acdb-654b-41d7-963c-44a0349bd285
@@ -3684,7 +3684,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2b6e685aba7648de89b8f8e37193b06f
+      - 37b949f4c3ef46d687c80f5b1092442c
   response:
     status:
       code: 200
@@ -3695,14 +3695,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-012cbcca-d2e4-42d0-b919-a811a59738f6
+      - req-216035b9-0d04-4550-a491-2cd38efffc02
       Date:
-      - Thu, 03 Jan 2019 19:27:45 GMT
+      - Fri, 04 Jan 2019 16:52:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:45 GMT
+  recorded_at: Fri, 04 Jan 2019 16:52:57 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images?limit=1000
@@ -3717,7 +3717,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f1f4a851beb64693960c643f6c066743
+      - 227ace59082f4e579949cc74f09753a2
   response:
     status:
       code: 200
@@ -3728,9 +3728,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-773d1fe9-56be-4bf3-ba6b-53247853003f
+      - req-57b97009-b8e9-433a-a2ac-d5623b10942c
       Date:
-      - Thu, 03 Jan 2019 19:27:45 GMT
+      - Fri, 04 Jan 2019 16:52:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -3772,7 +3772,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:45 GMT
+  recorded_at: Fri, 04 Jan 2019 16:52:57 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images?limit=1000&marker=b672acdb-654b-41d7-963c-44a0349bd285
@@ -3787,7 +3787,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f1f4a851beb64693960c643f6c066743
+      - 227ace59082f4e579949cc74f09753a2
   response:
     status:
       code: 200
@@ -3798,14 +3798,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-2a4b3158-d29e-4f7c-b121-fc188b876e8f
+      - req-bc9504ce-5f33-49ed-b775-e703b179c682
       Date:
-      - Thu, 03 Jan 2019 19:27:45 GMT
+      - Fri, 04 Jan 2019 16:52:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:45 GMT
+  recorded_at: Fri, 04 Jan 2019 16:52:58 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3/os-keypairs?limit=1000
@@ -3820,7 +3820,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 654ef627e4b8456b9c86cd14fe4ce9f4
+      - a3dba1b2b9834ce4b9caa20427196f3f
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3833,9 +3833,9 @@ http_interactions:
       Content-Length:
       - '1611'
       X-Compute-Request-Id:
-      - req-58151d4f-723a-44da-9908-0cb3fc7b12e6
+      - req-8ca5e0a4-716e-406e-936c-be398ef15e81
       Date:
-      - Thu, 03 Jan 2019 19:27:45 GMT
+      - Fri, 04 Jan 2019 16:52:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKQyhM0ECmYmB8mI4vfeTEaY90skgHYgA/5apgT+cHhKzZX59Go+LGfb98dOCYEjnV3XKdO5dy7MrSdI5QSvGJmJIQPsH4WZNpRNuEhHzcHS1fEPe9zMceRlLafkTeUKhUGMIi1gOmBRdyZtz6fJw37AK6ioM4+16IhXjNVLV09jHn2PsUjh2RsGX5TzA3eHivptzINBD8eMBkyQwS2uejY42FlIg9qBpa8KEMgyo4KLvd/99kw9wLg1D9Y5+3OxA/J6hLfjSBv7Vd7Xvwd4ZmDlkU5+yH88b2ZOte8MyfAnlVA4v8bMdSsAf1e5NvUuZsoZC8goZCHjXmTDSI+yen
@@ -3845,7 +3845,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:45 GMT
+  recorded_at: Fri, 04 Jan 2019 16:52:58 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -3860,7 +3860,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 654ef627e4b8456b9c86cd14fe4ce9f4
+      - a3dba1b2b9834ce4b9caa20427196f3f
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3873,9 +3873,9 @@ http_interactions:
       Content-Length:
       - '1611'
       X-Compute-Request-Id:
-      - req-59e9cd37-cf78-41cb-b25e-8bb74c9e9d3f
+      - req-341d8049-3f78-47cf-9494-575a8a49f008
       Date:
-      - Thu, 03 Jan 2019 19:27:45 GMT
+      - Fri, 04 Jan 2019 16:52:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKQyhM0ECmYmB8mI4vfeTEaY90skgHYgA/5apgT+cHhKzZX59Go+LGfb98dOCYEjnV3XKdO5dy7MrSdI5QSvGJmJIQPsH4WZNpRNuEhHzcHS1fEPe9zMceRlLafkTeUKhUGMIi1gOmBRdyZtz6fJw37AK6ioM4+16IhXjNVLV09jHn2PsUjh2RsGX5TzA3eHivptzINBD8eMBkyQwS2uejY42FlIg9qBpa8KEMgyo4KLvd/99kw9wLg1D9Y5+3OxA/J6hLfjSBv7Vd7Xvwd4ZmDlkU5+yH88b2ZOte8MyfAnlVA4v8bMdSsAf1e5NvUuZsoZC8goZCHjXmTDSI+yen
@@ -3885,7 +3885,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:45 GMT
+  recorded_at: Fri, 04 Jan 2019 16:52:58 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/28db8f69ba9e4305b7fad82da4c86e74/os-keypairs?limit=1000
@@ -3900,7 +3900,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - aefaf05b99744a83b823ee109916244a
+      - 75446880ba2e4189986da3671c19cf8c
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3913,9 +3913,9 @@ http_interactions:
       Content-Length:
       - '1611'
       X-Compute-Request-Id:
-      - req-052f2f26-6f40-418c-ab96-81f6b7fc9155
+      - req-c493b5ae-fd50-4e3f-b903-e1b3ef0170ec
       Date:
-      - Thu, 03 Jan 2019 19:27:45 GMT
+      - Fri, 04 Jan 2019 16:52:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKQyhM0ECmYmB8mI4vfeTEaY90skgHYgA/5apgT+cHhKzZX59Go+LGfb98dOCYEjnV3XKdO5dy7MrSdI5QSvGJmJIQPsH4WZNpRNuEhHzcHS1fEPe9zMceRlLafkTeUKhUGMIi1gOmBRdyZtz6fJw37AK6ioM4+16IhXjNVLV09jHn2PsUjh2RsGX5TzA3eHivptzINBD8eMBkyQwS2uejY42FlIg9qBpa8KEMgyo4KLvd/99kw9wLg1D9Y5+3OxA/J6hLfjSBv7Vd7Xvwd4ZmDlkU5+yH88b2ZOte8MyfAnlVA4v8bMdSsAf1e5NvUuZsoZC8goZCHjXmTDSI+yen
@@ -3925,7 +3925,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:45 GMT
+  recorded_at: Fri, 04 Jan 2019 16:52:58 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/28db8f69ba9e4305b7fad82da4c86e74/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -3940,7 +3940,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - aefaf05b99744a83b823ee109916244a
+      - 75446880ba2e4189986da3671c19cf8c
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3953,9 +3953,9 @@ http_interactions:
       Content-Length:
       - '1611'
       X-Compute-Request-Id:
-      - req-a662028b-0b3b-4748-b718-83ad5e90d6b0
+      - req-79f199b8-6067-4306-b890-6b5571465a37
       Date:
-      - Thu, 03 Jan 2019 19:27:45 GMT
+      - Fri, 04 Jan 2019 16:52:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKQyhM0ECmYmB8mI4vfeTEaY90skgHYgA/5apgT+cHhKzZX59Go+LGfb98dOCYEjnV3XKdO5dy7MrSdI5QSvGJmJIQPsH4WZNpRNuEhHzcHS1fEPe9zMceRlLafkTeUKhUGMIi1gOmBRdyZtz6fJw37AK6ioM4+16IhXjNVLV09jHn2PsUjh2RsGX5TzA3eHivptzINBD8eMBkyQwS2uejY42FlIg9qBpa8KEMgyo4KLvd/99kw9wLg1D9Y5+3OxA/J6hLfjSBv7Vd7Xvwd4ZmDlkU5+yH88b2ZOte8MyfAnlVA4v8bMdSsAf1e5NvUuZsoZC8goZCHjXmTDSI+yen
@@ -3965,7 +3965,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:46 GMT
+  recorded_at: Fri, 04 Jan 2019 16:52:58 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/os-keypairs?limit=1000
@@ -3980,7 +3980,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e35cba3cf22b4803a0aedc4da241c8f0
+      - 2f1de41faa384c5a9965f645e639128c
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3993,9 +3993,9 @@ http_interactions:
       Content-Length:
       - '1611'
       X-Compute-Request-Id:
-      - req-69967b1a-0dab-4fbe-bccf-d03fb85fd814
+      - req-b0d351d6-6fd5-4855-82cd-6f03e06e9b2d
       Date:
-      - Thu, 03 Jan 2019 19:27:46 GMT
+      - Fri, 04 Jan 2019 16:52:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKQyhM0ECmYmB8mI4vfeTEaY90skgHYgA/5apgT+cHhKzZX59Go+LGfb98dOCYEjnV3XKdO5dy7MrSdI5QSvGJmJIQPsH4WZNpRNuEhHzcHS1fEPe9zMceRlLafkTeUKhUGMIi1gOmBRdyZtz6fJw37AK6ioM4+16IhXjNVLV09jHn2PsUjh2RsGX5TzA3eHivptzINBD8eMBkyQwS2uejY42FlIg9qBpa8KEMgyo4KLvd/99kw9wLg1D9Y5+3OxA/J6hLfjSBv7Vd7Xvwd4ZmDlkU5+yH88b2ZOte8MyfAnlVA4v8bMdSsAf1e5NvUuZsoZC8goZCHjXmTDSI+yen
@@ -4005,7 +4005,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:46 GMT
+  recorded_at: Fri, 04 Jan 2019 16:52:58 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -4020,7 +4020,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e35cba3cf22b4803a0aedc4da241c8f0
+      - 2f1de41faa384c5a9965f645e639128c
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4033,9 +4033,9 @@ http_interactions:
       Content-Length:
       - '1611'
       X-Compute-Request-Id:
-      - req-dc59b877-8649-4c89-bb71-45841d06157a
+      - req-a4bf18c3-3907-4bc9-a465-ce1bfbf38cb6
       Date:
-      - Thu, 03 Jan 2019 19:27:46 GMT
+      - Fri, 04 Jan 2019 16:52:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKQyhM0ECmYmB8mI4vfeTEaY90skgHYgA/5apgT+cHhKzZX59Go+LGfb98dOCYEjnV3XKdO5dy7MrSdI5QSvGJmJIQPsH4WZNpRNuEhHzcHS1fEPe9zMceRlLafkTeUKhUGMIi1gOmBRdyZtz6fJw37AK6ioM4+16IhXjNVLV09jHn2PsUjh2RsGX5TzA3eHivptzINBD8eMBkyQwS2uejY42FlIg9qBpa8KEMgyo4KLvd/99kw9wLg1D9Y5+3OxA/J6hLfjSBv7Vd7Xvwd4ZmDlkU5+yH88b2ZOte8MyfAnlVA4v8bMdSsAf1e5NvUuZsoZC8goZCHjXmTDSI+yen
@@ -4045,7 +4045,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:46 GMT
+  recorded_at: Fri, 04 Jan 2019 16:52:58 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/52c452d7763a4295950527948232a3e5/os-keypairs?limit=1000
@@ -4060,7 +4060,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f2f6be8d940f45d7a9e16841bf8a42e2
+      - 100edbe9bd6c4ca5b01f6fdb0e3eab6e
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4073,9 +4073,9 @@ http_interactions:
       Content-Length:
       - '1611'
       X-Compute-Request-Id:
-      - req-234457b6-5e23-4a08-be12-651dbcc74a0a
+      - req-1948e7af-1905-4bce-86ca-04c63939cb78
       Date:
-      - Thu, 03 Jan 2019 19:27:46 GMT
+      - Fri, 04 Jan 2019 16:52:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKQyhM0ECmYmB8mI4vfeTEaY90skgHYgA/5apgT+cHhKzZX59Go+LGfb98dOCYEjnV3XKdO5dy7MrSdI5QSvGJmJIQPsH4WZNpRNuEhHzcHS1fEPe9zMceRlLafkTeUKhUGMIi1gOmBRdyZtz6fJw37AK6ioM4+16IhXjNVLV09jHn2PsUjh2RsGX5TzA3eHivptzINBD8eMBkyQwS2uejY42FlIg9qBpa8KEMgyo4KLvd/99kw9wLg1D9Y5+3OxA/J6hLfjSBv7Vd7Xvwd4ZmDlkU5+yH88b2ZOte8MyfAnlVA4v8bMdSsAf1e5NvUuZsoZC8goZCHjXmTDSI+yen
@@ -4085,7 +4085,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:46 GMT
+  recorded_at: Fri, 04 Jan 2019 16:52:58 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/52c452d7763a4295950527948232a3e5/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -4100,7 +4100,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f2f6be8d940f45d7a9e16841bf8a42e2
+      - 100edbe9bd6c4ca5b01f6fdb0e3eab6e
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4113,9 +4113,9 @@ http_interactions:
       Content-Length:
       - '1611'
       X-Compute-Request-Id:
-      - req-63604482-2731-490e-9547-9fed20dcbe00
+      - req-6830afd3-abef-4753-b566-0517877a73e6
       Date:
-      - Thu, 03 Jan 2019 19:27:46 GMT
+      - Fri, 04 Jan 2019 16:52:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKQyhM0ECmYmB8mI4vfeTEaY90skgHYgA/5apgT+cHhKzZX59Go+LGfb98dOCYEjnV3XKdO5dy7MrSdI5QSvGJmJIQPsH4WZNpRNuEhHzcHS1fEPe9zMceRlLafkTeUKhUGMIi1gOmBRdyZtz6fJw37AK6ioM4+16IhXjNVLV09jHn2PsUjh2RsGX5TzA3eHivptzINBD8eMBkyQwS2uejY42FlIg9qBpa8KEMgyo4KLvd/99kw9wLg1D9Y5+3OxA/J6hLfjSBv7Vd7Xvwd4ZmDlkU5+yH88b2ZOte8MyfAnlVA4v8bMdSsAf1e5NvUuZsoZC8goZCHjXmTDSI+yen
@@ -4125,7 +4125,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:46 GMT
+  recorded_at: Fri, 04 Jan 2019 16:52:58 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-keypairs?limit=1000
@@ -4140,7 +4140,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3709877b1e3a4eab97644519936f64ac
+      - 67233fa9000c437c9d6364f35a546600
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4153,9 +4153,9 @@ http_interactions:
       Content-Length:
       - '1611'
       X-Compute-Request-Id:
-      - req-bc4a9938-0dbd-4135-b748-78cecf1b9223
+      - req-1a5a4efa-12d9-487a-a3ea-d07cd21865ae
       Date:
-      - Thu, 03 Jan 2019 19:27:46 GMT
+      - Fri, 04 Jan 2019 16:52:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKQyhM0ECmYmB8mI4vfeTEaY90skgHYgA/5apgT+cHhKzZX59Go+LGfb98dOCYEjnV3XKdO5dy7MrSdI5QSvGJmJIQPsH4WZNpRNuEhHzcHS1fEPe9zMceRlLafkTeUKhUGMIi1gOmBRdyZtz6fJw37AK6ioM4+16IhXjNVLV09jHn2PsUjh2RsGX5TzA3eHivptzINBD8eMBkyQwS2uejY42FlIg9qBpa8KEMgyo4KLvd/99kw9wLg1D9Y5+3OxA/J6hLfjSBv7Vd7Xvwd4ZmDlkU5+yH88b2ZOte8MyfAnlVA4v8bMdSsAf1e5NvUuZsoZC8goZCHjXmTDSI+yen
@@ -4165,7 +4165,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:46 GMT
+  recorded_at: Fri, 04 Jan 2019 16:52:58 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -4180,7 +4180,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3709877b1e3a4eab97644519936f64ac
+      - 67233fa9000c437c9d6364f35a546600
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4193,9 +4193,9 @@ http_interactions:
       Content-Length:
       - '1611'
       X-Compute-Request-Id:
-      - req-8382f59c-21c1-4582-a3aa-75e8e12b6943
+      - req-d91a7357-0fcc-4b5a-81e9-7d935f803d99
       Date:
-      - Thu, 03 Jan 2019 19:27:46 GMT
+      - Fri, 04 Jan 2019 16:52:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKQyhM0ECmYmB8mI4vfeTEaY90skgHYgA/5apgT+cHhKzZX59Go+LGfb98dOCYEjnV3XKdO5dy7MrSdI5QSvGJmJIQPsH4WZNpRNuEhHzcHS1fEPe9zMceRlLafkTeUKhUGMIi1gOmBRdyZtz6fJw37AK6ioM4+16IhXjNVLV09jHn2PsUjh2RsGX5TzA3eHivptzINBD8eMBkyQwS2uejY42FlIg9qBpa8KEMgyo4KLvd/99kw9wLg1D9Y5+3OxA/J6hLfjSBv7Vd7Xvwd4ZmDlkU5+yH88b2ZOte8MyfAnlVA4v8bMdSsAf1e5NvUuZsoZC8goZCHjXmTDSI+yen
@@ -4205,7 +4205,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:46 GMT
+  recorded_at: Fri, 04 Jan 2019 16:52:59 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/d09cbe26295d47ff848ea73c74264e23/os-keypairs?limit=1000
@@ -4220,7 +4220,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c582350c8c88431b8628509dd43449be
+      - 29995e284e9a457b9b9327dec05d8fdf
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4233,9 +4233,9 @@ http_interactions:
       Content-Length:
       - '1611'
       X-Compute-Request-Id:
-      - req-bcb6ae08-4c57-4293-bb29-2cac24ee4d1e
+      - req-48c42f16-b1cb-42e5-b18f-a45aae589118
       Date:
-      - Thu, 03 Jan 2019 19:27:46 GMT
+      - Fri, 04 Jan 2019 16:52:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKQyhM0ECmYmB8mI4vfeTEaY90skgHYgA/5apgT+cHhKzZX59Go+LGfb98dOCYEjnV3XKdO5dy7MrSdI5QSvGJmJIQPsH4WZNpRNuEhHzcHS1fEPe9zMceRlLafkTeUKhUGMIi1gOmBRdyZtz6fJw37AK6ioM4+16IhXjNVLV09jHn2PsUjh2RsGX5TzA3eHivptzINBD8eMBkyQwS2uejY42FlIg9qBpa8KEMgyo4KLvd/99kw9wLg1D9Y5+3OxA/J6hLfjSBv7Vd7Xvwd4ZmDlkU5+yH88b2ZOte8MyfAnlVA4v8bMdSsAf1e5NvUuZsoZC8goZCHjXmTDSI+yen
@@ -4245,7 +4245,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:46 GMT
+  recorded_at: Fri, 04 Jan 2019 16:52:59 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/d09cbe26295d47ff848ea73c74264e23/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -4260,7 +4260,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c582350c8c88431b8628509dd43449be
+      - 29995e284e9a457b9b9327dec05d8fdf
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4273,9 +4273,9 @@ http_interactions:
       Content-Length:
       - '1611'
       X-Compute-Request-Id:
-      - req-f24ee50a-f630-45aa-82cf-d2e12255fce6
+      - req-45efbd1c-4977-4a0b-a81d-cd49187cad32
       Date:
-      - Thu, 03 Jan 2019 19:27:46 GMT
+      - Fri, 04 Jan 2019 16:52:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKQyhM0ECmYmB8mI4vfeTEaY90skgHYgA/5apgT+cHhKzZX59Go+LGfb98dOCYEjnV3XKdO5dy7MrSdI5QSvGJmJIQPsH4WZNpRNuEhHzcHS1fEPe9zMceRlLafkTeUKhUGMIi1gOmBRdyZtz6fJw37AK6ioM4+16IhXjNVLV09jHn2PsUjh2RsGX5TzA3eHivptzINBD8eMBkyQwS2uejY42FlIg9qBpa8KEMgyo4KLvd/99kw9wLg1D9Y5+3OxA/J6hLfjSBv7Vd7Xvwd4ZmDlkU5+yH88b2ZOte8MyfAnlVA4v8bMdSsAf1e5NvUuZsoZC8goZCHjXmTDSI+yen
@@ -4285,7 +4285,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:46 GMT
+  recorded_at: Fri, 04 Jan 2019 16:52:59 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/os-keypairs?limit=1000
@@ -4300,7 +4300,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7255979f42234e738a4f26b6c49aec2b
+      - e709285606e54fd88109676cad5a9182
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4313,9 +4313,9 @@ http_interactions:
       Content-Length:
       - '1611'
       X-Compute-Request-Id:
-      - req-2e801a2c-7e98-43c1-83b8-5b49ff7676a2
+      - req-3d374783-c918-49ea-b6cb-597f1a1d99d0
       Date:
-      - Thu, 03 Jan 2019 19:27:46 GMT
+      - Fri, 04 Jan 2019 16:52:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKQyhM0ECmYmB8mI4vfeTEaY90skgHYgA/5apgT+cHhKzZX59Go+LGfb98dOCYEjnV3XKdO5dy7MrSdI5QSvGJmJIQPsH4WZNpRNuEhHzcHS1fEPe9zMceRlLafkTeUKhUGMIi1gOmBRdyZtz6fJw37AK6ioM4+16IhXjNVLV09jHn2PsUjh2RsGX5TzA3eHivptzINBD8eMBkyQwS2uejY42FlIg9qBpa8KEMgyo4KLvd/99kw9wLg1D9Y5+3OxA/J6hLfjSBv7Vd7Xvwd4ZmDlkU5+yH88b2ZOte8MyfAnlVA4v8bMdSsAf1e5NvUuZsoZC8goZCHjXmTDSI+yen
@@ -4325,7 +4325,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:46 GMT
+  recorded_at: Fri, 04 Jan 2019 16:52:59 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -4340,7 +4340,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7255979f42234e738a4f26b6c49aec2b
+      - e709285606e54fd88109676cad5a9182
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4353,9 +4353,9 @@ http_interactions:
       Content-Length:
       - '1611'
       X-Compute-Request-Id:
-      - req-e105f89c-471d-44b8-98b0-8b8997939bfd
+      - req-bb587126-33cd-41e3-a00c-5cf192245cf2
       Date:
-      - Thu, 03 Jan 2019 19:27:46 GMT
+      - Fri, 04 Jan 2019 16:52:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKQyhM0ECmYmB8mI4vfeTEaY90skgHYgA/5apgT+cHhKzZX59Go+LGfb98dOCYEjnV3XKdO5dy7MrSdI5QSvGJmJIQPsH4WZNpRNuEhHzcHS1fEPe9zMceRlLafkTeUKhUGMIi1gOmBRdyZtz6fJw37AK6ioM4+16IhXjNVLV09jHn2PsUjh2RsGX5TzA3eHivptzINBD8eMBkyQwS2uejY42FlIg9qBpa8KEMgyo4KLvd/99kw9wLg1D9Y5+3OxA/J6hLfjSBv7Vd7Xvwd4ZmDlkU5+yH88b2ZOte8MyfAnlVA4v8bMdSsAf1e5NvUuZsoZC8goZCHjXmTDSI+yen
@@ -4365,7 +4365,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:47 GMT
+  recorded_at: Fri, 04 Jan 2019 16:52:59 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -4383,15 +4383,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:27:47 GMT
+      - Fri, 04 Jan 2019 16:52:59 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 532f0826c9c34f97b7bb1b1ba3156b7e
+      - b0c865ce2e134c5f9e448accc696ebdf
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-b01e318c-a21a-4f69-9891-7a26b3f1974d
+      - req-1f57c02e-067f-491f-a9e6-f65bca025418
       Content-Length:
       - '7311'
       Connection:
@@ -4403,7 +4403,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2019-01-03T20:27:47.201684Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2019-01-04T17:52:59.761228Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -4482,10 +4482,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["cd3G3sbCT5-yWkWOKCwpoA"],
-        "issued_at": "2019-01-03T19:27:47.201712Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["-ADNmZneRDi8mdRD0q3k8w"],
+        "issued_at": "2019-01-04T16:52:59.761250Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:47 GMT
+  recorded_at: Fri, 04 Jan 2019 16:52:59 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -4503,15 +4503,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:27:47 GMT
+      - Fri, 04 Jan 2019 16:52:59 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 87f46012ee9e44eab27e54888297a53a
+      - 49681d17e6904a83ac72f75235bf86d6
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-bb1e2c55-2087-43bb-9d2f-6322d831dcd9
+      - req-c45f8686-62e4-4e63-8b68-d7d3eed7c4f6
       Content-Length:
       - '7278'
       Connection:
@@ -4523,7 +4523,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:27:47.411603Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:52:59.972705Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -4602,10 +4602,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["S-LhhI41TpykgFtzmmf_6g"],
-        "issued_at": "2019-01-03T19:27:47.411622Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["XFI3T387S9W8h3VWqWqTeg"],
+        "issued_at": "2019-01-04T16:52:59.972726Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:47 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:00 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -4623,15 +4623,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:27:47 GMT
+      - Fri, 04 Jan 2019 16:53:00 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - e70a67312f5a4d2ea510a23cc7311708
+      - f721a120e47d4570a94285fecd58c1ec
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-a878fb88-ec16-43b3-871a-9d3a3444ce56
+      - req-d6ff3e9d-691a-41a5-8e7f-9d36c57a5b44
       Content-Length:
       - '7278'
       Connection:
@@ -4643,7 +4643,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:27:47.619816Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:53:00.185144Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -4722,10 +4722,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["L-Ry0U1ATOGmg7rKzkGJ3w"],
-        "issued_at": "2019-01-03T19:27:47.619836Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["QkeTFy5SQcaepnlQN1cndg"],
+        "issued_at": "2019-01-04T16:53:00.185166Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:47 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:00 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -4743,15 +4743,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:27:47 GMT
+      - Fri, 04 Jan 2019 16:53:00 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 64e61ea57850459cbbd3e6bfbc195ecc
+      - a48657b5e95741c2bb4d7adca9e2ee72
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-78babbd3-11e6-4b31-803e-8458ff06ff66
+      - req-9fedec65-7c81-43eb-81e5-83903fa891de
       Content-Length:
       - '7264'
       Connection:
@@ -4763,7 +4763,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:27:47.838115Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:53:00.400936Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -4842,10 +4842,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["3d-doeQISrCooCNwsryBgg"],
-        "issued_at": "2019-01-03T19:27:47.838140Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["e1DDZFQWSOWQIfX5wtWfzg"],
+        "issued_at": "2019-01-04T16:53:00.400976Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:47 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:00 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -4863,15 +4863,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:27:47 GMT
+      - Fri, 04 Jan 2019 16:53:00 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - da653bcb86554315b30a7ac1e4b86b2d
+      - c1db7802ac5245c69fedd2f7a3af993d
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-e676036a-3105-40e3-9ee0-d91458eb5735
+      - req-6c25bc9c-b02a-4ce4-a811-9cddff89e476
       Content-Length:
       - '7278'
       Connection:
@@ -4883,7 +4883,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:27:48.067647Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:53:00.619504Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -4962,10 +4962,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["9qNq4NttQyOIwTpFlCNOPw"],
-        "issued_at": "2019-01-03T19:27:48.067674Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["GsQfPokKTaSpa0fWOrElOg"],
+        "issued_at": "2019-01-04T16:53:00.619533Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:48 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:00 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -4983,15 +4983,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:27:48 GMT
+      - Fri, 04 Jan 2019 16:53:00 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 5b173ff6948344ca829f2f0ea4fd57da
+      - d4061122b43749a99e5f3bf352e9cd9a
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-88d11108-b870-466d-8a28-868412ff80e5
+      - req-56ddb2b8-d531-467e-a0b9-b99b90026c24
       Content-Length:
       - '7265'
       Connection:
@@ -5003,7 +5003,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:27:48.270177Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:53:00.833030Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -5082,10 +5082,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["r9ryuwpcSa2SaBUYY-9BJA"],
-        "issued_at": "2019-01-03T19:27:48.270195Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["2iWhZJ_OTAqU0G-e6e179Q"],
+        "issued_at": "2019-01-04T16:53:00.833052Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:48 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:00 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -5103,15 +5103,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:27:48 GMT
+      - Fri, 04 Jan 2019 16:53:00 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 566a83496bb648da94f656e5f4cc5b4e
+      - 6126bb88295a413db142d8cccca98341
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-a45c635a-a690-49a3-b8ca-c1821e1b8bb8
+      - req-72b9542a-1d57-40e9-9c04-e59a11673c5c
       Content-Length:
       - '7278'
       Connection:
@@ -5123,7 +5123,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:27:48.492707Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:53:01.043710Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -5202,10 +5202,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["f9m2vExiQhCv4OrMWiEQFQ"],
-        "issued_at": "2019-01-03T19:27:48.492731Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["RdEKSKCPTcGENwASs3vnFg"],
+        "issued_at": "2019-01-04T16:53:01.043732Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:48 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:01 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/0098405163cd4c9dbb42c2cb43eb6fd3/stacks?limit=1000&show_nested=true
@@ -5220,7 +5220,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 87f46012ee9e44eab27e54888297a53a
+      - 49681d17e6904a83ac72f75235bf86d6
   response:
     status:
       code: 200
@@ -5231,14 +5231,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-73549cd2-73aa-45c0-a040-b45c9301cbd9
+      - req-f11600ef-8fcb-40ac-b32e-2d413384ee07
       Date:
-      - Thu, 03 Jan 2019 19:27:48 GMT
+      - Fri, 04 Jan 2019 16:53:01 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:48 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:01 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/28db8f69ba9e4305b7fad82da4c86e74/stacks?limit=1000&show_nested=true
@@ -5253,7 +5253,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e70a67312f5a4d2ea510a23cc7311708
+      - f721a120e47d4570a94285fecd58c1ec
   response:
     status:
       code: 200
@@ -5264,14 +5264,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-bf2aa34a-6743-4bdd-b4c6-33ac3769e8e2
+      - req-73328098-85bc-41f5-b703-5d4198badcf0
       Date:
-      - Thu, 03 Jan 2019 19:27:48 GMT
+      - Fri, 04 Jan 2019 16:53:01 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:48 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:01 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks?limit=1000&show_nested=true
@@ -5286,7 +5286,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 64e61ea57850459cbbd3e6bfbc195ecc
+      - a48657b5e95741c2bb4d7adca9e2ee72
   response:
     status:
       code: 200
@@ -5297,9 +5297,9 @@ http_interactions:
       Content-Length:
       - '2559'
       X-Openstack-Request-Id:
-      - req-32eabd82-2471-4e26-89f3-bfe9a54264a3
+      - req-62a406ab-aabb-4faf-a054-f6a20f8fc18b
       Date:
-      - Thu, 03 Jan 2019 19:27:48 GMT
+      - Fri, 04 Jan 2019 16:53:01 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": [{"description": "Heat WordPress template to support F20,
@@ -5333,7 +5333,7 @@ http_interactions:
         "rel": "self"}], "updated_time": null, "stack_owner": null, "stack_status":
         "CREATE_COMPLETE", "id": "7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:48 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:01 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks?limit=1000&marker=7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0&show_nested=true
@@ -5348,7 +5348,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 64e61ea57850459cbbd3e6bfbc195ecc
+      - a48657b5e95741c2bb4d7adca9e2ee72
   response:
     status:
       code: 200
@@ -5359,14 +5359,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-e007976b-fed5-4e0c-8f4f-263ba8834894
+      - req-b36e7512-b928-4726-9d66-c89433d12a57
       Date:
-      - Thu, 03 Jan 2019 19:27:49 GMT
+      - Fri, 04 Jan 2019 16:53:01 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:49 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:01 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/52c452d7763a4295950527948232a3e5/stacks?limit=1000&show_nested=true
@@ -5381,7 +5381,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - da653bcb86554315b30a7ac1e4b86b2d
+      - c1db7802ac5245c69fedd2f7a3af993d
   response:
     status:
       code: 200
@@ -5392,14 +5392,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-5a3d5c6e-70e1-4453-8858-367635ab3bd8
+      - req-eff9ef3c-0a37-4a2d-86c4-f13e8411702b
       Date:
-      - Thu, 03 Jan 2019 19:27:49 GMT
+      - Fri, 04 Jan 2019 16:53:01 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:49 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:01 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/88ae57d444fd485ab2dfddd5a2615d52/stacks?limit=1000&show_nested=true
@@ -5414,7 +5414,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 532f0826c9c34f97b7bb1b1ba3156b7e
+      - b0c865ce2e134c5f9e448accc696ebdf
   response:
     status:
       code: 200
@@ -5425,14 +5425,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-429bcdf4-8cbe-4fa8-8007-85ba0efa04ff
+      - req-b4d85639-7458-4c0c-94f1-9e03919c4499
       Date:
-      - Thu, 03 Jan 2019 19:27:49 GMT
+      - Fri, 04 Jan 2019 16:53:01 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:49 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:01 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/d09cbe26295d47ff848ea73c74264e23/stacks?limit=1000&show_nested=true
@@ -5447,7 +5447,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5b173ff6948344ca829f2f0ea4fd57da
+      - d4061122b43749a99e5f3bf352e9cd9a
   response:
     status:
       code: 200
@@ -5458,14 +5458,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-6ac1cc07-d3f6-4bb8-8308-9667f123d3b4
+      - req-e5501426-d377-4e5e-ac40-b395ea08ff4a
       Date:
-      - Thu, 03 Jan 2019 19:27:49 GMT
+      - Fri, 04 Jan 2019 16:53:02 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:49 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:02 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/ef2a3405d1ef4dfd9a3616993ef46a4d/stacks?limit=1000&show_nested=true
@@ -5480,7 +5480,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 566a83496bb648da94f656e5f4cc5b4e
+      - 6126bb88295a413db142d8cccca98341
   response:
     status:
       code: 200
@@ -5491,14 +5491,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-ee08dd12-8084-498b-a8aa-704086db1c49
+      - req-784672fb-4db3-47d1-a055-08e00e4e3520
       Date:
-      - Thu, 03 Jan 2019 19:27:49 GMT
+      - Fri, 04 Jan 2019 16:53:02 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:49 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:02 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack3/00c5dc04-2c94-48d2-8031-db08934e9a44
@@ -5513,7 +5513,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 64e61ea57850459cbbd3e6bfbc195ecc
+      - a48657b5e95741c2bb4d7adca9e2ee72
   response:
     status:
       code: 200
@@ -5524,9 +5524,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-42c2a2c6-97ea-43a5-abac-e980bdcd4303
+      - req-dd753c75-cf5a-4e02-98e4-f09fa3f8424b
       Date:
-      - Thu, 03 Jan 2019 19:27:49 GMT
+      - Fri, 04 Jan 2019 16:53:02 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -5553,7 +5553,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:49 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:02 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack2/d6eba2a2-7b0d-4213-afbb-69c8f6dddd8d
@@ -5568,7 +5568,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 64e61ea57850459cbbd3e6bfbc195ecc
+      - a48657b5e95741c2bb4d7adca9e2ee72
   response:
     status:
       code: 200
@@ -5579,9 +5579,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-09301c1a-766c-44e2-9db9-801ce8dd73b8
+      - req-775c2d9a-863f-45e7-be8d-f9b59ed281e0
       Date:
-      - Thu, 03 Jan 2019 19:27:50 GMT
+      - Fri, 04 Jan 2019 16:53:02 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -5608,7 +5608,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:50 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:02 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack1/7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0
@@ -5623,7 +5623,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 64e61ea57850459cbbd3e6bfbc195ecc
+      - a48657b5e95741c2bb4d7adca9e2ee72
   response:
     status:
       code: 200
@@ -5634,9 +5634,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-7d3fa0ce-7837-4e09-9a27-7c75d65e37a5
+      - req-28604a28-4da1-4fc7-9a71-f2c6bf10468b
       Date:
-      - Thu, 03 Jan 2019 19:27:50 GMT
+      - Fri, 04 Jan 2019 16:53:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -5663,7 +5663,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:50 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:03 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack3/00c5dc04-2c94-48d2-8031-db08934e9a44/template
@@ -5678,7 +5678,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 64e61ea57850459cbbd3e6bfbc195ecc
+      - a48657b5e95741c2bb4d7adca9e2ee72
   response:
     status:
       code: 200
@@ -5689,9 +5689,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-2fe184e8-491b-4429-b90c-9d23830197e7
+      - req-41dc1f6c-a760-4095-8052-c4e6fb0297fe
       Date:
-      - Thu, 03 Jan 2019 19:27:50 GMT
+      - Fri, 04 Jan 2019 16:53:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -5747,7 +5747,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:50 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:03 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack3/00c5dc04-2c94-48d2-8031-db08934e9a44/resources
@@ -5762,7 +5762,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 64e61ea57850459cbbd3e6bfbc195ecc
+      - a48657b5e95741c2bb4d7adca9e2ee72
   response:
     status:
       code: 200
@@ -5773,9 +5773,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-f1df080e-26bc-4302-ac1e-1d01a791c026
+      - req-b32bf4f2-46eb-4ab1-b2a5-989cb161c191
       Date:
-      - Thu, 03 Jan 2019 19:27:50 GMT
+      - Fri, 04 Jan 2019 16:53:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -5787,7 +5787,7 @@ http_interactions:
         changed", "physical_resource_id": "40989f26-9c38-4f72-b739-afccb44397cf",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:50 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:03 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3/servers/detail?limit=1000
@@ -5802,7 +5802,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 654ef627e4b8456b9c86cd14fe4ce9f4
+      - a3dba1b2b9834ce4b9caa20427196f3f
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5815,14 +5815,14 @@ http_interactions:
       Content-Length:
       - '15'
       X-Compute-Request-Id:
-      - req-d10d9f89-11bd-4d6b-a563-3f3198c0534f
+      - req-32abf8ef-ec64-4864-8364-d7f6a19531fe
       Date:
-      - Thu, 03 Jan 2019 19:27:50 GMT
+      - Fri, 04 Jan 2019 16:53:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:50 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:03 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/28db8f69ba9e4305b7fad82da4c86e74/servers/detail?limit=1000
@@ -5837,7 +5837,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - aefaf05b99744a83b823ee109916244a
+      - 75446880ba2e4189986da3671c19cf8c
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5850,14 +5850,14 @@ http_interactions:
       Content-Length:
       - '15'
       X-Compute-Request-Id:
-      - req-f6c6d845-4aed-4c42-9458-c69ff340f18f
+      - req-d00c759e-e867-4819-8b84-d7eefc40bbc2
       Date:
-      - Thu, 03 Jan 2019 19:27:51 GMT
+      - Fri, 04 Jan 2019 16:53:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:51 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:03 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/servers/detail?limit=1000
@@ -5872,7 +5872,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e35cba3cf22b4803a0aedc4da241c8f0
+      - 2f1de41faa384c5a9965f645e639128c
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5885,9 +5885,9 @@ http_interactions:
       Content-Length:
       - '3981'
       X-Compute-Request-Id:
-      - req-67bbc5d8-cdc7-4483-8d1d-9fc46f9acf01
+      - req-89629c5d-e277-4e7e-aae6-154cbf1c95cd
       Date:
-      - Thu, 03 Jan 2019 19:27:51 GMT
+      - Fri, 04 Jan 2019 16:53:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/servers/detail?limit=1000&marker=43f23d3a-fe8d-4bbb-9d23-fe1c437c7813",
@@ -5933,7 +5933,7 @@ http_interactions:
         [], "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:51 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:03 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/servers/detail?limit=1000&marker=43f23d3a-fe8d-4bbb-9d23-fe1c437c7813
@@ -5948,7 +5948,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e35cba3cf22b4803a0aedc4da241c8f0
+      - 2f1de41faa384c5a9965f645e639128c
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5961,9 +5961,9 @@ http_interactions:
       Content-Length:
       - '4045'
       X-Compute-Request-Id:
-      - req-c7af9b88-1061-452f-ad18-557a34d82356
+      - req-be7b0ab0-d426-430e-815d-c2a8d6a6afba
       Date:
-      - Thu, 03 Jan 2019 19:27:51 GMT
+      - Fri, 04 Jan 2019 16:53:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/servers/detail?limit=1000&marker=5d121f19-3e04-4743-8ed7-c5dfaa6ef71f",
@@ -6009,7 +6009,7 @@ http_interactions:
         [], "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 3, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:51 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:04 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/servers/detail?limit=1000&marker=5d121f19-3e04-4743-8ed7-c5dfaa6ef71f
@@ -6024,7 +6024,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e35cba3cf22b4803a0aedc4da241c8f0
+      - 2f1de41faa384c5a9965f645e639128c
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6037,9 +6037,9 @@ http_interactions:
       Content-Length:
       - '4127'
       X-Compute-Request-Id:
-      - req-7b682166-9955-49b7-8375-08833d40cc9a
+      - req-3e82878f-c213-4e95-9f7f-71187994b17c
       Date:
-      - Thu, 03 Jan 2019 19:27:51 GMT
+      - Fri, 04 Jan 2019 16:53:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/servers/detail?limit=1000&marker=7edb7855-d974-4e45-8ad2-88491541ab91",
@@ -6087,7 +6087,7 @@ http_interactions:
         "", "progress": 0, "OS-EXT-STS:power_state": 1, "config_drive": "", "metadata":
         {}}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:51 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:04 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/servers/detail?limit=1000&marker=7edb7855-d974-4e45-8ad2-88491541ab91
@@ -6102,7 +6102,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e35cba3cf22b4803a0aedc4da241c8f0
+      - 2f1de41faa384c5a9965f645e639128c
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6115,9 +6115,9 @@ http_interactions:
       Content-Length:
       - '3796'
       X-Compute-Request-Id:
-      - req-c77dc364-1ae0-4ad8-90e7-85d9a20dcc69
+      - req-5807bc8a-f453-4d7d-82e7-2dea2f66cb68
       Date:
-      - Thu, 03 Jan 2019 19:27:52 GMT
+      - Fri, 04 Jan 2019 16:53:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/servers/detail?limit=1000&marker=ad4f7eb0-9122-41a6-a0f7-55c1d4ca5e02",
@@ -6159,7 +6159,7 @@ http_interactions:
         "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:52 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:04 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/servers/detail?limit=1000&marker=ad4f7eb0-9122-41a6-a0f7-55c1d4ca5e02
@@ -6174,7 +6174,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e35cba3cf22b4803a0aedc4da241c8f0
+      - 2f1de41faa384c5a9965f645e639128c
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6187,9 +6187,9 @@ http_interactions:
       Content-Length:
       - '1816'
       X-Compute-Request-Id:
-      - req-890daf7f-f149-4ec9-b50b-292e46a68bef
+      - req-2ab9ee5f-9366-4767-b7e0-946b3a148405
       Date:
-      - Thu, 03 Jan 2019 19:27:52 GMT
+      - Fri, 04 Jan 2019 16:53:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": [{"status": "SHUTOFF", "updated": "2017-05-22T16:01:49Z",
@@ -6212,7 +6212,7 @@ http_interactions:
         "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:52 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:04 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/52c452d7763a4295950527948232a3e5/servers/detail?limit=1000
@@ -6227,7 +6227,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f2f6be8d940f45d7a9e16841bf8a42e2
+      - 100edbe9bd6c4ca5b01f6fdb0e3eab6e
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6240,14 +6240,14 @@ http_interactions:
       Content-Length:
       - '15'
       X-Compute-Request-Id:
-      - req-ccc8792c-2328-4901-9645-432e16eff0e2
+      - req-5215e114-819d-490b-b63f-73ad6cec9d61
       Date:
-      - Thu, 03 Jan 2019 19:27:52 GMT
+      - Fri, 04 Jan 2019 16:53:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:52 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:04 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?limit=1000
@@ -6262,7 +6262,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3709877b1e3a4eab97644519936f64ac
+      - 67233fa9000c437c9d6364f35a546600
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6275,14 +6275,14 @@ http_interactions:
       Content-Length:
       - '15'
       X-Compute-Request-Id:
-      - req-ab0a815f-4a28-42fd-b7ff-dccff1871e6a
+      - req-85cd2c48-bdaa-486b-9533-8d09e133c2e9
       Date:
-      - Thu, 03 Jan 2019 19:27:52 GMT
+      - Fri, 04 Jan 2019 16:53:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:52 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:05 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/d09cbe26295d47ff848ea73c74264e23/servers/detail?limit=1000
@@ -6297,7 +6297,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c582350c8c88431b8628509dd43449be
+      - 29995e284e9a457b9b9327dec05d8fdf
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6310,14 +6310,14 @@ http_interactions:
       Content-Length:
       - '15'
       X-Compute-Request-Id:
-      - req-31b9a3a9-33a4-4981-bf3f-e6e0c92664d6
+      - req-1dab132b-69d1-4899-bc43-6bd5632c6703
       Date:
-      - Thu, 03 Jan 2019 19:27:52 GMT
+      - Fri, 04 Jan 2019 16:53:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:52 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:05 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/servers/detail?limit=1000
@@ -6332,7 +6332,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7255979f42234e738a4f26b6c49aec2b
+      - e709285606e54fd88109676cad5a9182
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6345,14 +6345,14 @@ http_interactions:
       Content-Length:
       - '15'
       X-Compute-Request-Id:
-      - req-aaa5f051-8706-45ad-95c1-cbdfc06b63e9
+      - req-6fbfe122-9037-4705-81e1-0f01be81c30b
       Date:
-      - Thu, 03 Jan 2019 19:27:52 GMT
+      - Fri, 04 Jan 2019 16:53:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:52 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:05 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack2/d6eba2a2-7b0d-4213-afbb-69c8f6dddd8d/template
@@ -6367,7 +6367,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 64e61ea57850459cbbd3e6bfbc195ecc
+      - a48657b5e95741c2bb4d7adca9e2ee72
   response:
     status:
       code: 200
@@ -6378,9 +6378,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-cfd28ba7-1b3c-4e79-a9f8-a946daaa260b
+      - req-7019d1ff-7576-4bc3-8513-15e6a3fd1f41
       Date:
-      - Thu, 03 Jan 2019 19:27:52 GMT
+      - Fri, 04 Jan 2019 16:53:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -6436,7 +6436,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:52 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:05 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack2/d6eba2a2-7b0d-4213-afbb-69c8f6dddd8d/resources
@@ -6451,7 +6451,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 64e61ea57850459cbbd3e6bfbc195ecc
+      - a48657b5e95741c2bb4d7adca9e2ee72
   response:
     status:
       code: 200
@@ -6462,9 +6462,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-40f79fce-44c6-40d4-8e07-84426300841b
+      - req-6637331d-0dd1-46a6-bafc-5d69ee63eea4
       Date:
-      - Thu, 03 Jan 2019 19:27:53 GMT
+      - Fri, 04 Jan 2019 16:53:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -6476,7 +6476,7 @@ http_interactions:
         changed", "physical_resource_id": "ad4f7eb0-9122-41a6-a0f7-55c1d4ca5e02",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:53 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:05 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack1/7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0/template
@@ -6491,7 +6491,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 64e61ea57850459cbbd3e6bfbc195ecc
+      - a48657b5e95741c2bb4d7adca9e2ee72
   response:
     status:
       code: 200
@@ -6502,9 +6502,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-d9e8de76-571d-4397-a280-5b46ceb7ee42
+      - req-cbe94530-0112-4f21-88bf-43f591ebb4e8
       Date:
-      - Thu, 03 Jan 2019 19:27:53 GMT
+      - Fri, 04 Jan 2019 16:53:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -6560,7 +6560,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:53 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:05 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack1/7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0/resources
@@ -6575,7 +6575,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 64e61ea57850459cbbd3e6bfbc195ecc
+      - a48657b5e95741c2bb4d7adca9e2ee72
   response:
     status:
       code: 200
@@ -6586,9 +6586,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-fbba6151-c90c-4317-b609-1326fec8c592
+      - req-6e3c71ca-2b77-4b55-89cd-faf361329892
       Date:
-      - Thu, 03 Jan 2019 19:27:53 GMT
+      - Fri, 04 Jan 2019 16:53:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -6600,7 +6600,7 @@ http_interactions:
         changed", "physical_resource_id": "8022b967-813a-4e3b-8ff4-7c036957a8a0",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:53 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:05 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3//os-quota-sets/0098405163cd4c9dbb42c2cb43eb6fd3
@@ -6615,7 +6615,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 654ef627e4b8456b9c86cd14fe4ce9f4
+      - a3dba1b2b9834ce4b9caa20427196f3f
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6628,9 +6628,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-217b06b1-6b65-4c5a-b149-2f20a9c4a628
+      - req-de3df10c-7aab-4108-90e8-2db67fc56a44
       Date:
-      - Thu, 03 Jan 2019 19:27:53 GMT
+      - Fri, 04 Jan 2019 16:53:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -6639,7 +6639,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:53 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:05 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/28db8f69ba9e4305b7fad82da4c86e74//os-quota-sets/28db8f69ba9e4305b7fad82da4c86e74
@@ -6654,7 +6654,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - aefaf05b99744a83b823ee109916244a
+      - 75446880ba2e4189986da3671c19cf8c
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6667,9 +6667,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-bcea701d-1894-441f-bcb2-845adb398976
+      - req-87a4511e-bb5b-4f2c-872c-a5246fe44014
       Date:
-      - Thu, 03 Jan 2019 19:27:53 GMT
+      - Fri, 04 Jan 2019 16:53:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -6678,7 +6678,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:53 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:06 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91//os-quota-sets/4637c33fee924ebea81f8d209e452c91
@@ -6693,7 +6693,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e35cba3cf22b4803a0aedc4da241c8f0
+      - 2f1de41faa384c5a9965f645e639128c
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6706,9 +6706,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-eb95f755-3839-473a-bb59-1846f05f8aae
+      - req-21ef20e1-0f42-44ae-8e00-7744b95dc203
       Date:
-      - Thu, 03 Jan 2019 19:27:53 GMT
+      - Fri, 04 Jan 2019 16:53:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -6717,7 +6717,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:53 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:06 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/52c452d7763a4295950527948232a3e5//os-quota-sets/52c452d7763a4295950527948232a3e5
@@ -6732,7 +6732,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f2f6be8d940f45d7a9e16841bf8a42e2
+      - 100edbe9bd6c4ca5b01f6fdb0e3eab6e
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6745,9 +6745,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-49865f3c-3801-4ee5-9468-b918b35f2315
+      - req-fc4c15c8-625d-411c-a4bf-3c1d61b3a817
       Date:
-      - Thu, 03 Jan 2019 19:27:53 GMT
+      - Fri, 04 Jan 2019 16:53:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -6756,7 +6756,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:53 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:06 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52//os-quota-sets/88ae57d444fd485ab2dfddd5a2615d52
@@ -6771,7 +6771,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3709877b1e3a4eab97644519936f64ac
+      - 67233fa9000c437c9d6364f35a546600
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6784,9 +6784,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-f82decbb-85ab-4b52-a34f-f970d95ca74a
+      - req-31f33d33-d0f4-4cd4-a6ed-4e680ceb5ad5
       Date:
-      - Thu, 03 Jan 2019 19:27:53 GMT
+      - Fri, 04 Jan 2019 16:53:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -6795,7 +6795,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:53 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:06 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/d09cbe26295d47ff848ea73c74264e23//os-quota-sets/d09cbe26295d47ff848ea73c74264e23
@@ -6810,7 +6810,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c582350c8c88431b8628509dd43449be
+      - 29995e284e9a457b9b9327dec05d8fdf
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6823,9 +6823,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-6e657863-57f1-426f-b999-44ef1b35a639
+      - req-c4cdb5e2-d267-4201-8944-ee934fa3d968
       Date:
-      - Thu, 03 Jan 2019 19:27:53 GMT
+      - Fri, 04 Jan 2019 16:53:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -6834,7 +6834,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:53 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:06 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/ef2a3405d1ef4dfd9a3616993ef46a4d//os-quota-sets/ef2a3405d1ef4dfd9a3616993ef46a4d
@@ -6849,7 +6849,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7255979f42234e738a4f26b6c49aec2b
+      - e709285606e54fd88109676cad5a9182
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6862,9 +6862,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-678d8e49-b1c3-4065-a964-1e0a3d2d3203
+      - req-f88eeb39-7e64-4793-82a7-ab7a0153c7f3
       Date:
-      - Thu, 03 Jan 2019 19:27:54 GMT
+      - Fri, 04 Jan 2019 16:53:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -6873,7 +6873,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:54 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:06 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -6891,15 +6891,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:27:54 GMT
+      - Fri, 04 Jan 2019 16:53:06 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 3c919bc10052477b890bfc626cf765c5
+      - 9b2e826446b24be2bb6e67ecbdea674b
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-9cb7eece-8998-4d49-8738-e0fd7d754b41
+      - req-15eeacd1-4694-4bc5-8eb2-bb3010f63f98
       Content-Length:
       - '7278'
       Connection:
@@ -6911,7 +6911,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:27:54.254086Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:53:06.743823Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -6990,10 +6990,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["UXMNx9UURRaxjQUOCpFg7A"],
-        "issued_at": "2019-01-03T19:27:54.254121Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["vrdOuxXyQ1-HDk7AF59o5w"],
+        "issued_at": "2019-01-04T16:53:06.743844Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:54 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:06 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -7011,15 +7011,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:27:54 GMT
+      - Fri, 04 Jan 2019 16:53:06 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - cb151bd939d04bd19325ea8a5a0cb8c2
+      - e9c3d0a8d42143929069d5917190b7ff
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-cd1b6d47-b56a-4ff0-964c-34c59dcc28a8
+      - req-f05b2249-ae07-4525-91ab-c8af1c4afde1
       Content-Length:
       - '7278'
       Connection:
@@ -7031,7 +7031,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:27:54.464213Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:53:06.982647Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -7110,10 +7110,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["9zf9GF-eT6SwF4haq-8FCA"],
-        "issued_at": "2019-01-03T19:27:54.464248Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["LHP7WoCfQyK11jhCBjgpUw"],
+        "issued_at": "2019-01-04T16:53:06.982670Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:54 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:07 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -7131,15 +7131,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:27:54 GMT
+      - Fri, 04 Jan 2019 16:53:07 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - abbaf7fc236c422db388c09a57cdc866
+      - ef2c83cebd0740f2abd3df1bcb7c428e
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-32b832b4-f4a2-4ab0-ae2e-d8ce98f84f4d
+      - req-782ea792-50e6-421a-981f-be86a38ab322
       Content-Length:
       - '7264'
       Connection:
@@ -7151,7 +7151,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:27:54.673070Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:53:07.187710Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -7230,10 +7230,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["E2rX9wsURzmnG_yvXz8Tog"],
-        "issued_at": "2019-01-03T19:27:54.673090Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["OQEXWRpTSR-VhGlO2ZnBhg"],
+        "issued_at": "2019-01-04T16:53:07.187730Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:54 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:07 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -7251,15 +7251,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:27:54 GMT
+      - Fri, 04 Jan 2019 16:53:07 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 38d90dbb5af04078979c436b81119665
+      - 37b82c8e28da4a35ac19583f28c2369b
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-80d59ac0-7a05-46c0-8863-93a28eacdfbd
+      - req-31503a8a-de68-4ad5-b1e1-4534a151f42c
       Content-Length:
       - '7278'
       Connection:
@@ -7271,7 +7271,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:27:54.903185Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:53:07.392855Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -7350,10 +7350,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["jK1qravIScylq-LblCde_A"],
-        "issued_at": "2019-01-03T19:27:54.903211Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["9c5hBKawTW-pHxzqvLaiSw"],
+        "issued_at": "2019-01-04T16:53:07.392876Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:55 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:07 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -7371,15 +7371,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:27:55 GMT
+      - Fri, 04 Jan 2019 16:53:07 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 7f3eb56cf6b14037a31cc99be2854fef
+      - 5f606dbee6b14efe93e725498cd3d7f7
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-2bc21ab8-a986-49be-b757-8618d0ae5ed8
+      - req-c892012f-98e5-4bde-87da-e943bbef00b7
       Content-Length:
       - '7265'
       Connection:
@@ -7391,7 +7391,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:27:55.398212Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:53:07.598050Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -7470,10 +7470,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["9LHbIhGARNm8Q0nvpVvjjQ"],
-        "issued_at": "2019-01-03T19:27:55.398238Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["k1eSACg-SA-TIIuu4jzqZA"],
+        "issued_at": "2019-01-04T16:53:07.598069Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:55 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:07 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -7491,15 +7491,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:27:55 GMT
+      - Fri, 04 Jan 2019 16:53:07 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 70371ce8b0044f63a78f6d65973e93cf
+      - 4ada193837594dd98419dea108f06d15
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-dae69f4d-3206-47e9-94da-fcc22e16fa85
+      - req-85eefac3-1676-4f9c-8996-265990c3a37b
       Content-Length:
       - '7278'
       Connection:
@@ -7511,7 +7511,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:27:55.609684Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:53:07.804494Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -7590,10 +7590,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["9RAhioSeQ0iioycB27IUtQ"],
-        "issued_at": "2019-01-03T19:27:55.609707Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["kdFpR0U0Q3afRDTFdMJpCA"],
+        "issued_at": "2019-01-04T16:53:07.804513Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:55 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:07 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3//os-quota-sets/0098405163cd4c9dbb42c2cb43eb6fd3
@@ -7608,22 +7608,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3c919bc10052477b890bfc626cf765c5
+      - 9b2e826446b24be2bb6e67ecbdea674b
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-dec6f271-e51b-4f3c-ab23-c8577a64ea0b
+      - req-0a433590-5de5-4f0d-a49f-6c1d9757cfae
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-dec6f271-e51b-4f3c-ab23-c8577a64ea0b
+      - req-0a433590-5de5-4f0d-a49f-6c1d9757cfae
       Date:
-      - Thu, 03 Jan 2019 19:27:55 GMT
+      - Fri, 04 Jan 2019 16:53:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -7633,7 +7633,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "0098405163cd4c9dbb42c2cb43eb6fd3"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:55 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:08 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74//os-quota-sets/28db8f69ba9e4305b7fad82da4c86e74
@@ -7648,22 +7648,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cb151bd939d04bd19325ea8a5a0cb8c2
+      - e9c3d0a8d42143929069d5917190b7ff
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-6566d2d2-565c-44dc-bd28-2aff0b4a14e7
+      - req-fc0ab350-e883-4e0f-abdf-fce97400084b
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-6566d2d2-565c-44dc-bd28-2aff0b4a14e7
+      - req-fc0ab350-e883-4e0f-abdf-fce97400084b
       Date:
-      - Thu, 03 Jan 2019 19:27:56 GMT
+      - Fri, 04 Jan 2019 16:53:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -7673,7 +7673,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "28db8f69ba9e4305b7fad82da4c86e74"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:56 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:08 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91//os-quota-sets/4637c33fee924ebea81f8d209e452c91
@@ -7688,22 +7688,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - abbaf7fc236c422db388c09a57cdc866
+      - ef2c83cebd0740f2abd3df1bcb7c428e
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-a36d7bbe-44a2-453f-8c3d-043471967ea0
+      - req-35ff1825-430e-4889-b5e8-c8152d2867ea
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-a36d7bbe-44a2-453f-8c3d-043471967ea0
+      - req-35ff1825-430e-4889-b5e8-c8152d2867ea
       Date:
-      - Thu, 03 Jan 2019 19:27:56 GMT
+      - Fri, 04 Jan 2019 16:53:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -7713,7 +7713,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "4637c33fee924ebea81f8d209e452c91"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:56 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:08 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5//os-quota-sets/52c452d7763a4295950527948232a3e5
@@ -7728,22 +7728,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 38d90dbb5af04078979c436b81119665
+      - 37b82c8e28da4a35ac19583f28c2369b
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-1e4c0ca2-3048-4623-ba18-b57de89c8461
+      - req-87d92919-0b4e-405a-ae4b-e6e8a2bcd5c3
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-1e4c0ca2-3048-4623-ba18-b57de89c8461
+      - req-87d92919-0b4e-405a-ae4b-e6e8a2bcd5c3
       Date:
-      - Thu, 03 Jan 2019 19:27:56 GMT
+      - Fri, 04 Jan 2019 16:53:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -7753,7 +7753,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "52c452d7763a4295950527948232a3e5"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:56 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:08 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52//os-quota-sets/88ae57d444fd485ab2dfddd5a2615d52
@@ -7768,22 +7768,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5bc11c8dda904e298ff9a1f80d667acb
+      - f242ad24b5ea4e5f965fed56419cf25b
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-afe419ba-f989-4948-87b7-5ebb33ac0d8d
+      - req-c17fe04d-7762-4375-836b-de6941a67123
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-afe419ba-f989-4948-87b7-5ebb33ac0d8d
+      - req-c17fe04d-7762-4375-836b-de6941a67123
       Date:
-      - Thu, 03 Jan 2019 19:27:56 GMT
+      - Fri, 04 Jan 2019 16:53:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -7793,7 +7793,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "88ae57d444fd485ab2dfddd5a2615d52"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:56 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:09 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23//os-quota-sets/d09cbe26295d47ff848ea73c74264e23
@@ -7808,22 +7808,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7f3eb56cf6b14037a31cc99be2854fef
+      - 5f606dbee6b14efe93e725498cd3d7f7
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-24aec458-404d-4b91-928e-f0dcdd98daf8
+      - req-27f0908a-7297-4eeb-af7f-c548743ef54c
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-24aec458-404d-4b91-928e-f0dcdd98daf8
+      - req-27f0908a-7297-4eeb-af7f-c548743ef54c
       Date:
-      - Thu, 03 Jan 2019 19:27:57 GMT
+      - Fri, 04 Jan 2019 16:53:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -7833,7 +7833,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "d09cbe26295d47ff848ea73c74264e23"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:57 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:09 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d//os-quota-sets/ef2a3405d1ef4dfd9a3616993ef46a4d
@@ -7848,22 +7848,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 70371ce8b0044f63a78f6d65973e93cf
+      - 4ada193837594dd98419dea108f06d15
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-d94632be-9747-4dd1-865c-423d5c0cd140
+      - req-6e91f8ef-60bb-4a85-bed2-6814777b1136
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-d94632be-9747-4dd1-865c-423d5c0cd140
+      - req-6e91f8ef-60bb-4a85-bed2-6814777b1136
       Date:
-      - Thu, 03 Jan 2019 19:27:57 GMT
+      - Fri, 04 Jan 2019 16:53:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -7873,7 +7873,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:57 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:09 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -7891,15 +7891,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:27:57 GMT
+      - Fri, 04 Jan 2019 16:53:10 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - a85539c9071540df9dd6eb36197bd1e7
+      - 3268916704804b1ba063cce31c58f9e9
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-dda5bcb3-83da-4a90-8d9d-c10748488fa9
+      - req-1e8dfde6-b731-473f-a3c7-45a16f54dddc
       Content-Length:
       - '7311'
       Connection:
@@ -7911,7 +7911,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2019-01-03T20:27:57.735586Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2019-01-04T17:53:10.218645Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -7990,10 +7990,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["vT4jLSaFRD2iP3Vd6ZpZ_A"],
-        "issued_at": "2019-01-03T19:27:57.735605Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["9aoR3QJHQCy9LVMnjrnsWg"],
+        "issued_at": "2019-01-04T16:53:10.218666Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:57 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:10 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -8011,15 +8011,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:27:57 GMT
+      - Fri, 04 Jan 2019 16:53:10 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 87053fecb3d14e2eb9ea51232047bfd5
+      - daf8a9e7aa1b4a2c8e7634c97cf6202b
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-634e1b8c-8eac-4393-8cb2-3fb6e8274ea4
+      - req-102265f8-e4e1-4f0a-985c-4a81ee7b3681
       Content-Length:
       - '7278'
       Connection:
@@ -8031,7 +8031,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:27:57.949816Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:53:10.426244Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -8110,10 +8110,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["bXoFwZ93R6ePWYOR6u1YXQ"],
-        "issued_at": "2019-01-03T19:27:57.949854Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["UTuh5bvBTN6RwzDeWTQUqw"],
+        "issued_at": "2019-01-04T16:53:10.426264Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:57 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:10 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -8131,15 +8131,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:27:58 GMT
+      - Fri, 04 Jan 2019 16:53:10 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 5898f40d3d8440468ea902ac1ec136e4
+      - eafe0820045c4492b0fa9141c472c1fb
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-08427783-996f-4e20-a11e-91a56788a36b
+      - req-f4fc6be0-9fa8-448c-a71e-7a5b0e2adaab
       Content-Length:
       - '7278'
       Connection:
@@ -8151,7 +8151,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:27:58.185609Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:53:10.624580Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -8230,10 +8230,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["CdLmHI27RKGs2gLlZqIBqw"],
-        "issued_at": "2019-01-03T19:27:58.185635Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["WWtITFnTSR2128_Y-QPwUw"],
+        "issued_at": "2019-01-04T16:53:10.624598Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:58 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:10 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -8251,15 +8251,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:27:58 GMT
+      - Fri, 04 Jan 2019 16:53:10 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - eca8a7e9e42b42e98ae95c181785868b
+      - 00b2ceb7491a4c898c97eb9d3e2e7f69
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-6fe38802-e522-43fe-987c-2a299ffdd373
+      - req-930eaceb-199a-4ddc-8a82-cc5c5e00f8f5
       Content-Length:
       - '7264'
       Connection:
@@ -8271,7 +8271,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:27:58.392094Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:53:10.835341Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -8350,10 +8350,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["DlUD8B9HQzaOfzxVYm7Jlw"],
-        "issued_at": "2019-01-03T19:27:58.392118Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["RShU-ymnS3KH0Q5TihbdDA"],
+        "issued_at": "2019-01-04T16:53:10.835361Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:58 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:10 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -8371,15 +8371,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:27:58 GMT
+      - Fri, 04 Jan 2019 16:53:10 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - d06fcfe52a7e40fb9fed6dfb3bfadad3
+      - 3ce2ed33b02d4412b7f5ff6531727bb6
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-a5d4affd-1864-4098-b28e-26d890cd928f
+      - req-e058b0c0-b885-4b8e-904b-c82d22c8536a
       Content-Length:
       - '7278'
       Connection:
@@ -8391,7 +8391,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:27:58.602614Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:53:11.046627Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -8470,10 +8470,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["5Vg6WDOZSAuMY3JD9jqT8Q"],
-        "issued_at": "2019-01-03T19:27:58.602634Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["mAOr-FysSw2eNXofCyMAKg"],
+        "issued_at": "2019-01-04T16:53:11.046649Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:58 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:11 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -8491,15 +8491,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:27:58 GMT
+      - Fri, 04 Jan 2019 16:53:11 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - ecc4e3b585ed47f984969c2ea77506fd
+      - bc047a7f5dc84b9782811b30abe3c40b
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-06111800-949e-4eac-a133-ea9da6c21599
+      - req-1fadb174-9524-4a1e-abd2-0f58799e621d
       Content-Length:
       - '7265'
       Connection:
@@ -8511,7 +8511,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:27:58.820749Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:53:11.266980Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -8590,10 +8590,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["XHKLo_isRBiMDmQl6BwlSA"],
-        "issued_at": "2019-01-03T19:27:58.820781Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["HajkcA71R_mMiax-6wIYlA"],
+        "issued_at": "2019-01-04T16:53:11.267015Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:58 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:11 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -8611,15 +8611,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:27:58 GMT
+      - Fri, 04 Jan 2019 16:53:11 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 0aa8d586958041d1ba669968f3dd6797
+      - ded981573f4544f98dca691f640b5921
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-beec17da-15a4-47fc-ba41-0f54e96a13fd
+      - req-6ccb2bd9-e08c-42ab-a1f1-d73374be5980
       Content-Length:
       - '7278'
       Connection:
@@ -8631,7 +8631,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:27:59.029636Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:53:11.480163Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -8710,10 +8710,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["GrEVAs6vTrGQjed-JGpPbQ"],
-        "issued_at": "2019-01-03T19:27:59.029656Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["rCV-_bSlT8eXtGLiw3HKgg"],
+        "issued_at": "2019-01-04T16:53:11.480189Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:59 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:11 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/0098405163cd4c9dbb42c2cb43eb6fd3
@@ -8728,7 +8728,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 87053fecb3d14e2eb9ea51232047bfd5
+      - daf8a9e7aa1b4a2c8e7634c97cf6202b
   response:
     status:
       code: 200
@@ -8739,16 +8739,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-2d341e2d-dbfa-4616-9c65-c4cb76a25a4a
+      - req-bfef6179-57df-4945-b297-d78a47681967
       Date:
-      - Thu, 03 Jan 2019 19:27:59 GMT
+      - Fri, 04 Jan 2019 16:53:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:59 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:11 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/28db8f69ba9e4305b7fad82da4c86e74
@@ -8763,7 +8763,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5898f40d3d8440468ea902ac1ec136e4
+      - eafe0820045c4492b0fa9141c472c1fb
   response:
     status:
       code: 200
@@ -8774,16 +8774,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-dc0089b7-96b9-43b1-abf8-dcdfc629024d
+      - req-2f0545b3-b0cf-4186-a980-86723a1befa4
       Date:
-      - Thu, 03 Jan 2019 19:27:59 GMT
+      - Fri, 04 Jan 2019 16:53:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:59 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:11 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/4637c33fee924ebea81f8d209e452c91
@@ -8798,7 +8798,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - eca8a7e9e42b42e98ae95c181785868b
+      - 00b2ceb7491a4c898c97eb9d3e2e7f69
   response:
     status:
       code: 200
@@ -8809,16 +8809,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-67d0b557-7074-46fe-afa7-1b5a2d9e297f
+      - req-04337332-ab60-4c2d-9ec4-73d79d294107
       Date:
-      - Thu, 03 Jan 2019 19:27:59 GMT
+      - Fri, 04 Jan 2019 16:53:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 20, "network": 20, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:59 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:11 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/52c452d7763a4295950527948232a3e5
@@ -8833,7 +8833,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d06fcfe52a7e40fb9fed6dfb3bfadad3
+      - 3ce2ed33b02d4412b7f5ff6531727bb6
   response:
     status:
       code: 200
@@ -8844,16 +8844,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-a2826c6d-1469-419c-a085-0b8786bbeae6
+      - req-fe36f927-fe94-43b8-8597-661759667969
       Date:
-      - Thu, 03 Jan 2019 19:27:59 GMT
+      - Fri, 04 Jan 2019 16:53:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:59 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:11 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/88ae57d444fd485ab2dfddd5a2615d52
@@ -8868,7 +8868,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a85539c9071540df9dd6eb36197bd1e7
+      - 3268916704804b1ba063cce31c58f9e9
   response:
     status:
       code: 200
@@ -8879,16 +8879,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-746a95e2-3cef-45e1-8213-798d49bde4d6
+      - req-c0216993-8b3c-4c08-a703-e04d10334a8a
       Date:
-      - Thu, 03 Jan 2019 19:27:59 GMT
+      - Fri, 04 Jan 2019 16:53:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:59 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:12 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/d09cbe26295d47ff848ea73c74264e23
@@ -8903,7 +8903,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ecc4e3b585ed47f984969c2ea77506fd
+      - bc047a7f5dc84b9782811b30abe3c40b
   response:
     status:
       code: 200
@@ -8914,16 +8914,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-8380a4d5-68a8-4773-be62-43bf94deceff
+      - req-7a9ab796-ab99-44ea-b3ec-ff16b038980c
       Date:
-      - Thu, 03 Jan 2019 19:27:59 GMT
+      - Fri, 04 Jan 2019 16:53:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:59 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:12 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/ef2a3405d1ef4dfd9a3616993ef46a4d
@@ -8938,7 +8938,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0aa8d586958041d1ba669968f3dd6797
+      - ded981573f4544f98dca691f640b5921
   response:
     status:
       code: 200
@@ -8949,16 +8949,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-3f80e100-f6ff-4b72-8753-e821df3b8345
+      - req-cd8a2c92-2f61-41c0-a999-6fad95bb2695
       Date:
-      - Thu, 03 Jan 2019 19:27:59 GMT
+      - Fri, 04 Jan 2019 16:53:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:59 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:12 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/servers/98b5cc33-7fb8-42b3-86f0-b35883e902aa/os-volume_attachments
@@ -8973,7 +8973,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e35cba3cf22b4803a0aedc4da241c8f0
+      - 2f1de41faa384c5a9965f645e639128c
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -8986,15 +8986,15 @@ http_interactions:
       Content-Length:
       - '197'
       X-Compute-Request-Id:
-      - req-5ba28e85-2a64-4891-9908-8b085a50f780
+      - req-e62f3259-6c41-4410-889c-37391483ba73
       Date:
-      - Thu, 03 Jan 2019 19:28:00 GMT
+      - Fri, 04 Jan 2019 16:53:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumeAttachments": [{"device": "/dev/vda", "serverId": "98b5cc33-7fb8-42b3-86f0-b35883e902aa",
         "id": "032b36d1-3dfc-4ff8-af30-5fa74ff47a39", "volumeId": "032b36d1-3dfc-4ff8-af30-5fa74ff47a39"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:00 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:12 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/servers/7edb7855-d974-4e45-8ad2-88491541ab91/os-volume_attachments
@@ -9009,7 +9009,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e35cba3cf22b4803a0aedc4da241c8f0
+      - 2f1de41faa384c5a9965f645e639128c
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -9022,15 +9022,15 @@ http_interactions:
       Content-Length:
       - '197'
       X-Compute-Request-Id:
-      - req-215f531d-ffe5-49ae-8e13-f4e626b285cd
+      - req-97719d1b-f98a-47bb-bbc2-ffc988cd7f61
       Date:
-      - Thu, 03 Jan 2019 19:28:00 GMT
+      - Fri, 04 Jan 2019 16:53:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumeAttachments": [{"device": "/dev/vdd", "serverId": "7edb7855-d974-4e45-8ad2-88491541ab91",
         "id": "8791e24f-874d-4f1e-99ec-75fdb9d48ca5", "volumeId": "8791e24f-874d-4f1e-99ec-75fdb9d48ca5"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:00 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:12 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -9048,15 +9048,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:28:00 GMT
+      - Fri, 04 Jan 2019 16:53:12 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - '013801a95d53440984f49cd2572b80c5'
+      - 3916abd122c84b8ea70879304470b896
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-2ce854fd-9cec-402a-8be6-c36b9495a6cd
+      - req-70a49303-7864-4358-b279-0121d2d1e3e6
       Content-Length:
       - '7311'
       Connection:
@@ -9068,7 +9068,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2019-01-03T20:28:00.361630Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2019-01-04T17:53:12.803330Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -9147,10 +9147,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["a8tzosOeT-OwEgh2pKvJZQ"],
-        "issued_at": "2019-01-03T19:28:00.361656Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["DH_fmudfScKMT_Rn7D-beg"],
+        "issued_at": "2019-01-04T16:53:12.803352Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:00 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:12 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -9168,15 +9168,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:28:00 GMT
+      - Fri, 04 Jan 2019 16:53:12 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - aa946ba5011c489287b7230656f6502a
+      - e7f0be56154e4c4e9017e022cc358238
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-46563950-4e28-44a6-98ef-e8402b451d57
+      - req-74b89b5d-94ce-44e8-b9a8-9a807d9e3898
       Content-Length:
       - '7311'
       Connection:
@@ -9188,7 +9188,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2019-01-03T20:28:00.568198Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2019-01-04T17:53:13.015554Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -9267,10 +9267,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["8gFdfT4gTxmuZ_Kicg8Ijw"],
-        "issued_at": "2019-01-03T19:28:00.568217Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["SDCE6YAuSz6Y0ifGSw63vg"],
+        "issued_at": "2019-01-04T16:53:13.015573Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:00 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:13 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-aggregates
@@ -9285,7 +9285,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3709877b1e3a4eab97644519936f64ac
+      - 67233fa9000c437c9d6364f35a546600
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -9298,14 +9298,14 @@ http_interactions:
       Content-Length:
       - '18'
       X-Compute-Request-Id:
-      - req-63446c63-9a05-4edf-8638-ff989d131876
+      - req-d5c9e6a0-4899-4b26-98f9-2b9b6f4341e0
       Date:
-      - Thu, 03 Jan 2019 19:28:00 GMT
+      - Fri, 04 Jan 2019 16:53:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"aggregates": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:00 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:13 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/volumes/detail?limit=1000&status=available
@@ -9320,27 +9320,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3c919bc10052477b890bfc626cf765c5
+      - 9b2e826446b24be2bb6e67ecbdea674b
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-b09f00e8-a9c6-49fa-918f-af654b4b9fbe
+      - req-2ed453d4-7ef3-4a0b-ac05-73be43dc6a0d
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-b09f00e8-a9c6-49fa-918f-af654b4b9fbe
+      - req-2ed453d4-7ef3-4a0b-ac05-73be43dc6a0d
       Date:
-      - Thu, 03 Jan 2019 19:28:00 GMT
+      - Fri, 04 Jan 2019 16:53:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:00 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:13 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/volumes/detail?limit=1000&status=available
@@ -9355,27 +9355,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cb151bd939d04bd19325ea8a5a0cb8c2
+      - e9c3d0a8d42143929069d5917190b7ff
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-36461bc6-fe76-4f99-bd66-23b1469ae1a9
+      - req-a750b821-accb-45d6-9224-0b8b0d3d37b5
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-36461bc6-fe76-4f99-bd66-23b1469ae1a9
+      - req-a750b821-accb-45d6-9224-0b8b0d3d37b5
       Date:
-      - Thu, 03 Jan 2019 19:28:00 GMT
+      - Fri, 04 Jan 2019 16:53:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:00 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:13 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&status=available
@@ -9390,22 +9390,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - abbaf7fc236c422db388c09a57cdc866
+      - ef2c83cebd0740f2abd3df1bcb7c428e
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-d2252111-90d6-41ac-999b-e55e4c5b79b8
+      - req-bcb2298f-15e8-4309-93e9-7d9aa24146d0
       Content-Type:
       - application/json
       Content-Length:
       - '2723'
       X-Openstack-Request-Id:
-      - req-d2252111-90d6-41ac-999b-e55e4c5b79b8
+      - req-bcb2298f-15e8-4309-93e9-7d9aa24146d0
       Date:
-      - Thu, 03 Jan 2019 19:28:01 GMT
+      - Fri, 04 Jan 2019 16:53:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&status=available&marker=f46458aa-309d-4f47-b996-a39db065030a",
@@ -9438,7 +9438,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-4", "bootable": "true", "created_at":
         "2016-08-19T08:37:45.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:01 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:13 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=f46458aa-309d-4f47-b996-a39db065030a&status=available
@@ -9453,22 +9453,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - abbaf7fc236c422db388c09a57cdc866
+      - ef2c83cebd0740f2abd3df1bcb7c428e
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-e7b3a83c-12c8-4314-bd07-394a1509a7de
+      - req-fb9d34a6-7d19-4db3-882c-cdf8525b3a55
       Content-Type:
       - application/json
       Content-Length:
       - '1180'
       X-Openstack-Request-Id:
-      - req-e7b3a83c-12c8-4314-bd07-394a1509a7de
+      - req-fb9d34a6-7d19-4db3-882c-cdf8525b3a55
       Date:
-      - Thu, 03 Jan 2019 19:28:01 GMT
+      - Fri, 04 Jan 2019 16:53:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": [{"migration_status": null, "attachments": [], "links":
@@ -9485,7 +9485,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-FromSnapshot", "bootable": "false", "created_at":
         "2016-08-19T08:37:13.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:01 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:13 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/volumes/detail?limit=1000&status=available
@@ -9500,27 +9500,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 38d90dbb5af04078979c436b81119665
+      - 37b82c8e28da4a35ac19583f28c2369b
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-685ea5a3-8fdb-443d-8e0a-d3f4d6760489
+      - req-a8d84ecf-2f4c-48db-8cf4-7625a7f4ed31
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-685ea5a3-8fdb-443d-8e0a-d3f4d6760489
+      - req-a8d84ecf-2f4c-48db-8cf4-7625a7f4ed31
       Date:
-      - Thu, 03 Jan 2019 19:28:01 GMT
+      - Fri, 04 Jan 2019 16:53:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:01 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:14 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/volumes/detail?limit=1000&status=available
@@ -9535,27 +9535,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5bc11c8dda904e298ff9a1f80d667acb
+      - f242ad24b5ea4e5f965fed56419cf25b
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-edd4b4d2-c27b-44e4-947f-c635e53c69c1
+      - req-43f18e1b-9969-4e06-8543-0eb29433cf68
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-edd4b4d2-c27b-44e4-947f-c635e53c69c1
+      - req-43f18e1b-9969-4e06-8543-0eb29433cf68
       Date:
-      - Thu, 03 Jan 2019 19:28:01 GMT
+      - Fri, 04 Jan 2019 16:53:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:01 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:14 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/volumes/detail?limit=1000&status=available
@@ -9570,27 +9570,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7f3eb56cf6b14037a31cc99be2854fef
+      - 5f606dbee6b14efe93e725498cd3d7f7
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-fc34137c-9cb5-405d-b6d6-f3cde63cd108
+      - req-6de50915-6299-4f1a-b31b-74bc7be56d5f
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-fc34137c-9cb5-405d-b6d6-f3cde63cd108
+      - req-6de50915-6299-4f1a-b31b-74bc7be56d5f
       Date:
-      - Thu, 03 Jan 2019 19:28:01 GMT
+      - Fri, 04 Jan 2019 16:53:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:01 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:14 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/volumes/detail?limit=1000&status=available
@@ -9605,27 +9605,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 70371ce8b0044f63a78f6d65973e93cf
+      - 4ada193837594dd98419dea108f06d15
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-765785ce-11c8-459a-8ad2-f6cdf346612d
+      - req-b314c8bb-dd15-4ce5-817e-3f6068b48e1c
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-765785ce-11c8-459a-8ad2-f6cdf346612d
+      - req-b314c8bb-dd15-4ce5-817e-3f6068b48e1c
       Date:
-      - Thu, 03 Jan 2019 19:28:01 GMT
+      - Fri, 04 Jan 2019 16:53:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:01 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:14 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/snapshots/detail
@@ -9640,27 +9640,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3c919bc10052477b890bfc626cf765c5
+      - 9b2e826446b24be2bb6e67ecbdea674b
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-0fe354aa-ae93-4840-b601-7d5afe943977
+      - req-3f760584-5f4b-4a2d-8ffa-3bb557cdfe1b
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-0fe354aa-ae93-4840-b601-7d5afe943977
+      - req-3f760584-5f4b-4a2d-8ffa-3bb557cdfe1b
       Date:
-      - Thu, 03 Jan 2019 19:28:01 GMT
+      - Fri, 04 Jan 2019 16:53:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:01 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:14 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/snapshots/detail?limit=1000&status=available
@@ -9675,27 +9675,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3c919bc10052477b890bfc626cf765c5
+      - 9b2e826446b24be2bb6e67ecbdea674b
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-1b366d86-6929-4720-84cb-a99f343b28a3
+      - req-d5bdbfb7-a39d-463f-bf9b-6823e2ee5246
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-1b366d86-6929-4720-84cb-a99f343b28a3
+      - req-d5bdbfb7-a39d-463f-bf9b-6823e2ee5246
       Date:
-      - Thu, 03 Jan 2019 19:28:02 GMT
+      - Fri, 04 Jan 2019 16:53:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:02 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:14 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/snapshots/detail
@@ -9710,27 +9710,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cb151bd939d04bd19325ea8a5a0cb8c2
+      - e9c3d0a8d42143929069d5917190b7ff
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-3b8a48a8-e9b8-4058-a90a-fad415d68675
+      - req-5d902ff8-ca5f-4e34-accc-14a7a0cb26a3
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-3b8a48a8-e9b8-4058-a90a-fad415d68675
+      - req-5d902ff8-ca5f-4e34-accc-14a7a0cb26a3
       Date:
-      - Thu, 03 Jan 2019 19:28:02 GMT
+      - Fri, 04 Jan 2019 16:53:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:02 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:14 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/snapshots/detail?limit=1000&status=available
@@ -9745,27 +9745,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cb151bd939d04bd19325ea8a5a0cb8c2
+      - e9c3d0a8d42143929069d5917190b7ff
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-170f7674-1db9-4fd2-b31a-eff2a6110564
+      - req-5369fabd-0868-4969-9992-7b0dbb8816d0
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-170f7674-1db9-4fd2-b31a-eff2a6110564
+      - req-5369fabd-0868-4969-9992-7b0dbb8816d0
       Date:
-      - Thu, 03 Jan 2019 19:28:02 GMT
+      - Fri, 04 Jan 2019 16:53:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:02 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:14 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/snapshots/detail
@@ -9780,22 +9780,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - abbaf7fc236c422db388c09a57cdc866
+      - ef2c83cebd0740f2abd3df1bcb7c428e
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-1a1ff226-031c-4e46-b76d-c04817494038
+      - req-b217ce3e-08ee-49ef-aa26-07133e98ec0b
       Content-Type:
       - application/json
       Content-Length:
       - '1053'
       X-Openstack-Request-Id:
-      - req-1a1ff226-031c-4e46-b76d-c04817494038
+      - req-b217ce3e-08ee-49ef-aa26-07133e98ec0b
       Date:
-      - Thu, 03 Jan 2019 19:28:02 GMT
+      - Fri, 04 Jan 2019 16:53:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/snapshots/detail?marker=c44d3eb3-31fe-46ed-bfae-707920be171d",
@@ -9810,7 +9810,7 @@ http_interactions:
         "created_at": "2016-08-19T08:37:24.000000", "size": 1, "id": "c44d3eb3-31fe-46ed-bfae-707920be171d",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:02 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:14 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/snapshots/detail?limit=1000&status=available
@@ -9825,22 +9825,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - abbaf7fc236c422db388c09a57cdc866
+      - ef2c83cebd0740f2abd3df1bcb7c428e
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-3b14f651-e0ff-4703-94da-b899cc858b72
+      - req-0a85d5d7-c7d1-406e-abaf-a80b71a4885e
       Content-Type:
       - application/json
       Content-Length:
       - '1081'
       X-Openstack-Request-Id:
-      - req-3b14f651-e0ff-4703-94da-b899cc858b72
+      - req-0a85d5d7-c7d1-406e-abaf-a80b71a4885e
       Date:
-      - Thu, 03 Jan 2019 19:28:02 GMT
+      - Fri, 04 Jan 2019 16:53:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/snapshots/detail?limit=1000&status=available&marker=c44d3eb3-31fe-46ed-bfae-707920be171d",
@@ -9855,7 +9855,7 @@ http_interactions:
         "created_at": "2016-08-19T08:37:24.000000", "size": 1, "id": "c44d3eb3-31fe-46ed-bfae-707920be171d",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:02 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:15 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/snapshots/detail
@@ -9870,27 +9870,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 38d90dbb5af04078979c436b81119665
+      - 37b82c8e28da4a35ac19583f28c2369b
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-ea3f3877-3dbf-4f07-828d-bef5591b3814
+      - req-f7a8679a-858c-4cfb-b79b-0fe2a8f06fee
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-ea3f3877-3dbf-4f07-828d-bef5591b3814
+      - req-f7a8679a-858c-4cfb-b79b-0fe2a8f06fee
       Date:
-      - Thu, 03 Jan 2019 19:28:02 GMT
+      - Fri, 04 Jan 2019 16:53:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:02 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:15 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/snapshots/detail?limit=1000&status=available
@@ -9905,27 +9905,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 38d90dbb5af04078979c436b81119665
+      - 37b82c8e28da4a35ac19583f28c2369b
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-951f38e2-ebfc-4aeb-9271-4d10185253f0
+      - req-c6fb7154-1689-42a3-9b4f-04c7230ac6a3
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-951f38e2-ebfc-4aeb-9271-4d10185253f0
+      - req-c6fb7154-1689-42a3-9b4f-04c7230ac6a3
       Date:
-      - Thu, 03 Jan 2019 19:28:02 GMT
+      - Fri, 04 Jan 2019 16:53:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:02 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:15 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/snapshots/detail
@@ -9940,27 +9940,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5bc11c8dda904e298ff9a1f80d667acb
+      - f242ad24b5ea4e5f965fed56419cf25b
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-7e2520ed-65c0-4c26-a582-68eea092ecba
+      - req-b31c7b46-ef0d-4734-8d85-ce9bddd792af
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-7e2520ed-65c0-4c26-a582-68eea092ecba
+      - req-b31c7b46-ef0d-4734-8d85-ce9bddd792af
       Date:
-      - Thu, 03 Jan 2019 19:28:02 GMT
+      - Fri, 04 Jan 2019 16:53:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:02 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:15 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/snapshots/detail?limit=1000&status=available
@@ -9975,27 +9975,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5bc11c8dda904e298ff9a1f80d667acb
+      - f242ad24b5ea4e5f965fed56419cf25b
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-0caee756-36b4-4d7e-ad71-285206a6c182
+      - req-66752b8f-b5c1-4bc5-8dd6-58baf7b17beb
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-0caee756-36b4-4d7e-ad71-285206a6c182
+      - req-66752b8f-b5c1-4bc5-8dd6-58baf7b17beb
       Date:
-      - Thu, 03 Jan 2019 19:28:02 GMT
+      - Fri, 04 Jan 2019 16:53:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:02 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:15 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/snapshots/detail
@@ -10010,27 +10010,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7f3eb56cf6b14037a31cc99be2854fef
+      - 5f606dbee6b14efe93e725498cd3d7f7
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-10b56252-016e-4fdb-bb4b-50fd4181f6f2
+      - req-36042fe0-7348-4c51-b8ab-4b52e5e0ffa9
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-10b56252-016e-4fdb-bb4b-50fd4181f6f2
+      - req-36042fe0-7348-4c51-b8ab-4b52e5e0ffa9
       Date:
-      - Thu, 03 Jan 2019 19:28:03 GMT
+      - Fri, 04 Jan 2019 16:53:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:03 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:15 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/snapshots/detail?limit=1000&status=available
@@ -10045,27 +10045,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7f3eb56cf6b14037a31cc99be2854fef
+      - 5f606dbee6b14efe93e725498cd3d7f7
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-23433866-8ddc-4650-a214-94eec989751f
+      - req-8314e5e9-b52b-49bc-9b2b-22d1f6e3348d
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-23433866-8ddc-4650-a214-94eec989751f
+      - req-8314e5e9-b52b-49bc-9b2b-22d1f6e3348d
       Date:
-      - Thu, 03 Jan 2019 19:28:03 GMT
+      - Fri, 04 Jan 2019 16:53:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:03 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:15 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/snapshots/detail
@@ -10080,27 +10080,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 70371ce8b0044f63a78f6d65973e93cf
+      - 4ada193837594dd98419dea108f06d15
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-b5e0704c-67b0-406e-ad5c-0cb76bc68d71
+      - req-a0e9b131-d90d-44d3-bd7b-b5a4dbb46ce4
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-b5e0704c-67b0-406e-ad5c-0cb76bc68d71
+      - req-a0e9b131-d90d-44d3-bd7b-b5a4dbb46ce4
       Date:
-      - Thu, 03 Jan 2019 19:28:03 GMT
+      - Fri, 04 Jan 2019 16:53:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:03 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:15 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/snapshots/detail?limit=1000&status=available
@@ -10115,27 +10115,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 70371ce8b0044f63a78f6d65973e93cf
+      - 4ada193837594dd98419dea108f06d15
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-6e74bc00-9f61-45db-b6ee-03d4a251f30d
+      - req-3f50ece2-32fd-416b-b7b8-72d17862f9b8
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-6e74bc00-9f61-45db-b6ee-03d4a251f30d
+      - req-3f50ece2-32fd-416b-b7b8-72d17862f9b8
       Date:
-      - Thu, 03 Jan 2019 19:28:03 GMT
+      - Fri, 04 Jan 2019 16:53:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:03 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:15 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/volumes/detail?limit=1000
@@ -10150,27 +10150,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3c919bc10052477b890bfc626cf765c5
+      - 9b2e826446b24be2bb6e67ecbdea674b
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-11456cac-5c2f-49c8-8aee-1aed95bb7e6d
+      - req-f8ce262b-e40c-43b6-bc70-d543c1d0c334
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-11456cac-5c2f-49c8-8aee-1aed95bb7e6d
+      - req-f8ce262b-e40c-43b6-bc70-d543c1d0c334
       Date:
-      - Thu, 03 Jan 2019 19:28:03 GMT
+      - Fri, 04 Jan 2019 16:53:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:03 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:16 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/volumes/detail?limit=1000
@@ -10185,27 +10185,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cb151bd939d04bd19325ea8a5a0cb8c2
+      - e9c3d0a8d42143929069d5917190b7ff
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-e64e979c-89cd-411f-9cef-a79463d54788
+      - req-1d33d775-58a1-4aab-beef-fee79cac8694
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-e64e979c-89cd-411f-9cef-a79463d54788
+      - req-1d33d775-58a1-4aab-beef-fee79cac8694
       Date:
-      - Thu, 03 Jan 2019 19:28:03 GMT
+      - Fri, 04 Jan 2019 16:53:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:03 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:16 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000
@@ -10220,22 +10220,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - abbaf7fc236c422db388c09a57cdc866
+      - ef2c83cebd0740f2abd3df1bcb7c428e
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-01db26e0-896c-42d0-a6ba-99c85549de66
+      - req-08191d61-20c6-4cd6-92de-979d06d3ac2d
       Content-Type:
       - application/json
       Content-Length:
       - '2706'
       X-Openstack-Request-Id:
-      - req-01db26e0-896c-42d0-a6ba-99c85549de66
+      - req-08191d61-20c6-4cd6-92de-979d06d3ac2d
       Date:
-      - Thu, 03 Jan 2019 19:28:03 GMT
+      - Fri, 04 Jan 2019 16:53:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=f46458aa-309d-4f47-b996-a39db065030a",
@@ -10268,7 +10268,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-4", "bootable": "true", "created_at":
         "2016-08-19T08:37:45.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:03 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:16 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=f46458aa-309d-4f47-b996-a39db065030a
@@ -10283,22 +10283,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - abbaf7fc236c422db388c09a57cdc866
+      - ef2c83cebd0740f2abd3df1bcb7c428e
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-a247b563-aeed-45a4-ac1c-e622d5bdf6c8
+      - req-5035d2fb-7650-408c-b634-658a05d2ae04
       Content-Type:
       - application/json
       Content-Length:
       - '3284'
       X-Openstack-Request-Id:
-      - req-a247b563-aeed-45a4-ac1c-e622d5bdf6c8
+      - req-5035d2fb-7650-408c-b634-658a05d2ae04
       Date:
-      - Thu, 03 Jan 2019 19:28:03 GMT
+      - Fri, 04 Jan 2019 16:53:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=476a0c89-4322-42aa-b7ce-3ac21be55af7",
@@ -10339,7 +10339,7 @@ http_interactions:
         "name": "EmsRefreshSpec-Volume-2", "bootable": "false", "created_at": "2016-08-19T08:37:33.000000",
         "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:03 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:16 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=476a0c89-4322-42aa-b7ce-3ac21be55af7
@@ -10354,22 +10354,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - abbaf7fc236c422db388c09a57cdc866
+      - ef2c83cebd0740f2abd3df1bcb7c428e
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-7c103dbb-e88e-4a99-a1fc-fde970d4ff26
+      - req-aa7de814-c60a-4b5d-869e-9e89361fc9c5
       Content-Type:
       - application/json
       Content-Length:
       - '2753'
       X-Openstack-Request-Id:
-      - req-7c103dbb-e88e-4a99-a1fc-fde970d4ff26
+      - req-aa7de814-c60a-4b5d-869e-9e89361fc9c5
       Date:
-      - Thu, 03 Jan 2019 19:28:04 GMT
+      - Fri, 04 Jan 2019 16:53:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=8791e24f-874d-4f1e-99ec-75fdb9d48ca5",
@@ -10403,7 +10403,7 @@ http_interactions:
         "bootable": "false", "created_at": "2016-08-19T08:37:05.000000", "volume_type":
         "iscsi"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:04 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:17 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=8791e24f-874d-4f1e-99ec-75fdb9d48ca5
@@ -10418,27 +10418,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - abbaf7fc236c422db388c09a57cdc866
+      - ef2c83cebd0740f2abd3df1bcb7c428e
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-6ab0b9bf-fc3a-4def-8c5f-a4142ea79709
+      - req-ff4aca96-0bb0-4dab-8195-76dc7653ba53
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-6ab0b9bf-fc3a-4def-8c5f-a4142ea79709
+      - req-ff4aca96-0bb0-4dab-8195-76dc7653ba53
       Date:
-      - Thu, 03 Jan 2019 19:28:04 GMT
+      - Fri, 04 Jan 2019 16:53:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:04 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:17 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/volumes/detail?limit=1000
@@ -10453,27 +10453,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 38d90dbb5af04078979c436b81119665
+      - 37b82c8e28da4a35ac19583f28c2369b
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-cf7d6176-5e81-4edf-aa1d-035ac34e2f4b
+      - req-e3fe9e0f-8737-4439-a6a1-cf798e55bdb4
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-cf7d6176-5e81-4edf-aa1d-035ac34e2f4b
+      - req-e3fe9e0f-8737-4439-a6a1-cf798e55bdb4
       Date:
-      - Thu, 03 Jan 2019 19:28:04 GMT
+      - Fri, 04 Jan 2019 16:53:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:04 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:17 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/volumes/detail?limit=1000
@@ -10488,27 +10488,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5bc11c8dda904e298ff9a1f80d667acb
+      - f242ad24b5ea4e5f965fed56419cf25b
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-fe698be8-5660-4f11-ba94-9b8eb7d52ffd
+      - req-690bfbf9-911e-4519-880c-da79b35787a0
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-fe698be8-5660-4f11-ba94-9b8eb7d52ffd
+      - req-690bfbf9-911e-4519-880c-da79b35787a0
       Date:
-      - Thu, 03 Jan 2019 19:28:04 GMT
+      - Fri, 04 Jan 2019 16:53:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:04 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:17 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/volumes/detail?limit=1000
@@ -10523,27 +10523,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7f3eb56cf6b14037a31cc99be2854fef
+      - 5f606dbee6b14efe93e725498cd3d7f7
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-80db723d-9919-46f4-baab-b52865bb9eb6
+      - req-32afc2bd-e508-4955-97ac-a8d627ec379b
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-80db723d-9919-46f4-baab-b52865bb9eb6
+      - req-32afc2bd-e508-4955-97ac-a8d627ec379b
       Date:
-      - Thu, 03 Jan 2019 19:28:04 GMT
+      - Fri, 04 Jan 2019 16:53:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:04 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:17 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/volumes/detail?limit=1000
@@ -10558,27 +10558,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 70371ce8b0044f63a78f6d65973e93cf
+      - 4ada193837594dd98419dea108f06d15
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-e8b3df7b-1a30-4af3-99b9-16eff75e6bfc
+      - req-d19e8457-1399-4f25-a339-f8b09a7349bb
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-e8b3df7b-1a30-4af3-99b9-16eff75e6bfc
+      - req-d19e8457-1399-4f25-a339-f8b09a7349bb
       Date:
-      - Thu, 03 Jan 2019 19:28:04 GMT
+      - Fri, 04 Jan 2019 16:53:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:04 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:17 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -10596,15 +10596,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:28:05 GMT
+      - Fri, 04 Jan 2019 16:53:20 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 9869bc3898bd4b758973a5364be6989d
+      - 2085eaa8157c46c3ac6a31ea8a8291fd
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-29941079-8daa-49a2-8c2b-e6024c9d567b
+      - req-48897056-7a2c-4dfc-be3f-406999c30b9f
       Content-Length:
       - '7311'
       Connection:
@@ -10616,7 +10616,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2019-01-03T20:28:06.039697Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2019-01-04T17:53:20.407667Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -10695,10 +10695,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["PwJFr3t-SpeS8Wn-M6MQ5Q"],
-        "issued_at": "2019-01-03T19:28:06.039719Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["yn0dp3FgSkexF_VHLOD8bQ"],
+        "issued_at": "2019-01-04T16:53:20.407688Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:06 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:20 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -10716,15 +10716,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:28:06 GMT
+      - Fri, 04 Jan 2019 16:53:20 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - ca35cd693ad14e9987559af97589f30d
+      - 135de8cb22204669a28a2c5a9548f7e6
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-4a7712db-609e-471a-9625-2de568e6c6c5
+      - req-7c873333-30a8-4599-87ec-c30f4bbb7f99
       Content-Length:
       - '7311'
       Connection:
@@ -10736,7 +10736,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2019-01-03T20:28:06.244857Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2019-01-04T17:53:20.613630Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -10815,10 +10815,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["UwY8pLHwQUKxoJ3yzs6oug"],
-        "issued_at": "2019-01-03T19:28:06.244876Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["e4Im1v9YRyKhJQMhksHscQ"],
+        "issued_at": "2019-01-04T16:53:20.613650Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:06 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:20 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/networks
@@ -10833,7 +10833,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ca35cd693ad14e9987559af97589f30d
+      - 135de8cb22204669a28a2c5a9548f7e6
   response:
     status:
       code: 200
@@ -10844,9 +10844,9 @@ http_interactions:
       Content-Length:
       - '5330'
       X-Openstack-Request-Id:
-      - req-8e509052-4517-406a-9982-dbf906824cb5
+      - req-a8f1709a-d96c-4d02-9e2b-4b875b9179dd
       Date:
-      - Thu, 03 Jan 2019 19:28:06 GMT
+      - Fri, 04 Jan 2019 16:53:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"networks": [{"status": "ACTIVE", "subnets": ["75e7a9c8-eeaf-4cd0-80da-05165f897e69"],
@@ -10909,14 +10909,14 @@ http_interactions:
         "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
         0, "router:external": true, "shared": false, "provider:network_type": "flat",
         "id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "provider:segmentation_id":
-        null}, {"status": "ACTIVE", "subnets": ["24c83610-eab6-4f68-99dd-ab22a638b4a0",
-        "f4c17602-9618-4604-b3c9-9e4801d094d3"], "name": "EmsRefreshSpec-NetworkPrivate",
+        null}, {"status": "ACTIVE", "subnets": ["f4c17602-9618-4604-b3c9-9e4801d094d3",
+        "24c83610-eab6-4f68-99dd-ab22a638b4a0"], "name": "EmsRefreshSpec-NetworkPrivate",
         "provider:physical_network": null, "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
         "vxlan", "id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "provider:segmentation_id":
         11}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:06 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:20 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -10934,15 +10934,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:28:06 GMT
+      - Fri, 04 Jan 2019 16:53:20 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 33ca714497834a3db94562f01860931c
+      - a410adc5af3842db979b74bc3c9ac476
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-dfa82e68-2d45-413d-93f9-1ad3d4d17be9
+      - req-6faba670-0862-4fbf-a614-4e1d985c92dc
       Content-Length:
       - '7311'
       Connection:
@@ -10954,7 +10954,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2019-01-03T20:28:06.662166Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2019-01-04T17:53:20.982928Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -11033,10 +11033,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["fp57r53MT1e3o_Twt9Z9Og"],
-        "issued_at": "2019-01-03T19:28:06.662186Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["SEmp0uWHT_uThxYNP-bLsw"],
+        "issued_at": "2019-01-04T16:53:20.982950Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:06 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:21 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -11054,15 +11054,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:28:06 GMT
+      - Fri, 04 Jan 2019 16:53:21 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 734228126afb4ce392dec64911a72c87
+      - 8ffe850064204d57b9c48ddb2ae9570f
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-53e7428a-7646-43ed-ade2-6f002434c4e5
+      - req-19766a2c-5e65-4f6d-8002-b2bd5d84b4a5
       Content-Length:
       - '297'
       Connection:
@@ -11071,12 +11071,12 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"token": {"methods": ["password"], "expires_at": "2019-01-03T20:28:06.838705Z",
+      string: '{"token": {"methods": ["password"], "expires_at": "2019-01-04T17:53:21.167031Z",
         "extras": {}, "user": {"domain": {"id": "default", "name": "Default"}, "id":
-        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["edZX49HPS-md85fCUI8-Ng"],
-        "issued_at": "2019-01-03T19:28:06.838726Z"}}'
+        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["7dNnUrY8Sqy9lEqNGtAQrw"],
+        "issued_at": "2019-01-04T16:53:21.167050Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:06 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:21 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects?domain_id=default
@@ -11091,20 +11091,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 734228126afb4ce392dec64911a72c87
+      - 8ffe850064204d57b9c48ddb2ae9570f
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:28:06 GMT
+      - Fri, 04 Jan 2019 16:53:21 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-bf745106-50dc-4d58-bd71-3a7f387ad097
+      - req-92faeed6-af19-47cc-bb6b-c09fdd3e542d
       Content-Length:
       - '2475'
       Connection:
@@ -11137,7 +11137,7 @@ http_interactions:
         "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
         "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:07 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:21 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -11155,15 +11155,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:28:07 GMT
+      - Fri, 04 Jan 2019 16:53:21 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 7fb7d4d42015468193a89189d918230b
+      - fddb1ab04a46489fa6261b72b2c77ca5
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-c89ee316-0659-475f-abe7-226cbcf96fb7
+      - req-88e6cb84-1f38-4e7f-b0c3-77d4160107ac
       Content-Length:
       - '7278'
       Connection:
@@ -11175,7 +11175,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:28:07.179372Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:53:21.503344Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -11254,10 +11254,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["WRZ4MjpHSQ-cPeXlo1uobw"],
-        "issued_at": "2019-01-03T19:28:07.179390Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["D654Bf8zSoGqeBmPD8QCgg"],
+        "issued_at": "2019-01-04T16:53:21.503365Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:07 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:21 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -11275,15 +11275,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:28:07 GMT
+      - Fri, 04 Jan 2019 16:53:21 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 7ab71782a7344f0fba3e20d6559108bc
+      - d08bb75d1b6e4b06a165b640338eb87b
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-e0828e6d-5684-4947-a7a3-8b3b658da13b
+      - req-fc4c25d3-0aae-492a-b9dc-9618c6ea93f9
       Content-Length:
       - '7278'
       Connection:
@@ -11295,7 +11295,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:28:07.378698Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:53:21.708338Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -11374,10 +11374,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["RSvq1kixTl2Gzq1WNLGFvA"],
-        "issued_at": "2019-01-03T19:28:07.378715Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["FzIqtPKIR1WF5ML6vO6I5g"],
+        "issued_at": "2019-01-04T16:53:21.708357Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:07 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:21 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -11395,15 +11395,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:28:07 GMT
+      - Fri, 04 Jan 2019 16:53:21 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 9c46ad4a921149c69b2f2f2d3bec53ea
+      - 6af72b16b0bd481988e75c452e262111
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-f37763b2-2acf-4193-8aff-41b8fdb3cc85
+      - req-7e0aa96c-3840-475d-9247-659a6a9d5aae
       Content-Length:
       - '7264'
       Connection:
@@ -11415,7 +11415,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:28:07.593021Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:53:21.916856Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -11494,10 +11494,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Trh4oI5yS7moaZUO9OXQpg"],
-        "issued_at": "2019-01-03T19:28:07.593041Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["zpqVDGBOSi25HVFMMAGZzA"],
+        "issued_at": "2019-01-04T16:53:21.916877Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:07 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:21 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -11515,15 +11515,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:28:07 GMT
+      - Fri, 04 Jan 2019 16:53:22 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 80b5d2822abb4902846ed0b98bd6fc36
+      - a7fd7cf2cdd1451d91399f7fc457ce30
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-f4aa2eac-5eab-4d55-9dd4-d6f14c3ddbdd
+      - req-b366b0a8-33ff-4960-99c4-625b80bb76d0
       Content-Length:
       - '7278'
       Connection:
@@ -11535,7 +11535,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:28:07.803121Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:53:22.132235Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -11614,10 +11614,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["eOZSEcKQTXCkIMO_lT6gyQ"],
-        "issued_at": "2019-01-03T19:28:07.803142Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["EsuExhzrR62uFfCLpv8KMg"],
+        "issued_at": "2019-01-04T16:53:22.132256Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:07 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:22 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -11635,15 +11635,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:28:07 GMT
+      - Fri, 04 Jan 2019 16:53:22 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 9c1d072e57d94528a17c7b68ab9ac992
+      - acdbccc6d7e94f5094c303ff03a6afb7
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-414c496c-7b15-45db-9e29-12d2b0983d4b
+      - req-18a43318-8868-4b68-a71f-7ba0ed1ee5a0
       Content-Length:
       - '7265'
       Connection:
@@ -11655,7 +11655,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:28:08.004380Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:53:22.349302Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -11734,10 +11734,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["mVM2ivhmQDSqXALtnAu-yA"],
-        "issued_at": "2019-01-03T19:28:08.004399Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["luT4YkZPS_2I3UcWRxab3w"],
+        "issued_at": "2019-01-04T16:53:22.349329Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:08 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:22 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -11755,15 +11755,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:28:08 GMT
+      - Fri, 04 Jan 2019 16:53:22 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 8fe1c953cb764ebab313bdbb98073c92
+      - 32b7ed63b4c14fb39a3516058a2ba42d
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-394033f1-8c7a-4473-bd45-e7a2207ec3ab
+      - req-a8397ae3-e25b-4501-aa7a-e4ed20bed676
       Content-Length:
       - '7278'
       Connection:
@@ -11775,7 +11775,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:28:08.221997Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:53:22.556861Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -11854,10 +11854,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["bbihIrndRMurEITaXAsJmQ"],
-        "issued_at": "2019-01-03T19:28:08.222023Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["wfKiDAT3T26k6sRTEIKjPg"],
+        "issued_at": "2019-01-04T16:53:22.556881Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:08 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:22 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/0098405163cd4c9dbb42c2cb43eb6fd3/stacks?limit=1000&show_nested=true
@@ -11872,7 +11872,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7fb7d4d42015468193a89189d918230b
+      - fddb1ab04a46489fa6261b72b2c77ca5
   response:
     status:
       code: 200
@@ -11883,14 +11883,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-b2a1cedb-0773-4fc1-ba39-baf51f6d18ca
+      - req-fa9d68bd-175d-4d1b-95d9-60f5b0a8a6df
       Date:
-      - Thu, 03 Jan 2019 19:28:08 GMT
+      - Fri, 04 Jan 2019 16:53:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:08 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:22 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/28db8f69ba9e4305b7fad82da4c86e74/stacks?limit=1000&show_nested=true
@@ -11905,7 +11905,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7ab71782a7344f0fba3e20d6559108bc
+      - d08bb75d1b6e4b06a165b640338eb87b
   response:
     status:
       code: 200
@@ -11916,14 +11916,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-77c1eb87-54e5-4258-a7b4-6dcb4684a963
+      - req-5c1fc91c-4a17-43c1-95a5-3360e2e87b98
       Date:
-      - Thu, 03 Jan 2019 19:28:08 GMT
+      - Fri, 04 Jan 2019 16:53:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:08 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:22 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks?limit=1000&show_nested=true
@@ -11938,7 +11938,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9c46ad4a921149c69b2f2f2d3bec53ea
+      - 6af72b16b0bd481988e75c452e262111
   response:
     status:
       code: 200
@@ -11949,9 +11949,9 @@ http_interactions:
       Content-Length:
       - '2559'
       X-Openstack-Request-Id:
-      - req-aedb780e-dd5e-48bb-b8fd-55c348e07e1a
+      - req-79855ee9-e7d1-4246-bf80-45280f28edee
       Date:
-      - Thu, 03 Jan 2019 19:28:08 GMT
+      - Fri, 04 Jan 2019 16:53:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": [{"description": "Heat WordPress template to support F20,
@@ -11985,7 +11985,7 @@ http_interactions:
         "rel": "self"}], "updated_time": null, "stack_owner": null, "stack_status":
         "CREATE_COMPLETE", "id": "7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:08 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:22 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks?limit=1000&marker=7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0&show_nested=true
@@ -12000,7 +12000,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9c46ad4a921149c69b2f2f2d3bec53ea
+      - 6af72b16b0bd481988e75c452e262111
   response:
     status:
       code: 200
@@ -12011,14 +12011,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-b8416991-9aea-492f-a88f-88842278d31b
+      - req-14be0e7b-42a6-4d55-a8f8-ea0c12486118
       Date:
-      - Thu, 03 Jan 2019 19:28:08 GMT
+      - Fri, 04 Jan 2019 16:53:23 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:08 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:23 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/52c452d7763a4295950527948232a3e5/stacks?limit=1000&show_nested=true
@@ -12033,7 +12033,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 80b5d2822abb4902846ed0b98bd6fc36
+      - a7fd7cf2cdd1451d91399f7fc457ce30
   response:
     status:
       code: 200
@@ -12044,14 +12044,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-2a9c5eb2-e410-4509-a592-1887024e3be8
+      - req-8e430d13-7f8b-4c4c-85d6-e35c6bd2b152
       Date:
-      - Thu, 03 Jan 2019 19:28:08 GMT
+      - Fri, 04 Jan 2019 16:53:23 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:08 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:23 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/88ae57d444fd485ab2dfddd5a2615d52/stacks?limit=1000&show_nested=true
@@ -12066,7 +12066,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 33ca714497834a3db94562f01860931c
+      - a410adc5af3842db979b74bc3c9ac476
   response:
     status:
       code: 200
@@ -12077,14 +12077,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-6db85400-e561-42a5-bb46-f9cd62c1050a
+      - req-e0c8c97b-c516-49a8-bc52-ed9bdd6b7e20
       Date:
-      - Thu, 03 Jan 2019 19:28:08 GMT
+      - Fri, 04 Jan 2019 16:53:23 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:09 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:23 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/d09cbe26295d47ff848ea73c74264e23/stacks?limit=1000&show_nested=true
@@ -12099,7 +12099,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9c1d072e57d94528a17c7b68ab9ac992
+      - acdbccc6d7e94f5094c303ff03a6afb7
   response:
     status:
       code: 200
@@ -12110,14 +12110,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-6e71d2ab-9da1-4fb8-bf3e-4f95deac8a67
+      - req-39157e96-7a4f-4c10-a80e-e2e2b98f21e2
       Date:
-      - Thu, 03 Jan 2019 19:28:09 GMT
+      - Fri, 04 Jan 2019 16:53:23 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:09 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:23 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/ef2a3405d1ef4dfd9a3616993ef46a4d/stacks?limit=1000&show_nested=true
@@ -12132,7 +12132,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8fe1c953cb764ebab313bdbb98073c92
+      - 32b7ed63b4c14fb39a3516058a2ba42d
   response:
     status:
       code: 200
@@ -12143,14 +12143,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-1eb03cab-c143-4d42-b48d-6466ae5ed06b
+      - req-7acef86b-ca88-4c22-a7c7-08453ff92a6f
       Date:
-      - Thu, 03 Jan 2019 19:28:09 GMT
+      - Fri, 04 Jan 2019 16:53:23 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:09 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:23 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack3/00c5dc04-2c94-48d2-8031-db08934e9a44
@@ -12165,7 +12165,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9c46ad4a921149c69b2f2f2d3bec53ea
+      - 6af72b16b0bd481988e75c452e262111
   response:
     status:
       code: 200
@@ -12176,9 +12176,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-36731185-f0b4-4920-8522-6d151d9d856f
+      - req-9b7035b0-7292-4f17-8080-1c0b983d1caa
       Date:
-      - Thu, 03 Jan 2019 19:28:09 GMT
+      - Fri, 04 Jan 2019 16:53:23 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -12205,7 +12205,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:09 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:23 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack2/d6eba2a2-7b0d-4213-afbb-69c8f6dddd8d
@@ -12220,7 +12220,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9c46ad4a921149c69b2f2f2d3bec53ea
+      - 6af72b16b0bd481988e75c452e262111
   response:
     status:
       code: 200
@@ -12231,9 +12231,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-bc93ae4f-febe-4a7b-bc26-c2e2841105cd
+      - req-f0d48ec0-7839-42df-8ba2-f57f850ed9dc
       Date:
-      - Thu, 03 Jan 2019 19:28:09 GMT
+      - Fri, 04 Jan 2019 16:53:24 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -12260,7 +12260,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:09 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:24 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack1/7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0
@@ -12275,7 +12275,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9c46ad4a921149c69b2f2f2d3bec53ea
+      - 6af72b16b0bd481988e75c452e262111
   response:
     status:
       code: 200
@@ -12286,9 +12286,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-7cb30169-c91f-4f07-869d-0ef9db279feb
+      - req-9c89cc68-75a9-4df6-8428-7e14c9cc6456
       Date:
-      - Thu, 03 Jan 2019 19:28:10 GMT
+      - Fri, 04 Jan 2019 16:53:24 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -12315,7 +12315,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:10 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:24 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack3/00c5dc04-2c94-48d2-8031-db08934e9a44/resources
@@ -12330,7 +12330,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9c46ad4a921149c69b2f2f2d3bec53ea
+      - 6af72b16b0bd481988e75c452e262111
   response:
     status:
       code: 200
@@ -12341,9 +12341,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-e707c48b-b70c-4f29-8bd6-dfa22c978a95
+      - req-c994e8ea-0adf-4d80-b10f-91f98d355103
       Date:
-      - Thu, 03 Jan 2019 19:28:10 GMT
+      - Fri, 04 Jan 2019 16:53:24 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -12355,7 +12355,7 @@ http_interactions:
         changed", "physical_resource_id": "40989f26-9c38-4f72-b739-afccb44397cf",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:10 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:24 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack2/d6eba2a2-7b0d-4213-afbb-69c8f6dddd8d/resources
@@ -12370,7 +12370,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9c46ad4a921149c69b2f2f2d3bec53ea
+      - 6af72b16b0bd481988e75c452e262111
   response:
     status:
       code: 200
@@ -12381,9 +12381,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-da218e3c-0126-40e0-bff5-b79195048c97
+      - req-3756d0d0-b913-4fdf-84ca-b4e63a6bdb13
       Date:
-      - Thu, 03 Jan 2019 19:28:10 GMT
+      - Fri, 04 Jan 2019 16:53:24 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -12395,7 +12395,7 @@ http_interactions:
         changed", "physical_resource_id": "ad4f7eb0-9122-41a6-a0f7-55c1d4ca5e02",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:10 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:24 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack1/7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0/resources
@@ -12410,7 +12410,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9c46ad4a921149c69b2f2f2d3bec53ea
+      - 6af72b16b0bd481988e75c452e262111
   response:
     status:
       code: 200
@@ -12421,9 +12421,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-5e40c937-6a00-490e-86ad-7ba22122de7b
+      - req-3836479e-f444-4542-a61f-8690f4bf5e26
       Date:
-      - Thu, 03 Jan 2019 19:28:10 GMT
+      - Fri, 04 Jan 2019 16:53:24 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -12435,7 +12435,7 @@ http_interactions:
         changed", "physical_resource_id": "8022b967-813a-4e3b-8ff4-7c036957a8a0",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:10 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:24 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -12453,15 +12453,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:28:10 GMT
+      - Fri, 04 Jan 2019 16:53:24 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 07c96dff03e744d180b460e38e6ea27d
+      - 77076a65adfc4d59a64c672e6169d98b
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-e3a277d7-68dd-4cd8-b641-ab868875dd89
+      - req-9977d6b0-e9da-4dcd-afc2-0dba1ee65473
       Content-Length:
       - '7278'
       Connection:
@@ -12473,7 +12473,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:28:10.618517Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:53:25.017529Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -12552,10 +12552,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["QBAA1FSeQP-K5dYl_JeJ7w"],
-        "issued_at": "2019-01-03T19:28:10.618538Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["THxoFo2JS0yOrYyFL12TwQ"],
+        "issued_at": "2019-01-04T16:53:25.017551Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:10 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:25 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -12573,15 +12573,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:28:10 GMT
+      - Fri, 04 Jan 2019 16:53:25 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - fd02ebd2e5e54552a0022b4743b809c5
+      - '0585c373afcb41df8a4e22a8ae233c16'
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-18a40c4c-5b76-4b78-9499-fd9ee2e4a0a3
+      - req-7a6e3328-0801-432f-b6c9-5dec8bd5e33d
       Content-Length:
       - '7278'
       Connection:
@@ -12593,7 +12593,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:28:10.830736Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:53:25.238638Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -12672,10 +12672,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["1othg8DOQMiKlYP0BKaEpA"],
-        "issued_at": "2019-01-03T19:28:10.830757Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["AWXDno9GSkS-n9xkWZGptQ"],
+        "issued_at": "2019-01-04T16:53:25.238659Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:10 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:25 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -12693,15 +12693,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:28:10 GMT
+      - Fri, 04 Jan 2019 16:53:25 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 15902651ca424f4183b45c1f45c4497d
+      - 023a443153874b72831968c54187d177
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-e498c87b-9e7b-4ab3-a51d-1d6b338870fd
+      - req-e6a2ad79-f1c8-4a81-91d3-c38c005ec6c1
       Content-Length:
       - '7264'
       Connection:
@@ -12713,7 +12713,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:28:11.040605Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:53:25.449040Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -12792,10 +12792,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["MfeZrUZIQm-6xKvQLtnJ8Q"],
-        "issued_at": "2019-01-03T19:28:11.040626Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["oXpn-n9mRGuuhQoZsmYx9w"],
+        "issued_at": "2019-01-04T16:53:25.449068Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:11 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:25 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -12813,15 +12813,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:28:11 GMT
+      - Fri, 04 Jan 2019 16:53:25 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 89004f4eb6324035b8bf0b9371842b60
+      - bf86ec7f07ee483f8c716a1a487f013a
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-7754fc07-4be5-4516-9134-76e6678ee98c
+      - req-214022f2-2cd1-4424-ae56-0a09acfbae68
       Content-Length:
       - '7278'
       Connection:
@@ -12833,7 +12833,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:28:11.254203Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:53:25.654939Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -12912,10 +12912,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["rCHxxnKcRjqHoxYUcnYxQQ"],
-        "issued_at": "2019-01-03T19:28:11.254230Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["QPjDWi6DQtyyvQjpSTeA0Q"],
+        "issued_at": "2019-01-04T16:53:25.654981Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:11 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:25 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -12933,15 +12933,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:28:11 GMT
+      - Fri, 04 Jan 2019 16:53:25 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - aaf62729bc314530a015d95a94afe0bb
+      - 6ea2374de8c9479f8063355234345074
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-e4d6e123-2aea-4a14-be1f-48b9ec4d9bc5
+      - req-de6cc43c-5f0f-4879-bfc5-9fef3590ca28
       Content-Length:
       - '7265'
       Connection:
@@ -12953,7 +12953,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:28:11.464440Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:53:25.860996Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -13032,10 +13032,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Ciw-zh0ZRkeE0N-qZ03NQQ"],
-        "issued_at": "2019-01-03T19:28:11.464473Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["E1UoHjn8Qi67zKzWRu5_GA"],
+        "issued_at": "2019-01-04T16:53:25.861030Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:11 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:25 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -13053,15 +13053,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:28:11 GMT
+      - Fri, 04 Jan 2019 16:53:26 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - b52bb7a984544b4b8a17e3534ca65560
+      - e662586b5ee54bb08514d390a5709b8b
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-49fd65d9-5200-4ed8-883f-c8bf73aa36c1
+      - req-ef0c61d8-649b-4ffd-86b4-e930029dada6
       Content-Length:
       - '7278'
       Connection:
@@ -13073,7 +13073,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:28:11.671346Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:53:26.072676Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -13152,10 +13152,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["74FooDjZSz2gnAlFUAZDhg"],
-        "issued_at": "2019-01-03T19:28:11.671366Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["dsSWlFFmSZWhOOj252UjdQ"],
+        "issued_at": "2019-01-04T16:53:26.072695Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:11 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:26 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000
@@ -13170,7 +13170,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 07c96dff03e744d180b460e38e6ea27d
+      - 77076a65adfc4d59a64c672e6169d98b
   response:
     status:
       code: 200
@@ -13181,9 +13181,669 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-fd50f54c-a7a0-4769-81e4-beaf02ef244d
+      - req-408d6c3a-d6a0-4c90-9c39-78ba2a5e4838
       Date:
-      - Thu, 03 Jan 2019 19:28:11 GMT
+      - Fri, 04 Jan 2019 16:53:26 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
+        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.8",
+        "end": "192.168.3.10"}, {"start": "192.168.3.2", "end": "192.168.3.6"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
+        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
+        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Fri, 04 Jan 2019 16:53:26 GMT
+- request:
+    method: get
+    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=24c83610-eab6-4f68-99dd-ab22a638b4a0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 77076a65adfc4d59a64c672e6169d98b
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-a0e08c1a-a6ce-4dbd-ba6d-db860a13352d
+      Date:
+      - Fri, 04 Jan 2019 16:53:26 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
+        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.8",
+        "end": "192.168.3.10"}, {"start": "192.168.3.2", "end": "192.168.3.6"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
+        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
+        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Fri, 04 Jan 2019 16:53:26 GMT
+- request:
+    method: get
+    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - '0585c373afcb41df8a4e22a8ae233c16'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-6a3510c5-9e26-447a-b1e9-7d297712d6b6
+      Date:
+      - Fri, 04 Jan 2019 16:53:26 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
+        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.8",
+        "end": "192.168.3.10"}, {"start": "192.168.3.2", "end": "192.168.3.6"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
+        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
+        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Fri, 04 Jan 2019 16:53:26 GMT
+- request:
+    method: get
+    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=24c83610-eab6-4f68-99dd-ab22a638b4a0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - '0585c373afcb41df8a4e22a8ae233c16'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-a95867ca-e0ae-4545-9679-94e2668c982a
+      Date:
+      - Fri, 04 Jan 2019 16:53:26 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
+        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.8",
+        "end": "192.168.3.10"}, {"start": "192.168.3.2", "end": "192.168.3.6"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
+        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
+        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Fri, 04 Jan 2019 16:53:26 GMT
+- request:
+    method: get
+    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 023a443153874b72831968c54187d177
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-aa512f3a-b8c8-4894-a780-a083c0ac4543
+      Date:
+      - Fri, 04 Jan 2019 16:53:26 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
+        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.8",
+        "end": "192.168.3.10"}, {"start": "192.168.3.2", "end": "192.168.3.6"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
+        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
+        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Fri, 04 Jan 2019 16:53:26 GMT
+- request:
+    method: get
+    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=24c83610-eab6-4f68-99dd-ab22a638b4a0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 023a443153874b72831968c54187d177
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-f4b72387-73d8-405c-9fc4-55741c965c8c
+      Date:
+      - Fri, 04 Jan 2019 16:53:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
@@ -13287,10 +13947,10 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:11 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:27 GMT
 - request:
     method: get
-    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=24c83610-eab6-4f68-99dd-ab22a638b4a0
+    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000
     body:
       encoding: US-ASCII
       string: ''
@@ -13302,7 +13962,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 07c96dff03e744d180b460e38e6ea27d
+      - bf86ec7f07ee483f8c716a1a487f013a
   response:
     status:
       code: 200
@@ -13313,141 +13973,9 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-3cf7ee9a-e13e-4cf9-b450-5e31c29529ca
+      - req-61878fa0-f7ea-466e-9afc-595fd5286845
       Date:
-      - Thu, 03 Jan 2019 19:28:12 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
-        true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
-        "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
-        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.8",
-        "end": "192.168.3.10"}, {"start": "192.168.3.2", "end": "192.168.3.6"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
-        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "f4c17602-9618-4604-b3c9-9e4801d094d3",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:12 GMT
-- request:
-    method: get
-    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=f4c17602-9618-4604-b3c9-9e4801d094d3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 07c96dff03e744d180b460e38e6ea27d
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-fedb7da2-c368-45a8-a607-3cf69ae47cbd
-      Date:
-      - Thu, 03 Jan 2019 19:28:12 GMT
+      - Fri, 04 Jan 2019 16:53:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
@@ -13551,7 +14079,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:12 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:27 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=24c83610-eab6-4f68-99dd-ab22a638b4a0
@@ -13566,7 +14094,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 07c96dff03e744d180b460e38e6ea27d
+      - bf86ec7f07ee483f8c716a1a487f013a
   response:
     status:
       code: 200
@@ -13577,141 +14105,9 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-8de2f7e4-db4f-4715-a009-d0c542b094ec
+      - req-0d7e363d-18e8-4bb5-b20f-3b1b780b4585
       Date:
-      - Thu, 03 Jan 2019 19:28:12 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
-        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
-        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.8",
-        "end": "192.168.3.10"}, {"start": "192.168.3.2", "end": "192.168.3.6"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
-        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
-        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
-        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.8", "end": "192.168.0.8"},
-        {"start": "192.168.0.3", "end": "192.168.0.5"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:12 GMT
-- request:
-    method: get
-    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=f4c17602-9618-4604-b3c9-9e4801d094d3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 07c96dff03e744d180b460e38e6ea27d
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-32d10afe-eda7-4d94-aa3f-2b25b39a8eaf
-      Date:
-      - Thu, 03 Jan 2019 19:28:12 GMT
+      - Fri, 04 Jan 2019 16:53:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
@@ -13815,10 +14211,10 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:12 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:27 GMT
 - request:
     method: get
-    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=24c83610-eab6-4f68-99dd-ab22a638b4a0
+    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000
     body:
       encoding: US-ASCII
       string: ''
@@ -13830,7 +14226,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 07c96dff03e744d180b460e38e6ea27d
+      - 135de8cb22204669a28a2c5a9548f7e6
   response:
     status:
       code: 200
@@ -13841,9 +14237,9 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-af186d7f-b4c6-4777-af33-0b3c21fa1299
+      - req-2eab92b2-4076-4793-8e57-3cdba537e8c6
       Date:
-      - Thu, 03 Jan 2019 19:28:12 GMT
+      - Fri, 04 Jan 2019 16:53:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
@@ -13947,139 +14343,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:12 GMT
-- request:
-    method: get
-    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - fd02ebd2e5e54552a0022b4743b809c5
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-595d8945-31d8-4d09-adfd-fae529d5f261
-      Date:
-      - Thu, 03 Jan 2019 19:28:12 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
-        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
-        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.8",
-        "end": "192.168.3.10"}, {"start": "192.168.3.2", "end": "192.168.3.6"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
-        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
-        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
-        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:12 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:27 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=24c83610-eab6-4f68-99dd-ab22a638b4a0
@@ -14094,7 +14358,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fd02ebd2e5e54552a0022b4743b809c5
+      - 135de8cb22204669a28a2c5a9548f7e6
   response:
     status:
       code: 200
@@ -14105,9 +14369,9 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-5c6816f9-9e14-4f7a-a17d-c72f143d34d9
+      - req-b010055e-a3e6-4357-b190-72551ae352fa
       Date:
-      - Thu, 03 Jan 2019 19:28:13 GMT
+      - Fri, 04 Jan 2019 16:53:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
@@ -14211,7 +14475,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:13 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:27 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000
@@ -14226,7 +14490,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 15902651ca424f4183b45c1f45c4497d
+      - 6ea2374de8c9479f8063355234345074
   response:
     status:
       code: 200
@@ -14237,141 +14501,9 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-55f2e1b7-f2d5-493d-bb68-49fb5f1e4d9d
+      - req-16e75d24-517d-498a-873d-de4ae8c2fcc9
       Date:
-      - Thu, 03 Jan 2019 19:28:13 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
-        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
-        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.8",
-        "end": "192.168.3.10"}, {"start": "192.168.3.2", "end": "192.168.3.6"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
-        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
-        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
-        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.8", "end": "192.168.0.8"},
-        {"start": "192.168.0.3", "end": "192.168.0.5"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:13 GMT
-- request:
-    method: get
-    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=f4c17602-9618-4604-b3c9-9e4801d094d3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 15902651ca424f4183b45c1f45c4497d
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-ba2030e8-3b96-4f40-8442-7f1b4666e8c3
-      Date:
-      - Thu, 03 Jan 2019 19:28:13 GMT
+      - Fri, 04 Jan 2019 16:53:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
@@ -14475,7 +14607,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:13 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:27 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=24c83610-eab6-4f68-99dd-ab22a638b4a0
@@ -14490,7 +14622,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 15902651ca424f4183b45c1f45c4497d
+      - 6ea2374de8c9479f8063355234345074
   response:
     status:
       code: 200
@@ -14501,9 +14633,9 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-1ec5e191-717e-42c7-bfa8-727f8cce155d
+      - req-74be53fa-8b14-4f39-810e-26df72d370fa
       Date:
-      - Thu, 03 Jan 2019 19:28:13 GMT
+      - Fri, 04 Jan 2019 16:53:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
@@ -14607,7 +14739,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:13 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:28 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000
@@ -14622,7 +14754,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 89004f4eb6324035b8bf0b9371842b60
+      - e662586b5ee54bb08514d390a5709b8b
   response:
     status:
       code: 200
@@ -14633,9 +14765,9 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-88d8da45-90ce-4591-bdc8-a65e4d6bc331
+      - req-6d41dce3-1824-4ce2-ade2-16ac56fc45bf
       Date:
-      - Thu, 03 Jan 2019 19:28:13 GMT
+      - Fri, 04 Jan 2019 16:53:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
@@ -14739,7 +14871,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:13 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:28 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=24c83610-eab6-4f68-99dd-ab22a638b4a0
@@ -14754,7 +14886,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 89004f4eb6324035b8bf0b9371842b60
+      - e662586b5ee54bb08514d390a5709b8b
   response:
     status:
       code: 200
@@ -14765,141 +14897,9 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-6ce51e1b-f31e-4226-8e1e-71d9202360e5
+      - req-78edd056-b79e-4bf8-ad32-44cd28de9512
       Date:
-      - Thu, 03 Jan 2019 19:28:13 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
-        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
-        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.8",
-        "end": "192.168.3.10"}, {"start": "192.168.3.2", "end": "192.168.3.6"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
-        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
-        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
-        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.8", "end": "192.168.0.8"},
-        {"start": "192.168.0.3", "end": "192.168.0.5"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:13 GMT
-- request:
-    method: get
-    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=f4c17602-9618-4604-b3c9-9e4801d094d3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 89004f4eb6324035b8bf0b9371842b60
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-0ad545c6-8e4a-42c2-8e43-deceeaf10d1d
-      Date:
-      - Thu, 03 Jan 2019 19:28:14 GMT
+      - Fri, 04 Jan 2019 16:53:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
@@ -15003,1195 +15003,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:14 GMT
-- request:
-    method: get
-    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=24c83610-eab6-4f68-99dd-ab22a638b4a0
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 89004f4eb6324035b8bf0b9371842b60
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-8f7eed7d-460a-4b4a-9296-17bf087e7a93
-      Date:
-      - Thu, 03 Jan 2019 19:28:14 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
-        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
-        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.8",
-        "end": "192.168.3.10"}, {"start": "192.168.3.2", "end": "192.168.3.6"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
-        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
-        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
-        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:14 GMT
-- request:
-    method: get
-    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - ca35cd693ad14e9987559af97589f30d
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-3a18d6d1-82ea-450a-9a70-98ac1ba6f41a
-      Date:
-      - Thu, 03 Jan 2019 19:28:14 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
-        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
-        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.8",
-        "end": "192.168.3.10"}, {"start": "192.168.3.2", "end": "192.168.3.6"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
-        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
-        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
-        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:14 GMT
-- request:
-    method: get
-    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=24c83610-eab6-4f68-99dd-ab22a638b4a0
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - ca35cd693ad14e9987559af97589f30d
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-53229d9f-bc80-497b-a233-34d6bd179db2
-      Date:
-      - Thu, 03 Jan 2019 19:28:14 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
-        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
-        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.8",
-        "end": "192.168.3.10"}, {"start": "192.168.3.2", "end": "192.168.3.6"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
-        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
-        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
-        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:14 GMT
-- request:
-    method: get
-    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - aaf62729bc314530a015d95a94afe0bb
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-b62a9353-72be-41b3-a656-bef890367a85
-      Date:
-      - Thu, 03 Jan 2019 19:28:14 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.2", "end": "192.168.3.6"}, {"start":
-        "192.168.3.8", "end": "192.168.3.10"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
-        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
-        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
-        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
-        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:14 GMT
-- request:
-    method: get
-    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=24c83610-eab6-4f68-99dd-ab22a638b4a0
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - aaf62729bc314530a015d95a94afe0bb
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-28b2a669-7d43-43f6-b498-d978f817833d
-      Date:
-      - Thu, 03 Jan 2019 19:28:14 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
-        true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
-        "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
-        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.8",
-        "end": "192.168.3.10"}, {"start": "192.168.3.2", "end": "192.168.3.6"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
-        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "f4c17602-9618-4604-b3c9-9e4801d094d3",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:15 GMT
-- request:
-    method: get
-    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=f4c17602-9618-4604-b3c9-9e4801d094d3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - aaf62729bc314530a015d95a94afe0bb
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-cebebe8a-af82-473a-8343-a45dc0df18f8
-      Date:
-      - Thu, 03 Jan 2019 19:28:15 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
-        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
-        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.8",
-        "end": "192.168.3.10"}, {"start": "192.168.3.2", "end": "192.168.3.6"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
-        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
-        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
-        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:15 GMT
-- request:
-    method: get
-    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=24c83610-eab6-4f68-99dd-ab22a638b4a0
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - aaf62729bc314530a015d95a94afe0bb
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-decb7042-0e7d-4920-a854-35c0ef11411e
-      Date:
-      - Thu, 03 Jan 2019 19:28:15 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
-        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
-        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.8",
-        "end": "192.168.3.10"}, {"start": "192.168.3.2", "end": "192.168.3.6"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
-        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
-        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
-        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:15 GMT
-- request:
-    method: get
-    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - b52bb7a984544b4b8a17e3534ca65560
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-de88ff0f-196d-4e2e-9f8f-132a8b7b2c50
-      Date:
-      - Thu, 03 Jan 2019 19:28:15 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
-        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
-        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.8",
-        "end": "192.168.3.10"}, {"start": "192.168.3.2", "end": "192.168.3.6"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
-        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
-        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
-        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:15 GMT
-- request:
-    method: get
-    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=24c83610-eab6-4f68-99dd-ab22a638b4a0
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - b52bb7a984544b4b8a17e3534ca65560
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-835e9087-67e3-42e4-8e4d-aa0fa89cce91
-      Date:
-      - Thu, 03 Jan 2019 19:28:15 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
-        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
-        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.8",
-        "end": "192.168.3.10"}, {"start": "192.168.3.2", "end": "192.168.3.6"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
-        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
-        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
-        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:15 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:28 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/floatingips?limit=1000
@@ -16206,7 +15018,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 07c96dff03e744d180b460e38e6ea27d
+      - 77076a65adfc4d59a64c672e6169d98b
   response:
     status:
       code: 200
@@ -16217,9 +15029,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-923950ce-4734-4769-85d7-8572195d3f73
+      - req-01b06242-9d27-4e5a-86d4-19c51c5f3e12
       Date:
-      - Thu, 03 Jan 2019 19:28:15 GMT
+      - Fri, 04 Jan 2019 16:53:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
@@ -16261,7 +15073,7 @@ http_interactions:
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:15 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:28 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/floatingips?limit=1000&marker=e5a4a7fd-b2c7-4a38-b725-a666d4f90f60
@@ -16276,7 +15088,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 07c96dff03e744d180b460e38e6ea27d
+      - 77076a65adfc4d59a64c672e6169d98b
   response:
     status:
       code: 200
@@ -16287,9 +15099,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-52ca1407-f29a-458f-9a6f-4d50797eb302
+      - req-aef906d7-2fd5-4b44-818d-4be2a175023c
       Date:
-      - Thu, 03 Jan 2019 19:28:15 GMT
+      - Fri, 04 Jan 2019 16:53:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
@@ -16331,7 +15143,7 @@ http_interactions:
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:15 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:28 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/floatingips?limit=1000
@@ -16346,7 +15158,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fd02ebd2e5e54552a0022b4743b809c5
+      - '0585c373afcb41df8a4e22a8ae233c16'
   response:
     status:
       code: 200
@@ -16357,9 +15169,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-de8b0080-50fc-4ed2-ae1f-6250e8b5e019
+      - req-53b1de38-e334-4d65-8ff1-10c8d17e1d49
       Date:
-      - Thu, 03 Jan 2019 19:28:15 GMT
+      - Fri, 04 Jan 2019 16:53:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
@@ -16401,7 +15213,7 @@ http_interactions:
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:15 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:28 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/floatingips?limit=1000&marker=e5a4a7fd-b2c7-4a38-b725-a666d4f90f60
@@ -16416,7 +15228,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fd02ebd2e5e54552a0022b4743b809c5
+      - '0585c373afcb41df8a4e22a8ae233c16'
   response:
     status:
       code: 200
@@ -16427,9 +15239,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-c384a8b4-553e-4aaf-8191-00344c9915ab
+      - req-3100bbdf-1217-41dc-aafb-65a48a3a2df5
       Date:
-      - Thu, 03 Jan 2019 19:28:16 GMT
+      - Fri, 04 Jan 2019 16:53:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
@@ -16471,7 +15283,7 @@ http_interactions:
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:16 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:29 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/floatingips?limit=1000
@@ -16486,7 +15298,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 15902651ca424f4183b45c1f45c4497d
+      - 023a443153874b72831968c54187d177
   response:
     status:
       code: 200
@@ -16497,9 +15309,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-ad44335e-9cc3-4e3b-8dbb-c852c8544c2d
+      - req-e1b7ae64-2403-441d-9910-23db8613850f
       Date:
-      - Thu, 03 Jan 2019 19:28:16 GMT
+      - Fri, 04 Jan 2019 16:53:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
@@ -16541,7 +15353,7 @@ http_interactions:
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:16 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:29 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/floatingips?limit=1000&marker=e5a4a7fd-b2c7-4a38-b725-a666d4f90f60
@@ -16556,7 +15368,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 15902651ca424f4183b45c1f45c4497d
+      - 023a443153874b72831968c54187d177
   response:
     status:
       code: 200
@@ -16567,9 +15379,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-91057aca-09cc-40d5-af34-4a9131b02e94
+      - req-4ab3d8d6-e778-4da9-b516-4e47dedeefc5
       Date:
-      - Thu, 03 Jan 2019 19:28:16 GMT
+      - Fri, 04 Jan 2019 16:53:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
@@ -16611,7 +15423,7 @@ http_interactions:
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:16 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:29 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/floatingips?limit=1000
@@ -16626,7 +15438,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 89004f4eb6324035b8bf0b9371842b60
+      - bf86ec7f07ee483f8c716a1a487f013a
   response:
     status:
       code: 200
@@ -16637,9 +15449,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-6306af48-3057-4181-a3d7-e89587c9e6eb
+      - req-f836e860-03c3-4cc7-8dd0-926db6adbeb5
       Date:
-      - Thu, 03 Jan 2019 19:28:16 GMT
+      - Fri, 04 Jan 2019 16:53:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
@@ -16681,7 +15493,7 @@ http_interactions:
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:16 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:29 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/floatingips?limit=1000&marker=e5a4a7fd-b2c7-4a38-b725-a666d4f90f60
@@ -16696,7 +15508,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 89004f4eb6324035b8bf0b9371842b60
+      - bf86ec7f07ee483f8c716a1a487f013a
   response:
     status:
       code: 200
@@ -16707,9 +15519,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-386bd701-466e-47a9-a981-1de133a8747c
+      - req-23d88e28-21c2-42c1-b29d-9a1ecef40a64
       Date:
-      - Thu, 03 Jan 2019 19:28:16 GMT
+      - Fri, 04 Jan 2019 16:53:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
@@ -16751,7 +15563,7 @@ http_interactions:
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:16 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:29 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/floatingips?limit=1000
@@ -16766,7 +15578,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ca35cd693ad14e9987559af97589f30d
+      - 135de8cb22204669a28a2c5a9548f7e6
   response:
     status:
       code: 200
@@ -16777,9 +15589,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-b1f2a02c-c6c2-403f-85b7-41cc781e0c26
+      - req-2c20deb2-6013-4b5a-8b54-65dd3771843c
       Date:
-      - Thu, 03 Jan 2019 19:28:16 GMT
+      - Fri, 04 Jan 2019 16:53:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
@@ -16821,7 +15633,7 @@ http_interactions:
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:16 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:29 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/floatingips?limit=1000&marker=e5a4a7fd-b2c7-4a38-b725-a666d4f90f60
@@ -16836,7 +15648,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ca35cd693ad14e9987559af97589f30d
+      - 135de8cb22204669a28a2c5a9548f7e6
   response:
     status:
       code: 200
@@ -16847,9 +15659,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-5fcfc350-6d62-4b89-9515-c326a19beb05
+      - req-3560401e-9339-44f1-9543-472c8999d685
       Date:
-      - Thu, 03 Jan 2019 19:28:16 GMT
+      - Fri, 04 Jan 2019 16:53:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
@@ -16891,7 +15703,7 @@ http_interactions:
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:16 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:29 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/floatingips?limit=1000
@@ -16906,7 +15718,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - aaf62729bc314530a015d95a94afe0bb
+      - 6ea2374de8c9479f8063355234345074
   response:
     status:
       code: 200
@@ -16917,9 +15729,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-9e5427b9-0486-4b23-bcd3-6d19b4a401b6
+      - req-108d90a0-59ad-49a5-8d08-1b1413cfcd98
       Date:
-      - Thu, 03 Jan 2019 19:28:16 GMT
+      - Fri, 04 Jan 2019 16:53:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
@@ -16961,7 +15773,7 @@ http_interactions:
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:16 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:29 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/floatingips?limit=1000&marker=e5a4a7fd-b2c7-4a38-b725-a666d4f90f60
@@ -16976,7 +15788,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - aaf62729bc314530a015d95a94afe0bb
+      - 6ea2374de8c9479f8063355234345074
   response:
     status:
       code: 200
@@ -16987,9 +15799,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-0acc955f-c1c7-4ac3-9e63-1e872358ed7f
+      - req-c1dfc54b-a1d7-428b-9938-ec4b1caf4929
       Date:
-      - Thu, 03 Jan 2019 19:28:16 GMT
+      - Fri, 04 Jan 2019 16:53:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
@@ -17031,7 +15843,7 @@ http_interactions:
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:16 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:29 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/floatingips?limit=1000
@@ -17046,7 +15858,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b52bb7a984544b4b8a17e3534ca65560
+      - e662586b5ee54bb08514d390a5709b8b
   response:
     status:
       code: 200
@@ -17057,9 +15869,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-75457000-eb55-49b6-88a8-5cd6cdc91612
+      - req-bc1b8b17-a2d8-49c6-ba0e-4e05b0080d29
       Date:
-      - Thu, 03 Jan 2019 19:28:16 GMT
+      - Fri, 04 Jan 2019 16:53:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
@@ -17101,7 +15913,7 @@ http_interactions:
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:17 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:29 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/floatingips?limit=1000&marker=e5a4a7fd-b2c7-4a38-b725-a666d4f90f60
@@ -17116,7 +15928,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b52bb7a984544b4b8a17e3534ca65560
+      - e662586b5ee54bb08514d390a5709b8b
   response:
     status:
       code: 200
@@ -17127,9 +15939,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-3f273d16-288c-471b-8341-200f4ec5d1d8
+      - req-79450320-a2b5-421d-ba7c-61f6d437140e
       Date:
-      - Thu, 03 Jan 2019 19:28:17 GMT
+      - Fri, 04 Jan 2019 16:53:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
@@ -17171,7 +15983,7 @@ http_interactions:
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:17 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:30 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/ports?limit=1000
@@ -17186,7 +15998,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 07c96dff03e744d180b460e38e6ea27d
+      - 77076a65adfc4d59a64c672e6169d98b
   response:
     status:
       code: 200
@@ -17197,9 +16009,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-76cf1dcf-be1f-4dfd-9976-631d5418bdce
+      - req-4e6242fd-66d9-4889-84c0-af6d2f206e1a
       Date:
-      - Thu, 03 Jan 2019 19:28:17 GMT
+      - Fri, 04 Jan 2019 16:53:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -17602,7 +16414,7 @@ http_interactions:
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:17 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:30 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/ports?limit=1000&marker=fb9152f8-5f19-4171-9b8e-f1e594c24d64
@@ -17617,7 +16429,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 07c96dff03e744d180b460e38e6ea27d
+      - 77076a65adfc4d59a64c672e6169d98b
   response:
     status:
       code: 200
@@ -17628,9 +16440,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-0067d9ff-7795-489b-b541-0b990fdb6cca
+      - req-e904676a-1359-4a6b-8b87-69073de45acb
       Date:
-      - Thu, 03 Jan 2019 19:28:17 GMT
+      - Fri, 04 Jan 2019 16:53:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -18033,7 +16845,7 @@ http_interactions:
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:17 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:30 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/ports?limit=1000
@@ -18048,7 +16860,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fd02ebd2e5e54552a0022b4743b809c5
+      - '0585c373afcb41df8a4e22a8ae233c16'
   response:
     status:
       code: 200
@@ -18059,9 +16871,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-b962403a-c77d-44a2-99a4-46760a17a1af
+      - req-d68fc782-fb6a-4e54-a53b-9bceca739ed0
       Date:
-      - Thu, 03 Jan 2019 19:28:17 GMT
+      - Fri, 04 Jan 2019 16:53:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -18464,7 +17276,7 @@ http_interactions:
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:17 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:30 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/ports?limit=1000&marker=fb9152f8-5f19-4171-9b8e-f1e594c24d64
@@ -18479,7 +17291,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fd02ebd2e5e54552a0022b4743b809c5
+      - '0585c373afcb41df8a4e22a8ae233c16'
   response:
     status:
       code: 200
@@ -18490,9 +17302,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-982c2404-43e1-4c24-9731-ae7bf6ae41d4
+      - req-024fc351-b70b-4833-a2dd-4e61fcb3d18b
       Date:
-      - Thu, 03 Jan 2019 19:28:17 GMT
+      - Fri, 04 Jan 2019 16:53:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -18895,7 +17707,7 @@ http_interactions:
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:17 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:30 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/ports?limit=1000
@@ -18910,7 +17722,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 15902651ca424f4183b45c1f45c4497d
+      - 023a443153874b72831968c54187d177
   response:
     status:
       code: 200
@@ -18921,9 +17733,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-6dbde9f3-87bd-4eb5-9b5f-5c3ca6b73d81
+      - req-24f20baa-4cb5-443b-87d1-c7e17d08b4db
       Date:
-      - Thu, 03 Jan 2019 19:28:18 GMT
+      - Fri, 04 Jan 2019 16:53:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -19326,7 +18138,7 @@ http_interactions:
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:18 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:31 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/ports?limit=1000&marker=fb9152f8-5f19-4171-9b8e-f1e594c24d64
@@ -19341,7 +18153,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 15902651ca424f4183b45c1f45c4497d
+      - 023a443153874b72831968c54187d177
   response:
     status:
       code: 200
@@ -19352,9 +18164,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-f683b69b-7a09-411f-a177-3f2163bf51a8
+      - req-da73ba20-e8a9-4656-adb2-358d82fc3635
       Date:
-      - Thu, 03 Jan 2019 19:28:18 GMT
+      - Fri, 04 Jan 2019 16:53:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -19757,7 +18569,7 @@ http_interactions:
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:18 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:31 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/ports?limit=1000
@@ -19772,7 +18584,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 89004f4eb6324035b8bf0b9371842b60
+      - bf86ec7f07ee483f8c716a1a487f013a
   response:
     status:
       code: 200
@@ -19783,9 +18595,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-ac50a5f1-bded-4e70-a60d-c633648a155d
+      - req-14b3eb6f-de27-4e30-8c15-c8e2553af3d0
       Date:
-      - Thu, 03 Jan 2019 19:28:18 GMT
+      - Fri, 04 Jan 2019 16:53:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -20188,7 +19000,7 @@ http_interactions:
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:18 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:31 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/ports?limit=1000&marker=fb9152f8-5f19-4171-9b8e-f1e594c24d64
@@ -20203,7 +19015,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 89004f4eb6324035b8bf0b9371842b60
+      - bf86ec7f07ee483f8c716a1a487f013a
   response:
     status:
       code: 200
@@ -20214,9 +19026,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-e1a4f805-0d70-40f6-9f80-18f6d3e1217d
+      - req-dae43de6-4cb9-4464-b08c-fcf168256d61
       Date:
-      - Thu, 03 Jan 2019 19:28:18 GMT
+      - Fri, 04 Jan 2019 16:53:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -20619,7 +19431,7 @@ http_interactions:
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:18 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:31 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/ports?limit=1000
@@ -20634,7 +19446,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ca35cd693ad14e9987559af97589f30d
+      - 135de8cb22204669a28a2c5a9548f7e6
   response:
     status:
       code: 200
@@ -20645,9 +19457,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-0917b334-10b4-40cd-93f0-d863575a2f0d
+      - req-4ebcb260-879f-4aee-bfbb-44caac1c2b34
       Date:
-      - Thu, 03 Jan 2019 19:28:18 GMT
+      - Fri, 04 Jan 2019 16:53:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -21050,7 +19862,7 @@ http_interactions:
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:18 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:31 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/ports?limit=1000&marker=fb9152f8-5f19-4171-9b8e-f1e594c24d64
@@ -21065,7 +19877,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ca35cd693ad14e9987559af97589f30d
+      - 135de8cb22204669a28a2c5a9548f7e6
   response:
     status:
       code: 200
@@ -21076,9 +19888,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-885eb49f-ec8f-407b-91ae-9b6ff24f1f3b
+      - req-7be02e6a-a1a7-4198-b5b8-95ecb9a5554e
       Date:
-      - Thu, 03 Jan 2019 19:28:19 GMT
+      - Fri, 04 Jan 2019 16:53:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -21481,7 +20293,7 @@ http_interactions:
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:19 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:32 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/ports?limit=1000
@@ -21496,7 +20308,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - aaf62729bc314530a015d95a94afe0bb
+      - 6ea2374de8c9479f8063355234345074
   response:
     status:
       code: 200
@@ -21507,9 +20319,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-fbf4492a-b9b0-4842-9e9b-78eccb2d2066
+      - req-9c492c25-ba56-4a6d-9c3a-7154ac685981
       Date:
-      - Thu, 03 Jan 2019 19:28:19 GMT
+      - Fri, 04 Jan 2019 16:53:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -21912,7 +20724,7 @@ http_interactions:
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:19 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:32 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/ports?limit=1000&marker=fb9152f8-5f19-4171-9b8e-f1e594c24d64
@@ -21927,7 +20739,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - aaf62729bc314530a015d95a94afe0bb
+      - 6ea2374de8c9479f8063355234345074
   response:
     status:
       code: 200
@@ -21938,9 +20750,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-b869db0c-50f3-454a-b27d-ef1ce9dd6e7d
+      - req-e509bf89-bb15-4335-85ac-378005628d08
       Date:
-      - Thu, 03 Jan 2019 19:28:19 GMT
+      - Fri, 04 Jan 2019 16:53:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -22343,7 +21155,7 @@ http_interactions:
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:19 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:32 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/ports?limit=1000
@@ -22358,7 +21170,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b52bb7a984544b4b8a17e3534ca65560
+      - e662586b5ee54bb08514d390a5709b8b
   response:
     status:
       code: 200
@@ -22369,9 +21181,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-fe7828fa-5dbd-4a11-90b4-e5b69fb726b8
+      - req-fa529aff-386e-467e-953e-3ae22e33ec6b
       Date:
-      - Thu, 03 Jan 2019 19:28:19 GMT
+      - Fri, 04 Jan 2019 16:53:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -22774,7 +21586,7 @@ http_interactions:
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:19 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:32 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/ports?limit=1000&marker=fb9152f8-5f19-4171-9b8e-f1e594c24d64
@@ -22789,7 +21601,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b52bb7a984544b4b8a17e3534ca65560
+      - e662586b5ee54bb08514d390a5709b8b
   response:
     status:
       code: 200
@@ -22800,9 +21612,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-c680f888-42a8-4bf1-991e-e1b7a754a2cc
+      - req-4af3483e-e107-43f6-95dc-3860ecbb8a0d
       Date:
-      - Thu, 03 Jan 2019 19:28:19 GMT
+      - Fri, 04 Jan 2019 16:53:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -23205,7 +22017,7 @@ http_interactions:
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:19 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:32 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/routers?limit=1000
@@ -23220,7 +22032,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 07c96dff03e744d180b460e38e6ea27d
+      - 77076a65adfc4d59a64c672e6169d98b
   response:
     status:
       code: 200
@@ -23231,9 +22043,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-59678906-2301-4274-85e1-050bf136dcd2
+      - req-6f8c5694-2308-4616-a850-1389353e5aed
       Date:
-      - Thu, 03 Jan 2019 19:28:20 GMT
+      - Fri, 04 Jan 2019 16:53:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -23265,7 +22077,7 @@ http_interactions:
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:20 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:33 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/routers?limit=1000&marker=e49f1a18-9fd8-4130-9e9f-f13b5190f9fd
@@ -23280,7 +22092,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 07c96dff03e744d180b460e38e6ea27d
+      - 77076a65adfc4d59a64c672e6169d98b
   response:
     status:
       code: 200
@@ -23291,9 +22103,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-2cabd2a2-18cb-45da-8fd6-19b1fa04d8e7
+      - req-2f503d6b-5f25-461e-b24c-671470b9a16c
       Date:
-      - Thu, 03 Jan 2019 19:28:20 GMT
+      - Fri, 04 Jan 2019 16:53:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -23325,7 +22137,7 @@ http_interactions:
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:20 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:33 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/routers?limit=1000
@@ -23340,7 +22152,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fd02ebd2e5e54552a0022b4743b809c5
+      - '0585c373afcb41df8a4e22a8ae233c16'
   response:
     status:
       code: 200
@@ -23351,9 +22163,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-6c44cc8b-a8ce-4f43-8e6f-9b8dfdfa8b3f
+      - req-d94108a0-21dc-459c-8578-ab0139e000e7
       Date:
-      - Thu, 03 Jan 2019 19:28:20 GMT
+      - Fri, 04 Jan 2019 16:53:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -23385,7 +22197,7 @@ http_interactions:
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:20 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:33 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/routers?limit=1000&marker=e49f1a18-9fd8-4130-9e9f-f13b5190f9fd
@@ -23400,7 +22212,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fd02ebd2e5e54552a0022b4743b809c5
+      - '0585c373afcb41df8a4e22a8ae233c16'
   response:
     status:
       code: 200
@@ -23411,9 +22223,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-6e6f384c-1f8e-4d5e-814d-36114a51bf79
+      - req-a810b4a1-515c-4918-a21e-5e4a4dcc6c33
       Date:
-      - Thu, 03 Jan 2019 19:28:20 GMT
+      - Fri, 04 Jan 2019 16:53:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -23445,7 +22257,7 @@ http_interactions:
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:20 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:33 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/routers?limit=1000
@@ -23460,7 +22272,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 15902651ca424f4183b45c1f45c4497d
+      - 023a443153874b72831968c54187d177
   response:
     status:
       code: 200
@@ -23471,9 +22283,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-4042a461-12d1-42bd-ac94-82341c8b161f
+      - req-c27becb7-1be0-4e74-9816-be8ffd2e68b2
       Date:
-      - Thu, 03 Jan 2019 19:28:20 GMT
+      - Fri, 04 Jan 2019 16:53:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -23505,7 +22317,7 @@ http_interactions:
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:20 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:33 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/routers?limit=1000&marker=e49f1a18-9fd8-4130-9e9f-f13b5190f9fd
@@ -23520,7 +22332,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 15902651ca424f4183b45c1f45c4497d
+      - 023a443153874b72831968c54187d177
   response:
     status:
       code: 200
@@ -23531,9 +22343,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-578b481e-9fe1-4235-87dd-0fe467aee9fd
+      - req-682cedee-42c3-4c4a-b4fa-c47b167b35df
       Date:
-      - Thu, 03 Jan 2019 19:28:20 GMT
+      - Fri, 04 Jan 2019 16:53:34 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -23565,7 +22377,7 @@ http_interactions:
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:20 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:34 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/routers?limit=1000
@@ -23580,7 +22392,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 89004f4eb6324035b8bf0b9371842b60
+      - bf86ec7f07ee483f8c716a1a487f013a
   response:
     status:
       code: 200
@@ -23591,9 +22403,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-f9226df3-a0f7-41ad-8efe-1b6391792f36
+      - req-4eaca27a-7f7f-487f-a35c-5f06806107d2
       Date:
-      - Thu, 03 Jan 2019 19:28:20 GMT
+      - Fri, 04 Jan 2019 16:53:34 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -23625,7 +22437,7 @@ http_interactions:
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:20 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:34 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/routers?limit=1000&marker=e49f1a18-9fd8-4130-9e9f-f13b5190f9fd
@@ -23640,7 +22452,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 89004f4eb6324035b8bf0b9371842b60
+      - bf86ec7f07ee483f8c716a1a487f013a
   response:
     status:
       code: 200
@@ -23651,9 +22463,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-ec128561-9fae-446b-9cd2-ca4d3ff801a3
+      - req-63273045-ee30-4026-9be2-31a420a661cd
       Date:
-      - Thu, 03 Jan 2019 19:28:20 GMT
+      - Fri, 04 Jan 2019 16:53:34 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -23685,7 +22497,7 @@ http_interactions:
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:20 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:34 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/routers?limit=1000
@@ -23700,7 +22512,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ca35cd693ad14e9987559af97589f30d
+      - 135de8cb22204669a28a2c5a9548f7e6
   response:
     status:
       code: 200
@@ -23711,9 +22523,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-cbae8eab-e634-45c8-8872-4b45009b5283
+      - req-426fb0a5-a21a-440f-a799-2c8902c7c995
       Date:
-      - Thu, 03 Jan 2019 19:28:20 GMT
+      - Fri, 04 Jan 2019 16:53:34 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -23745,7 +22557,7 @@ http_interactions:
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:21 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:34 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/routers?limit=1000&marker=e49f1a18-9fd8-4130-9e9f-f13b5190f9fd
@@ -23760,7 +22572,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ca35cd693ad14e9987559af97589f30d
+      - 135de8cb22204669a28a2c5a9548f7e6
   response:
     status:
       code: 200
@@ -23771,9 +22583,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-d6f9b263-2e08-464f-8283-9351fb98d8e5
+      - req-38df2fec-2068-4f66-ad62-78c12547a772
       Date:
-      - Thu, 03 Jan 2019 19:28:21 GMT
+      - Fri, 04 Jan 2019 16:53:34 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -23805,7 +22617,7 @@ http_interactions:
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:21 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:34 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/routers?limit=1000
@@ -23820,7 +22632,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - aaf62729bc314530a015d95a94afe0bb
+      - 6ea2374de8c9479f8063355234345074
   response:
     status:
       code: 200
@@ -23831,9 +22643,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-b7d77b65-7ff4-4e04-959d-a6ee1dfca6f5
+      - req-c629b447-4a20-4239-90c0-bd59bfa8e3e5
       Date:
-      - Thu, 03 Jan 2019 19:28:21 GMT
+      - Fri, 04 Jan 2019 16:53:34 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -23865,7 +22677,7 @@ http_interactions:
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:21 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:34 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/routers?limit=1000&marker=e49f1a18-9fd8-4130-9e9f-f13b5190f9fd
@@ -23880,7 +22692,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - aaf62729bc314530a015d95a94afe0bb
+      - 6ea2374de8c9479f8063355234345074
   response:
     status:
       code: 200
@@ -23891,9 +22703,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-ebf4564f-cfa0-48aa-a1f1-c604981334ed
+      - req-c1acceb9-a85e-47a5-9b1c-6cae955860aa
       Date:
-      - Thu, 03 Jan 2019 19:28:21 GMT
+      - Fri, 04 Jan 2019 16:53:34 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -23925,7 +22737,7 @@ http_interactions:
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:21 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:34 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/routers?limit=1000
@@ -23940,7 +22752,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b52bb7a984544b4b8a17e3534ca65560
+      - e662586b5ee54bb08514d390a5709b8b
   response:
     status:
       code: 200
@@ -23951,9 +22763,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-396d1f9c-2033-4c2e-b998-480ffa461386
+      - req-1cb1bac9-1b2b-4017-9fae-bccd98413346
       Date:
-      - Thu, 03 Jan 2019 19:28:21 GMT
+      - Fri, 04 Jan 2019 16:53:34 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -23985,7 +22797,7 @@ http_interactions:
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:21 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:34 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/routers?limit=1000&marker=e49f1a18-9fd8-4130-9e9f-f13b5190f9fd
@@ -24000,7 +22812,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b52bb7a984544b4b8a17e3534ca65560
+      - e662586b5ee54bb08514d390a5709b8b
   response:
     status:
       code: 200
@@ -24011,9 +22823,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-0efc171f-556c-45d9-a9d3-32a13f4fc1dc
+      - req-33cf1cc3-1e9a-49f6-a228-b604ded63747
       Date:
-      - Thu, 03 Jan 2019 19:28:21 GMT
+      - Fri, 04 Jan 2019 16:53:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -24045,7 +22857,7 @@ http_interactions:
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:21 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:35 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000
@@ -24060,7 +22872,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 07c96dff03e744d180b460e38e6ea27d
+      - 77076a65adfc4d59a64c672e6169d98b
   response:
     status:
       code: 200
@@ -24071,9 +22883,9 @@ http_interactions:
       Content-Length:
       - '2717'
       X-Openstack-Request-Id:
-      - req-723738dd-073d-495d-be59-06c0aaf701b7
+      - req-3e6eda13-fde6-4a19-82c6-a1d0a48920ac
       Date:
-      - Thu, 03 Jan 2019 19:28:21 GMT
+      - Fri, 04 Jan 2019 16:53:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=2e57d382-aeb2-4107-85cd-9dbde325f8f7",
@@ -24108,7 +22920,7 @@ http_interactions:
         null, "port_range_min": null, "id": "7e354503-9d45-4cc4-a742-4ff9501ba396",
         "security_group_id": "2e57d382-aeb2-4107-85cd-9dbde325f8f7"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:21 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:35 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=2e57d382-aeb2-4107-85cd-9dbde325f8f7
@@ -24123,7 +22935,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 07c96dff03e744d180b460e38e6ea27d
+      - 77076a65adfc4d59a64c672e6169d98b
   response:
     status:
       code: 200
@@ -24134,9 +22946,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-2f010c7f-6a8a-4c7b-9e27-1a8af88391a4
+      - req-310f187f-8727-4ac8-b672-e2fb73d8ebdf
       Date:
-      - Thu, 03 Jan 2019 19:28:21 GMT
+      - Fri, 04 Jan 2019 16:53:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=42bcab35-fe98-49f3-ba0e-705a2737b81d",
@@ -24179,7 +22991,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "f87c3733-0682-46d9-8df1-05f1207541d1",
         "security_group_id": "42bcab35-fe98-49f3-ba0e-705a2737b81d"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:21 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:35 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=42bcab35-fe98-49f3-ba0e-705a2737b81d
@@ -24194,7 +23006,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 07c96dff03e744d180b460e38e6ea27d
+      - 77076a65adfc4d59a64c672e6169d98b
   response:
     status:
       code: 200
@@ -24205,9 +23017,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-edc0e0e2-97a5-4db0-a153-022cbf041c52
+      - req-ba2df7b4-0681-4307-93ae-0b1ed145a46b
       Date:
-      - Thu, 03 Jan 2019 19:28:21 GMT
+      - Fri, 04 Jan 2019 16:53:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=7250f04f-facd-4731-b072-f346b1cc7a80",
@@ -24250,7 +23062,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "d0ee1562-3ff7-4ad5-b29f-8dd350ed221f",
         "security_group_id": "7250f04f-facd-4731-b072-f346b1cc7a80"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:21 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:35 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=7250f04f-facd-4731-b072-f346b1cc7a80
@@ -24265,7 +23077,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 07c96dff03e744d180b460e38e6ea27d
+      - 77076a65adfc4d59a64c672e6169d98b
   response:
     status:
       code: 200
@@ -24276,9 +23088,9 @@ http_interactions:
       Content-Length:
       - '8737'
       X-Openstack-Request-Id:
-      - req-a39e8373-a258-4553-8fc7-48819ea9831b
+      - req-61e9a241-447b-449d-ba29-38a912722eab
       Date:
-      - Thu, 03 Jan 2019 19:28:22 GMT
+      - Fri, 04 Jan 2019 16:53:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d",
@@ -24385,7 +23197,7 @@ http_interactions:
         "port_range_max": 65535, "port_range_min": 1, "id": "e483857b-5eb5-4cb0-94d6-b431a2f0cb10",
         "security_group_id": "8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:22 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:35 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d
@@ -24400,7 +23212,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 07c96dff03e744d180b460e38e6ea27d
+      - 77076a65adfc4d59a64c672e6169d98b
   response:
     status:
       code: 200
@@ -24411,9 +23223,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-9431c709-6cca-4742-98fe-ee9873674df1
+      - req-26f336c1-7876-4dac-8156-998b350b25bb
       Date:
-      - Thu, 03 Jan 2019 19:28:22 GMT
+      - Fri, 04 Jan 2019 16:53:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=bab65d2f-4717-47eb-bfb2-95100b254563",
@@ -24455,7 +23267,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "e1aa03c0-0758-42ca-b030-a3d62800e578",
         "security_group_id": "bab65d2f-4717-47eb-bfb2-95100b254563"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:22 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:35 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=bab65d2f-4717-47eb-bfb2-95100b254563
@@ -24470,7 +23282,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 07c96dff03e744d180b460e38e6ea27d
+      - 77076a65adfc4d59a64c672e6169d98b
   response:
     status:
       code: 200
@@ -24481,15 +23293,15 @@ http_interactions:
       Content-Length:
       - '156'
       X-Openstack-Request-Id:
-      - req-755dad68-94cb-4e5d-870b-dd92e0e63290
+      - req-c4f053f2-cb25-4ca2-9423-ee733e8147d6
       Date:
-      - Thu, 03 Jan 2019 19:28:22 GMT
+      - Fri, 04 Jan 2019 16:53:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&page_reverse=True",
         "rel": "previous"}], "security_groups": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:22 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:35 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000
@@ -24504,7 +23316,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fd02ebd2e5e54552a0022b4743b809c5
+      - '0585c373afcb41df8a4e22a8ae233c16'
   response:
     status:
       code: 200
@@ -24515,9 +23327,9 @@ http_interactions:
       Content-Length:
       - '2717'
       X-Openstack-Request-Id:
-      - req-a2d6549c-a7c8-4c72-b799-e38a50f7211e
+      - req-d703ddcf-a26b-49f5-9d4f-38bf85d067e7
       Date:
-      - Thu, 03 Jan 2019 19:28:22 GMT
+      - Fri, 04 Jan 2019 16:53:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=2e57d382-aeb2-4107-85cd-9dbde325f8f7",
@@ -24552,7 +23364,7 @@ http_interactions:
         null, "port_range_min": null, "id": "7e354503-9d45-4cc4-a742-4ff9501ba396",
         "security_group_id": "2e57d382-aeb2-4107-85cd-9dbde325f8f7"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:22 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:35 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=2e57d382-aeb2-4107-85cd-9dbde325f8f7
@@ -24567,7 +23379,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fd02ebd2e5e54552a0022b4743b809c5
+      - '0585c373afcb41df8a4e22a8ae233c16'
   response:
     status:
       code: 200
@@ -24578,9 +23390,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-fe887281-a071-4822-9328-ed852e3764aa
+      - req-63cfc357-2434-4f87-9ad9-59e6cf8f16a5
       Date:
-      - Thu, 03 Jan 2019 19:28:22 GMT
+      - Fri, 04 Jan 2019 16:53:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=42bcab35-fe98-49f3-ba0e-705a2737b81d",
@@ -24623,7 +23435,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "f87c3733-0682-46d9-8df1-05f1207541d1",
         "security_group_id": "42bcab35-fe98-49f3-ba0e-705a2737b81d"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:22 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:36 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=42bcab35-fe98-49f3-ba0e-705a2737b81d
@@ -24638,7 +23450,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fd02ebd2e5e54552a0022b4743b809c5
+      - '0585c373afcb41df8a4e22a8ae233c16'
   response:
     status:
       code: 200
@@ -24649,9 +23461,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-03815fdf-0e2f-44a3-854e-302f9cf9e167
+      - req-a3c87881-1623-472f-a4f9-973a174b6712
       Date:
-      - Thu, 03 Jan 2019 19:28:22 GMT
+      - Fri, 04 Jan 2019 16:53:36 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=7250f04f-facd-4731-b072-f346b1cc7a80",
@@ -24694,7 +23506,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "d0ee1562-3ff7-4ad5-b29f-8dd350ed221f",
         "security_group_id": "7250f04f-facd-4731-b072-f346b1cc7a80"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:22 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:36 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=7250f04f-facd-4731-b072-f346b1cc7a80
@@ -24709,7 +23521,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fd02ebd2e5e54552a0022b4743b809c5
+      - '0585c373afcb41df8a4e22a8ae233c16'
   response:
     status:
       code: 200
@@ -24720,9 +23532,9 @@ http_interactions:
       Content-Length:
       - '8737'
       X-Openstack-Request-Id:
-      - req-a558ba29-a413-4601-85e5-03ad2f1f0ce7
+      - req-a33948e9-08a3-4ae5-9580-de1ecca1400c
       Date:
-      - Thu, 03 Jan 2019 19:28:22 GMT
+      - Fri, 04 Jan 2019 16:53:36 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d",
@@ -24829,7 +23641,7 @@ http_interactions:
         "port_range_max": 65535, "port_range_min": 1, "id": "e483857b-5eb5-4cb0-94d6-b431a2f0cb10",
         "security_group_id": "8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:22 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:36 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d
@@ -24844,7 +23656,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fd02ebd2e5e54552a0022b4743b809c5
+      - '0585c373afcb41df8a4e22a8ae233c16'
   response:
     status:
       code: 200
@@ -24855,9 +23667,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-6b7685a8-3706-428e-b79f-e30c833c9436
+      - req-e07730a4-6071-4947-8765-fc27eb4b1bee
       Date:
-      - Thu, 03 Jan 2019 19:28:23 GMT
+      - Fri, 04 Jan 2019 16:53:36 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=bab65d2f-4717-47eb-bfb2-95100b254563",
@@ -24899,7 +23711,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "e1aa03c0-0758-42ca-b030-a3d62800e578",
         "security_group_id": "bab65d2f-4717-47eb-bfb2-95100b254563"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:23 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:36 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=bab65d2f-4717-47eb-bfb2-95100b254563
@@ -24914,7 +23726,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fd02ebd2e5e54552a0022b4743b809c5
+      - '0585c373afcb41df8a4e22a8ae233c16'
   response:
     status:
       code: 200
@@ -24925,15 +23737,15 @@ http_interactions:
       Content-Length:
       - '156'
       X-Openstack-Request-Id:
-      - req-5a848b0c-5ae8-4944-9e33-58322c928840
+      - req-4884522c-f772-4e19-aaa6-27f84f0e1731
       Date:
-      - Thu, 03 Jan 2019 19:28:23 GMT
+      - Fri, 04 Jan 2019 16:53:36 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&page_reverse=True",
         "rel": "previous"}], "security_groups": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:23 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:36 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000
@@ -24948,7 +23760,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 15902651ca424f4183b45c1f45c4497d
+      - 023a443153874b72831968c54187d177
   response:
     status:
       code: 200
@@ -24959,9 +23771,9 @@ http_interactions:
       Content-Length:
       - '2717'
       X-Openstack-Request-Id:
-      - req-9eed9ec2-afa4-4f66-b668-77111ba26c98
+      - req-6315e3b7-e7b1-4902-969d-f2d5cf5e911b
       Date:
-      - Thu, 03 Jan 2019 19:28:23 GMT
+      - Fri, 04 Jan 2019 16:53:36 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=2e57d382-aeb2-4107-85cd-9dbde325f8f7",
@@ -24996,7 +23808,7 @@ http_interactions:
         null, "port_range_min": null, "id": "7e354503-9d45-4cc4-a742-4ff9501ba396",
         "security_group_id": "2e57d382-aeb2-4107-85cd-9dbde325f8f7"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:23 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:36 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=2e57d382-aeb2-4107-85cd-9dbde325f8f7
@@ -25011,7 +23823,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 15902651ca424f4183b45c1f45c4497d
+      - 023a443153874b72831968c54187d177
   response:
     status:
       code: 200
@@ -25022,9 +23834,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-00a3ceb0-c2f9-4664-8b48-5582f9807fd6
+      - req-a62e7525-c65a-42fd-826f-33c9cc2355fa
       Date:
-      - Thu, 03 Jan 2019 19:28:23 GMT
+      - Fri, 04 Jan 2019 16:53:36 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=42bcab35-fe98-49f3-ba0e-705a2737b81d",
@@ -25067,7 +23879,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "f87c3733-0682-46d9-8df1-05f1207541d1",
         "security_group_id": "42bcab35-fe98-49f3-ba0e-705a2737b81d"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:23 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:36 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=42bcab35-fe98-49f3-ba0e-705a2737b81d
@@ -25082,7 +23894,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 15902651ca424f4183b45c1f45c4497d
+      - 023a443153874b72831968c54187d177
   response:
     status:
       code: 200
@@ -25093,9 +23905,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-9b68617b-c96e-4e76-bba3-35cb511c10ae
+      - req-3f08d5a7-3fdf-413e-8208-279430b40b7d
       Date:
-      - Thu, 03 Jan 2019 19:28:23 GMT
+      - Fri, 04 Jan 2019 16:53:36 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=7250f04f-facd-4731-b072-f346b1cc7a80",
@@ -25138,7 +23950,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "d0ee1562-3ff7-4ad5-b29f-8dd350ed221f",
         "security_group_id": "7250f04f-facd-4731-b072-f346b1cc7a80"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:23 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:36 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=7250f04f-facd-4731-b072-f346b1cc7a80
@@ -25153,7 +23965,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 15902651ca424f4183b45c1f45c4497d
+      - 023a443153874b72831968c54187d177
   response:
     status:
       code: 200
@@ -25164,9 +23976,9 @@ http_interactions:
       Content-Length:
       - '8737'
       X-Openstack-Request-Id:
-      - req-ea1b1074-3d8c-4935-8a6d-4d6b17a39d56
+      - req-ad606953-b5e1-4b97-a8b1-59b20aace8f1
       Date:
-      - Thu, 03 Jan 2019 19:28:23 GMT
+      - Fri, 04 Jan 2019 16:53:36 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d",
@@ -25273,7 +24085,7 @@ http_interactions:
         "port_range_max": 65535, "port_range_min": 1, "id": "e483857b-5eb5-4cb0-94d6-b431a2f0cb10",
         "security_group_id": "8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:23 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:37 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d
@@ -25288,7 +24100,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 15902651ca424f4183b45c1f45c4497d
+      - 023a443153874b72831968c54187d177
   response:
     status:
       code: 200
@@ -25299,9 +24111,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-8704aaa0-e286-4b8c-afeb-0a90a7622705
+      - req-98049839-8442-42b9-b8b5-7ed2e09a83f5
       Date:
-      - Thu, 03 Jan 2019 19:28:23 GMT
+      - Fri, 04 Jan 2019 16:53:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=bab65d2f-4717-47eb-bfb2-95100b254563",
@@ -25343,7 +24155,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "e1aa03c0-0758-42ca-b030-a3d62800e578",
         "security_group_id": "bab65d2f-4717-47eb-bfb2-95100b254563"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:23 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:37 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=bab65d2f-4717-47eb-bfb2-95100b254563
@@ -25358,7 +24170,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 15902651ca424f4183b45c1f45c4497d
+      - 023a443153874b72831968c54187d177
   response:
     status:
       code: 200
@@ -25369,15 +24181,15 @@ http_interactions:
       Content-Length:
       - '156'
       X-Openstack-Request-Id:
-      - req-f9675a7d-e16e-4dd8-b217-b6a111dfc276
+      - req-33672893-6074-4f52-8c12-be865176f1e6
       Date:
-      - Thu, 03 Jan 2019 19:28:23 GMT
+      - Fri, 04 Jan 2019 16:53:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&page_reverse=True",
         "rel": "previous"}], "security_groups": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:23 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:37 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000
@@ -25392,7 +24204,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 89004f4eb6324035b8bf0b9371842b60
+      - bf86ec7f07ee483f8c716a1a487f013a
   response:
     status:
       code: 200
@@ -25403,9 +24215,9 @@ http_interactions:
       Content-Length:
       - '2717'
       X-Openstack-Request-Id:
-      - req-95766672-0ae5-4b18-a9e4-e050f9016b07
+      - req-70aae377-c2db-4dae-9aea-7fd3df777afe
       Date:
-      - Thu, 03 Jan 2019 19:28:23 GMT
+      - Fri, 04 Jan 2019 16:53:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=2e57d382-aeb2-4107-85cd-9dbde325f8f7",
@@ -25440,7 +24252,7 @@ http_interactions:
         null, "port_range_min": null, "id": "7e354503-9d45-4cc4-a742-4ff9501ba396",
         "security_group_id": "2e57d382-aeb2-4107-85cd-9dbde325f8f7"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:23 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:37 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=2e57d382-aeb2-4107-85cd-9dbde325f8f7
@@ -25455,7 +24267,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 89004f4eb6324035b8bf0b9371842b60
+      - bf86ec7f07ee483f8c716a1a487f013a
   response:
     status:
       code: 200
@@ -25466,9 +24278,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-6c0fcae3-f20f-408c-b5f8-d7a258b6fb2a
+      - req-8459a6fd-3a07-41d3-8613-6db404dc345e
       Date:
-      - Thu, 03 Jan 2019 19:28:24 GMT
+      - Fri, 04 Jan 2019 16:53:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=42bcab35-fe98-49f3-ba0e-705a2737b81d",
@@ -25511,7 +24323,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "f87c3733-0682-46d9-8df1-05f1207541d1",
         "security_group_id": "42bcab35-fe98-49f3-ba0e-705a2737b81d"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:24 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:37 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=42bcab35-fe98-49f3-ba0e-705a2737b81d
@@ -25526,7 +24338,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 89004f4eb6324035b8bf0b9371842b60
+      - bf86ec7f07ee483f8c716a1a487f013a
   response:
     status:
       code: 200
@@ -25537,9 +24349,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-44584202-ad03-4206-aeca-3e67260a2a27
+      - req-165156ee-7f22-44af-bf59-eab81deba9ca
       Date:
-      - Thu, 03 Jan 2019 19:28:24 GMT
+      - Fri, 04 Jan 2019 16:53:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=7250f04f-facd-4731-b072-f346b1cc7a80",
@@ -25582,7 +24394,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "d0ee1562-3ff7-4ad5-b29f-8dd350ed221f",
         "security_group_id": "7250f04f-facd-4731-b072-f346b1cc7a80"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:24 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:37 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=7250f04f-facd-4731-b072-f346b1cc7a80
@@ -25597,7 +24409,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 89004f4eb6324035b8bf0b9371842b60
+      - bf86ec7f07ee483f8c716a1a487f013a
   response:
     status:
       code: 200
@@ -25608,9 +24420,9 @@ http_interactions:
       Content-Length:
       - '8737'
       X-Openstack-Request-Id:
-      - req-c14971b7-259a-4099-b86a-b059ef967060
+      - req-3cc99bd9-d72c-40fd-b0cf-34f5c7fbb0c6
       Date:
-      - Thu, 03 Jan 2019 19:28:24 GMT
+      - Fri, 04 Jan 2019 16:53:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d",
@@ -25717,7 +24529,7 @@ http_interactions:
         "port_range_max": 65535, "port_range_min": 1, "id": "e483857b-5eb5-4cb0-94d6-b431a2f0cb10",
         "security_group_id": "8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:24 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:37 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d
@@ -25732,7 +24544,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 89004f4eb6324035b8bf0b9371842b60
+      - bf86ec7f07ee483f8c716a1a487f013a
   response:
     status:
       code: 200
@@ -25743,9 +24555,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-1eec8906-ebf3-4ccf-aa79-fffbf6d64e91
+      - req-8ad81baf-5d1a-4deb-855f-81b1f7e3c64f
       Date:
-      - Thu, 03 Jan 2019 19:28:24 GMT
+      - Fri, 04 Jan 2019 16:53:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=bab65d2f-4717-47eb-bfb2-95100b254563",
@@ -25787,7 +24599,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "e1aa03c0-0758-42ca-b030-a3d62800e578",
         "security_group_id": "bab65d2f-4717-47eb-bfb2-95100b254563"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:24 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:37 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=bab65d2f-4717-47eb-bfb2-95100b254563
@@ -25802,7 +24614,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 89004f4eb6324035b8bf0b9371842b60
+      - bf86ec7f07ee483f8c716a1a487f013a
   response:
     status:
       code: 200
@@ -25813,15 +24625,15 @@ http_interactions:
       Content-Length:
       - '156'
       X-Openstack-Request-Id:
-      - req-29f6d3cf-914a-412a-bd86-fb101e28165e
+      - req-e3e2c53b-1372-4f6c-bfef-74438ab44efd
       Date:
-      - Thu, 03 Jan 2019 19:28:24 GMT
+      - Fri, 04 Jan 2019 16:53:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&page_reverse=True",
         "rel": "previous"}], "security_groups": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:24 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:37 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000
@@ -25836,7 +24648,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ca35cd693ad14e9987559af97589f30d
+      - 135de8cb22204669a28a2c5a9548f7e6
   response:
     status:
       code: 200
@@ -25847,9 +24659,9 @@ http_interactions:
       Content-Length:
       - '2717'
       X-Openstack-Request-Id:
-      - req-9379ae81-7d79-48d2-babc-c5301f1b2964
+      - req-f145360c-62a3-4f8f-ae04-9a09967f5e79
       Date:
-      - Thu, 03 Jan 2019 19:28:24 GMT
+      - Fri, 04 Jan 2019 16:53:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=2e57d382-aeb2-4107-85cd-9dbde325f8f7",
@@ -25884,7 +24696,7 @@ http_interactions:
         null, "port_range_min": null, "id": "7e354503-9d45-4cc4-a742-4ff9501ba396",
         "security_group_id": "2e57d382-aeb2-4107-85cd-9dbde325f8f7"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:24 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:38 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=2e57d382-aeb2-4107-85cd-9dbde325f8f7
@@ -25899,7 +24711,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ca35cd693ad14e9987559af97589f30d
+      - 135de8cb22204669a28a2c5a9548f7e6
   response:
     status:
       code: 200
@@ -25910,9 +24722,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-aec734df-e4db-49ab-bd2d-b6c35bd750a2
+      - req-2def8599-4846-4d4b-9ec2-012e37b7a077
       Date:
-      - Thu, 03 Jan 2019 19:28:24 GMT
+      - Fri, 04 Jan 2019 16:53:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=42bcab35-fe98-49f3-ba0e-705a2737b81d",
@@ -25955,7 +24767,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "f87c3733-0682-46d9-8df1-05f1207541d1",
         "security_group_id": "42bcab35-fe98-49f3-ba0e-705a2737b81d"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:24 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:38 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=42bcab35-fe98-49f3-ba0e-705a2737b81d
@@ -25970,7 +24782,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ca35cd693ad14e9987559af97589f30d
+      - 135de8cb22204669a28a2c5a9548f7e6
   response:
     status:
       code: 200
@@ -25981,9 +24793,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-013b964e-f7ff-41f2-9ae1-9bc080570381
+      - req-297854aa-932e-42a3-9db4-47cef29969de
       Date:
-      - Thu, 03 Jan 2019 19:28:24 GMT
+      - Fri, 04 Jan 2019 16:53:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=7250f04f-facd-4731-b072-f346b1cc7a80",
@@ -26026,7 +24838,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "d0ee1562-3ff7-4ad5-b29f-8dd350ed221f",
         "security_group_id": "7250f04f-facd-4731-b072-f346b1cc7a80"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:24 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:38 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=7250f04f-facd-4731-b072-f346b1cc7a80
@@ -26041,7 +24853,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ca35cd693ad14e9987559af97589f30d
+      - 135de8cb22204669a28a2c5a9548f7e6
   response:
     status:
       code: 200
@@ -26052,9 +24864,9 @@ http_interactions:
       Content-Length:
       - '8737'
       X-Openstack-Request-Id:
-      - req-35a90dbb-3684-4f57-9d63-79bd632b0b4e
+      - req-72f80f28-9bda-43ba-9b2c-228dd0366d30
       Date:
-      - Thu, 03 Jan 2019 19:28:25 GMT
+      - Fri, 04 Jan 2019 16:53:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d",
@@ -26161,7 +24973,7 @@ http_interactions:
         "port_range_max": 65535, "port_range_min": 1, "id": "e483857b-5eb5-4cb0-94d6-b431a2f0cb10",
         "security_group_id": "8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:25 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:38 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d
@@ -26176,7 +24988,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ca35cd693ad14e9987559af97589f30d
+      - 135de8cb22204669a28a2c5a9548f7e6
   response:
     status:
       code: 200
@@ -26187,9 +24999,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-386d5b30-5740-4d4d-a197-1d8fb4951ccf
+      - req-f137f134-d7c7-478e-a0b3-17983473e867
       Date:
-      - Thu, 03 Jan 2019 19:28:25 GMT
+      - Fri, 04 Jan 2019 16:53:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=bab65d2f-4717-47eb-bfb2-95100b254563",
@@ -26231,7 +25043,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "e1aa03c0-0758-42ca-b030-a3d62800e578",
         "security_group_id": "bab65d2f-4717-47eb-bfb2-95100b254563"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:25 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:38 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=bab65d2f-4717-47eb-bfb2-95100b254563
@@ -26246,7 +25058,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ca35cd693ad14e9987559af97589f30d
+      - 135de8cb22204669a28a2c5a9548f7e6
   response:
     status:
       code: 200
@@ -26257,15 +25069,15 @@ http_interactions:
       Content-Length:
       - '156'
       X-Openstack-Request-Id:
-      - req-f0eb8751-8035-42f0-9007-bfc8385a23b5
+      - req-beeaaefa-69f9-4cec-bdb4-6e58368bd581
       Date:
-      - Thu, 03 Jan 2019 19:28:25 GMT
+      - Fri, 04 Jan 2019 16:53:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&page_reverse=True",
         "rel": "previous"}], "security_groups": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:25 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:38 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000
@@ -26280,7 +25092,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - aaf62729bc314530a015d95a94afe0bb
+      - 6ea2374de8c9479f8063355234345074
   response:
     status:
       code: 200
@@ -26291,9 +25103,9 @@ http_interactions:
       Content-Length:
       - '2717'
       X-Openstack-Request-Id:
-      - req-3bd5f2c6-5217-4fee-92de-4e2a3e5794c6
+      - req-df8fad2e-1225-45df-b564-7355c51c1493
       Date:
-      - Thu, 03 Jan 2019 19:28:25 GMT
+      - Fri, 04 Jan 2019 16:53:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=2e57d382-aeb2-4107-85cd-9dbde325f8f7",
@@ -26328,7 +25140,7 @@ http_interactions:
         null, "port_range_min": null, "id": "7e354503-9d45-4cc4-a742-4ff9501ba396",
         "security_group_id": "2e57d382-aeb2-4107-85cd-9dbde325f8f7"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:25 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:38 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=2e57d382-aeb2-4107-85cd-9dbde325f8f7
@@ -26343,7 +25155,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - aaf62729bc314530a015d95a94afe0bb
+      - 6ea2374de8c9479f8063355234345074
   response:
     status:
       code: 200
@@ -26354,9 +25166,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-fc9f11bc-d9f2-4c4d-af00-c6b1cb3f0bce
+      - req-10d6d22e-053a-4f39-b793-fb5e69dcc4d2
       Date:
-      - Thu, 03 Jan 2019 19:28:25 GMT
+      - Fri, 04 Jan 2019 16:53:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=42bcab35-fe98-49f3-ba0e-705a2737b81d",
@@ -26399,7 +25211,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "f87c3733-0682-46d9-8df1-05f1207541d1",
         "security_group_id": "42bcab35-fe98-49f3-ba0e-705a2737b81d"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:25 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:38 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=42bcab35-fe98-49f3-ba0e-705a2737b81d
@@ -26414,7 +25226,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - aaf62729bc314530a015d95a94afe0bb
+      - 6ea2374de8c9479f8063355234345074
   response:
     status:
       code: 200
@@ -26425,9 +25237,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-87fb774d-34f8-4b3a-8a5c-352527f69890
+      - req-fa31b0ba-f3f7-409e-8f70-08f6517b617f
       Date:
-      - Thu, 03 Jan 2019 19:28:25 GMT
+      - Fri, 04 Jan 2019 16:53:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=7250f04f-facd-4731-b072-f346b1cc7a80",
@@ -26470,7 +25282,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "d0ee1562-3ff7-4ad5-b29f-8dd350ed221f",
         "security_group_id": "7250f04f-facd-4731-b072-f346b1cc7a80"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:25 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:39 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=7250f04f-facd-4731-b072-f346b1cc7a80
@@ -26485,7 +25297,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - aaf62729bc314530a015d95a94afe0bb
+      - 6ea2374de8c9479f8063355234345074
   response:
     status:
       code: 200
@@ -26496,9 +25308,9 @@ http_interactions:
       Content-Length:
       - '8737'
       X-Openstack-Request-Id:
-      - req-cbf541f3-ed9b-4b00-9e4f-677398c4bdbe
+      - req-bfcec84e-91ac-4d6d-900b-e2ac172b1766
       Date:
-      - Thu, 03 Jan 2019 19:28:25 GMT
+      - Fri, 04 Jan 2019 16:53:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d",
@@ -26605,7 +25417,7 @@ http_interactions:
         "port_range_max": 65535, "port_range_min": 1, "id": "e483857b-5eb5-4cb0-94d6-b431a2f0cb10",
         "security_group_id": "8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:25 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:39 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d
@@ -26620,7 +25432,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - aaf62729bc314530a015d95a94afe0bb
+      - 6ea2374de8c9479f8063355234345074
   response:
     status:
       code: 200
@@ -26631,9 +25443,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-1004bbd6-61ab-44b7-a0fe-0844aa03b1e5
+      - req-920276d5-18e5-41c9-bbea-eb23126c5cfc
       Date:
-      - Thu, 03 Jan 2019 19:28:25 GMT
+      - Fri, 04 Jan 2019 16:53:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=bab65d2f-4717-47eb-bfb2-95100b254563",
@@ -26675,7 +25487,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "e1aa03c0-0758-42ca-b030-a3d62800e578",
         "security_group_id": "bab65d2f-4717-47eb-bfb2-95100b254563"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:25 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:39 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=bab65d2f-4717-47eb-bfb2-95100b254563
@@ -26690,7 +25502,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - aaf62729bc314530a015d95a94afe0bb
+      - 6ea2374de8c9479f8063355234345074
   response:
     status:
       code: 200
@@ -26701,15 +25513,15 @@ http_interactions:
       Content-Length:
       - '156'
       X-Openstack-Request-Id:
-      - req-3660611a-531e-4aee-afce-df4732223eb6
+      - req-846293bf-0719-4c69-940c-dbbc2500bc4c
       Date:
-      - Thu, 03 Jan 2019 19:28:26 GMT
+      - Fri, 04 Jan 2019 16:53:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&page_reverse=True",
         "rel": "previous"}], "security_groups": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:26 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:39 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000
@@ -26724,7 +25536,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b52bb7a984544b4b8a17e3534ca65560
+      - e662586b5ee54bb08514d390a5709b8b
   response:
     status:
       code: 200
@@ -26735,9 +25547,9 @@ http_interactions:
       Content-Length:
       - '2717'
       X-Openstack-Request-Id:
-      - req-2a7b5812-70ed-415c-b902-ebb91dd727eb
+      - req-8c351240-2bb7-4f22-a9e2-5a428c59d2bd
       Date:
-      - Thu, 03 Jan 2019 19:28:26 GMT
+      - Fri, 04 Jan 2019 16:53:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=2e57d382-aeb2-4107-85cd-9dbde325f8f7",
@@ -26772,7 +25584,7 @@ http_interactions:
         null, "port_range_min": null, "id": "7e354503-9d45-4cc4-a742-4ff9501ba396",
         "security_group_id": "2e57d382-aeb2-4107-85cd-9dbde325f8f7"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:26 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:39 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=2e57d382-aeb2-4107-85cd-9dbde325f8f7
@@ -26787,7 +25599,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b52bb7a984544b4b8a17e3534ca65560
+      - e662586b5ee54bb08514d390a5709b8b
   response:
     status:
       code: 200
@@ -26798,9 +25610,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-2a1ae652-d400-4bf2-a937-0b5458ac4432
+      - req-a41e9b87-fc00-4ecb-b741-d151f1a60a2f
       Date:
-      - Thu, 03 Jan 2019 19:28:26 GMT
+      - Fri, 04 Jan 2019 16:53:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=42bcab35-fe98-49f3-ba0e-705a2737b81d",
@@ -26843,7 +25655,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "f87c3733-0682-46d9-8df1-05f1207541d1",
         "security_group_id": "42bcab35-fe98-49f3-ba0e-705a2737b81d"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:26 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:39 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=42bcab35-fe98-49f3-ba0e-705a2737b81d
@@ -26858,7 +25670,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b52bb7a984544b4b8a17e3534ca65560
+      - e662586b5ee54bb08514d390a5709b8b
   response:
     status:
       code: 200
@@ -26869,9 +25681,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-941e92b5-0088-4d47-9b0b-254ae1d8031c
+      - req-1b16db9a-c6a4-4c93-871b-db3f861cf0a5
       Date:
-      - Thu, 03 Jan 2019 19:28:26 GMT
+      - Fri, 04 Jan 2019 16:53:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=7250f04f-facd-4731-b072-f346b1cc7a80",
@@ -26914,7 +25726,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "d0ee1562-3ff7-4ad5-b29f-8dd350ed221f",
         "security_group_id": "7250f04f-facd-4731-b072-f346b1cc7a80"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:26 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:39 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=7250f04f-facd-4731-b072-f346b1cc7a80
@@ -26929,7 +25741,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b52bb7a984544b4b8a17e3534ca65560
+      - e662586b5ee54bb08514d390a5709b8b
   response:
     status:
       code: 200
@@ -26940,9 +25752,9 @@ http_interactions:
       Content-Length:
       - '8737'
       X-Openstack-Request-Id:
-      - req-f3e5bd74-fac3-447e-984e-a20c6cc16d70
+      - req-6637b1a5-299e-4447-b021-1e69d8c8eb1b
       Date:
-      - Thu, 03 Jan 2019 19:28:26 GMT
+      - Fri, 04 Jan 2019 16:53:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d",
@@ -27049,7 +25861,7 @@ http_interactions:
         "port_range_max": 65535, "port_range_min": 1, "id": "e483857b-5eb5-4cb0-94d6-b431a2f0cb10",
         "security_group_id": "8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:26 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:39 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d
@@ -27064,7 +25876,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b52bb7a984544b4b8a17e3534ca65560
+      - e662586b5ee54bb08514d390a5709b8b
   response:
     status:
       code: 200
@@ -27075,9 +25887,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-5cc4b405-5875-4a89-a32f-8a652e8d6cc4
+      - req-48ea043d-3712-4495-a49e-adb32b1a201b
       Date:
-      - Thu, 03 Jan 2019 19:28:26 GMT
+      - Fri, 04 Jan 2019 16:53:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=bab65d2f-4717-47eb-bfb2-95100b254563",
@@ -27119,7 +25931,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "e1aa03c0-0758-42ca-b030-a3d62800e578",
         "security_group_id": "bab65d2f-4717-47eb-bfb2-95100b254563"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:26 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:40 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=bab65d2f-4717-47eb-bfb2-95100b254563
@@ -27134,7 +25946,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b52bb7a984544b4b8a17e3534ca65560
+      - e662586b5ee54bb08514d390a5709b8b
   response:
     status:
       code: 200
@@ -27145,15 +25957,15 @@ http_interactions:
       Content-Length:
       - '156'
       X-Openstack-Request-Id:
-      - req-03fac255-57d3-4357-a634-229c777efe38
+      - req-7ec62b45-d8d3-464e-919a-e634e9353a8f
       Date:
-      - Thu, 03 Jan 2019 19:28:26 GMT
+      - Fri, 04 Jan 2019 16:53:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&page_reverse=True",
         "rel": "previous"}], "security_groups": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:26 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:40 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -27171,15 +25983,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:28:27 GMT
+      - Fri, 04 Jan 2019 16:53:40 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - b0fae10114e94bd78b4504abf167bea6
+      - 53a47e1136ff4dd59ae509aa1c881d8c
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-202ed241-2d4a-4ecb-b3ac-f66e44a0a770
+      - req-97e2aee4-3305-4a11-9c5a-7ccfd5ac912b
       Content-Length:
       - '7311'
       Connection:
@@ -27191,7 +26003,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2019-01-03T20:28:27.493659Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2019-01-04T17:53:41.032480Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -27270,10 +26082,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["4_PGVNCdSAKJJ9gHUGyTvQ"],
-        "issued_at": "2019-01-03T19:28:27.493678Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["SKXgmSw2RzSPXABXH37SmQ"],
+        "issued_at": "2019-01-04T16:53:41.032507Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:27 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:41 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -27291,15 +26103,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:28:27 GMT
+      - Fri, 04 Jan 2019 16:53:41 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - b2c46dae36f84281bbb353a8834ac560
+      - bec5b3fcddea4328a89df2c1090c40bb
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-f7dc0be3-2763-47d9-80d1-968b8d7f7ee6
+      - req-81ea48e9-8816-491d-b519-2022bb63fd06
       Content-Length:
       - '7311'
       Connection:
@@ -27311,7 +26123,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2019-01-03T20:28:27.704970Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2019-01-04T17:53:41.263916Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -27390,10 +26202,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["9sxtENqEQdKCAHtqj8oIhg"],
-        "issued_at": "2019-01-03T19:28:27.704989Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["_j7UnDh4RQ-0WPSZtLuIGQ"],
+        "issued_at": "2019-01-04T16:53:41.263941Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:27 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:41 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -27411,15 +26223,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:28:27 GMT
+      - Fri, 04 Jan 2019 16:53:41 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 7ae314e55ca9413cbca3e2bbb4004f72
+      - 9e006659c1984429a73f68bb479926e7
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-cc92f7f0-2d48-4248-8519-0d0004f877fb
+      - req-0efe9df4-9303-43b0-bd2f-2acb604cd8c2
       Content-Length:
       - '297'
       Connection:
@@ -27428,12 +26240,12 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"token": {"methods": ["password"], "expires_at": "2019-01-03T20:28:27.887403Z",
+      string: '{"token": {"methods": ["password"], "expires_at": "2019-01-04T17:53:41.702291Z",
         "extras": {}, "user": {"domain": {"id": "default", "name": "Default"}, "id":
-        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["IoDPITkTSAOVgUmGxYeQvQ"],
-        "issued_at": "2019-01-03T19:28:27.887421Z"}}'
+        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["HXsY2p5FRMm63KV7c48lZg"],
+        "issued_at": "2019-01-04T16:53:41.702312Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:27 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:41 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects?domain_id=default
@@ -27448,20 +26260,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7ae314e55ca9413cbca3e2bbb4004f72
+      - 9e006659c1984429a73f68bb479926e7
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:28:28 GMT
+      - Fri, 04 Jan 2019 16:53:41 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-a01b8ccd-9783-41dc-8627-990921d141ff
+      - req-4c14d842-9ae9-4a7a-93cb-28ec10ab5fb4
       Content-Length:
       - '2475'
       Connection:
@@ -27494,7 +26306,7 @@ http_interactions:
         "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
         "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:28 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:41 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -27512,15 +26324,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:28:28 GMT
+      - Fri, 04 Jan 2019 16:53:41 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - d87e5c5ba4b147fd96eab111440d6f41
+      - f443c7d170af43ecb796571af120f0f6
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-fab0b118-db91-4f08-9210-a1b1328205e3
+      - req-e9a8728f-7b81-47dc-851a-37a48fac2bff
       Content-Length:
       - '7278'
       Connection:
@@ -27532,7 +26344,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:28:28.237272Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:53:42.040594Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -27611,10 +26423,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["DGGkqpfBSCKSTgZFv1JXaA"],
-        "issued_at": "2019-01-03T19:28:28.237290Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["P5kYbzhFQMSKup0iJnFiMA"],
+        "issued_at": "2019-01-04T16:53:42.040621Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:28 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:42 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -27632,15 +26444,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:28:28 GMT
+      - Fri, 04 Jan 2019 16:53:42 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - e540f66fca624eceb089502ea8e98ae1
+      - caacd4a41ca34b4283bd18adfb34deb3
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-0aeffb91-367f-42c7-9de5-3c741b511fb6
+      - req-3e153dce-eede-4307-9fe0-b9c799705d6a
       Content-Length:
       - '7278'
       Connection:
@@ -27652,7 +26464,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:28:28.449321Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:53:42.260584Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -27731,10 +26543,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["VMvzEOcGQ8anzZ8p3suT0g"],
-        "issued_at": "2019-01-03T19:28:28.449339Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["iOMR06q-S5WzZ7IN1AjJ5g"],
+        "issued_at": "2019-01-04T16:53:42.260609Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:28 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:42 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -27752,15 +26564,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:28:28 GMT
+      - Fri, 04 Jan 2019 16:53:42 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 39ede911e3f64e039f5fc80e40625242
+      - 3bd42847fa824ef4a9f310e2e771271b
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-9c1ec6e4-b585-4889-8f1d-6ccf71648447
+      - req-2993aac9-270b-4b6e-a391-db1451cfcc6d
       Content-Length:
       - '7264'
       Connection:
@@ -27772,7 +26584,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:28:28.656083Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:53:42.461689Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -27851,10 +26663,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["z5UnjnpmQWesoebhreh87g"],
-        "issued_at": "2019-01-03T19:28:28.656102Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["lkkbpQUzQcu7JwJpKYxpUw"],
+        "issued_at": "2019-01-04T16:53:42.461713Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:28 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:42 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -27872,15 +26684,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:28:28 GMT
+      - Fri, 04 Jan 2019 16:53:42 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 7166a411b97545dab2da9eb8f7507716
+      - 1878bb770cee478ba3389c9b1737e694
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-f8c98933-e95c-4965-8484-57c787985e22
+      - req-1cdca531-d3f0-4c9e-8347-f81d415bfea2
       Content-Length:
       - '7278'
       Connection:
@@ -27892,7 +26704,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:28:28.877847Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:53:42.672120Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -27971,10 +26783,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["nrPXgmpKS0GtM-UCx8jd-w"],
-        "issued_at": "2019-01-03T19:28:28.877866Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["-TRJ0hz9QKeqVTrgxLgdrw"],
+        "issued_at": "2019-01-04T16:53:42.672155Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:28 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:42 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -27992,15 +26804,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:28:29 GMT
+      - Fri, 04 Jan 2019 16:53:42 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - e3fdc7917d5e4b1bbd62fd789ce8bd9a
+      - 402b16759e19408a9858774ffbc464ef
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-9f629b81-ab86-4537-976d-29cd52a6f447
+      - req-056df799-2f8c-45e0-abab-cc1f6f8e60ec
       Content-Length:
       - '7265'
       Connection:
@@ -28012,7 +26824,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:28:29.086715Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:53:42.885771Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -28091,10 +26903,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["hanpt_5LSWWQdxHmRtW2lA"],
-        "issued_at": "2019-01-03T19:28:29.086733Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Nd7VoNfdSV6NC_5nWr_kVQ"],
+        "issued_at": "2019-01-04T16:53:42.885800Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:29 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:42 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -28112,15 +26924,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:28:29 GMT
+      - Fri, 04 Jan 2019 16:53:43 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 95c835c4cdc54ddb8440d94063013fee
+      - 45c454404abd4d1fa57cf2a01ec13b67
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-e963fb14-35cd-4f7c-a8d5-6bc8e34d2c67
+      - req-16abcfbc-a58a-4604-b6b7-4cfb3153ced9
       Content-Length:
       - '7278'
       Connection:
@@ -28132,7 +26944,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:28:29.297609Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:53:43.105704Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -28211,10 +27023,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["WvhNJSTOQK-GwvKGFXLNtw"],
-        "issued_at": "2019-01-03T19:28:29.297628Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["o-qx_EEiR4KBm-WcYlUSFg"],
+        "issued_at": "2019-01-04T16:53:43.105726Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:29 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:43 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/volumes/detail?limit=1000
@@ -28229,27 +27041,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d87e5c5ba4b147fd96eab111440d6f41
+      - f443c7d170af43ecb796571af120f0f6
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-91c562ab-2ae8-4ac7-876c-92fbb459c6de
+      - req-21932e19-551e-4167-96df-e3834e0ccf4b
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-91c562ab-2ae8-4ac7-876c-92fbb459c6de
+      - req-21932e19-551e-4167-96df-e3834e0ccf4b
       Date:
-      - Thu, 03 Jan 2019 19:28:29 GMT
+      - Fri, 04 Jan 2019 16:53:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:29 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:43 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/volumes/detail?limit=1000
@@ -28264,27 +27076,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e540f66fca624eceb089502ea8e98ae1
+      - caacd4a41ca34b4283bd18adfb34deb3
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-116db898-576f-4cfa-be66-3aede6c3c80e
+      - req-f985aae9-c4bb-4066-869c-092146b5a906
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-116db898-576f-4cfa-be66-3aede6c3c80e
+      - req-f985aae9-c4bb-4066-869c-092146b5a906
       Date:
-      - Thu, 03 Jan 2019 19:28:29 GMT
+      - Fri, 04 Jan 2019 16:53:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:29 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:43 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000
@@ -28299,22 +27111,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 39ede911e3f64e039f5fc80e40625242
+      - 3bd42847fa824ef4a9f310e2e771271b
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-1c1488eb-87e3-46a3-9f10-d96fbf85c017
+      - req-72d918f4-3d4f-4939-964b-f1fd0f278dd0
       Content-Type:
       - application/json
       Content-Length:
       - '2706'
       X-Openstack-Request-Id:
-      - req-1c1488eb-87e3-46a3-9f10-d96fbf85c017
+      - req-72d918f4-3d4f-4939-964b-f1fd0f278dd0
       Date:
-      - Thu, 03 Jan 2019 19:28:29 GMT
+      - Fri, 04 Jan 2019 16:53:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=f46458aa-309d-4f47-b996-a39db065030a",
@@ -28347,7 +27159,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-4", "bootable": "true", "created_at":
         "2016-08-19T08:37:45.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:29 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:43 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=f46458aa-309d-4f47-b996-a39db065030a
@@ -28362,22 +27174,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 39ede911e3f64e039f5fc80e40625242
+      - 3bd42847fa824ef4a9f310e2e771271b
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-4c75ed07-b4ae-4546-b857-73705ed68436
+      - req-a3d134a0-bcf0-4f4b-8456-f15ca6f98374
       Content-Type:
       - application/json
       Content-Length:
       - '3284'
       X-Openstack-Request-Id:
-      - req-4c75ed07-b4ae-4546-b857-73705ed68436
+      - req-a3d134a0-bcf0-4f4b-8456-f15ca6f98374
       Date:
-      - Thu, 03 Jan 2019 19:28:29 GMT
+      - Fri, 04 Jan 2019 16:53:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=476a0c89-4322-42aa-b7ce-3ac21be55af7",
@@ -28418,7 +27230,7 @@ http_interactions:
         "name": "EmsRefreshSpec-Volume-2", "bootable": "false", "created_at": "2016-08-19T08:37:33.000000",
         "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:29 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:43 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=476a0c89-4322-42aa-b7ce-3ac21be55af7
@@ -28433,22 +27245,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 39ede911e3f64e039f5fc80e40625242
+      - 3bd42847fa824ef4a9f310e2e771271b
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-6458383a-4dd1-46d9-898a-a386bad61949
+      - req-6ef1de58-03a4-4d12-9e39-2cb97737c6ab
       Content-Type:
       - application/json
       Content-Length:
       - '2753'
       X-Openstack-Request-Id:
-      - req-6458383a-4dd1-46d9-898a-a386bad61949
+      - req-6ef1de58-03a4-4d12-9e39-2cb97737c6ab
       Date:
-      - Thu, 03 Jan 2019 19:28:30 GMT
+      - Fri, 04 Jan 2019 16:53:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=8791e24f-874d-4f1e-99ec-75fdb9d48ca5",
@@ -28482,7 +27294,7 @@ http_interactions:
         "bootable": "false", "created_at": "2016-08-19T08:37:05.000000", "volume_type":
         "iscsi"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:30 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:43 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=8791e24f-874d-4f1e-99ec-75fdb9d48ca5
@@ -28497,27 +27309,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 39ede911e3f64e039f5fc80e40625242
+      - 3bd42847fa824ef4a9f310e2e771271b
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-95fcb0b6-6ad5-4e0d-a643-7efc5c3529d4
+      - req-761b58b4-29ae-473e-b59c-bd5e8881e160
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-95fcb0b6-6ad5-4e0d-a643-7efc5c3529d4
+      - req-761b58b4-29ae-473e-b59c-bd5e8881e160
       Date:
-      - Thu, 03 Jan 2019 19:28:30 GMT
+      - Fri, 04 Jan 2019 16:53:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:30 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:44 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/volumes/detail?limit=1000
@@ -28532,27 +27344,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7166a411b97545dab2da9eb8f7507716
+      - 1878bb770cee478ba3389c9b1737e694
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-71e9d604-9e45-491f-9aa5-d610451c7a92
+      - req-10523494-0c4e-4b9e-b713-a8adf0e3fa16
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-71e9d604-9e45-491f-9aa5-d610451c7a92
+      - req-10523494-0c4e-4b9e-b713-a8adf0e3fa16
       Date:
-      - Thu, 03 Jan 2019 19:28:30 GMT
+      - Fri, 04 Jan 2019 16:53:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:30 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:44 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/volumes/detail?limit=1000
@@ -28567,27 +27379,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b2c46dae36f84281bbb353a8834ac560
+      - bec5b3fcddea4328a89df2c1090c40bb
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-efc35cfb-58a8-4485-9d98-7adf4a2b2c31
+      - req-6042fe7d-623e-42b5-acb0-b2aec5201936
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-efc35cfb-58a8-4485-9d98-7adf4a2b2c31
+      - req-6042fe7d-623e-42b5-acb0-b2aec5201936
       Date:
-      - Thu, 03 Jan 2019 19:28:30 GMT
+      - Fri, 04 Jan 2019 16:53:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:30 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:44 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/volumes/detail?limit=1000
@@ -28602,27 +27414,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e3fdc7917d5e4b1bbd62fd789ce8bd9a
+      - 402b16759e19408a9858774ffbc464ef
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-368203d2-3733-4426-a98f-aa8dd0c3694c
+      - req-b77bfe68-6441-4ee7-a81b-f52b452338e0
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-368203d2-3733-4426-a98f-aa8dd0c3694c
+      - req-b77bfe68-6441-4ee7-a81b-f52b452338e0
       Date:
-      - Thu, 03 Jan 2019 19:28:30 GMT
+      - Fri, 04 Jan 2019 16:53:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:30 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:44 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/volumes/detail?limit=1000
@@ -28637,27 +27449,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 95c835c4cdc54ddb8440d94063013fee
+      - 45c454404abd4d1fa57cf2a01ec13b67
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-7ce03e8f-d22b-4f33-af6c-076a8ff42fcf
+      - req-c44a2adf-2f21-4fa8-8156-73baba778f26
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-7ce03e8f-d22b-4f33-af6c-076a8ff42fcf
+      - req-c44a2adf-2f21-4fa8-8156-73baba778f26
       Date:
-      - Thu, 03 Jan 2019 19:28:30 GMT
+      - Fri, 04 Jan 2019 16:53:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:30 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:44 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/snapshots/detail
@@ -28672,27 +27484,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d87e5c5ba4b147fd96eab111440d6f41
+      - f443c7d170af43ecb796571af120f0f6
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-41471633-2094-4922-80dc-6d48c55de1fe
+      - req-9cdbd065-4629-44b8-9dc4-c1665cba75d4
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-41471633-2094-4922-80dc-6d48c55de1fe
+      - req-9cdbd065-4629-44b8-9dc4-c1665cba75d4
       Date:
-      - Thu, 03 Jan 2019 19:28:30 GMT
+      - Fri, 04 Jan 2019 16:53:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:30 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:44 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/snapshots/detail?limit=1000
@@ -28707,27 +27519,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d87e5c5ba4b147fd96eab111440d6f41
+      - f443c7d170af43ecb796571af120f0f6
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-b5b960b8-a1a3-4520-ba71-75538ba75c0f
+      - req-bf24d3cc-bf16-4be8-90d9-419f48d1f8a4
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-b5b960b8-a1a3-4520-ba71-75538ba75c0f
+      - req-bf24d3cc-bf16-4be8-90d9-419f48d1f8a4
       Date:
-      - Thu, 03 Jan 2019 19:28:31 GMT
+      - Fri, 04 Jan 2019 16:53:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:31 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:44 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/snapshots/detail
@@ -28742,27 +27554,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e540f66fca624eceb089502ea8e98ae1
+      - caacd4a41ca34b4283bd18adfb34deb3
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-0279be5c-d4df-4a6b-a5a1-4a45caeb4e86
+      - req-7c168ca5-cca4-4d76-bbfa-a6162048f94b
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-0279be5c-d4df-4a6b-a5a1-4a45caeb4e86
+      - req-7c168ca5-cca4-4d76-bbfa-a6162048f94b
       Date:
-      - Thu, 03 Jan 2019 19:28:31 GMT
+      - Fri, 04 Jan 2019 16:53:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:31 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:45 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/snapshots/detail?limit=1000
@@ -28777,27 +27589,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e540f66fca624eceb089502ea8e98ae1
+      - caacd4a41ca34b4283bd18adfb34deb3
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-b5aec156-fe8a-4324-b955-09ac43858ad8
+      - req-0fa9c46b-672c-41b5-a1a0-dec62927a364
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-b5aec156-fe8a-4324-b955-09ac43858ad8
+      - req-0fa9c46b-672c-41b5-a1a0-dec62927a364
       Date:
-      - Thu, 03 Jan 2019 19:28:31 GMT
+      - Fri, 04 Jan 2019 16:53:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:31 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:45 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/snapshots/detail
@@ -28812,22 +27624,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 39ede911e3f64e039f5fc80e40625242
+      - 3bd42847fa824ef4a9f310e2e771271b
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-2c772547-7109-4470-adcb-020271900056
+      - req-b54a728d-8ccf-4ade-8b8f-7db3be2a1f26
       Content-Type:
       - application/json
       Content-Length:
       - '1053'
       X-Openstack-Request-Id:
-      - req-2c772547-7109-4470-adcb-020271900056
+      - req-b54a728d-8ccf-4ade-8b8f-7db3be2a1f26
       Date:
-      - Thu, 03 Jan 2019 19:28:31 GMT
+      - Fri, 04 Jan 2019 16:53:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/snapshots/detail?marker=c44d3eb3-31fe-46ed-bfae-707920be171d",
@@ -28842,7 +27654,7 @@ http_interactions:
         "created_at": "2016-08-19T08:37:24.000000", "size": 1, "id": "c44d3eb3-31fe-46ed-bfae-707920be171d",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:31 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:45 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/snapshots/detail?limit=1000
@@ -28857,22 +27669,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 39ede911e3f64e039f5fc80e40625242
+      - 3bd42847fa824ef4a9f310e2e771271b
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-34ccc58f-7d97-4a41-b19c-e2713019070e
+      - req-f53d60b9-5f4e-41e1-9d08-93db1ff0fe34
       Content-Type:
       - application/json
       Content-Length:
       - '1064'
       X-Openstack-Request-Id:
-      - req-34ccc58f-7d97-4a41-b19c-e2713019070e
+      - req-f53d60b9-5f4e-41e1-9d08-93db1ff0fe34
       Date:
-      - Thu, 03 Jan 2019 19:28:31 GMT
+      - Fri, 04 Jan 2019 16:53:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/snapshots/detail?limit=1000&marker=c44d3eb3-31fe-46ed-bfae-707920be171d",
@@ -28887,7 +27699,7 @@ http_interactions:
         "created_at": "2016-08-19T08:37:24.000000", "size": 1, "id": "c44d3eb3-31fe-46ed-bfae-707920be171d",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:31 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:45 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/snapshots/detail
@@ -28902,27 +27714,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7166a411b97545dab2da9eb8f7507716
+      - 1878bb770cee478ba3389c9b1737e694
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-1f6a529d-8489-4ea7-b1fc-475c72e3d33e
+      - req-f008a77f-3e8e-40d5-a83c-be8105a94498
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-1f6a529d-8489-4ea7-b1fc-475c72e3d33e
+      - req-f008a77f-3e8e-40d5-a83c-be8105a94498
       Date:
-      - Thu, 03 Jan 2019 19:28:31 GMT
+      - Fri, 04 Jan 2019 16:53:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:31 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:45 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/snapshots/detail?limit=1000
@@ -28937,27 +27749,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7166a411b97545dab2da9eb8f7507716
+      - 1878bb770cee478ba3389c9b1737e694
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-d6f9609d-4952-4779-be7f-7a5703608a30
+      - req-6c159cd5-46c6-47e0-bc34-4a61df4f5478
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-d6f9609d-4952-4779-be7f-7a5703608a30
+      - req-6c159cd5-46c6-47e0-bc34-4a61df4f5478
       Date:
-      - Thu, 03 Jan 2019 19:28:31 GMT
+      - Fri, 04 Jan 2019 16:53:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:31 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:45 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/snapshots/detail
@@ -28972,27 +27784,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b2c46dae36f84281bbb353a8834ac560
+      - bec5b3fcddea4328a89df2c1090c40bb
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-52420914-7c82-4012-b139-6fc9319d1e64
+      - req-099a3c5b-eded-4480-8ddf-0fcf25a6b735
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-52420914-7c82-4012-b139-6fc9319d1e64
+      - req-099a3c5b-eded-4480-8ddf-0fcf25a6b735
       Date:
-      - Thu, 03 Jan 2019 19:28:31 GMT
+      - Fri, 04 Jan 2019 16:53:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:31 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:45 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/snapshots/detail?limit=1000
@@ -29007,27 +27819,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b2c46dae36f84281bbb353a8834ac560
+      - bec5b3fcddea4328a89df2c1090c40bb
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-9fbb07eb-20f4-46ae-ba25-7a4e31d56c85
+      - req-aad126fc-ffa4-42c5-b6c6-91e18e11702e
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-9fbb07eb-20f4-46ae-ba25-7a4e31d56c85
+      - req-aad126fc-ffa4-42c5-b6c6-91e18e11702e
       Date:
-      - Thu, 03 Jan 2019 19:28:31 GMT
+      - Fri, 04 Jan 2019 16:53:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:32 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:45 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/snapshots/detail
@@ -29042,27 +27854,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e3fdc7917d5e4b1bbd62fd789ce8bd9a
+      - 402b16759e19408a9858774ffbc464ef
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-452546f6-6094-4301-9a00-e9fdc3a69169
+      - req-1e87ef1c-6cb6-43bc-b8c1-0ced16e1e4a9
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-452546f6-6094-4301-9a00-e9fdc3a69169
+      - req-1e87ef1c-6cb6-43bc-b8c1-0ced16e1e4a9
       Date:
-      - Thu, 03 Jan 2019 19:28:32 GMT
+      - Fri, 04 Jan 2019 16:53:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:32 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:45 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/snapshots/detail?limit=1000
@@ -29077,27 +27889,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e3fdc7917d5e4b1bbd62fd789ce8bd9a
+      - 402b16759e19408a9858774ffbc464ef
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-225ba681-045f-4064-9721-7d476a341f5b
+      - req-07b78390-e512-4cee-8dcd-27d81bcf6953
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-225ba681-045f-4064-9721-7d476a341f5b
+      - req-07b78390-e512-4cee-8dcd-27d81bcf6953
       Date:
-      - Thu, 03 Jan 2019 19:28:32 GMT
+      - Fri, 04 Jan 2019 16:53:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:32 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:46 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/snapshots/detail
@@ -29112,27 +27924,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 95c835c4cdc54ddb8440d94063013fee
+      - 45c454404abd4d1fa57cf2a01ec13b67
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-9f949a9f-088e-4fc4-a6bd-c83b87d965dc
+      - req-b8f6eb50-a344-4326-b9bc-5ba7436fd707
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-9f949a9f-088e-4fc4-a6bd-c83b87d965dc
+      - req-b8f6eb50-a344-4326-b9bc-5ba7436fd707
       Date:
-      - Thu, 03 Jan 2019 19:28:32 GMT
+      - Fri, 04 Jan 2019 16:53:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:32 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:46 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/snapshots/detail?limit=1000
@@ -29147,27 +27959,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 95c835c4cdc54ddb8440d94063013fee
+      - 45c454404abd4d1fa57cf2a01ec13b67
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-0473dad3-cded-4501-a5ee-ab9b706af116
+      - req-8d56215c-d319-4d3a-bb5e-832b006acd62
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-0473dad3-cded-4501-a5ee-ab9b706af116
+      - req-8d56215c-d319-4d3a-bb5e-832b006acd62
       Date:
-      - Thu, 03 Jan 2019 19:28:32 GMT
+      - Fri, 04 Jan 2019 16:53:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:32 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:46 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/backups/detail
@@ -29182,27 +27994,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d87e5c5ba4b147fd96eab111440d6f41
+      - f443c7d170af43ecb796571af120f0f6
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-e775494e-eb6f-42e8-88c2-81a579533d59
+      - req-5615ce3d-cac9-4ff7-ae34-06825d45682c
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-e775494e-eb6f-42e8-88c2-81a579533d59
+      - req-5615ce3d-cac9-4ff7-ae34-06825d45682c
       Date:
-      - Thu, 03 Jan 2019 19:28:32 GMT
+      - Fri, 04 Jan 2019 16:53:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:32 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:46 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/backups/detail?limit=1000
@@ -29217,27 +28029,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d87e5c5ba4b147fd96eab111440d6f41
+      - f443c7d170af43ecb796571af120f0f6
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-d6508737-3389-4e89-8c01-4030f61686d1
+      - req-46353e3f-6f56-4f54-bdbb-4e96a20ec044
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-d6508737-3389-4e89-8c01-4030f61686d1
+      - req-46353e3f-6f56-4f54-bdbb-4e96a20ec044
       Date:
-      - Thu, 03 Jan 2019 19:28:32 GMT
+      - Fri, 04 Jan 2019 16:53:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:32 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:46 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/backups/detail
@@ -29252,27 +28064,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e540f66fca624eceb089502ea8e98ae1
+      - caacd4a41ca34b4283bd18adfb34deb3
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-cac53c70-aeb5-4c3d-9795-3c1a93cc7f75
+      - req-d312ea53-2468-4575-958f-78b7cf14d918
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-cac53c70-aeb5-4c3d-9795-3c1a93cc7f75
+      - req-d312ea53-2468-4575-958f-78b7cf14d918
       Date:
-      - Thu, 03 Jan 2019 19:28:33 GMT
+      - Fri, 04 Jan 2019 16:53:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:33 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:46 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/backups/detail?limit=1000
@@ -29287,27 +28099,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e540f66fca624eceb089502ea8e98ae1
+      - caacd4a41ca34b4283bd18adfb34deb3
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-af355e3b-0557-4edd-98cd-aba429de19dd
+      - req-d3aa5d85-b98d-4cac-b007-133200d901f1
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-af355e3b-0557-4edd-98cd-aba429de19dd
+      - req-d3aa5d85-b98d-4cac-b007-133200d901f1
       Date:
-      - Thu, 03 Jan 2019 19:28:33 GMT
+      - Fri, 04 Jan 2019 16:53:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:33 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:46 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/backups/detail
@@ -29322,27 +28134,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 39ede911e3f64e039f5fc80e40625242
+      - 3bd42847fa824ef4a9f310e2e771271b
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-6d6e284a-8679-41ca-8d30-70933a0037e8
+      - req-9de74303-68b2-4e74-8cc4-d169fd0aca98
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-6d6e284a-8679-41ca-8d30-70933a0037e8
+      - req-9de74303-68b2-4e74-8cc4-d169fd0aca98
       Date:
-      - Thu, 03 Jan 2019 19:28:33 GMT
+      - Fri, 04 Jan 2019 16:53:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:33 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:46 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/backups/detail?limit=1000
@@ -29357,27 +28169,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 39ede911e3f64e039f5fc80e40625242
+      - 3bd42847fa824ef4a9f310e2e771271b
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-5efdcc39-377b-45ce-aabd-f40b7c2ef4d8
+      - req-8cb5fa9d-419a-4fee-a828-10a16c27b7d5
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-5efdcc39-377b-45ce-aabd-f40b7c2ef4d8
+      - req-8cb5fa9d-419a-4fee-a828-10a16c27b7d5
       Date:
-      - Thu, 03 Jan 2019 19:28:33 GMT
+      - Fri, 04 Jan 2019 16:53:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:33 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:46 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/backups/detail
@@ -29392,27 +28204,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7166a411b97545dab2da9eb8f7507716
+      - 1878bb770cee478ba3389c9b1737e694
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-e9c4ff77-a276-4fe9-b8eb-662351904ba5
+      - req-1d85f527-5c3d-43e9-82b6-f2cd9b52757a
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-e9c4ff77-a276-4fe9-b8eb-662351904ba5
+      - req-1d85f527-5c3d-43e9-82b6-f2cd9b52757a
       Date:
-      - Thu, 03 Jan 2019 19:28:33 GMT
+      - Fri, 04 Jan 2019 16:53:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:33 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:46 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/backups/detail?limit=1000
@@ -29427,27 +28239,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7166a411b97545dab2da9eb8f7507716
+      - 1878bb770cee478ba3389c9b1737e694
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-6307d5a0-458d-47e2-bd24-b5f0e16f51e8
+      - req-2da28c71-c547-4208-838d-5158020a6ab8
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-6307d5a0-458d-47e2-bd24-b5f0e16f51e8
+      - req-2da28c71-c547-4208-838d-5158020a6ab8
       Date:
-      - Thu, 03 Jan 2019 19:28:33 GMT
+      - Fri, 04 Jan 2019 16:53:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:33 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:47 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/backups/detail
@@ -29462,27 +28274,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b2c46dae36f84281bbb353a8834ac560
+      - bec5b3fcddea4328a89df2c1090c40bb
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-7792b69e-bf00-4394-8691-e15925695f6c
+      - req-b0886fe1-c105-4944-9744-58e501d2da1e
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-7792b69e-bf00-4394-8691-e15925695f6c
+      - req-b0886fe1-c105-4944-9744-58e501d2da1e
       Date:
-      - Thu, 03 Jan 2019 19:28:33 GMT
+      - Fri, 04 Jan 2019 16:53:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:33 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:47 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/backups/detail?limit=1000
@@ -29497,27 +28309,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b2c46dae36f84281bbb353a8834ac560
+      - bec5b3fcddea4328a89df2c1090c40bb
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-3ee55a27-66b7-460b-bc36-61c154a41106
+      - req-7f504dae-b1d8-497c-8e84-529a71a572ad
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-3ee55a27-66b7-460b-bc36-61c154a41106
+      - req-7f504dae-b1d8-497c-8e84-529a71a572ad
       Date:
-      - Thu, 03 Jan 2019 19:28:33 GMT
+      - Fri, 04 Jan 2019 16:53:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:33 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:47 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/backups/detail
@@ -29532,27 +28344,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e3fdc7917d5e4b1bbd62fd789ce8bd9a
+      - 402b16759e19408a9858774ffbc464ef
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-0864dbc4-209f-42a1-a3b5-5863aa6b6eed
+      - req-9f05e1b1-832c-448a-8fd9-97eed394b3f4
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-0864dbc4-209f-42a1-a3b5-5863aa6b6eed
+      - req-9f05e1b1-832c-448a-8fd9-97eed394b3f4
       Date:
-      - Thu, 03 Jan 2019 19:28:33 GMT
+      - Fri, 04 Jan 2019 16:53:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:33 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:47 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/backups/detail?limit=1000
@@ -29567,27 +28379,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e3fdc7917d5e4b1bbd62fd789ce8bd9a
+      - 402b16759e19408a9858774ffbc464ef
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-ac53cb72-e8f4-461f-9e22-984afcc00a9f
+      - req-3776a2c2-20d4-4624-853e-6ccd879204c5
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-ac53cb72-e8f4-461f-9e22-984afcc00a9f
+      - req-3776a2c2-20d4-4624-853e-6ccd879204c5
       Date:
-      - Thu, 03 Jan 2019 19:28:33 GMT
+      - Fri, 04 Jan 2019 16:53:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:33 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:47 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/backups/detail
@@ -29602,27 +28414,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 95c835c4cdc54ddb8440d94063013fee
+      - 45c454404abd4d1fa57cf2a01ec13b67
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-91011dd0-73d7-4515-a8cc-bcb19ba45176
+      - req-42db6eca-fb27-4cdc-8544-04fbccb510a7
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-91011dd0-73d7-4515-a8cc-bcb19ba45176
+      - req-42db6eca-fb27-4cdc-8544-04fbccb510a7
       Date:
-      - Thu, 03 Jan 2019 19:28:34 GMT
+      - Fri, 04 Jan 2019 16:53:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:34 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:47 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/backups/detail?limit=1000
@@ -29637,27 +28449,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 95c835c4cdc54ddb8440d94063013fee
+      - 45c454404abd4d1fa57cf2a01ec13b67
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-bed70e2c-ab17-48e1-8226-62c5779e442e
+      - req-175f91bc-b485-4ea5-be02-f96ebfbde8b7
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-bed70e2c-ab17-48e1-8226-62c5779e442e
+      - req-175f91bc-b485-4ea5-be02-f96ebfbde8b7
       Date:
-      - Thu, 03 Jan 2019 19:28:34 GMT
+      - Fri, 04 Jan 2019 16:53:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:34 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:47 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/types?limit=1000
@@ -29672,22 +28484,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d87e5c5ba4b147fd96eab111440d6f41
+      - f443c7d170af43ecb796571af120f0f6
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-5387af52-2848-4152-b042-91b46136388d
+      - req-9d096e7d-9461-4aca-8f47-ee52c300b60f
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-5387af52-2848-4152-b042-91b46136388d
+      - req-9d096e7d-9461-4aca-8f47-ee52c300b60f
       Date:
-      - Thu, 03 Jan 2019 19:28:34 GMT
+      - Fri, 04 Jan 2019 16:53:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -29699,7 +28511,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:34 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:47 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/types?limit=1000&marker=b953db40-aeea-4a55-9bd9-c08dcafd6f7e
@@ -29714,22 +28526,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d87e5c5ba4b147fd96eab111440d6f41
+      - f443c7d170af43ecb796571af120f0f6
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-f428f4d6-7a2d-4a1b-8858-662db24b0cd0
+      - req-3f2e0a59-2741-4da2-83b1-4365ea4ad2c8
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-f428f4d6-7a2d-4a1b-8858-662db24b0cd0
+      - req-3f2e0a59-2741-4da2-83b1-4365ea4ad2c8
       Date:
-      - Thu, 03 Jan 2019 19:28:34 GMT
+      - Fri, 04 Jan 2019 16:53:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -29741,7 +28553,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:34 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:47 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/types?limit=1000
@@ -29756,22 +28568,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e540f66fca624eceb089502ea8e98ae1
+      - caacd4a41ca34b4283bd18adfb34deb3
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-947f4e60-b4a6-4cb5-91b8-2a9f828203dd
+      - req-7f5b21f1-53b4-49ea-8e6e-a9db0abb63d1
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-947f4e60-b4a6-4cb5-91b8-2a9f828203dd
+      - req-7f5b21f1-53b4-49ea-8e6e-a9db0abb63d1
       Date:
-      - Thu, 03 Jan 2019 19:28:34 GMT
+      - Fri, 04 Jan 2019 16:53:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -29783,7 +28595,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:34 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:47 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/types?limit=1000&marker=b953db40-aeea-4a55-9bd9-c08dcafd6f7e
@@ -29798,22 +28610,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e540f66fca624eceb089502ea8e98ae1
+      - caacd4a41ca34b4283bd18adfb34deb3
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-8195688c-50f4-4a9a-a01d-e7101265d9d3
+      - req-979c6a13-b481-473e-bcc0-8769e0fad87c
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-8195688c-50f4-4a9a-a01d-e7101265d9d3
+      - req-979c6a13-b481-473e-bcc0-8769e0fad87c
       Date:
-      - Thu, 03 Jan 2019 19:28:34 GMT
+      - Fri, 04 Jan 2019 16:53:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -29825,7 +28637,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:34 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:48 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/types?limit=1000
@@ -29840,22 +28652,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 39ede911e3f64e039f5fc80e40625242
+      - 3bd42847fa824ef4a9f310e2e771271b
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-e42edfbc-5aaa-4177-9f7a-8d35ec517593
+      - req-0e0abb2e-3d0e-45b0-9d5f-de3d30ca4b9e
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-e42edfbc-5aaa-4177-9f7a-8d35ec517593
+      - req-0e0abb2e-3d0e-45b0-9d5f-de3d30ca4b9e
       Date:
-      - Thu, 03 Jan 2019 19:28:34 GMT
+      - Fri, 04 Jan 2019 16:53:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -29867,7 +28679,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:34 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:48 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/types?limit=1000&marker=b953db40-aeea-4a55-9bd9-c08dcafd6f7e
@@ -29882,22 +28694,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 39ede911e3f64e039f5fc80e40625242
+      - 3bd42847fa824ef4a9f310e2e771271b
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-214cd56b-f1fb-45ad-a773-536ea1c5a3e3
+      - req-22a4871c-af78-4a07-a923-e2564b65a0f1
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-214cd56b-f1fb-45ad-a773-536ea1c5a3e3
+      - req-22a4871c-af78-4a07-a923-e2564b65a0f1
       Date:
-      - Thu, 03 Jan 2019 19:28:34 GMT
+      - Fri, 04 Jan 2019 16:53:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -29909,7 +28721,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:34 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:48 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/types?limit=1000
@@ -29924,22 +28736,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7166a411b97545dab2da9eb8f7507716
+      - 1878bb770cee478ba3389c9b1737e694
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-548fcc5a-fa7b-4c3a-b198-75455d15306d
+      - req-ac5019cc-432c-4b21-afd1-b37a36d5bd72
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-548fcc5a-fa7b-4c3a-b198-75455d15306d
+      - req-ac5019cc-432c-4b21-afd1-b37a36d5bd72
       Date:
-      - Thu, 03 Jan 2019 19:28:34 GMT
+      - Fri, 04 Jan 2019 16:53:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -29951,7 +28763,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:34 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:48 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/types?limit=1000&marker=b953db40-aeea-4a55-9bd9-c08dcafd6f7e
@@ -29966,22 +28778,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7166a411b97545dab2da9eb8f7507716
+      - 1878bb770cee478ba3389c9b1737e694
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-89226124-849d-4e03-8329-81e96aae8f53
+      - req-a5b22a63-ee1f-4652-9fbc-06dc5bcc76db
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-89226124-849d-4e03-8329-81e96aae8f53
+      - req-a5b22a63-ee1f-4652-9fbc-06dc5bcc76db
       Date:
-      - Thu, 03 Jan 2019 19:28:34 GMT
+      - Fri, 04 Jan 2019 16:53:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -29993,7 +28805,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:34 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:48 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/types?limit=1000
@@ -30008,22 +28820,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b2c46dae36f84281bbb353a8834ac560
+      - bec5b3fcddea4328a89df2c1090c40bb
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-c0f1118e-7efc-4586-8ed9-62192aeaf00f
+      - req-3c5215c3-8c2e-463b-bc81-d1dc7bf5e071
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-c0f1118e-7efc-4586-8ed9-62192aeaf00f
+      - req-3c5215c3-8c2e-463b-bc81-d1dc7bf5e071
       Date:
-      - Thu, 03 Jan 2019 19:28:35 GMT
+      - Fri, 04 Jan 2019 16:53:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -30035,7 +28847,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:35 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:48 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/types?limit=1000&marker=b953db40-aeea-4a55-9bd9-c08dcafd6f7e
@@ -30050,22 +28862,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b2c46dae36f84281bbb353a8834ac560
+      - bec5b3fcddea4328a89df2c1090c40bb
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-4aafec3c-bbcc-4dea-9b78-a34f0c5ffbbb
+      - req-843b6bd2-dc6a-426b-9146-4ec5f171b9e3
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-4aafec3c-bbcc-4dea-9b78-a34f0c5ffbbb
+      - req-843b6bd2-dc6a-426b-9146-4ec5f171b9e3
       Date:
-      - Thu, 03 Jan 2019 19:28:35 GMT
+      - Fri, 04 Jan 2019 16:53:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -30077,7 +28889,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:35 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:48 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/types?limit=1000
@@ -30092,22 +28904,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e3fdc7917d5e4b1bbd62fd789ce8bd9a
+      - 402b16759e19408a9858774ffbc464ef
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-fd536358-5471-4518-9988-3dba9e7a97c9
+      - req-9c1dc366-96c9-4638-a892-f2a2df66d7a7
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-fd536358-5471-4518-9988-3dba9e7a97c9
+      - req-9c1dc366-96c9-4638-a892-f2a2df66d7a7
       Date:
-      - Thu, 03 Jan 2019 19:28:35 GMT
+      - Fri, 04 Jan 2019 16:53:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -30119,7 +28931,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:35 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:48 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/types?limit=1000&marker=b953db40-aeea-4a55-9bd9-c08dcafd6f7e
@@ -30134,22 +28946,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e3fdc7917d5e4b1bbd62fd789ce8bd9a
+      - 402b16759e19408a9858774ffbc464ef
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-f8031306-9214-4e73-875e-169e2ff34452
+      - req-a86dba0a-62b9-4a24-a9c5-7a43232547a2
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-f8031306-9214-4e73-875e-169e2ff34452
+      - req-a86dba0a-62b9-4a24-a9c5-7a43232547a2
       Date:
-      - Thu, 03 Jan 2019 19:28:35 GMT
+      - Fri, 04 Jan 2019 16:53:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -30161,7 +28973,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:35 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:48 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/types?limit=1000
@@ -30176,22 +28988,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 95c835c4cdc54ddb8440d94063013fee
+      - 45c454404abd4d1fa57cf2a01ec13b67
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-890c4d76-2011-4de4-861e-0a342a99e303
+      - req-088d3051-6259-4975-be98-321690627f49
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-890c4d76-2011-4de4-861e-0a342a99e303
+      - req-088d3051-6259-4975-be98-321690627f49
       Date:
-      - Thu, 03 Jan 2019 19:28:35 GMT
+      - Fri, 04 Jan 2019 16:53:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -30203,7 +29015,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:35 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:49 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/types?limit=1000&marker=b953db40-aeea-4a55-9bd9-c08dcafd6f7e
@@ -30218,22 +29030,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 95c835c4cdc54ddb8440d94063013fee
+      - 45c454404abd4d1fa57cf2a01ec13b67
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-0acad624-fcb5-4623-8d3a-5dc26bdfb046
+      - req-d8d6b8b4-ca0a-4143-9aea-96ac3bcf3517
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-0acad624-fcb5-4623-8d3a-5dc26bdfb046
+      - req-d8d6b8b4-ca0a-4143-9aea-96ac3bcf3517
       Date:
-      - Thu, 03 Jan 2019 19:28:35 GMT
+      - Fri, 04 Jan 2019 16:53:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -30245,7 +29057,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:35 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:49 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -30263,15 +29075,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:28:35 GMT
+      - Fri, 04 Jan 2019 16:53:49 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 98a08240e4d3439d97348ba59f7e89b7
+      - c2ff59b732c84782828ca33905fde93f
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-6ac00413-a661-4060-887b-be37649e9cc0
+      - req-77f7b636-83f4-465f-b31a-de0c09f021a3
       Content-Length:
       - '7311'
       Connection:
@@ -30283,7 +29095,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2019-01-03T20:28:35.850461Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2019-01-04T17:53:49.458517Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -30362,10 +29174,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["VTaiP7QLQOuKmT8y3h7hUg"],
-        "issued_at": "2019-01-03T19:28:35.850479Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["xFtUaiLTTfG33TxZRRi-KA"],
+        "issued_at": "2019-01-04T16:53:49.458538Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:35 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:49 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -30383,15 +29195,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:28:36 GMT
+      - Fri, 04 Jan 2019 16:53:49 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 6f66ae7716d54786b33d7b62d8274dae
+      - 9468336bbcb24b31a7ff31986a81ccbb
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-498ded23-d8d1-41c8-998e-0a1775638373
+      - req-34a2200e-a779-4df0-a941-dbd4c36437bb
       Content-Length:
       - '7311'
       Connection:
@@ -30403,7 +29215,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2019-01-03T20:28:36.086433Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2019-01-04T17:53:49.744431Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -30482,10 +29294,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["WFxM2rAhRFamLikxx784Vg"],
-        "issued_at": "2019-01-03T19:28:36.086450Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Nj2OdkYVR7Wo-4_0YQMnbA"],
+        "issued_at": "2019-01-04T16:53:49.744455Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:36 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:49 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -30503,15 +29315,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:28:36 GMT
+      - Fri, 04 Jan 2019 16:53:49 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 4b59976b9f70442cbf56c28f22cf4355
+      - 6254485f78a5486194dd955731d03134
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-b5ce357d-c15d-4a72-9e9a-c5278f47a5fd
+      - req-ab4e2256-3b42-418e-8d33-ed0b1d5c7161
       Content-Length:
       - '297'
       Connection:
@@ -30520,12 +29332,12 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"token": {"methods": ["password"], "expires_at": "2019-01-03T20:28:36.261535Z",
+      string: '{"token": {"methods": ["password"], "expires_at": "2019-01-04T17:53:49.928449Z",
         "extras": {}, "user": {"domain": {"id": "default", "name": "Default"}, "id":
-        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["7CgvZ2n7RoqXPkIY41cOoQ"],
-        "issued_at": "2019-01-03T19:28:36.261552Z"}}'
+        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["tFPueCE9TOC0_XBw7kYcLA"],
+        "issued_at": "2019-01-04T16:53:49.928472Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:36 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:49 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects?domain_id=default
@@ -30540,20 +29352,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4b59976b9f70442cbf56c28f22cf4355
+      - 6254485f78a5486194dd955731d03134
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:28:36 GMT
+      - Fri, 04 Jan 2019 16:53:50 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-6ac5b6fc-6bfb-46cf-b254-4a290f87aeee
+      - req-013b62ea-c096-4882-992b-a196b6656544
       Content-Length:
       - '2475'
       Connection:
@@ -30586,7 +29398,7 @@ http_interactions:
         "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
         "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:36 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:50 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -30604,15 +29416,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:28:36 GMT
+      - Fri, 04 Jan 2019 16:53:50 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - f252612978c64f0ea95635515a45e727
+      - 501a4cee7b564782bee9d80c7d28c990
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-2a16d106-9d38-4b5f-9be7-8a562c6d4124
+      - req-458bd240-25e9-4994-9fb8-fe4342c1792d
       Content-Length:
       - '7278'
       Connection:
@@ -30624,7 +29436,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:28:36.602594Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:53:50.309349Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -30703,10 +29515,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["-wfcGXHLRXqEtIgFd4R-OA"],
-        "issued_at": "2019-01-03T19:28:36.602614Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["ES6IhWJ7TI-PXs0uTBU9ug"],
+        "issued_at": "2019-01-04T16:53:50.309370Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:36 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:50 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -30724,15 +29536,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:28:36 GMT
+      - Fri, 04 Jan 2019 16:53:50 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - '0372968b607943919d64269acb7ffd7a'
+      - e114a4aabadd4ee8b2480bc025b3931c
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-8a9fd9be-a863-4e37-be3a-d18ef4ce5e75
+      - req-52dc8896-c96f-488f-add7-d98bf6327183
       Content-Length:
       - '7278'
       Connection:
@@ -30744,7 +29556,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:28:36.813735Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:53:50.535045Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -30823,10 +29635,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["UDgGbY3bQCOVr_n5c0VqLw"],
-        "issued_at": "2019-01-03T19:28:36.813754Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["_XPI4429Tb2MqFnW1p44ZA"],
+        "issued_at": "2019-01-04T16:53:50.535077Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:36 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:50 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -30844,15 +29656,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:28:36 GMT
+      - Fri, 04 Jan 2019 16:53:50 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - '078160646ede42e3946da771bd7a1f9c'
+      - ad6573a88c21477a9cbc9e5a0b62590b
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-a84fc481-3b46-4b16-b6a8-c580017b7a01
+      - req-fcbd55dd-66e6-4159-8554-e50a4aba93b7
       Content-Length:
       - '7264'
       Connection:
@@ -30864,7 +29676,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:28:37.022829Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:53:50.737306Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -30943,10 +29755,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["TUsKb2VyTnST0VWNBaBuqA"],
-        "issued_at": "2019-01-03T19:28:37.022847Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["CDHM3ZC9R6qBqtZ7gvH4yA"],
+        "issued_at": "2019-01-04T16:53:50.737324Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:37 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:50 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -30964,15 +29776,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:28:37 GMT
+      - Fri, 04 Jan 2019 16:53:50 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - c723197d1db74c2195b5d9205a1c2713
+      - cbecca58ffc24ca39102cea6606b733c
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-24b218a8-1856-4481-99b9-c892cbd77f32
+      - req-59e44c40-de48-4155-b963-a93615bfac70
       Content-Length:
       - '7278'
       Connection:
@@ -30984,7 +29796,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:28:37.229761Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:53:50.980702Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -31063,10 +29875,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["a4e-BPSOTRKhQT3gF1gpXA"],
-        "issued_at": "2019-01-03T19:28:37.229779Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["TK90SV3VS9COoTBkGI50PQ"],
+        "issued_at": "2019-01-04T16:53:50.980725Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:37 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:51 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -31084,15 +29896,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:28:37 GMT
+      - Fri, 04 Jan 2019 16:53:51 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 1327720245934879ae57e93829179450
+      - 4785fef63a5c4c32b78668e1e060a175
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-7d9fc274-a440-4976-9bf8-e572fb06c836
+      - req-6744a00c-8bad-4586-8ca8-4a8dc5e8230e
       Content-Length:
       - '7265'
       Connection:
@@ -31104,7 +29916,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:28:37.435648Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:53:51.201520Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -31183,10 +29995,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["zb_NuKjXRqqOTxHin9kU0Q"],
-        "issued_at": "2019-01-03T19:28:37.435666Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["S4Y5DhAHS82INAVp3cqOJA"],
+        "issued_at": "2019-01-04T16:53:51.201540Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:37 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:51 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -31204,15 +30016,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:28:37 GMT
+      - Fri, 04 Jan 2019 16:53:51 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - c3e465743f524e5f930137f4434a7fb7
+      - 13d8b2c9cc0c446782f32a7014fe149b
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-311a8439-5482-4d83-8683-f8cca46c48c0
+      - req-b00e838e-24ca-4a9b-9e80-58b38e18837c
       Content-Length:
       - '7278'
       Connection:
@@ -31224,7 +30036,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:28:37.645734Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:53:51.430525Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -31303,10 +30115,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["xqO7Zn34SCe5uirBRdwjSw"],
-        "issued_at": "2019-01-03T19:28:37.645753Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["f5c4Y5d3Tdu_UUGG8Dau1g"],
+        "issued_at": "2019-01-04T16:53:51.430544Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:37 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:51 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_0098405163cd4c9dbb42c2cb43eb6fd3/?format=json&limit=1000
@@ -31321,7 +30133,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f252612978c64f0ea95635515a45e727
+      - 501a4cee7b564782bee9d80c7d28c990
   response:
     status:
       code: 200
@@ -31334,22 +30146,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1546543717.77724'
+      - '1546620831.56642'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1546543717.77724'
+      - '1546620831.56642'
       X-Trans-Id:
-      - tx2d8cfc294a0544a3b503b-005c2e6265
+      - tx15210c537eee4be588bc5-005c2f8f9f
       Date:
-      - Thu, 03 Jan 2019 19:28:37 GMT
+      - Fri, 04 Jan 2019 16:53:51 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:37 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:51 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_28db8f69ba9e4305b7fad82da4c86e74/?format=json&limit=1000
@@ -31364,7 +30176,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '0372968b607943919d64269acb7ffd7a'
+      - e114a4aabadd4ee8b2480bc025b3931c
   response:
     status:
       code: 200
@@ -31377,22 +30189,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1546543717.89984'
+      - '1546620831.70694'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1546543717.89984'
+      - '1546620831.70694'
       X-Trans-Id:
-      - tx88fbe3130b8240c6b4eb0-005c2e6265
+      - txa886143c1dfb47b28b5d3-005c2f8f9f
       Date:
-      - Thu, 03 Jan 2019 19:28:37 GMT
+      - Fri, 04 Jan 2019 16:53:51 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:37 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:51 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_4637c33fee924ebea81f8d209e452c91/?format=json&limit=1000
@@ -31407,7 +30219,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '078160646ede42e3946da771bd7a1f9c'
+      - ad6573a88c21477a9cbc9e5a0b62590b
   response:
     status:
       code: 200
@@ -31436,15 +30248,15 @@ http_interactions:
       X-Account-Project-Domain-Id:
       - default
       X-Trans-Id:
-      - tx57abdc96be1a4897a1d0d-005c2e6265
+      - tx8fcb23f2ead44cb19d1fe-005c2f8f9f
       Date:
-      - Thu, 03 Jan 2019 19:28:38 GMT
+      - Fri, 04 Jan 2019 16:53:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '[{"count": 3, "bytes": 33, "name": "dir_1"}, {"count": 0, "bytes":
         0, "name": "dir_2"}, {"count": 0, "bytes": 0, "name": "dir_3"}]'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:38 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:51 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_4637c33fee924ebea81f8d209e452c91/?format=json&limit=1000&marker=dir_3
@@ -31459,7 +30271,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '078160646ede42e3946da771bd7a1f9c'
+      - ad6573a88c21477a9cbc9e5a0b62590b
   response:
     status:
       code: 200
@@ -31488,14 +30300,14 @@ http_interactions:
       X-Account-Project-Domain-Id:
       - default
       X-Trans-Id:
-      - txf7ce235a6f3e48a7935fb-005c2e6266
+      - tx95b55a860e834572ac171-005c2f8f9f
       Date:
-      - Thu, 03 Jan 2019 19:28:38 GMT
+      - Fri, 04 Jan 2019 16:53:51 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:38 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:51 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_52c452d7763a4295950527948232a3e5/?format=json&limit=1000
@@ -31510,7 +30322,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c723197d1db74c2195b5d9205a1c2713
+      - cbecca58ffc24ca39102cea6606b733c
   response:
     status:
       code: 200
@@ -31523,22 +30335,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1546543718.22884'
+      - '1546620832.06770'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1546543718.22884'
+      - '1546620832.06770'
       X-Trans-Id:
-      - tx3664b9554f45498e8b1c1-005c2e6266
+      - txb82562aa928640ccb2d41-005c2f8fa0
       Date:
-      - Thu, 03 Jan 2019 19:28:38 GMT
+      - Fri, 04 Jan 2019 16:53:52 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:38 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:52 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_88ae57d444fd485ab2dfddd5a2615d52/?format=json&limit=1000
@@ -31553,7 +30365,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6f66ae7716d54786b33d7b62d8274dae
+      - 9468336bbcb24b31a7ff31986a81ccbb
   response:
     status:
       code: 200
@@ -31566,22 +30378,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1546543718.35380'
+      - '1546620832.18574'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1546543718.35380'
+      - '1546620832.18574'
       X-Trans-Id:
-      - tx8027634585db4c55926f3-005c2e6266
+      - tx919106068505446d974a5-005c2f8fa0
       Date:
-      - Thu, 03 Jan 2019 19:28:38 GMT
+      - Fri, 04 Jan 2019 16:53:52 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:38 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:52 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_d09cbe26295d47ff848ea73c74264e23/?format=json&limit=1000
@@ -31596,7 +30408,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1327720245934879ae57e93829179450
+      - 4785fef63a5c4c32b78668e1e060a175
   response:
     status:
       code: 200
@@ -31609,22 +30421,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1546543718.46404'
+      - '1546620832.31508'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1546543718.46404'
+      - '1546620832.31508'
       X-Trans-Id:
-      - txe770ed64bad84d069aa49-005c2e6266
+      - tx13f77701e2194b589031b-005c2f8fa0
       Date:
-      - Thu, 03 Jan 2019 19:28:38 GMT
+      - Fri, 04 Jan 2019 16:53:52 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:38 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:52 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_ef2a3405d1ef4dfd9a3616993ef46a4d/?format=json&limit=1000
@@ -31639,7 +30451,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c3e465743f524e5f930137f4434a7fb7
+      - 13d8b2c9cc0c446782f32a7014fe149b
   response:
     status:
       code: 200
@@ -31652,22 +30464,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1546543718.58632'
+      - '1546620832.43068'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1546543718.58632'
+      - '1546620832.43068'
       X-Trans-Id:
-      - tx5bbafdad04cc436ba320c-005c2e6266
+      - txdaeec6aa1363420aae15f-005c2f8fa0
       Date:
-      - Thu, 03 Jan 2019 19:28:38 GMT
+      - Fri, 04 Jan 2019 16:53:52 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:38 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:52 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_4637c33fee924ebea81f8d209e452c91/dir_1?format=json
@@ -31682,7 +30494,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '078160646ede42e3946da771bd7a1f9c'
+      - ad6573a88c21477a9cbc9e5a0b62590b
   response:
     status:
       code: 200
@@ -31703,9 +30515,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - tx828f948977bb4e27ae6d6-005c2e6266
+      - txd93e73a114cc4e238b059-005c2f8fa0
       Date:
-      - Thu, 03 Jan 2019 19:28:38 GMT
+      - Fri, 04 Jan 2019 16:53:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '[{"hash": "61257bf228e2f6802a196c9a460d19a8", "last_modified": "2016-08-19T08:37:59.564460",
@@ -31715,7 +30527,7 @@ http_interactions:
         {"hash": "1727a9b61bddf85bbe7a5710c9f45691", "last_modified": "2016-08-19T08:38:00.995870",
         "bytes": 11, "name": "file_3", "content_type": "application/octet-stream"}]'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:38 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:52 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_4637c33fee924ebea81f8d209e452c91/dir_2?format=json
@@ -31730,7 +30542,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '078160646ede42e3946da771bd7a1f9c'
+      - ad6573a88c21477a9cbc9e5a0b62590b
   response:
     status:
       code: 200
@@ -31751,14 +30563,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - txa545f3d30f3e4006ad556-005c2e6266
+      - txdd66374795ed4eadb063a-005c2f8fa0
       Date:
-      - Thu, 03 Jan 2019 19:28:38 GMT
+      - Fri, 04 Jan 2019 16:53:52 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:38 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:52 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_4637c33fee924ebea81f8d209e452c91/dir_3?format=json
@@ -31773,7 +30585,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '078160646ede42e3946da771bd7a1f9c'
+      - ad6573a88c21477a9cbc9e5a0b62590b
   response:
     status:
       code: 200
@@ -31794,12 +30606,12 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - txae4c0737ebf5490e90107-005c2e6266
+      - tx943fee373ef747a79a7ad-005c2f8fa0
       Date:
-      - Thu, 03 Jan 2019 19:28:38 GMT
+      - Fri, 04 Jan 2019 16:53:52 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:38 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:52 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_keystone_v3_fast_refresh.yml
+++ b/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_keystone_v3_fast_refresh.yml
@@ -17,15 +17,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:28:45 GMT
+      - Fri, 04 Jan 2019 16:54:38 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 7555c7a4e6bc431697561cae8f862603
+      - 0567a65438ff454fabd68fa89ac27e68
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-b3030932-c8b1-4d0e-8057-29227e7065d4
+      - req-7538c65e-4f37-4b77-9e2c-4c87f7303589
       Content-Length:
       - '7311'
       Connection:
@@ -37,7 +37,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2019-01-03T20:28:45.370055Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2019-01-04T17:54:38.808689Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -116,10 +116,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["zT41SOYlT0CtmvYTRGlvQg"],
-        "issued_at": "2019-01-03T19:28:45.370080Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["AmupxlhmTG6k5ygww_Nj4Q"],
+        "issued_at": "2019-01-04T16:54:38.808715Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:45 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:38 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -134,7 +134,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7555c7a4e6bc431697561cae8f862603
+      - 0567a65438ff454fabd68fa89ac27e68
   response:
     status:
       code: 200
@@ -145,7 +145,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Thu, 03 Jan 2019 19:28:45 GMT
+      - Fri, 04 Jan 2019 16:54:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -154,7 +154,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:45 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:38 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-availability-zone
@@ -169,7 +169,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7555c7a4e6bc431697561cae8f862603
+      - 0567a65438ff454fabd68fa89ac27e68
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -182,15 +182,15 @@ http_interactions:
       Content-Length:
       - '97'
       X-Compute-Request-Id:
-      - req-286b7f37-0fdd-43c3-91a3-8a83f613e9b6
+      - req-205f96b0-8ae8-4350-aef5-e90bf73ab0bc
       Date:
-      - Thu, 03 Jan 2019 19:28:45 GMT
+      - Fri, 04 Jan 2019 16:54:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"availabilityZoneInfo": [{"zoneState": {"available": true}, "hosts":
         null, "zoneName": "nova"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:45 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:39 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -208,15 +208,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:28:45 GMT
+      - Fri, 04 Jan 2019 16:54:39 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 443852d8dba7463887caafdfdfbe1e11
+      - 1f305a9e8c4e4830af2750a162287254
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-2d9e95d3-6e75-4c63-afaa-5d024e1d63dd
+      - req-df2d22ba-449c-4b89-bbb4-53f0a39abb3f
       Content-Length:
       - '7311'
       Connection:
@@ -228,7 +228,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2019-01-03T20:28:45.821707Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2019-01-04T17:54:39.249879Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -307,10 +307,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["lyCpSc5YRuiaSy9qB74Nuw"],
-        "issued_at": "2019-01-03T19:28:45.821731Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["1laiw84SRbGkyptGlw__IQ"],
+        "issued_at": "2019-01-04T16:54:39.249905Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:45 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:39 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/os-availability-zone.json
@@ -325,28 +325,28 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 443852d8dba7463887caafdfdfbe1e11
+      - 1f305a9e8c4e4830af2750a162287254
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-3d3c6972-ef5b-48c9-b573-e7c5fc63fb55
+      - req-e7880626-b57d-4191-afb2-c3c38d5cc998
       Content-Type:
       - application/json
       Content-Length:
       - '82'
       X-Openstack-Request-Id:
-      - req-3d3c6972-ef5b-48c9-b573-e7c5fc63fb55
+      - req-e7880626-b57d-4191-afb2-c3c38d5cc998
       Date:
-      - Thu, 03 Jan 2019 19:28:45 GMT
+      - Fri, 04 Jan 2019 16:54:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"availabilityZoneInfo": [{"zoneState": {"available": true}, "zoneName":
         "nova"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:45 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:39 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-services?all_tenants=True&limit=1000
@@ -361,7 +361,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7555c7a4e6bc431697561cae8f862603
+      - 0567a65438ff454fabd68fa89ac27e68
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -374,26 +374,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-edaff94f-a778-4078-a148-6b4a77f2b869
+      - req-bf72dff6-3ecd-4ca6-b694-b81a7ebad5a5
       Date:
-      - Thu, 03 Jan 2019 19:28:46 GMT
+      - Fri, 04 Jan 2019 16:54:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-01-03T19:28:38.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-01-04T16:54:30.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2019-01-03T19:28:43.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2019-01-04T16:54:35.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-01-03T19:28:45.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-01-04T16:54:38.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 5, "updated_at":
-        "2019-01-03T19:28:37.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2019-01-04T16:54:30.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2019-01-03T19:28:41.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2019-01-04T16:54:34.000000"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:46 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:39 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-services?all_tenants=True&limit=1000&marker=6
@@ -408,7 +408,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7555c7a4e6bc431697561cae8f862603
+      - 0567a65438ff454fabd68fa89ac27e68
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -421,26 +421,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-2088af9d-ec98-4b8e-8331-3a31b464f7e8
+      - req-12c28fd8-5318-4652-83f9-609043f62f85
       Date:
-      - Thu, 03 Jan 2019 19:28:46 GMT
+      - Fri, 04 Jan 2019 16:54:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-01-03T19:28:38.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-01-04T16:54:30.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2019-01-03T19:28:43.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2019-01-04T16:54:35.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-01-03T19:28:45.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-01-04T16:54:38.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 5, "updated_at":
-        "2019-01-03T19:28:37.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2019-01-04T16:54:30.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2019-01-03T19:28:41.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2019-01-04T16:54:34.000000"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:46 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:39 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000
@@ -455,7 +455,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7555c7a4e6bc431697561cae8f862603
+      - 0567a65438ff454fabd68fa89ac27e68
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -468,9 +468,9 @@ http_interactions:
       Content-Length:
       - '1010'
       X-Compute-Request-Id:
-      - req-3db58748-35d1-4173-a863-e3cc5fb29e9b
+      - req-d37c4e56-b6e7-4fe9-afef-673a23ee603d
       Date:
-      - Thu, 03 Jan 2019 19:28:46 GMT
+      - Fri, 04 Jan 2019 16:54:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.tiny", "links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/1",
@@ -484,7 +484,7 @@ http_interactions:
         0, "disk": 20, "id": "2"}], "flavors_links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=2",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:46 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:39 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=2
@@ -499,7 +499,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7555c7a4e6bc431697561cae8f862603
+      - 0567a65438ff454fabd68fa89ac27e68
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -512,9 +512,9 @@ http_interactions:
       Content-Length:
       - '1014'
       X-Compute-Request-Id:
-      - req-2f161a49-6927-474f-aac9-2a7115e8a457
+      - req-c1102892-49f9-4304-8a1c-9fd5f0cc7e8d
       Date:
-      - Thu, 03 Jan 2019 19:28:46 GMT
+      - Fri, 04 Jan 2019 16:54:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.medium", "links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/3",
@@ -528,7 +528,7 @@ http_interactions:
         0, "disk": 80, "id": "4"}], "flavors_links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=4",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:46 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:39 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=4
@@ -543,7 +543,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7555c7a4e6bc431697561cae8f862603
+      - 0567a65438ff454fabd68fa89ac27e68
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -556,9 +556,9 @@ http_interactions:
       Content-Length:
       - '1026'
       X-Compute-Request-Id:
-      - req-11916392-23c0-4f7c-a6be-5eedbc2b6da6
+      - req-cfc50a68-d3f9-4159-a55c-4876d15326ca
       Date:
-      - Thu, 03 Jan 2019 19:28:46 GMT
+      - Fri, 04 Jan 2019 16:54:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.xlarge", "links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/5",
@@ -573,7 +573,7 @@ http_interactions:
         1, "disk": 1, "id": "6"}], "flavors_links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=6",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:46 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:39 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=6
@@ -588,7 +588,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7555c7a4e6bc431697561cae8f862603
+      - 0567a65438ff454fabd68fa89ac27e68
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -601,9 +601,9 @@ http_interactions:
       Content-Length:
       - '448'
       X-Compute-Request-Id:
-      - req-2a27eddf-aaaa-4e95-a381-1fd2c4b7e09b
+      - req-369ce5da-dd69-4e0a-a978-81ed3d6e4ea4
       Date:
-      - Thu, 03 Jan 2019 19:28:46 GMT
+      - Fri, 04 Jan 2019 16:54:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.ems_refresh_spec_private", "links": [{"href":
@@ -613,7 +613,7 @@ http_interactions:
         8, "swap": "", "os-flavor-access:is_public": false, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         0, "disk": 160, "id": "7"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:46 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:40 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -631,15 +631,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:28:47 GMT
+      - Fri, 04 Jan 2019 16:54:40 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 22263746cc9f40109041211f2339104b
+      - d177664229434e3ea464d084f6471fbc
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-1f094994-17e7-4d2b-b90f-4b02be05e404
+      - req-d6f2a1b9-79be-423a-bbe9-76ae4f8cbfcf
       Content-Length:
       - '297'
       Connection:
@@ -648,12 +648,12 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"token": {"methods": ["password"], "expires_at": "2019-01-03T20:28:47.112046Z",
+      string: '{"token": {"methods": ["password"], "expires_at": "2019-01-04T17:54:40.241275Z",
         "extras": {}, "user": {"domain": {"id": "default", "name": "Default"}, "id":
-        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["9CjVqwatQg6G7sqI-_iNEA"],
-        "issued_at": "2019-01-03T19:28:47.112064Z"}}'
+        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["tSIklP84QTWXz4iYX97rgQ"],
+        "issued_at": "2019-01-04T16:54:40.241295Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:47 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:40 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects?domain_id=default
@@ -668,20 +668,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 22263746cc9f40109041211f2339104b
+      - d177664229434e3ea464d084f6471fbc
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:28:47 GMT
+      - Fri, 04 Jan 2019 16:54:40 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-e60497ca-1dad-4062-8eac-484e0834fb5f
+      - req-eae7e3a1-7764-4e67-ac81-5cb437920d92
       Content-Length:
       - '2475'
       Connection:
@@ -714,7 +714,7 @@ http_interactions:
         "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
         "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:47 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:40 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/7/os-flavor-access
@@ -729,7 +729,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7555c7a4e6bc431697561cae8f862603
+      - 0567a65438ff454fabd68fa89ac27e68
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -742,15 +742,15 @@ http_interactions:
       Content-Length:
       - '88'
       X-Compute-Request-Id:
-      - req-a661711b-f968-4009-980d-5db616c86855
+      - req-db5d8693-5743-4424-8b13-47a9176ca62e
       Date:
-      - Thu, 03 Jan 2019 19:28:47 GMT
+      - Fri, 04 Jan 2019 16:54:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavor_access": [{"tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "flavor_id": "7"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:47 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:40 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -768,15 +768,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:28:47 GMT
+      - Fri, 04 Jan 2019 16:54:40 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - c40eab013dab407b84ebac31f4815e56
+      - 7136e825d2da40d5af7d6107811568de
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-e9a6efcc-b058-4c6d-99c1-32e1ab00fea6
+      - req-87b28343-ec8a-45e3-bc02-344eb6739ff3
       Content-Length:
       - '7311'
       Connection:
@@ -788,7 +788,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2019-01-03T20:28:47.602923Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2019-01-04T17:54:40.737038Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -867,10 +867,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["7gXWfcOaQkmQeZIuXfiR3A"],
-        "issued_at": "2019-01-03T19:28:47.602952Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["1RFxgTbMQWeIfN0pA9ujAg"],
+        "issued_at": "2019-01-04T16:54:40.737071Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:47 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:40 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images
@@ -885,7 +885,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c40eab013dab407b84ebac31f4815e56
+      - 7136e825d2da40d5af7d6107811568de
   response:
     status:
       code: 200
@@ -896,9 +896,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-edda08f8-ea29-4897-8534-0beff57048c1
+      - req-02e41149-3f59-4068-b515-8a4aa31e64a7
       Date:
-      - Thu, 03 Jan 2019 19:28:47 GMT
+      - Fri, 04 Jan 2019 16:54:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -940,7 +940,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images"}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:47 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:40 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images?marker=b672acdb-654b-41d7-963c-44a0349bd285
@@ -955,7 +955,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c40eab013dab407b84ebac31f4815e56
+      - 7136e825d2da40d5af7d6107811568de
   response:
     status:
       code: 200
@@ -966,14 +966,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-5a628222-34e5-42a1-aa05-c894efbb3304
+      - req-c0f23d90-c896-439b-897e-f2a10ec5ff2c
       Date:
-      - Thu, 03 Jan 2019 19:28:47 GMT
+      - Fri, 04 Jan 2019 16:54:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images"}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:47 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:41 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-keypairs?all_tenants=True&limit=1000
@@ -988,7 +988,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7555c7a4e6bc431697561cae8f862603
+      - 0567a65438ff454fabd68fa89ac27e68
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1001,9 +1001,9 @@ http_interactions:
       Content-Length:
       - '1611'
       X-Compute-Request-Id:
-      - req-1d956e0c-f627-421f-82e6-51c4eebf538b
+      - req-5164eebf-5b12-4f00-abb5-927c6f274da6
       Date:
-      - Thu, 03 Jan 2019 19:28:47 GMT
+      - Fri, 04 Jan 2019 16:54:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKQyhM0ECmYmB8mI4vfeTEaY90skgHYgA/5apgT+cHhKzZX59Go+LGfb98dOCYEjnV3XKdO5dy7MrSdI5QSvGJmJIQPsH4WZNpRNuEhHzcHS1fEPe9zMceRlLafkTeUKhUGMIi1gOmBRdyZtz6fJw37AK6ioM4+16IhXjNVLV09jHn2PsUjh2RsGX5TzA3eHivptzINBD8eMBkyQwS2uejY42FlIg9qBpa8KEMgyo4KLvd/99kw9wLg1D9Y5+3OxA/J6hLfjSBv7Vd7Xvwd4ZmDlkU5+yH88b2ZOte8MyfAnlVA4v8bMdSsAf1e5NvUuZsoZC8goZCHjXmTDSI+yen
@@ -1013,7 +1013,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:48 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:41 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-keypairs?all_tenants=True&limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -1028,7 +1028,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7555c7a4e6bc431697561cae8f862603
+      - 0567a65438ff454fabd68fa89ac27e68
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1041,9 +1041,9 @@ http_interactions:
       Content-Length:
       - '1611'
       X-Compute-Request-Id:
-      - req-7fe8a439-6085-4326-8b36-9f6acd9d9a6a
+      - req-027a85d8-249c-43fa-b9bd-934a31c527fa
       Date:
-      - Thu, 03 Jan 2019 19:28:48 GMT
+      - Fri, 04 Jan 2019 16:54:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKQyhM0ECmYmB8mI4vfeTEaY90skgHYgA/5apgT+cHhKzZX59Go+LGfb98dOCYEjnV3XKdO5dy7MrSdI5QSvGJmJIQPsH4WZNpRNuEhHzcHS1fEPe9zMceRlLafkTeUKhUGMIi1gOmBRdyZtz6fJw37AK6ioM4+16IhXjNVLV09jHn2PsUjh2RsGX5TzA3eHivptzINBD8eMBkyQwS2uejY42FlIg9qBpa8KEMgyo4KLvd/99kw9wLg1D9Y5+3OxA/J6hLfjSBv7Vd7Xvwd4ZmDlkU5+yH88b2ZOte8MyfAnlVA4v8bMdSsAf1e5NvUuZsoZC8goZCHjXmTDSI+yen
@@ -1053,7 +1053,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:48 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:41 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -1071,15 +1071,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:28:48 GMT
+      - Fri, 04 Jan 2019 16:54:41 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 6573e50cf508457b9ca4786242b26f9d
+      - bc0b5c35c5994601b0a6c40dd0bf5ba3
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-0a668915-0054-423a-93dd-8408b02ebe01
+      - req-62cbaa2d-6739-4364-a203-2f87ea509bba
       Content-Length:
       - '7311'
       Connection:
@@ -1091,7 +1091,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2019-01-03T20:28:48.281516Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2019-01-04T17:54:41.449717Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -1170,10 +1170,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["F9XjvqQAS5qrHIj7N7fo2w"],
-        "issued_at": "2019-01-03T19:28:48.281535Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["rIz8jZSVQkC1AcAA64aeTw"],
+        "issued_at": "2019-01-04T16:54:41.449739Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:48 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:41 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -1191,15 +1191,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:28:48 GMT
+      - Fri, 04 Jan 2019 16:54:41 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 339c181978c745949b96201c683f82c9
+      - 282db08771a645ccb9030368ecdb2689
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-cf5ae254-18bc-4218-945b-9435293080fd
+      - req-296c3c0c-b215-4cdb-932c-4f849002f5e4
       Content-Length:
       - '7278'
       Connection:
@@ -1211,7 +1211,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:28:48.481417Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:54:41.666321Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -1290,10 +1290,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["9KU2v7Y9RYiD_w4x7Frcmg"],
-        "issued_at": "2019-01-03T19:28:48.481434Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["uyQHIu1cRiOI30fAeSYSzw"],
+        "issued_at": "2019-01-04T16:54:41.666342Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:48 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:41 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -1311,15 +1311,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:28:48 GMT
+      - Fri, 04 Jan 2019 16:54:41 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 045512c3c21f4294bba026f96a618890
+      - e556ffcf64014bedbb8e10bd8bbfec52
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-f55c651b-ccc1-4f4c-b906-350dd1d94f65
+      - req-a2bd8a71-c2e4-42e8-930c-cccd307cb5f6
       Content-Length:
       - '7278'
       Connection:
@@ -1331,7 +1331,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:28:48.683564Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:54:41.872815Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -1410,10 +1410,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["41FI0sIJRtWKVA6iUqaw4g"],
-        "issued_at": "2019-01-03T19:28:48.683582Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["6SElJEg6Q3C9-vZWmVX3XQ"],
+        "issued_at": "2019-01-04T16:54:41.872842Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:48 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:41 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -1431,15 +1431,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:28:48 GMT
+      - Fri, 04 Jan 2019 16:54:42 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 5a44c168ca13496fa4bacb234f7b926f
+      - 755d8ce1af574c23a770ca57371f2597
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-bd12468a-c0b2-4835-9c09-7d85e2c80d78
+      - req-14267d84-a85b-43d3-abc8-c8d5ce190157
       Content-Length:
       - '7264'
       Connection:
@@ -1451,7 +1451,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:28:48.894196Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:54:42.083727Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -1530,10 +1530,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["e8DHoPRrSuWMtoHe8QC7dg"],
-        "issued_at": "2019-01-03T19:28:48.894215Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["0zMPaZq8RhuZVi_Rh1c8_w"],
+        "issued_at": "2019-01-04T16:54:42.083747Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:48 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:42 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -1551,15 +1551,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:28:49 GMT
+      - Fri, 04 Jan 2019 16:54:42 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 6d884369ce7a47b181781529a1c63e50
+      - be4a8e1d6ee64b5aaa222aed1b9e6728
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-81613b52-dfa3-49e9-9f90-4d0e57789008
+      - req-dc306377-b521-4f1c-8cd9-4ec0a8942fdd
       Content-Length:
       - '7278'
       Connection:
@@ -1571,7 +1571,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:28:49.094062Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:54:42.289661Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -1650,10 +1650,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["PSLb8T-KQ-CNIcPYa9hbsg"],
-        "issued_at": "2019-01-03T19:28:49.094079Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["IdJfmUdoRmaZGhYcXxGf2g"],
+        "issued_at": "2019-01-04T16:54:42.289681Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:49 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:42 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -1671,15 +1671,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:28:49 GMT
+      - Fri, 04 Jan 2019 16:54:42 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 28ea6699a79e454b969ead8afba5f0b9
+      - 78e2a858e8a748338840c3639b3da5f6
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-4323d919-fafc-4945-9036-1aea04b270a7
+      - req-14cd8eec-5782-4d7d-97ed-a025e2a7a0ba
       Content-Length:
       - '7265'
       Connection:
@@ -1691,7 +1691,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:28:49.307627Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:54:42.495315Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -1770,10 +1770,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["O8FUL8ceQLOPWrgNx4PYAQ"],
-        "issued_at": "2019-01-03T19:28:49.307648Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["cMv2cwqkToyKWiRlPzF_tg"],
+        "issued_at": "2019-01-04T16:54:42.495336Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:49 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:42 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -1791,15 +1791,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:28:49 GMT
+      - Fri, 04 Jan 2019 16:54:42 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 5ec1a11196054a189f2e4e248d85c42e
+      - 6d4f1ff62e5f427a9a29e8e02c63d255
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-742b4a2b-2437-4d00-afb1-cec33c4b5311
+      - req-d8471e05-f3ba-4335-8459-13ab148658f6
       Content-Length:
       - '7278'
       Connection:
@@ -1811,7 +1811,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:28:49.509773Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:54:42.709670Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -1890,10 +1890,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["53U1E9SYTMSghmgfhFv8Ww"],
-        "issued_at": "2019-01-03T19:28:49.509792Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["oG_A-p5nST2zjk3iQlILzA"],
+        "issued_at": "2019-01-04T16:54:42.709689Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:49 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:42 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/0098405163cd4c9dbb42c2cb43eb6fd3/stacks?limit=1000&show_nested=true
@@ -1908,7 +1908,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 339c181978c745949b96201c683f82c9
+      - 282db08771a645ccb9030368ecdb2689
   response:
     status:
       code: 200
@@ -1919,14 +1919,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-0f767079-1674-4765-9528-bb1cec00b7b2
+      - req-dc6cb086-51f9-473b-9a5b-051509222a64
       Date:
-      - Thu, 03 Jan 2019 19:28:49 GMT
+      - Fri, 04 Jan 2019 16:54:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:49 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:42 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/28db8f69ba9e4305b7fad82da4c86e74/stacks?limit=1000&show_nested=true
@@ -1941,7 +1941,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 045512c3c21f4294bba026f96a618890
+      - e556ffcf64014bedbb8e10bd8bbfec52
   response:
     status:
       code: 200
@@ -1952,14 +1952,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-b15fd472-e54f-4451-bfe0-52a61c05eff0
+      - req-b5174551-f1ed-4531-9123-0076951b06c0
       Date:
-      - Thu, 03 Jan 2019 19:28:49 GMT
+      - Fri, 04 Jan 2019 16:54:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:49 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:43 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks?limit=1000&show_nested=true
@@ -1974,7 +1974,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5a44c168ca13496fa4bacb234f7b926f
+      - 755d8ce1af574c23a770ca57371f2597
   response:
     status:
       code: 200
@@ -1985,9 +1985,9 @@ http_interactions:
       Content-Length:
       - '2559'
       X-Openstack-Request-Id:
-      - req-e647db2d-58f3-48d9-b167-d7a9cc1fd9fd
+      - req-4973eec5-491e-49af-979e-c557bcd0cc73
       Date:
-      - Thu, 03 Jan 2019 19:28:49 GMT
+      - Fri, 04 Jan 2019 16:54:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": [{"description": "Heat WordPress template to support F20,
@@ -2021,7 +2021,7 @@ http_interactions:
         "rel": "self"}], "updated_time": null, "stack_owner": null, "stack_status":
         "CREATE_COMPLETE", "id": "7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:49 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:43 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks?limit=1000&marker=7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0&show_nested=true
@@ -2036,7 +2036,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5a44c168ca13496fa4bacb234f7b926f
+      - 755d8ce1af574c23a770ca57371f2597
   response:
     status:
       code: 200
@@ -2047,14 +2047,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-fcaf316c-8943-4d86-9e99-dcd09b0198e0
+      - req-fbbb6d64-fe79-456d-9066-9bd44ad3d63b
       Date:
-      - Thu, 03 Jan 2019 19:28:50 GMT
+      - Fri, 04 Jan 2019 16:54:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:50 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:43 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/52c452d7763a4295950527948232a3e5/stacks?limit=1000&show_nested=true
@@ -2069,7 +2069,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6d884369ce7a47b181781529a1c63e50
+      - be4a8e1d6ee64b5aaa222aed1b9e6728
   response:
     status:
       code: 200
@@ -2080,14 +2080,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-87cc8345-17d0-4c46-80a5-11b0dd80e388
+      - req-0922064b-9597-48d5-8579-4e925fe71404
       Date:
-      - Thu, 03 Jan 2019 19:28:50 GMT
+      - Fri, 04 Jan 2019 16:54:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:50 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:43 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/88ae57d444fd485ab2dfddd5a2615d52/stacks?limit=1000&show_nested=true
@@ -2102,7 +2102,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6573e50cf508457b9ca4786242b26f9d
+      - bc0b5c35c5994601b0a6c40dd0bf5ba3
   response:
     status:
       code: 200
@@ -2113,14 +2113,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-ae751672-1959-4b53-b815-4a0c27d9a66f
+      - req-8fcaf3b4-7249-4e91-8b56-b46a98fb5e95
       Date:
-      - Thu, 03 Jan 2019 19:28:50 GMT
+      - Fri, 04 Jan 2019 16:54:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:50 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:43 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/d09cbe26295d47ff848ea73c74264e23/stacks?limit=1000&show_nested=true
@@ -2135,7 +2135,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 28ea6699a79e454b969ead8afba5f0b9
+      - 78e2a858e8a748338840c3639b3da5f6
   response:
     status:
       code: 200
@@ -2146,14 +2146,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-3a0776e2-ad23-42f1-a1bc-a2b159d8c04b
+      - req-f9397b23-8bb7-4967-a014-b737ed8d7f5c
       Date:
-      - Thu, 03 Jan 2019 19:28:50 GMT
+      - Fri, 04 Jan 2019 16:54:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:50 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:43 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/ef2a3405d1ef4dfd9a3616993ef46a4d/stacks?limit=1000&show_nested=true
@@ -2168,7 +2168,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5ec1a11196054a189f2e4e248d85c42e
+      - 6d4f1ff62e5f427a9a29e8e02c63d255
   response:
     status:
       code: 200
@@ -2179,14 +2179,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-15b0b4a8-f003-4201-9571-88d270599fc4
+      - req-a290772a-c56c-4245-9dc4-b0294fcb02d6
       Date:
-      - Thu, 03 Jan 2019 19:28:50 GMT
+      - Fri, 04 Jan 2019 16:54:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:50 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:43 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack3/00c5dc04-2c94-48d2-8031-db08934e9a44
@@ -2201,7 +2201,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5a44c168ca13496fa4bacb234f7b926f
+      - 755d8ce1af574c23a770ca57371f2597
   response:
     status:
       code: 200
@@ -2212,9 +2212,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-054527b6-291e-4c9d-9d5f-3692e68c1098
+      - req-4bd09153-7a31-468b-a0db-c7fa344b2731
       Date:
-      - Thu, 03 Jan 2019 19:28:50 GMT
+      - Fri, 04 Jan 2019 16:54:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -2241,7 +2241,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:50 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:44 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack2/d6eba2a2-7b0d-4213-afbb-69c8f6dddd8d
@@ -2256,7 +2256,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5a44c168ca13496fa4bacb234f7b926f
+      - 755d8ce1af574c23a770ca57371f2597
   response:
     status:
       code: 200
@@ -2267,9 +2267,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-481092be-a8dc-416c-b629-e974088c5a5d
+      - req-e1d6547a-62aa-4dd2-9841-f0c97763bed4
       Date:
-      - Thu, 03 Jan 2019 19:28:51 GMT
+      - Fri, 04 Jan 2019 16:54:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -2296,7 +2296,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:51 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:44 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack1/7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0
@@ -2311,7 +2311,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5a44c168ca13496fa4bacb234f7b926f
+      - 755d8ce1af574c23a770ca57371f2597
   response:
     status:
       code: 200
@@ -2322,9 +2322,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-c7982735-db26-4fa3-b8d0-0a3b1e7906bd
+      - req-926adb0d-0cc9-4f61-9024-6f7bd87786e1
       Date:
-      - Thu, 03 Jan 2019 19:28:51 GMT
+      - Fri, 04 Jan 2019 16:54:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -2351,7 +2351,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:51 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:44 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack3/00c5dc04-2c94-48d2-8031-db08934e9a44/template
@@ -2366,7 +2366,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5a44c168ca13496fa4bacb234f7b926f
+      - 755d8ce1af574c23a770ca57371f2597
   response:
     status:
       code: 200
@@ -2377,9 +2377,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-97d033dd-2280-4cce-9792-c1ba937f1c39
+      - req-7f4782ff-c13e-4ced-9014-72d6a74874cf
       Date:
-      - Thu, 03 Jan 2019 19:28:51 GMT
+      - Fri, 04 Jan 2019 16:54:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -2435,7 +2435,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:51 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:45 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack3/00c5dc04-2c94-48d2-8031-db08934e9a44/resources
@@ -2450,7 +2450,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5a44c168ca13496fa4bacb234f7b926f
+      - 755d8ce1af574c23a770ca57371f2597
   response:
     status:
       code: 200
@@ -2461,9 +2461,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-339e79e5-ca1f-425b-8353-893473aff385
+      - req-7edb1bcb-54b4-49a9-b86f-8cfb00b732dc
       Date:
-      - Thu, 03 Jan 2019 19:28:51 GMT
+      - Fri, 04 Jan 2019 16:54:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -2475,7 +2475,7 @@ http_interactions:
         changed", "physical_resource_id": "40989f26-9c38-4f72-b739-afccb44397cf",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:51 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:45 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?all_tenants=True&limit=1000
@@ -2490,7 +2490,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7555c7a4e6bc431697561cae8f862603
+      - 0567a65438ff454fabd68fa89ac27e68
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2503,9 +2503,9 @@ http_interactions:
       Content-Length:
       - '3998'
       X-Compute-Request-Id:
-      - req-7ab3da28-2b2e-4b34-8c19-02a1226cb719
+      - req-61689de0-1917-4aaa-a379-b12a60df9fcf
       Date:
-      - Thu, 03 Jan 2019 19:28:52 GMT
+      - Fri, 04 Jan 2019 16:54:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?all_tenants=True&limit=1000&marker=43f23d3a-fe8d-4bbb-9d23-fe1c437c7813",
@@ -2551,7 +2551,7 @@ http_interactions:
         [], "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:52 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:45 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?all_tenants=True&limit=1000&marker=43f23d3a-fe8d-4bbb-9d23-fe1c437c7813
@@ -2566,7 +2566,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7555c7a4e6bc431697561cae8f862603
+      - 0567a65438ff454fabd68fa89ac27e68
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2579,9 +2579,9 @@ http_interactions:
       Content-Length:
       - '4062'
       X-Compute-Request-Id:
-      - req-0af756aa-cc10-432b-ab98-a2052e491f12
+      - req-f5da0097-fcb8-4ce3-97e4-fe0e2fa4ce11
       Date:
-      - Thu, 03 Jan 2019 19:28:52 GMT
+      - Fri, 04 Jan 2019 16:54:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?all_tenants=True&limit=1000&marker=5d121f19-3e04-4743-8ed7-c5dfaa6ef71f",
@@ -2627,7 +2627,7 @@ http_interactions:
         [], "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 3, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:52 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:45 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?all_tenants=True&limit=1000&marker=5d121f19-3e04-4743-8ed7-c5dfaa6ef71f
@@ -2642,7 +2642,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7555c7a4e6bc431697561cae8f862603
+      - 0567a65438ff454fabd68fa89ac27e68
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2655,9 +2655,9 @@ http_interactions:
       Content-Length:
       - '4144'
       X-Compute-Request-Id:
-      - req-c9e19d75-8a64-4d87-97f0-7f01b9522b43
+      - req-37897eac-e7fe-495c-99f8-92baa36523b7
       Date:
-      - Thu, 03 Jan 2019 19:28:52 GMT
+      - Fri, 04 Jan 2019 16:54:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?all_tenants=True&limit=1000&marker=7edb7855-d974-4e45-8ad2-88491541ab91",
@@ -2705,7 +2705,7 @@ http_interactions:
         "", "progress": 0, "OS-EXT-STS:power_state": 1, "config_drive": "", "metadata":
         {}}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:52 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:45 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?all_tenants=True&limit=1000&marker=7edb7855-d974-4e45-8ad2-88491541ab91
@@ -2720,7 +2720,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7555c7a4e6bc431697561cae8f862603
+      - 0567a65438ff454fabd68fa89ac27e68
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2733,9 +2733,9 @@ http_interactions:
       Content-Length:
       - '3813'
       X-Compute-Request-Id:
-      - req-1bd80f3f-534a-4a7c-895d-5cc1ac003624
+      - req-486f648a-8f82-4108-9a03-8e9864fe5bb3
       Date:
-      - Thu, 03 Jan 2019 19:28:52 GMT
+      - Fri, 04 Jan 2019 16:54:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?all_tenants=True&limit=1000&marker=ad4f7eb0-9122-41a6-a0f7-55c1d4ca5e02",
@@ -2777,7 +2777,7 @@ http_interactions:
         "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:52 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:46 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?all_tenants=True&limit=1000&marker=ad4f7eb0-9122-41a6-a0f7-55c1d4ca5e02
@@ -2792,7 +2792,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7555c7a4e6bc431697561cae8f862603
+      - 0567a65438ff454fabd68fa89ac27e68
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2805,9 +2805,9 @@ http_interactions:
       Content-Length:
       - '1816'
       X-Compute-Request-Id:
-      - req-f9331d3d-4d1b-431d-92db-3edc3a2827bc
+      - req-ab630f91-ee3b-4664-ae1b-709b62e1f22f
       Date:
-      - Thu, 03 Jan 2019 19:28:53 GMT
+      - Fri, 04 Jan 2019 16:54:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": [{"status": "SHUTOFF", "updated": "2017-05-22T16:01:49Z",
@@ -2830,7 +2830,7 @@ http_interactions:
         "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:53 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:46 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack2/d6eba2a2-7b0d-4213-afbb-69c8f6dddd8d/template
@@ -2845,7 +2845,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5a44c168ca13496fa4bacb234f7b926f
+      - 755d8ce1af574c23a770ca57371f2597
   response:
     status:
       code: 200
@@ -2856,9 +2856,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-dcf8fcf4-68e9-4fae-a4af-39a961bbc76c
+      - req-53fe5d6a-1e9d-46e1-8ce5-3c6446f2d793
       Date:
-      - Thu, 03 Jan 2019 19:28:53 GMT
+      - Fri, 04 Jan 2019 16:54:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -2914,7 +2914,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:53 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:46 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack2/d6eba2a2-7b0d-4213-afbb-69c8f6dddd8d/resources
@@ -2929,7 +2929,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5a44c168ca13496fa4bacb234f7b926f
+      - 755d8ce1af574c23a770ca57371f2597
   response:
     status:
       code: 200
@@ -2940,9 +2940,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-bebdcf07-3d4d-499d-a52c-0b4e105ed3cd
+      - req-c9d7a925-b0d4-4c86-a36a-c3785a34bee4
       Date:
-      - Thu, 03 Jan 2019 19:28:53 GMT
+      - Fri, 04 Jan 2019 16:54:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -2954,7 +2954,7 @@ http_interactions:
         changed", "physical_resource_id": "ad4f7eb0-9122-41a6-a0f7-55c1d4ca5e02",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:53 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:46 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack1/7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0/template
@@ -2969,7 +2969,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5a44c168ca13496fa4bacb234f7b926f
+      - 755d8ce1af574c23a770ca57371f2597
   response:
     status:
       code: 200
@@ -2980,9 +2980,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-b13259b6-724e-4cac-ac14-71e91fa6085c
+      - req-1af5d426-df6f-471e-bae4-4bf2351d49d1
       Date:
-      - Thu, 03 Jan 2019 19:28:53 GMT
+      - Fri, 04 Jan 2019 16:54:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -3038,7 +3038,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:53 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:46 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack1/7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0/resources
@@ -3053,7 +3053,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5a44c168ca13496fa4bacb234f7b926f
+      - 755d8ce1af574c23a770ca57371f2597
   response:
     status:
       code: 200
@@ -3064,9 +3064,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-b1645503-d9d1-4cf2-a269-3b65ea807c15
+      - req-32b465da-21ae-4af9-b04e-380e5d8caf6e
       Date:
-      - Thu, 03 Jan 2019 19:28:53 GMT
+      - Fri, 04 Jan 2019 16:54:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -3078,7 +3078,7 @@ http_interactions:
         changed", "physical_resource_id": "8022b967-813a-4e3b-8ff4-7c036957a8a0",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:53 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:46 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -3096,15 +3096,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:28:53 GMT
+      - Fri, 04 Jan 2019 16:54:47 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - b02c60376f2a4318ae27cc24aa16dfc6
+      - c22ef8537eee488c90ca36cd9b03dcb6
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-b9243e48-54d8-4342-9d6c-b12dae53b55f
+      - req-c9cef19a-04f6-4ef6-b6c9-5046abca4151
       Content-Length:
       - '7278'
       Connection:
@@ -3116,7 +3116,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:28:53.875061Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:54:47.172575Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -3195,10 +3195,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["h5ibgqUpQyKnXCp1Vqwyuw"],
-        "issued_at": "2019-01-03T19:28:53.875081Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["zb__By7mTImzwJFsxjlPfQ"],
+        "issued_at": "2019-01-04T16:54:47.172596Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:53 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:47 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -3213,7 +3213,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b02c60376f2a4318ae27cc24aa16dfc6
+      - c22ef8537eee488c90ca36cd9b03dcb6
   response:
     status:
       code: 200
@@ -3224,7 +3224,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Thu, 03 Jan 2019 19:28:53 GMT
+      - Fri, 04 Jan 2019 16:54:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -3233,7 +3233,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:53 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:47 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -3251,15 +3251,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:28:54 GMT
+      - Fri, 04 Jan 2019 16:54:47 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 1e0a7c9fe82641f8b4d271fdc5884747
+      - 4eae0c69dd074509817af44d49272267
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-da0b0604-06f6-4cd2-ad4a-2ede0c17659f
+      - req-c4e4035e-573f-422e-9bc5-f3ba08737fbb
       Content-Length:
       - '7278'
       Connection:
@@ -3271,7 +3271,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:28:54.167428Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:54:47.466276Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -3350,10 +3350,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Ps8Vo841SNyeUmV8yCceLw"],
-        "issued_at": "2019-01-03T19:28:54.167446Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["t6Mc7oS2RSqme2bIuD5uZg"],
+        "issued_at": "2019-01-04T16:54:47.466295Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:54 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:47 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -3368,7 +3368,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1e0a7c9fe82641f8b4d271fdc5884747
+      - 4eae0c69dd074509817af44d49272267
   response:
     status:
       code: 200
@@ -3379,7 +3379,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Thu, 03 Jan 2019 19:28:54 GMT
+      - Fri, 04 Jan 2019 16:54:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -3388,7 +3388,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:54 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:47 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -3406,15 +3406,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:28:54 GMT
+      - Fri, 04 Jan 2019 16:54:47 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 1fe02dcdebba41a5acd848350f1c05b1
+      - 17353dc0c3a041d4b03f4c36bbbcdc66
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-22c66a91-685a-49ea-98d1-ef9b9ca851a4
+      - req-e8eba49b-3448-4b3e-8202-6d6fd227495a
       Content-Length:
       - '7264'
       Connection:
@@ -3426,7 +3426,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:28:54.455183Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:54:47.777690Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -3505,10 +3505,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["HEAW2fwXSVWA31s8SlQyog"],
-        "issued_at": "2019-01-03T19:28:54.455202Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["c5_oMgs0RNSOcnLUK67EKg"],
+        "issued_at": "2019-01-04T16:54:47.777710Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:54 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:47 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -3523,7 +3523,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1fe02dcdebba41a5acd848350f1c05b1
+      - 17353dc0c3a041d4b03f4c36bbbcdc66
   response:
     status:
       code: 200
@@ -3534,7 +3534,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Thu, 03 Jan 2019 19:28:54 GMT
+      - Fri, 04 Jan 2019 16:54:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -3543,7 +3543,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:54 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:47 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -3561,15 +3561,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:28:54 GMT
+      - Fri, 04 Jan 2019 16:54:48 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 510a2174493249e292d3d28c2c895c68
+      - 8b7debd75ca6404a9e6ae955869e23e7
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-4ab4e6d0-bdb1-4a24-9543-e504f4d5a97c
+      - req-7100086f-6e15-466f-b8a1-8ff1ceb3d3d1
       Content-Length:
       - '7278'
       Connection:
@@ -3581,7 +3581,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:28:54.772587Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:54:48.066236Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -3660,10 +3660,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["1VbpDRYjRHmCcXkOdXiIXg"],
-        "issued_at": "2019-01-03T19:28:54.772608Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["I9j2XkSxQByBkpqZM1ce8w"],
+        "issued_at": "2019-01-04T16:54:48.066257Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:54 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:48 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -3678,7 +3678,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 510a2174493249e292d3d28c2c895c68
+      - 8b7debd75ca6404a9e6ae955869e23e7
   response:
     status:
       code: 200
@@ -3689,7 +3689,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Thu, 03 Jan 2019 19:28:54 GMT
+      - Fri, 04 Jan 2019 16:54:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -3698,7 +3698,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:54 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:48 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -3716,15 +3716,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:28:55 GMT
+      - Fri, 04 Jan 2019 16:54:48 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - ee347acf0bd94c8c90082dc42a97ac7e
+      - 249f14b51f424a85a076d42a965b11a9
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-4e5309ad-ac5e-4707-97cf-c103bc8cd940
+      - req-a6f66fb3-d69c-4649-bb0a-9a04e97a1c04
       Content-Length:
       - '7265'
       Connection:
@@ -3736,7 +3736,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:28:55.062387Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:54:48.358538Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -3815,10 +3815,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["2cdTCq2VRaGj524K85xWIw"],
-        "issued_at": "2019-01-03T19:28:55.062405Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["waXZAIUdRSW1da_t0hFJ5g"],
+        "issued_at": "2019-01-04T16:54:48.358559Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:55 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:48 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -3833,7 +3833,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ee347acf0bd94c8c90082dc42a97ac7e
+      - 249f14b51f424a85a076d42a965b11a9
   response:
     status:
       code: 200
@@ -3844,7 +3844,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Thu, 03 Jan 2019 19:28:55 GMT
+      - Fri, 04 Jan 2019 16:54:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -3853,7 +3853,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:55 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:48 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -3871,15 +3871,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:28:55 GMT
+      - Fri, 04 Jan 2019 16:54:48 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 39aa6e76ed3e4545947837668bf7c11d
+      - f2bbad190a774c318970a510b5409133
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-6be6bd82-9631-47ec-89bb-3d323d698f80
+      - req-4b91a798-e95e-49c1-8446-3ef52a80327e
       Content-Length:
       - '7278'
       Connection:
@@ -3891,7 +3891,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:28:55.347461Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:54:48.653383Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -3970,10 +3970,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["02Ha0VGVQ3mW2wHIBX5yKQ"],
-        "issued_at": "2019-01-03T19:28:55.347480Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["wbUpMYzQSkSi8uSt4Ut-0g"],
+        "issued_at": "2019-01-04T16:54:48.653407Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:55 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:48 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -3988,7 +3988,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 39aa6e76ed3e4545947837668bf7c11d
+      - f2bbad190a774c318970a510b5409133
   response:
     status:
       code: 200
@@ -3999,7 +3999,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Thu, 03 Jan 2019 19:28:55 GMT
+      - Fri, 04 Jan 2019 16:54:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -4008,7 +4008,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:55 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:48 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3//os-quota-sets/0098405163cd4c9dbb42c2cb43eb6fd3
@@ -4023,7 +4023,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b02c60376f2a4318ae27cc24aa16dfc6
+      - c22ef8537eee488c90ca36cd9b03dcb6
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4036,9 +4036,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-7fe4be6c-181c-4437-8c14-54fdded07b0c
+      - req-a1a755b5-af6b-46e2-bbf5-e47e18dc55d6
       Date:
-      - Thu, 03 Jan 2019 19:28:55 GMT
+      - Fri, 04 Jan 2019 16:54:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -4047,7 +4047,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:55 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:48 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/28db8f69ba9e4305b7fad82da4c86e74//os-quota-sets/28db8f69ba9e4305b7fad82da4c86e74
@@ -4062,7 +4062,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1e0a7c9fe82641f8b4d271fdc5884747
+      - 4eae0c69dd074509817af44d49272267
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4075,9 +4075,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-a12f2f6c-3f42-4db4-9741-e2d69cfa3049
+      - req-2bec2ce5-2223-4019-9fbd-d05b78703e7b
       Date:
-      - Thu, 03 Jan 2019 19:28:55 GMT
+      - Fri, 04 Jan 2019 16:54:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -4086,7 +4086,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:55 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:49 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91//os-quota-sets/4637c33fee924ebea81f8d209e452c91
@@ -4101,7 +4101,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1fe02dcdebba41a5acd848350f1c05b1
+      - 17353dc0c3a041d4b03f4c36bbbcdc66
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4114,9 +4114,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-c036495f-c4e5-448a-84f5-fb419728788c
+      - req-f4f8e2d8-ad14-4f08-a9fd-b59cdd7bbe9b
       Date:
-      - Thu, 03 Jan 2019 19:28:55 GMT
+      - Fri, 04 Jan 2019 16:54:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -4125,7 +4125,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:55 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:49 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/52c452d7763a4295950527948232a3e5//os-quota-sets/52c452d7763a4295950527948232a3e5
@@ -4140,7 +4140,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 510a2174493249e292d3d28c2c895c68
+      - 8b7debd75ca6404a9e6ae955869e23e7
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4153,9 +4153,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-f95c9b9d-a71b-4f66-af50-20b469112768
+      - req-40cbc845-ef9f-4464-a356-554c5d7f87ff
       Date:
-      - Thu, 03 Jan 2019 19:28:55 GMT
+      - Fri, 04 Jan 2019 16:54:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -4164,7 +4164,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:55 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:49 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52//os-quota-sets/88ae57d444fd485ab2dfddd5a2615d52
@@ -4179,7 +4179,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7555c7a4e6bc431697561cae8f862603
+      - 0567a65438ff454fabd68fa89ac27e68
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4192,9 +4192,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-eb90acd1-567b-47a1-b6be-61e0b9aa1189
+      - req-80bf37f9-837d-4124-9cd4-ba8b0f212f71
       Date:
-      - Thu, 03 Jan 2019 19:28:56 GMT
+      - Fri, 04 Jan 2019 16:54:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -4203,7 +4203,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:56 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:49 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/d09cbe26295d47ff848ea73c74264e23//os-quota-sets/d09cbe26295d47ff848ea73c74264e23
@@ -4218,7 +4218,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ee347acf0bd94c8c90082dc42a97ac7e
+      - 249f14b51f424a85a076d42a965b11a9
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4231,9 +4231,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-8a668106-8604-4ee5-af1d-efb9677e61ed
+      - req-8c9aedd2-ec50-4d4b-ad44-d98ffcb81c71
       Date:
-      - Thu, 03 Jan 2019 19:28:56 GMT
+      - Fri, 04 Jan 2019 16:54:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -4242,7 +4242,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:56 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:49 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/ef2a3405d1ef4dfd9a3616993ef46a4d//os-quota-sets/ef2a3405d1ef4dfd9a3616993ef46a4d
@@ -4257,7 +4257,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 39aa6e76ed3e4545947837668bf7c11d
+      - f2bbad190a774c318970a510b5409133
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4270,9 +4270,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-5a762acd-56ff-43b5-8415-2b5d4702c32f
+      - req-8395d915-b5f0-45a2-85d2-1da8869972cb
       Date:
-      - Thu, 03 Jan 2019 19:28:56 GMT
+      - Fri, 04 Jan 2019 16:54:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -4281,7 +4281,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:56 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:49 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -4299,15 +4299,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:28:56 GMT
+      - Fri, 04 Jan 2019 16:54:49 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 6dc55513a15d4c05868220ccb41ef3ab
+      - be993d8e705e418faf7ef920eb1304bc
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-12ae3fee-9bf1-481c-b949-9da438b73b86
+      - req-9f3683fd-9217-4b46-8b76-02438f7a72dc
       Content-Length:
       - '7278'
       Connection:
@@ -4319,7 +4319,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:28:56.421971Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:54:49.772136Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -4398,10 +4398,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["RXxSND8nRvSBnB9uPDcDOQ"],
-        "issued_at": "2019-01-03T19:28:56.421990Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["95z1dyQGTt-JAGT1ZHYDxw"],
+        "issued_at": "2019-01-04T16:54:49.772157Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:56 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:49 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -4419,15 +4419,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:28:56 GMT
+      - Fri, 04 Jan 2019 16:54:49 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - d374d95be65f4ff28f0f7f70cdba9b93
+      - fa7d6e19b6a44235812133b7d54a94e9
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-b9af098e-d122-4ace-855e-890fe1fd895e
+      - req-f1cbb4a1-ab01-45da-bbbb-3f2a9575ffd7
       Content-Length:
       - '7278'
       Connection:
@@ -4439,7 +4439,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:28:56.626667Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:54:49.982182Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -4518,10 +4518,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["DOTct0_aTyaR4dfZWZq1XQ"],
-        "issued_at": "2019-01-03T19:28:56.626686Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["X2KsLw83RKOaiuatTB4L7A"],
+        "issued_at": "2019-01-04T16:54:49.982202Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:56 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:50 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -4539,15 +4539,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:28:56 GMT
+      - Fri, 04 Jan 2019 16:54:50 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 85db258d4ee6404da34e828f6cb158f3
+      - f5ee9cb5bef44398bf011032856f6365
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-11ac1ef5-baab-4957-958b-11ebe0c309d4
+      - req-d8e3120d-e935-4c5f-88e1-e4c9633ef926
       Content-Length:
       - '7264'
       Connection:
@@ -4559,7 +4559,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:28:56.828019Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:54:50.189854Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -4638,10 +4638,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["SVGGPqA1Te-XTOCcABYibw"],
-        "issued_at": "2019-01-03T19:28:56.828037Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["BDiIO8PNTg2W_0Rqf7Rg9Q"],
+        "issued_at": "2019-01-04T16:54:50.189873Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:56 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:50 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -4659,15 +4659,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:28:56 GMT
+      - Fri, 04 Jan 2019 16:54:50 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - e1d3bee5370241859a8fd9e0c111b651
+      - ac1c4e8701c948fd87026e00396e8d1a
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-544c9009-aa8d-430d-a95c-5173b3b5edc6
+      - req-fe63b15f-a0ee-4493-9fe0-e7d4d1087dab
       Content-Length:
       - '7278'
       Connection:
@@ -4679,7 +4679,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:28:57.032103Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:54:50.402070Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -4758,10 +4758,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["MBwiD0k9SX-Kdv3PU-r7vQ"],
-        "issued_at": "2019-01-03T19:28:57.032123Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Efr-tueiQNKuHy44BhLbvw"],
+        "issued_at": "2019-01-04T16:54:50.402089Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:57 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:50 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -4779,15 +4779,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:28:57 GMT
+      - Fri, 04 Jan 2019 16:54:50 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - f66f63e799bf41c8994cfd2c3181d9f4
+      - 9c8de247ad5043ce9c02902bbbac74f4
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-111fcc55-94b2-4146-9129-64349cba859f
+      - req-d58b0871-02bc-49c4-a130-bfe65bfa72b2
       Content-Length:
       - '7265'
       Connection:
@@ -4799,7 +4799,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:28:57.234562Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:54:50.609340Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -4878,10 +4878,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["82jrJ-iwSES3a7L267iRag"],
-        "issued_at": "2019-01-03T19:28:57.234580Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["0kbEqhTqTfOIWmlW2S4NxQ"],
+        "issued_at": "2019-01-04T16:54:50.609362Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:57 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:50 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -4899,15 +4899,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:28:57 GMT
+      - Fri, 04 Jan 2019 16:54:50 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 14514c941c504ac49eb35c7f8e0ad737
+      - 3880a3d0d0cd4298a955a20c31215422
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-1d10f157-c853-4595-9792-b340c6604f97
+      - req-fc429164-c0cf-403f-945e-df9c48bc1636
       Content-Length:
       - '7278'
       Connection:
@@ -4919,7 +4919,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:28:57.444152Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:54:50.817787Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -4998,10 +4998,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["tOCYToFAS0K0RpgRKKRQaA"],
-        "issued_at": "2019-01-03T19:28:57.444169Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["UqZJsBaqQzyPuw6jHzW24w"],
+        "issued_at": "2019-01-04T16:54:50.817809Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:57 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:50 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3//os-quota-sets/0098405163cd4c9dbb42c2cb43eb6fd3
@@ -5016,22 +5016,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6dc55513a15d4c05868220ccb41ef3ab
+      - be993d8e705e418faf7ef920eb1304bc
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-28535604-baa4-46b5-9ee1-559f698ce8cc
+      - req-b3c8fb77-9e5f-4ec8-a664-7aaa5814f9d7
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-28535604-baa4-46b5-9ee1-559f698ce8cc
+      - req-b3c8fb77-9e5f-4ec8-a664-7aaa5814f9d7
       Date:
-      - Thu, 03 Jan 2019 19:28:57 GMT
+      - Fri, 04 Jan 2019 16:54:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -5041,7 +5041,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "0098405163cd4c9dbb42c2cb43eb6fd3"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:57 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:51 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74//os-quota-sets/28db8f69ba9e4305b7fad82da4c86e74
@@ -5056,22 +5056,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d374d95be65f4ff28f0f7f70cdba9b93
+      - fa7d6e19b6a44235812133b7d54a94e9
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-934cab9b-7580-4523-93db-4bb927558dab
+      - req-9b8e7c17-a73c-4f85-a8cd-fe0c7e139869
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-934cab9b-7580-4523-93db-4bb927558dab
+      - req-9b8e7c17-a73c-4f85-a8cd-fe0c7e139869
       Date:
-      - Thu, 03 Jan 2019 19:28:57 GMT
+      - Fri, 04 Jan 2019 16:54:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -5081,7 +5081,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "28db8f69ba9e4305b7fad82da4c86e74"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:57 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:51 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91//os-quota-sets/4637c33fee924ebea81f8d209e452c91
@@ -5096,22 +5096,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 85db258d4ee6404da34e828f6cb158f3
+      - f5ee9cb5bef44398bf011032856f6365
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-2cdd1282-8806-42c3-b3ec-5505b784b259
+      - req-0d687459-2cd3-497f-83b4-913ffbef2b22
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-2cdd1282-8806-42c3-b3ec-5505b784b259
+      - req-0d687459-2cd3-497f-83b4-913ffbef2b22
       Date:
-      - Thu, 03 Jan 2019 19:28:58 GMT
+      - Fri, 04 Jan 2019 16:54:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -5121,7 +5121,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "4637c33fee924ebea81f8d209e452c91"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:58 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:51 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5//os-quota-sets/52c452d7763a4295950527948232a3e5
@@ -5136,22 +5136,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e1d3bee5370241859a8fd9e0c111b651
+      - ac1c4e8701c948fd87026e00396e8d1a
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-dc5bd72b-6c2f-4826-8a66-6856123198d0
+      - req-9263a16d-bce8-4e47-8931-f3264f0c96c3
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-dc5bd72b-6c2f-4826-8a66-6856123198d0
+      - req-9263a16d-bce8-4e47-8931-f3264f0c96c3
       Date:
-      - Thu, 03 Jan 2019 19:28:58 GMT
+      - Fri, 04 Jan 2019 16:54:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -5161,7 +5161,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "52c452d7763a4295950527948232a3e5"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:58 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:51 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52//os-quota-sets/88ae57d444fd485ab2dfddd5a2615d52
@@ -5176,22 +5176,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 443852d8dba7463887caafdfdfbe1e11
+      - 1f305a9e8c4e4830af2750a162287254
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-035e174b-42a1-4ea7-8493-5853227f11ba
+      - req-9f189018-ef8e-4f61-91e4-e842bb25adbe
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-035e174b-42a1-4ea7-8493-5853227f11ba
+      - req-9f189018-ef8e-4f61-91e4-e842bb25adbe
       Date:
-      - Thu, 03 Jan 2019 19:28:58 GMT
+      - Fri, 04 Jan 2019 16:54:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -5201,7 +5201,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "88ae57d444fd485ab2dfddd5a2615d52"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:58 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:52 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23//os-quota-sets/d09cbe26295d47ff848ea73c74264e23
@@ -5216,22 +5216,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f66f63e799bf41c8994cfd2c3181d9f4
+      - 9c8de247ad5043ce9c02902bbbac74f4
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-78ec2659-679a-4da5-aabd-79a4e5ac263f
+      - req-6f71cea3-4d84-4422-8eec-bf7cad0eb81b
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-78ec2659-679a-4da5-aabd-79a4e5ac263f
+      - req-6f71cea3-4d84-4422-8eec-bf7cad0eb81b
       Date:
-      - Thu, 03 Jan 2019 19:28:58 GMT
+      - Fri, 04 Jan 2019 16:54:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -5241,7 +5241,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "d09cbe26295d47ff848ea73c74264e23"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:58 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:52 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d//os-quota-sets/ef2a3405d1ef4dfd9a3616993ef46a4d
@@ -5256,22 +5256,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 14514c941c504ac49eb35c7f8e0ad737
+      - 3880a3d0d0cd4298a955a20c31215422
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-f48ab611-254b-4d6f-a2fc-ae80e5ce0509
+      - req-1e85c6bb-eab8-45ab-81ea-4828eb1db6f5
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-f48ab611-254b-4d6f-a2fc-ae80e5ce0509
+      - req-1e85c6bb-eab8-45ab-81ea-4828eb1db6f5
       Date:
-      - Thu, 03 Jan 2019 19:28:59 GMT
+      - Fri, 04 Jan 2019 16:54:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -5281,7 +5281,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:59 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:52 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -5299,15 +5299,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:28:59 GMT
+      - Fri, 04 Jan 2019 16:54:52 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 8e7d59b042a545f1b0e50d4bfc28fd9b
+      - e11422c5956b435687431a180412ae38
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-41c93dd2-ae45-4970-a413-a95bf296a713
+      - req-b4744ef9-dcfa-4f34-8dd9-35f36c8aee85
       Content-Length:
       - '7311'
       Connection:
@@ -5319,7 +5319,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2019-01-03T20:28:59.365800Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2019-01-04T17:54:53.034439Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -5398,10 +5398,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["zk6D8rhvTxmFJ9zxozHfww"],
-        "issued_at": "2019-01-03T19:28:59.365819Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["jupHq3BIRji7Ktm1N9i48A"],
+        "issued_at": "2019-01-04T16:54:53.034460Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:59 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:53 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -5419,15 +5419,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:28:59 GMT
+      - Fri, 04 Jan 2019 16:54:53 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 8f6146f5533e4eefa88dd1f2d4382ab1
+      - b0cadf29409d40c29f77a10679357714
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-19fd42b1-69d7-4fa9-8cce-46133e54bfc9
+      - req-a22f35fd-522e-4daf-b165-e4ea510795a6
       Content-Length:
       - '7278'
       Connection:
@@ -5439,7 +5439,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:28:59.564084Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:54:53.246221Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -5518,10 +5518,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["XR3xhM7-RDCG9whHxkTFYQ"],
-        "issued_at": "2019-01-03T19:28:59.564102Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["JcpI_XflSQKoeqvPos2FQw"],
+        "issued_at": "2019-01-04T16:54:53.246240Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:59 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:53 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -5539,15 +5539,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:28:59 GMT
+      - Fri, 04 Jan 2019 16:54:53 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 27a932aec9164b1c98dce864d61a123c
+      - efd097778b824efe833cf0c01f309378
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-b7612be7-6912-4a3d-91c9-ea0a7cbeb2e4
+      - req-75ec71dd-8968-45fe-a105-b2276f3d4d22
       Content-Length:
       - '7278'
       Connection:
@@ -5559,7 +5559,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:28:59.773175Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:54:53.457181Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -5638,10 +5638,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["P16YY473TSKtN3BRTFGlEg"],
-        "issued_at": "2019-01-03T19:28:59.773192Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["azzF5FRIQkW2IOizl5yuyQ"],
+        "issued_at": "2019-01-04T16:54:53.457201Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:28:59 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:53 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -5659,15 +5659,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:28:59 GMT
+      - Fri, 04 Jan 2019 16:54:53 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - c90f24d0592a4b2fb8c6ce7ea2d2179e
+      - 6433ab2852804c2d88956a3c7bc008e6
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-f63058ce-edda-4b3b-9221-8a9e4d834122
+      - req-bc3ab245-f620-4220-8185-fe167a754458
       Content-Length:
       - '7264'
       Connection:
@@ -5679,7 +5679,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:28:59.974605Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:54:53.665977Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -5758,10 +5758,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["bjVAxajvT4m4JM-IuzFdVQ"],
-        "issued_at": "2019-01-03T19:28:59.974633Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["BPDtmqqATzemjSKcEEZINA"],
+        "issued_at": "2019-01-04T16:54:53.665999Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:00 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:53 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -5779,15 +5779,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:29:00 GMT
+      - Fri, 04 Jan 2019 16:54:53 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 4a714886660c4fa98980df1351b7beec
+      - a12555078cf34209afd8ba6102f66403
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-3b78742b-4d9a-4068-8fb6-7f3bd0c354a4
+      - req-94a5f3aa-6789-4625-841f-ed7f88fee1d4
       Content-Length:
       - '7278'
       Connection:
@@ -5799,7 +5799,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:29:00.191756Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:54:53.914325Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -5878,10 +5878,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["hHTO_L_6T2e2Z4UvrV0F0A"],
-        "issued_at": "2019-01-03T19:29:00.191794Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["gVvaKPomRhWsqJ94FSRZGA"],
+        "issued_at": "2019-01-04T16:54:53.914347Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:00 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:53 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -5899,15 +5899,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:29:00 GMT
+      - Fri, 04 Jan 2019 16:54:54 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - af0fd2a80d8b43b3a2059b6ba3dc64d8
+      - 72e3973d7e3645f59187f0b375c57f95
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-1fc88642-0a93-44d6-8aba-fd39328551bd
+      - req-f891109d-49e9-4e35-8b03-22e1132e778e
       Content-Length:
       - '7265'
       Connection:
@@ -5919,7 +5919,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:29:00.446720Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:54:54.129186Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -5998,10 +5998,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["FP6rxLOzSSW2bR0GJ_c1zw"],
-        "issued_at": "2019-01-03T19:29:00.446739Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["sAdmQv2FTO61_pNqBueh_w"],
+        "issued_at": "2019-01-04T16:54:54.129215Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:00 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:54 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -6019,15 +6019,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:29:00 GMT
+      - Fri, 04 Jan 2019 16:54:54 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 879081f1ea284bd9b05e0440c910e297
+      - e0ee06d99dea48cb88850311ca45e72c
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-74d2a576-582c-4fcd-a881-c58f930e57e0
+      - req-125653f0-8c58-45d8-99ab-56b2af5b22f6
       Content-Length:
       - '7278'
       Connection:
@@ -6039,7 +6039,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:29:00.658337Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:54:54.345432Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -6118,10 +6118,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["o0MB_zbhTn23e_LCK_vz1g"],
-        "issued_at": "2019-01-03T19:29:00.658354Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["sU0Kv840RO6ekgg_DEhAxg"],
+        "issued_at": "2019-01-04T16:54:54.345456Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:00 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:54 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/0098405163cd4c9dbb42c2cb43eb6fd3
@@ -6136,7 +6136,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8f6146f5533e4eefa88dd1f2d4382ab1
+      - b0cadf29409d40c29f77a10679357714
   response:
     status:
       code: 200
@@ -6147,16 +6147,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-60b02ce2-c5a4-4ce2-b42f-93edf45aa711
+      - req-e4d05f6a-a2bf-474b-99ae-c40dd3061b4b
       Date:
-      - Thu, 03 Jan 2019 19:29:00 GMT
+      - Fri, 04 Jan 2019 16:54:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:00 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:54 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/28db8f69ba9e4305b7fad82da4c86e74
@@ -6171,7 +6171,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 27a932aec9164b1c98dce864d61a123c
+      - efd097778b824efe833cf0c01f309378
   response:
     status:
       code: 200
@@ -6182,16 +6182,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-d5f7728d-3268-4de0-a907-e6bd163efc92
+      - req-16505fe1-f4ea-4d6b-9427-88ab9361b32c
       Date:
-      - Thu, 03 Jan 2019 19:29:00 GMT
+      - Fri, 04 Jan 2019 16:54:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:00 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:54 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/4637c33fee924ebea81f8d209e452c91
@@ -6206,7 +6206,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c90f24d0592a4b2fb8c6ce7ea2d2179e
+      - 6433ab2852804c2d88956a3c7bc008e6
   response:
     status:
       code: 200
@@ -6217,16 +6217,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-a07c7c32-56d8-4ddd-98a8-d368e5e5a2c4
+      - req-6c13d95a-36fa-4727-b7a8-df4be6a999a8
       Date:
-      - Thu, 03 Jan 2019 19:29:01 GMT
+      - Fri, 04 Jan 2019 16:54:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 20, "network": 20, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:01 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:54 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/52c452d7763a4295950527948232a3e5
@@ -6241,7 +6241,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4a714886660c4fa98980df1351b7beec
+      - a12555078cf34209afd8ba6102f66403
   response:
     status:
       code: 200
@@ -6252,16 +6252,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-6df13cc1-95fb-4392-8eb6-776943473454
+      - req-8bd2f392-8962-48a9-a532-0ac0a654469c
       Date:
-      - Thu, 03 Jan 2019 19:29:01 GMT
+      - Fri, 04 Jan 2019 16:54:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:01 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:54 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/88ae57d444fd485ab2dfddd5a2615d52
@@ -6276,7 +6276,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8e7d59b042a545f1b0e50d4bfc28fd9b
+      - e11422c5956b435687431a180412ae38
   response:
     status:
       code: 200
@@ -6287,16 +6287,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-b67e9b35-5e63-4859-8e34-c17987058309
+      - req-d7994a5d-5ac1-4186-af28-08d20c95ab58
       Date:
-      - Thu, 03 Jan 2019 19:29:01 GMT
+      - Fri, 04 Jan 2019 16:54:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:01 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:54 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/d09cbe26295d47ff848ea73c74264e23
@@ -6311,7 +6311,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - af0fd2a80d8b43b3a2059b6ba3dc64d8
+      - 72e3973d7e3645f59187f0b375c57f95
   response:
     status:
       code: 200
@@ -6322,16 +6322,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-b3f898c6-18f0-484a-b2d3-6488a51e049c
+      - req-18b386ee-9d3a-4624-9b42-b9bd22e71e7a
       Date:
-      - Thu, 03 Jan 2019 19:29:01 GMT
+      - Fri, 04 Jan 2019 16:54:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:01 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:55 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/ef2a3405d1ef4dfd9a3616993ef46a4d
@@ -6346,7 +6346,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 879081f1ea284bd9b05e0440c910e297
+      - e0ee06d99dea48cb88850311ca45e72c
   response:
     status:
       code: 200
@@ -6357,16 +6357,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-c7c12498-5b6b-460e-b497-3a0c5bfd6bb1
+      - req-bbe3ab85-6499-40e2-af3d-6863bacd5b15
       Date:
-      - Thu, 03 Jan 2019 19:29:01 GMT
+      - Fri, 04 Jan 2019 16:54:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:01 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:55 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/98b5cc33-7fb8-42b3-86f0-b35883e902aa/os-volume_attachments
@@ -6381,7 +6381,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7555c7a4e6bc431697561cae8f862603
+      - 0567a65438ff454fabd68fa89ac27e68
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6394,15 +6394,15 @@ http_interactions:
       Content-Length:
       - '197'
       X-Compute-Request-Id:
-      - req-9114754f-0b42-4bef-824f-b450f3b3d488
+      - req-25432de7-9bd1-4975-b69e-a8984b2d39ba
       Date:
-      - Thu, 03 Jan 2019 19:29:01 GMT
+      - Fri, 04 Jan 2019 16:54:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumeAttachments": [{"device": "/dev/vda", "serverId": "98b5cc33-7fb8-42b3-86f0-b35883e902aa",
         "id": "032b36d1-3dfc-4ff8-af30-5fa74ff47a39", "volumeId": "032b36d1-3dfc-4ff8-af30-5fa74ff47a39"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:01 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:55 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/7edb7855-d974-4e45-8ad2-88491541ab91/os-volume_attachments
@@ -6417,7 +6417,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7555c7a4e6bc431697561cae8f862603
+      - 0567a65438ff454fabd68fa89ac27e68
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6430,15 +6430,15 @@ http_interactions:
       Content-Length:
       - '197'
       X-Compute-Request-Id:
-      - req-93c307d9-be72-465b-bf00-ce843d3b3964
+      - req-08c62d0c-a7eb-4991-b6f9-ea7b292c7bf1
       Date:
-      - Thu, 03 Jan 2019 19:29:01 GMT
+      - Fri, 04 Jan 2019 16:54:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumeAttachments": [{"device": "/dev/vdd", "serverId": "7edb7855-d974-4e45-8ad2-88491541ab91",
         "id": "8791e24f-874d-4f1e-99ec-75fdb9d48ca5", "volumeId": "8791e24f-874d-4f1e-99ec-75fdb9d48ca5"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:01 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:55 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -6456,15 +6456,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:29:01 GMT
+      - Fri, 04 Jan 2019 16:54:55 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - d6e1737748624fb9b884015b9b104e95
+      - 8e513c11353d4f3194b8cfac02ee6a9e
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-012ec2ae-e6e7-4b70-a4ee-bcdc24afc81b
+      - req-f19a0fe6-54be-4a5d-aad2-4e8e30f95dc2
       Content-Length:
       - '7311'
       Connection:
@@ -6476,7 +6476,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2019-01-03T20:29:01.962077Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2019-01-04T17:54:55.670614Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -6555,10 +6555,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["ydqFTHAGSA-PU2CAsfEhKQ"],
-        "issued_at": "2019-01-03T19:29:01.962109Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Nps0CuY3TzCc5rnv5fS9GQ"],
+        "issued_at": "2019-01-04T16:54:55.670635Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:01 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:55 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -6576,15 +6576,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:29:02 GMT
+      - Fri, 04 Jan 2019 16:54:55 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 41e3f3589a074f0a877f76f73f21984a
+      - 595120d263e444a6971df6701836c962
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-492b0051-8cc5-44e3-8996-f5fd05f903d4
+      - req-ea703c6a-7e14-43f2-b767-33b587bf60dd
       Content-Length:
       - '7311'
       Connection:
@@ -6596,7 +6596,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2019-01-03T20:29:02.175408Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2019-01-04T17:54:55.878780Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -6675,10 +6675,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["DNsEgJbZTKekZ5MPzd9X8g"],
-        "issued_at": "2019-01-03T19:29:02.175439Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["EMgfTbxeSMaubyCVDUEQOw"],
+        "issued_at": "2019-01-04T16:54:55.878801Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:02 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:55 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-aggregates
@@ -6693,7 +6693,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7555c7a4e6bc431697561cae8f862603
+      - 0567a65438ff454fabd68fa89ac27e68
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6706,14 +6706,14 @@ http_interactions:
       Content-Length:
       - '18'
       X-Compute-Request-Id:
-      - req-16b22897-f0d1-481e-86ab-ec03769da908
+      - req-d0d5757d-63c4-41cc-ad1a-bc8d4254dfe6
       Date:
-      - Thu, 03 Jan 2019 19:29:02 GMT
+      - Fri, 04 Jan 2019 16:54:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"aggregates": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:02 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:56 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/volumes/detail?all_tenants=True&limit=1000&status=available
@@ -6728,22 +6728,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 443852d8dba7463887caafdfdfbe1e11
+      - 1f305a9e8c4e4830af2750a162287254
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-fd0b2357-152e-43a4-8873-4caa99fff7e0
+      - req-7decdf2d-85ad-4aae-90a4-de72c4299c14
       Content-Type:
       - application/json
       Content-Length:
       - '2740'
       X-Openstack-Request-Id:
-      - req-fd0b2357-152e-43a4-8873-4caa99fff7e0
+      - req-7decdf2d-85ad-4aae-90a4-de72c4299c14
       Date:
-      - Thu, 03 Jan 2019 19:29:02 GMT
+      - Fri, 04 Jan 2019 16:54:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/volumes/detail?all_tenants=True&limit=1000&status=available&marker=f46458aa-309d-4f47-b996-a39db065030a",
@@ -6776,7 +6776,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-4", "bootable": "true", "created_at":
         "2016-08-19T08:37:45.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:02 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:56 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/volumes/detail?all_tenants=True&limit=1000&marker=f46458aa-309d-4f47-b996-a39db065030a&status=available
@@ -6791,22 +6791,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 443852d8dba7463887caafdfdfbe1e11
+      - 1f305a9e8c4e4830af2750a162287254
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-40697737-2bba-4c70-9e0f-c1e665ba1be7
+      - req-4e7f6350-647a-4238-b49e-d4707661a846
       Content-Type:
       - application/json
       Content-Length:
       - '1180'
       X-Openstack-Request-Id:
-      - req-40697737-2bba-4c70-9e0f-c1e665ba1be7
+      - req-4e7f6350-647a-4238-b49e-d4707661a846
       Date:
-      - Thu, 03 Jan 2019 19:29:02 GMT
+      - Fri, 04 Jan 2019 16:54:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": [{"migration_status": null, "attachments": [], "links":
@@ -6823,7 +6823,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-FromSnapshot", "bootable": "false", "created_at":
         "2016-08-19T08:37:13.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:02 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:56 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/snapshots/detail
@@ -6838,27 +6838,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 443852d8dba7463887caafdfdfbe1e11
+      - 1f305a9e8c4e4830af2750a162287254
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-0d4dd1e5-efb0-40f4-a5fb-d1c5ac4e9f4e
+      - req-a89bea73-00be-4082-817b-08735dab56ca
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-0d4dd1e5-efb0-40f4-a5fb-d1c5ac4e9f4e
+      - req-a89bea73-00be-4082-817b-08735dab56ca
       Date:
-      - Thu, 03 Jan 2019 19:29:02 GMT
+      - Fri, 04 Jan 2019 16:54:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:02 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:56 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/snapshots/detail?all_tenants=True&limit=1000&status=available
@@ -6873,22 +6873,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 443852d8dba7463887caafdfdfbe1e11
+      - 1f305a9e8c4e4830af2750a162287254
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-e39d204d-c405-4233-85d1-53e31c1895c1
+      - req-a4ab744d-8936-4fb7-b25b-22ddf104e78a
       Content-Type:
       - application/json
       Content-Length:
       - '1098'
       X-Openstack-Request-Id:
-      - req-e39d204d-c405-4233-85d1-53e31c1895c1
+      - req-a4ab744d-8936-4fb7-b25b-22ddf104e78a
       Date:
-      - Thu, 03 Jan 2019 19:29:02 GMT
+      - Fri, 04 Jan 2019 16:54:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/snapshots/detail?all_tenants=True&limit=1000&status=available&marker=c44d3eb3-31fe-46ed-bfae-707920be171d",
@@ -6903,7 +6903,7 @@ http_interactions:
         "created_at": "2016-08-19T08:37:24.000000", "size": 1, "id": "c44d3eb3-31fe-46ed-bfae-707920be171d",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:02 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:56 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/volumes/detail?all_tenants=True&limit=1000
@@ -6918,22 +6918,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 443852d8dba7463887caafdfdfbe1e11
+      - 1f305a9e8c4e4830af2750a162287254
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-97d4a4d5-5bf5-421e-b7a5-90869b9e21b6
+      - req-37bf86f6-5d1f-43b8-a84e-a97cb3e6d6f7
       Content-Type:
       - application/json
       Content-Length:
       - '2723'
       X-Openstack-Request-Id:
-      - req-97d4a4d5-5bf5-421e-b7a5-90869b9e21b6
+      - req-37bf86f6-5d1f-43b8-a84e-a97cb3e6d6f7
       Date:
-      - Thu, 03 Jan 2019 19:29:02 GMT
+      - Fri, 04 Jan 2019 16:54:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/volumes/detail?all_tenants=True&limit=1000&marker=f46458aa-309d-4f47-b996-a39db065030a",
@@ -6966,7 +6966,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-4", "bootable": "true", "created_at":
         "2016-08-19T08:37:45.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:02 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:56 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/volumes/detail?all_tenants=True&limit=1000&marker=f46458aa-309d-4f47-b996-a39db065030a
@@ -6981,22 +6981,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 443852d8dba7463887caafdfdfbe1e11
+      - 1f305a9e8c4e4830af2750a162287254
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-2b215cbc-268a-414f-a3a7-bbba3990c607
+      - req-b869f84f-b2fc-4eb1-84ac-59a608f0f70e
       Content-Type:
       - application/json
       Content-Length:
       - '3301'
       X-Openstack-Request-Id:
-      - req-2b215cbc-268a-414f-a3a7-bbba3990c607
+      - req-b869f84f-b2fc-4eb1-84ac-59a608f0f70e
       Date:
-      - Thu, 03 Jan 2019 19:29:03 GMT
+      - Fri, 04 Jan 2019 16:54:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/volumes/detail?all_tenants=True&limit=1000&marker=476a0c89-4322-42aa-b7ce-3ac21be55af7",
@@ -7037,7 +7037,7 @@ http_interactions:
         "name": "EmsRefreshSpec-Volume-2", "bootable": "false", "created_at": "2016-08-19T08:37:33.000000",
         "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:03 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:56 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/volumes/detail?all_tenants=True&limit=1000&marker=476a0c89-4322-42aa-b7ce-3ac21be55af7
@@ -7052,22 +7052,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 443852d8dba7463887caafdfdfbe1e11
+      - 1f305a9e8c4e4830af2750a162287254
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-91658745-8688-48aa-b268-c66b0e09ea6e
+      - req-766ef52b-8a56-4a58-a7f6-73c762e58c12
       Content-Type:
       - application/json
       Content-Length:
       - '2770'
       X-Openstack-Request-Id:
-      - req-91658745-8688-48aa-b268-c66b0e09ea6e
+      - req-766ef52b-8a56-4a58-a7f6-73c762e58c12
       Date:
-      - Thu, 03 Jan 2019 19:29:03 GMT
+      - Fri, 04 Jan 2019 16:54:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/volumes/detail?all_tenants=True&limit=1000&marker=8791e24f-874d-4f1e-99ec-75fdb9d48ca5",
@@ -7101,7 +7101,7 @@ http_interactions:
         "bootable": "false", "created_at": "2016-08-19T08:37:05.000000", "volume_type":
         "iscsi"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:03 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:57 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/volumes/detail?all_tenants=True&limit=1000&marker=8791e24f-874d-4f1e-99ec-75fdb9d48ca5
@@ -7116,27 +7116,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 443852d8dba7463887caafdfdfbe1e11
+      - 1f305a9e8c4e4830af2750a162287254
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-2933b312-7577-4f3b-8451-a055e92c7189
+      - req-79cbc576-7600-4279-97ee-266e173f2c55
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-2933b312-7577-4f3b-8451-a055e92c7189
+      - req-79cbc576-7600-4279-97ee-266e173f2c55
       Date:
-      - Thu, 03 Jan 2019 19:29:03 GMT
+      - Fri, 04 Jan 2019 16:54:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:03 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:57 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -7154,15 +7154,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:29:04 GMT
+      - Fri, 04 Jan 2019 16:54:58 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - e04178ecab984374bbc693c7db7f36ff
+      - 8b010606a2eb4e59b4402f236c55c4cc
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-c04065e5-da33-419d-8a3d-c976d48a8a25
+      - req-5bd12ae2-2ee0-46e0-a1c3-ea4ff5672a13
       Content-Length:
       - '7311'
       Connection:
@@ -7174,7 +7174,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2019-01-03T20:29:04.601095Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2019-01-04T17:54:58.361395Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -7253,10 +7253,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["DzOu41aKSJCQaC07XVH0qQ"],
-        "issued_at": "2019-01-03T19:29:04.601114Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["IPzK15M2TMKqv66OEdVCMQ"],
+        "issued_at": "2019-01-04T16:54:58.361417Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:04 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:58 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -7274,15 +7274,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:29:04 GMT
+      - Fri, 04 Jan 2019 16:54:58 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 71629f0e64fd4fcd9d4496058026faaa
+      - 97d81708d6724a60bfb5abccaa507fc0
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-fa7efa0f-43a0-4841-9ca2-5c8418323afd
+      - req-45a276d9-cbbf-4f32-8cc9-365f7826a069
       Content-Length:
       - '7311'
       Connection:
@@ -7294,7 +7294,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2019-01-03T20:29:04.810827Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2019-01-04T17:54:58.571559Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -7373,10 +7373,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["6zNcEMxeR8WsUg_7f7R7mg"],
-        "issued_at": "2019-01-03T19:29:04.810845Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["8z080quASmKptcKYQrin4w"],
+        "issued_at": "2019-01-04T16:54:58.571588Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:04 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:58 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/networks
@@ -7391,7 +7391,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 71629f0e64fd4fcd9d4496058026faaa
+      - 97d81708d6724a60bfb5abccaa507fc0
   response:
     status:
       code: 200
@@ -7402,37 +7402,12 @@ http_interactions:
       Content-Length:
       - '5330'
       X-Openstack-Request-Id:
-      - req-a5a13866-5a59-4a44-829b-6774e6cadcfa
+      - req-b877cda7-03ef-4534-a699-2aff8dc41509
       Date:
-      - Thu, 03 Jan 2019 19:29:04 GMT
+      - Fri, 04 Jan 2019 16:54:58 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"networks": [{"status": "ACTIVE", "subnets": ["75e7a9c8-eeaf-4cd0-80da-05165f897e69"],
-        "name": "EmsRefreshSpec-NetworkPublic_10", "provider:physical_network": "public_net_1",
-        "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
-        0, "router:external": true, "shared": false, "provider:network_type": "flat",
-        "id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "provider:segmentation_id":
-        null}, {"status": "ACTIVE", "subnets": ["a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
-        "9bb84a96-3a02-45be-9b16-b0db19c167db"], "name": "EmsRefreshSpec-NetworkPublic_50",
-        "provider:physical_network": "public_net_5", "admin_state_up": true, "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "mtu": 0, "router:external": true, "shared":
-        false, "provider:network_type": "flat", "id": "f4823e3f-2c96-44e8-9366-915319145d8a",
-        "provider:segmentation_id": null}, {"status": "ACTIVE", "subnets": ["3be7c490-3820-43ad-8bc4-00d0367b8d21",
-        "c2ab9441-dd1c-4acc-a3a6-753f1a582291"], "name": "EmsRefreshSpec-NetworkPrivate_30",
-        "provider:physical_network": null, "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
-        "vxlan", "id": "91eed80f-14a3-41a1-8acb-558dd451ecec", "provider:segmentation_id":
-        59}, {"status": "ACTIVE", "subnets": ["c53efdb0-e706-4c94-b0e5-a9a2eb84b459"],
-        "name": "EmsRefreshSpec-IsolatedNetworkPrivate_1", "provider:physical_network":
-        null, "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
-        "vxlan", "id": "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "provider:segmentation_id":
-        13}, {"status": "ACTIVE", "subnets": ["64f64a1d-46bf-4862-a654-b004310cbd7f"],
-        "name": "EmsRefreshSpec-NetworkPrivate_2", "provider:physical_network": null,
-        "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
-        0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
-        "id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "provider:segmentation_id":
-        64}, {"status": "ACTIVE", "subnets": ["bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b"],
+      string: '{"networks": [{"status": "ACTIVE", "subnets": ["bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b"],
         "name": "EmsRefreshSpec-NetworkPublic_30", "provider:physical_network": "public_net_3",
         "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
         0, "router:external": true, "shared": false, "provider:network_type": "flat",
@@ -7467,14 +7442,39 @@ http_interactions:
         "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
         0, "router:external": true, "shared": false, "provider:network_type": "flat",
         "id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "provider:segmentation_id":
-        null}, {"status": "ACTIVE", "subnets": ["f4c17602-9618-4604-b3c9-9e4801d094d3",
+        null}, {"status": "ACTIVE", "subnets": ["c2ab9441-dd1c-4acc-a3a6-753f1a582291",
+        "3be7c490-3820-43ad-8bc4-00d0367b8d21"], "name": "EmsRefreshSpec-NetworkPrivate_30",
+        "provider:physical_network": null, "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
+        "vxlan", "id": "91eed80f-14a3-41a1-8acb-558dd451ecec", "provider:segmentation_id":
+        59}, {"status": "ACTIVE", "subnets": ["75e7a9c8-eeaf-4cd0-80da-05165f897e69"],
+        "name": "EmsRefreshSpec-NetworkPublic_10", "provider:physical_network": "public_net_1",
+        "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
+        0, "router:external": true, "shared": false, "provider:network_type": "flat",
+        "id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "provider:segmentation_id":
+        null}, {"status": "ACTIVE", "subnets": ["a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
+        "9bb84a96-3a02-45be-9b16-b0db19c167db"], "name": "EmsRefreshSpec-NetworkPublic_50",
+        "provider:physical_network": "public_net_5", "admin_state_up": true, "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "mtu": 0, "router:external": true, "shared":
+        false, "provider:network_type": "flat", "id": "f4823e3f-2c96-44e8-9366-915319145d8a",
+        "provider:segmentation_id": null}, {"status": "ACTIVE", "subnets": ["c53efdb0-e706-4c94-b0e5-a9a2eb84b459"],
+        "name": "EmsRefreshSpec-IsolatedNetworkPrivate_1", "provider:physical_network":
+        null, "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
+        "vxlan", "id": "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "provider:segmentation_id":
+        13}, {"status": "ACTIVE", "subnets": ["64f64a1d-46bf-4862-a654-b004310cbd7f"],
+        "name": "EmsRefreshSpec-NetworkPrivate_2", "provider:physical_network": null,
+        "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
+        0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
+        "id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "provider:segmentation_id":
+        64}, {"status": "ACTIVE", "subnets": ["f4c17602-9618-4604-b3c9-9e4801d094d3",
         "24c83610-eab6-4f68-99dd-ab22a638b4a0"], "name": "EmsRefreshSpec-NetworkPrivate",
         "provider:physical_network": null, "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
         "vxlan", "id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "provider:segmentation_id":
         11}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:04 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:58 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -7492,15 +7492,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:29:05 GMT
+      - Fri, 04 Jan 2019 16:54:58 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 90192c46debc4009b40492107045de00
+      - 37d2597c004c4d05bdba95f63229fd8c
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-50f9cc37-3882-4bba-8ca9-7a51604a301f
+      - req-e50bdf99-a938-4c50-b524-1280d5c2481c
       Content-Length:
       - '7311'
       Connection:
@@ -7512,7 +7512,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2019-01-03T20:29:05.158801Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2019-01-04T17:54:58.959704Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -7591,10 +7591,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["uBgBVKUiRQKvIe8cwrDbYg"],
-        "issued_at": "2019-01-03T19:29:05.158820Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["TT76Tta5ThGNyI067PZmOg"],
+        "issued_at": "2019-01-04T16:54:58.959726Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:05 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:58 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -7612,15 +7612,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:29:05 GMT
+      - Fri, 04 Jan 2019 16:54:59 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 8d719a12a9a9434f8f42bd36cbb4e84e
+      - 9743b8517c46488f9d55e9398cd3010a
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-d4ad3e8c-2173-4cd9-b551-f37197e497f9
+      - req-10f1e53b-9266-49fa-b66a-5b486d3a7193
       Content-Length:
       - '297'
       Connection:
@@ -7629,12 +7629,12 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"token": {"methods": ["password"], "expires_at": "2019-01-03T20:29:05.332022Z",
+      string: '{"token": {"methods": ["password"], "expires_at": "2019-01-04T17:54:59.141035Z",
         "extras": {}, "user": {"domain": {"id": "default", "name": "Default"}, "id":
-        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["MHmzsOczRI2RPh0KL18Rlw"],
-        "issued_at": "2019-01-03T19:29:05.332040Z"}}'
+        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["-z4RWuoER8erD5E1HKw6zQ"],
+        "issued_at": "2019-01-04T16:54:59.141056Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:05 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:59 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects?domain_id=default
@@ -7649,20 +7649,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8d719a12a9a9434f8f42bd36cbb4e84e
+      - 9743b8517c46488f9d55e9398cd3010a
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:29:05 GMT
+      - Fri, 04 Jan 2019 16:54:59 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-7a86e9f3-a26f-49b0-883d-2f0562089d37
+      - req-b5757cd2-a1ef-4a20-a9a8-8c61b9ac3e05
       Content-Length:
       - '2475'
       Connection:
@@ -7695,7 +7695,7 @@ http_interactions:
         "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
         "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:05 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:59 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -7713,15 +7713,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:29:05 GMT
+      - Fri, 04 Jan 2019 16:54:59 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - cf884ddf6440449b87c5cff8a4e20d2c
+      - dae439c06f194e8f9fe712212d08f826
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-9f2026df-74ec-4a5b-98b0-608a224b06db
+      - req-2923346f-fee3-437d-875f-2278d4a01d92
       Content-Length:
       - '7278'
       Connection:
@@ -7733,7 +7733,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:29:05.669443Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:54:59.479132Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -7812,10 +7812,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["6b-Xg-EDQXaexZEuLVcctQ"],
-        "issued_at": "2019-01-03T19:29:05.669461Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["5NzVFsY7Td2CHJQQXrrQTw"],
+        "issued_at": "2019-01-04T16:54:59.479151Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:05 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:59 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -7833,15 +7833,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:29:05 GMT
+      - Fri, 04 Jan 2019 16:54:59 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - f1f89730b923438b83f517c111ef99e0
+      - 0d136534de32457b990c10a64f0963ac
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-d3e37930-1958-42cb-8c9c-5a0f5285b79f
+      - req-cdc5598f-cd3e-48b8-86f0-618ece609510
       Content-Length:
       - '7278'
       Connection:
@@ -7853,7 +7853,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:29:05.873181Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:54:59.690419Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -7932,10 +7932,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["5z3mAH8nRmWP30ds0-yXOw"],
-        "issued_at": "2019-01-03T19:29:05.873199Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["xprphYVoR3aE6drmK3XGDQ"],
+        "issued_at": "2019-01-04T16:54:59.690439Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:05 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:59 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -7953,15 +7953,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:29:06 GMT
+      - Fri, 04 Jan 2019 16:54:59 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 864e8f101ad449e7a5ccfceb630a4dee
+      - fd3f5999cffc430d874c4a29a689ae25
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-80446294-96ac-49bb-92b0-9028f3dd4432
+      - req-4b76a6ad-5a36-4010-9435-bc308e918ab3
       Content-Length:
       - '7264'
       Connection:
@@ -7973,7 +7973,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:29:06.079784Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:54:59.896874Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -8052,10 +8052,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["W-IujqvfSLSjrUyZ_d9ICg"],
-        "issued_at": "2019-01-03T19:29:06.079802Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["h9Mmpu5BSZK3scAREuxYXw"],
+        "issued_at": "2019-01-04T16:54:59.896894Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:06 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:59 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -8073,15 +8073,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:29:06 GMT
+      - Fri, 04 Jan 2019 16:55:00 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - d4f3fa592e62415383aadf89542ae4bc
+      - 15de8a7e242846629364f5da4b836ef2
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-db8bdce3-3111-47ac-9686-215d2a16761b
+      - req-3635d29b-176f-483e-b635-0035f1eaa984
       Content-Length:
       - '7278'
       Connection:
@@ -8093,7 +8093,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:29:06.274027Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:55:00.105210Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -8172,10 +8172,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["CMQjoAMjQP2EEDMSdGDHaw"],
-        "issued_at": "2019-01-03T19:29:06.274045Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["9-xKdAIiSpGL7mV7-KISjA"],
+        "issued_at": "2019-01-04T16:55:00.105230Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:06 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:00 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -8193,15 +8193,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:29:06 GMT
+      - Fri, 04 Jan 2019 16:55:00 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 69364bbcbeea48e090d802ce62f81049
+      - fce689059a7b45c1bd4eb6e7c2b0e256
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-08f8a371-fe22-4072-aeb6-6d9b1b18d116
+      - req-6dc1a643-fc1a-43b7-8c10-ae137eb98e81
       Content-Length:
       - '7265'
       Connection:
@@ -8213,7 +8213,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:29:06.481930Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:55:00.314977Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -8292,10 +8292,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["4UsyLO0pQLehIkvIq0Moag"],
-        "issued_at": "2019-01-03T19:29:06.481972Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["waoDDxHRTRSN7QPc5URQvw"],
+        "issued_at": "2019-01-04T16:55:00.315003Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:06 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:00 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -8313,15 +8313,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:29:06 GMT
+      - Fri, 04 Jan 2019 16:55:00 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - b6cc481cdfb146158859de17ef2bd8c0
+      - f38393ac68044b0789cb2b6441f6cd72
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-f2bf1102-b13a-4a7c-b970-6128dced7643
+      - req-e6b29dab-6431-4b2d-87bf-83bca8be3b63
       Content-Length:
       - '7278'
       Connection:
@@ -8333,7 +8333,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:29:06.699019Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:55:00.522557Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -8412,10 +8412,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["g7YbuVu0RGqiSVuxBrlVGg"],
-        "issued_at": "2019-01-03T19:29:06.699042Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["T633uokfRiu6-1BoYpsNGg"],
+        "issued_at": "2019-01-04T16:55:00.522577Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:06 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:00 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/0098405163cd4c9dbb42c2cb43eb6fd3/stacks?limit=1000&show_nested=true
@@ -8430,7 +8430,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cf884ddf6440449b87c5cff8a4e20d2c
+      - dae439c06f194e8f9fe712212d08f826
   response:
     status:
       code: 200
@@ -8441,14 +8441,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-95bfa896-d8b3-440e-a371-a60e9932fea7
+      - req-b445478d-394e-4608-8c1a-9339d0ad1b1a
       Date:
-      - Thu, 03 Jan 2019 19:29:06 GMT
+      - Fri, 04 Jan 2019 16:55:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:06 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:00 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/28db8f69ba9e4305b7fad82da4c86e74/stacks?limit=1000&show_nested=true
@@ -8463,7 +8463,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f1f89730b923438b83f517c111ef99e0
+      - 0d136534de32457b990c10a64f0963ac
   response:
     status:
       code: 200
@@ -8474,14 +8474,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-cab6524d-a171-4150-b042-f9ecbf28dc6e
+      - req-ccefb865-ac3a-4d4a-bd5c-ed9bdcc6685c
       Date:
-      - Thu, 03 Jan 2019 19:29:06 GMT
+      - Fri, 04 Jan 2019 16:55:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:06 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:00 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks?limit=1000&show_nested=true
@@ -8496,7 +8496,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 864e8f101ad449e7a5ccfceb630a4dee
+      - fd3f5999cffc430d874c4a29a689ae25
   response:
     status:
       code: 200
@@ -8507,9 +8507,9 @@ http_interactions:
       Content-Length:
       - '2559'
       X-Openstack-Request-Id:
-      - req-d1b57d1a-f91d-41fc-8815-68753ab7844e
+      - req-692aee65-43dd-4ee2-afd2-62467f50b283
       Date:
-      - Thu, 03 Jan 2019 19:29:07 GMT
+      - Fri, 04 Jan 2019 16:55:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": [{"description": "Heat WordPress template to support F20,
@@ -8543,7 +8543,7 @@ http_interactions:
         "rel": "self"}], "updated_time": null, "stack_owner": null, "stack_status":
         "CREATE_COMPLETE", "id": "7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:07 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:01 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks?limit=1000&marker=7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0&show_nested=true
@@ -8558,7 +8558,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 864e8f101ad449e7a5ccfceb630a4dee
+      - fd3f5999cffc430d874c4a29a689ae25
   response:
     status:
       code: 200
@@ -8569,14 +8569,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-c0da7959-530e-43d9-a55a-087f544d1b3b
+      - req-e5e5fa3a-206a-4ac7-b37f-aa063214ebc9
       Date:
-      - Thu, 03 Jan 2019 19:29:07 GMT
+      - Fri, 04 Jan 2019 16:55:01 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:07 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:01 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/52c452d7763a4295950527948232a3e5/stacks?limit=1000&show_nested=true
@@ -8591,7 +8591,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d4f3fa592e62415383aadf89542ae4bc
+      - 15de8a7e242846629364f5da4b836ef2
   response:
     status:
       code: 200
@@ -8602,14 +8602,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-4ac48a9c-b003-4365-9eb3-f6ae78a41c54
+      - req-6c9e6365-9180-4d03-9c47-7c3dc6864f5b
       Date:
-      - Thu, 03 Jan 2019 19:29:07 GMT
+      - Fri, 04 Jan 2019 16:55:01 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:07 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:01 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/88ae57d444fd485ab2dfddd5a2615d52/stacks?limit=1000&show_nested=true
@@ -8624,7 +8624,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 90192c46debc4009b40492107045de00
+      - 37d2597c004c4d05bdba95f63229fd8c
   response:
     status:
       code: 200
@@ -8635,14 +8635,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-7ca24d6c-1956-45fc-bc8e-0bc65bc37748
+      - req-50404cbb-6a5d-4423-a6db-c81966f0be47
       Date:
-      - Thu, 03 Jan 2019 19:29:07 GMT
+      - Fri, 04 Jan 2019 16:55:01 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:07 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:01 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/d09cbe26295d47ff848ea73c74264e23/stacks?limit=1000&show_nested=true
@@ -8657,7 +8657,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 69364bbcbeea48e090d802ce62f81049
+      - fce689059a7b45c1bd4eb6e7c2b0e256
   response:
     status:
       code: 200
@@ -8668,14 +8668,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-0b7a3207-fd85-4cd4-bcc1-936daa4d4a00
+      - req-3c47c6cd-4588-46e5-98a6-edd4de22fed3
       Date:
-      - Thu, 03 Jan 2019 19:29:07 GMT
+      - Fri, 04 Jan 2019 16:55:01 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:07 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:01 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/ef2a3405d1ef4dfd9a3616993ef46a4d/stacks?limit=1000&show_nested=true
@@ -8690,7 +8690,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b6cc481cdfb146158859de17ef2bd8c0
+      - f38393ac68044b0789cb2b6441f6cd72
   response:
     status:
       code: 200
@@ -8701,14 +8701,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-0eed2668-6d25-46b7-9240-fdaa52fc8ca7
+      - req-ba6eecc8-7ef6-460e-b2bd-16cdb60d94dd
       Date:
-      - Thu, 03 Jan 2019 19:29:07 GMT
+      - Fri, 04 Jan 2019 16:55:01 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:07 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:01 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack3/00c5dc04-2c94-48d2-8031-db08934e9a44
@@ -8723,7 +8723,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 864e8f101ad449e7a5ccfceb630a4dee
+      - fd3f5999cffc430d874c4a29a689ae25
   response:
     status:
       code: 200
@@ -8734,9 +8734,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-d690b876-685e-4403-952b-59928778e3a7
+      - req-9814a97c-ed7e-409b-9219-7e4fff60b9e3
       Date:
-      - Thu, 03 Jan 2019 19:29:07 GMT
+      - Fri, 04 Jan 2019 16:55:01 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -8763,7 +8763,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:08 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:01 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack2/d6eba2a2-7b0d-4213-afbb-69c8f6dddd8d
@@ -8778,7 +8778,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 864e8f101ad449e7a5ccfceb630a4dee
+      - fd3f5999cffc430d874c4a29a689ae25
   response:
     status:
       code: 200
@@ -8789,9 +8789,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-51f6088d-89d7-405a-9e46-67b0eec04da9
+      - req-4e64d070-cd87-4803-9423-8e5d301c06b2
       Date:
-      - Thu, 03 Jan 2019 19:29:09 GMT
+      - Fri, 04 Jan 2019 16:55:02 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -8818,7 +8818,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:09 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:02 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack1/7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0
@@ -8833,7 +8833,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 864e8f101ad449e7a5ccfceb630a4dee
+      - fd3f5999cffc430d874c4a29a689ae25
   response:
     status:
       code: 200
@@ -8844,9 +8844,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-8783eea5-7d00-4d61-9d44-7f7316e4fc8f
+      - req-ee7146bc-3be9-4ff3-84a7-272faee3656e
       Date:
-      - Thu, 03 Jan 2019 19:29:09 GMT
+      - Fri, 04 Jan 2019 16:55:02 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -8873,7 +8873,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:09 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:02 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack3/00c5dc04-2c94-48d2-8031-db08934e9a44/resources
@@ -8888,7 +8888,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 864e8f101ad449e7a5ccfceb630a4dee
+      - fd3f5999cffc430d874c4a29a689ae25
   response:
     status:
       code: 200
@@ -8899,9 +8899,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-a35a1276-2537-48cf-be16-4ee430d23c90
+      - req-0fcd60cc-7102-4623-989c-db148ee03f32
       Date:
-      - Thu, 03 Jan 2019 19:29:09 GMT
+      - Fri, 04 Jan 2019 16:55:02 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -8913,7 +8913,7 @@ http_interactions:
         changed", "physical_resource_id": "40989f26-9c38-4f72-b739-afccb44397cf",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:09 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:02 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack2/d6eba2a2-7b0d-4213-afbb-69c8f6dddd8d/resources
@@ -8928,7 +8928,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 864e8f101ad449e7a5ccfceb630a4dee
+      - fd3f5999cffc430d874c4a29a689ae25
   response:
     status:
       code: 200
@@ -8939,9 +8939,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-7021d7c6-1739-4343-a2c5-ec5df15d348e
+      - req-c5390f3c-d8f4-4072-96bc-22eb1bd76599
       Date:
-      - Thu, 03 Jan 2019 19:29:09 GMT
+      - Fri, 04 Jan 2019 16:55:02 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -8953,7 +8953,7 @@ http_interactions:
         changed", "physical_resource_id": "ad4f7eb0-9122-41a6-a0f7-55c1d4ca5e02",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:09 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:02 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack1/7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0/resources
@@ -8968,7 +8968,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 864e8f101ad449e7a5ccfceb630a4dee
+      - fd3f5999cffc430d874c4a29a689ae25
   response:
     status:
       code: 200
@@ -8979,9 +8979,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-652a6c7e-419f-4dd6-9fc2-45bad3081fb6
+      - req-4c70c37f-e232-42ef-927d-071d15b3a14a
       Date:
-      - Thu, 03 Jan 2019 19:29:09 GMT
+      - Fri, 04 Jan 2019 16:55:02 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -8993,7 +8993,7 @@ http_interactions:
         changed", "physical_resource_id": "8022b967-813a-4e3b-8ff4-7c036957a8a0",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:09 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:02 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/subnets?all_tenants=True&limit=1000
@@ -9008,7 +9008,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 71629f0e64fd4fcd9d4496058026faaa
+      - 97d81708d6724a60bfb5abccaa507fc0
   response:
     status:
       code: 200
@@ -9019,9 +9019,9 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-876d3004-fe77-45ff-bddb-e4b33c8762fe
+      - req-d0c0cb41-0274-4ec8-b77a-cf04d1e4f96f
       Date:
-      - Thu, 03 Jan 2019 19:29:09 GMT
+      - Fri, 04 Jan 2019 16:55:02 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
@@ -9125,7 +9125,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:09 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:03 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/subnets?all_tenants=True&limit=1000&marker=24c83610-eab6-4f68-99dd-ab22a638b4a0
@@ -9140,7 +9140,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 71629f0e64fd4fcd9d4496058026faaa
+      - 97d81708d6724a60bfb5abccaa507fc0
   response:
     status:
       code: 200
@@ -9151,9 +9151,9 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-e800d77b-2d14-4d1e-ac1f-5e4f01abc5dd
+      - req-f3b040fd-ad64-417b-94b8-ced4748d998a
       Date:
-      - Thu, 03 Jan 2019 19:29:10 GMT
+      - Fri, 04 Jan 2019 16:55:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
@@ -9257,7 +9257,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:10 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:03 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/floatingips?all_tenants=True&limit=1000
@@ -9272,7 +9272,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 71629f0e64fd4fcd9d4496058026faaa
+      - 97d81708d6724a60bfb5abccaa507fc0
   response:
     status:
       code: 200
@@ -9283,9 +9283,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-5be49f10-be25-4ecd-9fa0-e3856fa4e036
+      - req-0f12dcca-761a-4f3e-9eb9-24b166c97949
       Date:
-      - Thu, 03 Jan 2019 19:29:10 GMT
+      - Fri, 04 Jan 2019 16:55:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
@@ -9327,7 +9327,7 @@ http_interactions:
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:10 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:03 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/floatingips?all_tenants=True&limit=1000&marker=e5a4a7fd-b2c7-4a38-b725-a666d4f90f60
@@ -9342,7 +9342,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 71629f0e64fd4fcd9d4496058026faaa
+      - 97d81708d6724a60bfb5abccaa507fc0
   response:
     status:
       code: 200
@@ -9353,9 +9353,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-4c96ca37-7ed1-4b79-9087-2dcbd7c1ac91
+      - req-d5021170-f308-44e3-84e1-62f8ddb8cbfa
       Date:
-      - Thu, 03 Jan 2019 19:29:10 GMT
+      - Fri, 04 Jan 2019 16:55:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
@@ -9397,7 +9397,7 @@ http_interactions:
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:10 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:03 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/ports?all_tenants=True&limit=1000
@@ -9412,7 +9412,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 71629f0e64fd4fcd9d4496058026faaa
+      - 97d81708d6724a60bfb5abccaa507fc0
   response:
     status:
       code: 200
@@ -9423,9 +9423,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-9864932e-cf83-4c05-bceb-9c7a48a7a1d1
+      - req-bc857b50-70cb-4fce-a9a7-bb46e940f777
       Date:
-      - Thu, 03 Jan 2019 19:29:10 GMT
+      - Fri, 04 Jan 2019 16:55:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -9828,7 +9828,7 @@ http_interactions:
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:10 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:03 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/ports?all_tenants=True&limit=1000&marker=fb9152f8-5f19-4171-9b8e-f1e594c24d64
@@ -9843,7 +9843,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 71629f0e64fd4fcd9d4496058026faaa
+      - 97d81708d6724a60bfb5abccaa507fc0
   response:
     status:
       code: 200
@@ -9854,9 +9854,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-0a7890f9-4dab-45c3-9260-ee3e7c693f5b
+      - req-0693f872-9fa4-4cdf-a28e-a33e636607b1
       Date:
-      - Thu, 03 Jan 2019 19:29:10 GMT
+      - Fri, 04 Jan 2019 16:55:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -10259,7 +10259,7 @@ http_interactions:
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:10 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:03 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/routers?all_tenants=True&limit=1000
@@ -10274,7 +10274,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 71629f0e64fd4fcd9d4496058026faaa
+      - 97d81708d6724a60bfb5abccaa507fc0
   response:
     status:
       code: 200
@@ -10285,9 +10285,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-27bad552-8746-42c6-a8ae-d000e04aca67
+      - req-ba8c7a9d-4740-4bb6-b363-deb61ab824ca
       Date:
-      - Thu, 03 Jan 2019 19:29:10 GMT
+      - Fri, 04 Jan 2019 16:55:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -10319,7 +10319,7 @@ http_interactions:
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:10 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:03 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/routers?all_tenants=True&limit=1000&marker=e49f1a18-9fd8-4130-9e9f-f13b5190f9fd
@@ -10334,7 +10334,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 71629f0e64fd4fcd9d4496058026faaa
+      - 97d81708d6724a60bfb5abccaa507fc0
   response:
     status:
       code: 200
@@ -10345,9 +10345,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-cbde4e4a-441d-46fd-9374-fbb5e49d1bc9
+      - req-3e61acc4-dd3f-46c2-aca7-203fac3c0290
       Date:
-      - Thu, 03 Jan 2019 19:29:10 GMT
+      - Fri, 04 Jan 2019 16:55:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -10379,7 +10379,7 @@ http_interactions:
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:11 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:04 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000
@@ -10394,7 +10394,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 71629f0e64fd4fcd9d4496058026faaa
+      - 97d81708d6724a60bfb5abccaa507fc0
   response:
     status:
       code: 200
@@ -10405,9 +10405,9 @@ http_interactions:
       Content-Length:
       - '2751'
       X-Openstack-Request-Id:
-      - req-670f9a24-b598-473a-b212-ffb3d1abea95
+      - req-a4aab14c-bd39-4835-8990-13556ebb5b93
       Date:
-      - Thu, 03 Jan 2019 19:29:11 GMT
+      - Fri, 04 Jan 2019 16:55:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=2e57d382-aeb2-4107-85cd-9dbde325f8f7",
@@ -10442,7 +10442,7 @@ http_interactions:
         null, "port_range_min": null, "id": "7e354503-9d45-4cc4-a742-4ff9501ba396",
         "security_group_id": "2e57d382-aeb2-4107-85cd-9dbde325f8f7"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:11 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:04 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=2e57d382-aeb2-4107-85cd-9dbde325f8f7
@@ -10457,7 +10457,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 71629f0e64fd4fcd9d4496058026faaa
+      - 97d81708d6724a60bfb5abccaa507fc0
   response:
     status:
       code: 200
@@ -10468,9 +10468,9 @@ http_interactions:
       Content-Length:
       - '3418'
       X-Openstack-Request-Id:
-      - req-f444a4f3-1934-4adb-8973-0a76244bb82b
+      - req-e94a1109-7f03-4672-a242-44028fb3adfe
       Date:
-      - Thu, 03 Jan 2019 19:29:11 GMT
+      - Fri, 04 Jan 2019 16:55:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=42bcab35-fe98-49f3-ba0e-705a2737b81d",
@@ -10513,7 +10513,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "f87c3733-0682-46d9-8df1-05f1207541d1",
         "security_group_id": "42bcab35-fe98-49f3-ba0e-705a2737b81d"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:11 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:04 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=42bcab35-fe98-49f3-ba0e-705a2737b81d
@@ -10528,7 +10528,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 71629f0e64fd4fcd9d4496058026faaa
+      - 97d81708d6724a60bfb5abccaa507fc0
   response:
     status:
       code: 200
@@ -10539,9 +10539,9 @@ http_interactions:
       Content-Length:
       - '3418'
       X-Openstack-Request-Id:
-      - req-b95ac819-0c63-464b-b241-6407d1dcb3c1
+      - req-c1154644-d39b-47f4-8a75-f1e459d55a35
       Date:
-      - Thu, 03 Jan 2019 19:29:11 GMT
+      - Fri, 04 Jan 2019 16:55:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=7250f04f-facd-4731-b072-f346b1cc7a80",
@@ -10584,7 +10584,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "d0ee1562-3ff7-4ad5-b29f-8dd350ed221f",
         "security_group_id": "7250f04f-facd-4731-b072-f346b1cc7a80"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:11 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:04 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=7250f04f-facd-4731-b072-f346b1cc7a80
@@ -10599,7 +10599,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 71629f0e64fd4fcd9d4496058026faaa
+      - 97d81708d6724a60bfb5abccaa507fc0
   response:
     status:
       code: 200
@@ -10610,9 +10610,9 @@ http_interactions:
       Content-Length:
       - '8771'
       X-Openstack-Request-Id:
-      - req-9a1b1f43-9df6-4cbb-9803-adfefffaae0f
+      - req-e5a1caa2-ec54-4d6d-81dc-c269a2c4ac58
       Date:
-      - Thu, 03 Jan 2019 19:29:11 GMT
+      - Fri, 04 Jan 2019 16:55:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d",
@@ -10719,7 +10719,7 @@ http_interactions:
         "port_range_max": 65535, "port_range_min": 1, "id": "e483857b-5eb5-4cb0-94d6-b431a2f0cb10",
         "security_group_id": "8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:11 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:04 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d
@@ -10734,7 +10734,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 71629f0e64fd4fcd9d4496058026faaa
+      - 97d81708d6724a60bfb5abccaa507fc0
   response:
     status:
       code: 200
@@ -10745,9 +10745,9 @@ http_interactions:
       Content-Length:
       - '3418'
       X-Openstack-Request-Id:
-      - req-9b5c17fa-7fac-4588-9964-dce90ffbc4a4
+      - req-b629c6bc-90b8-422e-bc91-b855c62b6d79
       Date:
-      - Thu, 03 Jan 2019 19:29:11 GMT
+      - Fri, 04 Jan 2019 16:55:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=bab65d2f-4717-47eb-bfb2-95100b254563",
@@ -10789,7 +10789,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "e1aa03c0-0758-42ca-b030-a3d62800e578",
         "security_group_id": "bab65d2f-4717-47eb-bfb2-95100b254563"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:11 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:04 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=bab65d2f-4717-47eb-bfb2-95100b254563
@@ -10804,7 +10804,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 71629f0e64fd4fcd9d4496058026faaa
+      - 97d81708d6724a60bfb5abccaa507fc0
   response:
     status:
       code: 200
@@ -10815,15 +10815,15 @@ http_interactions:
       Content-Length:
       - '173'
       X-Openstack-Request-Id:
-      - req-c9df88ee-a0e5-4bf1-8ebe-83c2198d4709
+      - req-f6c0cb51-0df5-43c1-a7c4-01ccbe3261c5
       Date:
-      - Thu, 03 Jan 2019 19:29:11 GMT
+      - Fri, 04 Jan 2019 16:55:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&page_reverse=True",
         "rel": "previous"}], "security_groups": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:11 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:04 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -10841,15 +10841,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:29:12 GMT
+      - Fri, 04 Jan 2019 16:55:05 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 56b3612d5a694fd2adc1152e6c10361d
+      - 367ef460422b4957ad4d68eed4b6eda3
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-78f3c656-b861-4f1b-916b-aa4451ba90ad
+      - req-e2644057-803e-4b9b-8415-a54f46517e26
       Content-Length:
       - '7311'
       Connection:
@@ -10861,7 +10861,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2019-01-03T20:29:12.374150Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2019-01-04T17:55:05.403593Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -10940,10 +10940,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Jf1FS57VT4OP9ERr-yQDDA"],
-        "issued_at": "2019-01-03T19:29:12.374169Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["C4GESl95TbiZFdSw19roSQ"],
+        "issued_at": "2019-01-04T16:55:05.403615Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:12 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:05 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -10961,15 +10961,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:29:12 GMT
+      - Fri, 04 Jan 2019 16:55:05 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 578bbc2d9c2a4f3789a90e4225cc621f
+      - e0438d41c5004d29a141c08b5770ae98
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-e044d407-85c3-42d7-9cc9-0893093336e2
+      - req-fe2950ae-64f8-4c21-8921-25c27a204270
       Content-Length:
       - '7311'
       Connection:
@@ -10981,7 +10981,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2019-01-03T20:29:12.579373Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2019-01-04T17:55:05.622404Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -11060,10 +11060,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["ndTtQ65vTqiNL35AjUGosQ"],
-        "issued_at": "2019-01-03T19:29:12.579391Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["-Jj11-1HQzu__heXTTFFjQ"],
+        "issued_at": "2019-01-04T16:55:05.622428Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:12 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:05 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -11081,15 +11081,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:29:12 GMT
+      - Fri, 04 Jan 2019 16:55:05 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 21d862731b924c248d2c3eb95b550211
+      - 9eb2866ddcfc4e71a855f0c325bed1a6
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-35dfed37-5551-470e-85db-3175effcb959
+      - req-8a513afd-ad0a-4514-b475-87bf07bbec0c
       Content-Length:
       - '297'
       Connection:
@@ -11098,12 +11098,12 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"token": {"methods": ["password"], "expires_at": "2019-01-03T20:29:12.761039Z",
+      string: '{"token": {"methods": ["password"], "expires_at": "2019-01-04T17:55:05.799104Z",
         "extras": {}, "user": {"domain": {"id": "default", "name": "Default"}, "id":
-        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["maSQucKpS_mBnAPC_jbpEg"],
-        "issued_at": "2019-01-03T19:29:12.761057Z"}}'
+        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["2ZgiMTXuQ4-Mc2_HeXlYRw"],
+        "issued_at": "2019-01-04T16:55:05.799126Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:12 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:05 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects?domain_id=default
@@ -11118,20 +11118,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 21d862731b924c248d2c3eb95b550211
+      - 9eb2866ddcfc4e71a855f0c325bed1a6
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:29:12 GMT
+      - Fri, 04 Jan 2019 16:55:05 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-130f4d19-b74f-4e22-bb3b-1b3faf63745f
+      - req-1e20baa1-453a-4a57-95a2-be45bb5e9b58
       Content-Length:
       - '2475'
       Connection:
@@ -11164,7 +11164,7 @@ http_interactions:
         "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
         "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:12 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:05 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -11182,15 +11182,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:29:13 GMT
+      - Fri, 04 Jan 2019 16:55:06 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - e0f67635f13845a8a9d0f40c13669e6b
+      - ae421589b77b47fa9f015fb1d0e708cd
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-5fbd27bf-35fa-4c7e-8a04-ed549b46ecbd
+      - req-9cdfb9dd-5446-4bec-aeb6-7f75ab48ccaa
       Content-Length:
       - '7278'
       Connection:
@@ -11202,7 +11202,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:29:13.100836Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:55:06.143144Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -11281,10 +11281,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["1U70SdLKQZijeBLQarKrXA"],
-        "issued_at": "2019-01-03T19:29:13.100854Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["EfeN0hp4RACna0frVI_cUA"],
+        "issued_at": "2019-01-04T16:55:06.143164Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:13 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:06 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -11302,15 +11302,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:29:13 GMT
+      - Fri, 04 Jan 2019 16:55:06 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 5b983e1168754bc89d95d4dcbbce4b0d
+      - c24caf87803e4f63a3d758d3a4e5eb89
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-18ff7f3f-4cad-49d3-aedb-5c23684ce270
+      - req-c938d52e-f0ed-4264-97c0-f7c451266446
       Content-Length:
       - '7278'
       Connection:
@@ -11322,7 +11322,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:29:13.305125Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:55:06.355718Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -11401,10 +11401,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["seeY9ngsQs2tRm-AHP2vIw"],
-        "issued_at": "2019-01-03T19:29:13.305143Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["tQAyMN_oRB2OUMQ4jXdQ2g"],
+        "issued_at": "2019-01-04T16:55:06.355741Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:13 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:06 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -11422,15 +11422,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:29:13 GMT
+      - Fri, 04 Jan 2019 16:55:06 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - caef88341a9942c6bb4d5120e3362481
+      - f1466ddaf2974e53ab68de7bbbfdbe34
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-17869f14-bc3f-402a-a795-24beef386904
+      - req-da4f180c-cf19-4e5e-9573-8783ad32365b
       Content-Length:
       - '7264'
       Connection:
@@ -11442,7 +11442,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:29:13.509263Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:55:06.570602Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -11521,10 +11521,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["sQURXtckT5OIQK028ZjbNA"],
-        "issued_at": "2019-01-03T19:29:13.509281Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["dr_lC2PHRECrSxcpo-ABcA"],
+        "issued_at": "2019-01-04T16:55:06.570621Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:13 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:06 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -11542,15 +11542,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:29:13 GMT
+      - Fri, 04 Jan 2019 16:55:06 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 5451d2c8e0ae4636b52a84776d17426a
+      - a8ce40ab0716487a90a94791fa6386aa
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-c6078ac2-07b5-40fb-ad99-ad87b64a3c47
+      - req-2a66a6b9-5cb8-410e-b785-6ef739e1ff89
       Content-Length:
       - '7278'
       Connection:
@@ -11562,7 +11562,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:29:13.725649Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:55:06.774393Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -11641,10 +11641,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["pzynFFcdSbCc4Sh_r2SM1A"],
-        "issued_at": "2019-01-03T19:29:13.725667Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["09IobF1TRwe5VqXgJIdqAw"],
+        "issued_at": "2019-01-04T16:55:06.774411Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:13 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:06 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -11662,15 +11662,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:29:13 GMT
+      - Fri, 04 Jan 2019 16:55:07 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - f16e1078d731457a9792fc3c1623b426
+      - a9c8587e6ca0499a8686b134d5d871fa
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-8613a528-8710-4b0e-9897-4f278a9ed56c
+      - req-1bb4ba97-61f4-44df-9087-2415374c90c7
       Content-Length:
       - '7265'
       Connection:
@@ -11682,7 +11682,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:29:13.923063Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:55:08.042142Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -11761,10 +11761,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["uthI6fasSFqZ9qd1RqC3vQ"],
-        "issued_at": "2019-01-03T19:29:13.923080Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["FcaWFzcaTMOZjGgYQMUGlA"],
+        "issued_at": "2019-01-04T16:55:08.042163Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:13 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:08 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -11782,15 +11782,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:29:14 GMT
+      - Fri, 04 Jan 2019 16:55:08 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - '076882700e1c413499453d732e4348ad'
+      - c0cdee71e3d54a4dbf8d933460ae73dc
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-86e8645f-f49d-49ac-819c-d0147a8e9ae1
+      - req-827bf08b-004e-4fef-8ced-7d6820a924ae
       Content-Length:
       - '7278'
       Connection:
@@ -11802,7 +11802,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:29:14.160701Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:55:08.260085Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -11881,10 +11881,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["JVzWPo3ZQLONNZop_zT-3g"],
-        "issued_at": "2019-01-03T19:29:14.160726Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["l8_gGnx5Sk23xSknKz0I2Q"],
+        "issued_at": "2019-01-04T16:55:08.260105Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:14 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:08 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/volumes/detail?limit=1000
@@ -11899,27 +11899,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e0f67635f13845a8a9d0f40c13669e6b
+      - ae421589b77b47fa9f015fb1d0e708cd
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-e0acdded-dd6f-40b9-8813-5a2cff7a86bb
+      - req-d7059fcc-130c-498b-856a-7f6052d421c6
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-e0acdded-dd6f-40b9-8813-5a2cff7a86bb
+      - req-d7059fcc-130c-498b-856a-7f6052d421c6
       Date:
-      - Thu, 03 Jan 2019 19:29:14 GMT
+      - Fri, 04 Jan 2019 16:55:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:14 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:08 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/volumes/detail?limit=1000
@@ -11934,27 +11934,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5b983e1168754bc89d95d4dcbbce4b0d
+      - c24caf87803e4f63a3d758d3a4e5eb89
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-dd52afb9-6f79-47d8-af88-9464c77351e9
+      - req-04c74b66-0124-46a1-a251-b50b073e2dbf
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-dd52afb9-6f79-47d8-af88-9464c77351e9
+      - req-04c74b66-0124-46a1-a251-b50b073e2dbf
       Date:
-      - Thu, 03 Jan 2019 19:29:14 GMT
+      - Fri, 04 Jan 2019 16:55:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:14 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:08 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000
@@ -11969,22 +11969,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - caef88341a9942c6bb4d5120e3362481
+      - f1466ddaf2974e53ab68de7bbbfdbe34
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-cd5c8335-0391-4529-a91b-b02dba331a54
+      - req-735b2fff-1788-4c4d-9c09-be65f570dbbd
       Content-Type:
       - application/json
       Content-Length:
       - '2706'
       X-Openstack-Request-Id:
-      - req-cd5c8335-0391-4529-a91b-b02dba331a54
+      - req-735b2fff-1788-4c4d-9c09-be65f570dbbd
       Date:
-      - Thu, 03 Jan 2019 19:29:14 GMT
+      - Fri, 04 Jan 2019 16:55:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=f46458aa-309d-4f47-b996-a39db065030a",
@@ -12017,7 +12017,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-4", "bootable": "true", "created_at":
         "2016-08-19T08:37:45.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:14 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:08 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=f46458aa-309d-4f47-b996-a39db065030a
@@ -12032,22 +12032,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - caef88341a9942c6bb4d5120e3362481
+      - f1466ddaf2974e53ab68de7bbbfdbe34
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-45185482-7230-4c4a-b55f-ed2b19f08a03
+      - req-0607e009-c41e-40f5-b813-2a600483ad60
       Content-Type:
       - application/json
       Content-Length:
       - '3284'
       X-Openstack-Request-Id:
-      - req-45185482-7230-4c4a-b55f-ed2b19f08a03
+      - req-0607e009-c41e-40f5-b813-2a600483ad60
       Date:
-      - Thu, 03 Jan 2019 19:29:14 GMT
+      - Fri, 04 Jan 2019 16:55:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=476a0c89-4322-42aa-b7ce-3ac21be55af7",
@@ -12088,7 +12088,7 @@ http_interactions:
         "name": "EmsRefreshSpec-Volume-2", "bootable": "false", "created_at": "2016-08-19T08:37:33.000000",
         "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:14 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:08 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=476a0c89-4322-42aa-b7ce-3ac21be55af7
@@ -12103,22 +12103,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - caef88341a9942c6bb4d5120e3362481
+      - f1466ddaf2974e53ab68de7bbbfdbe34
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-3c503aa7-dbcb-4fee-b244-1bc9dbc69afb
+      - req-6526f70f-bf52-4e46-b2d1-5d22b412c889
       Content-Type:
       - application/json
       Content-Length:
       - '2753'
       X-Openstack-Request-Id:
-      - req-3c503aa7-dbcb-4fee-b244-1bc9dbc69afb
+      - req-6526f70f-bf52-4e46-b2d1-5d22b412c889
       Date:
-      - Thu, 03 Jan 2019 19:29:14 GMT
+      - Fri, 04 Jan 2019 16:55:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=8791e24f-874d-4f1e-99ec-75fdb9d48ca5",
@@ -12152,7 +12152,7 @@ http_interactions:
         "bootable": "false", "created_at": "2016-08-19T08:37:05.000000", "volume_type":
         "iscsi"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:14 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:09 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=8791e24f-874d-4f1e-99ec-75fdb9d48ca5
@@ -12167,27 +12167,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - caef88341a9942c6bb4d5120e3362481
+      - f1466ddaf2974e53ab68de7bbbfdbe34
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-300d0d7d-e67a-416e-af18-4161e1e76189
+      - req-67ee2d20-3940-4dd9-96c0-67a0980aeb73
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-300d0d7d-e67a-416e-af18-4161e1e76189
+      - req-67ee2d20-3940-4dd9-96c0-67a0980aeb73
       Date:
-      - Thu, 03 Jan 2019 19:29:15 GMT
+      - Fri, 04 Jan 2019 16:55:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:15 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:09 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/volumes/detail?limit=1000
@@ -12202,27 +12202,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5451d2c8e0ae4636b52a84776d17426a
+      - a8ce40ab0716487a90a94791fa6386aa
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-cda69aad-3561-48d9-a81e-986a97098507
+      - req-b7a4d8a8-4e50-41e1-bbe5-673c5158f1b4
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-cda69aad-3561-48d9-a81e-986a97098507
+      - req-b7a4d8a8-4e50-41e1-bbe5-673c5158f1b4
       Date:
-      - Thu, 03 Jan 2019 19:29:15 GMT
+      - Fri, 04 Jan 2019 16:55:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:15 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:09 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/volumes/detail?limit=1000
@@ -12237,27 +12237,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 578bbc2d9c2a4f3789a90e4225cc621f
+      - e0438d41c5004d29a141c08b5770ae98
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-4895dd90-8cb3-4411-94e7-ccaff3c7a04f
+      - req-46d5961b-98e0-4159-a628-5d5142c975d0
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-4895dd90-8cb3-4411-94e7-ccaff3c7a04f
+      - req-46d5961b-98e0-4159-a628-5d5142c975d0
       Date:
-      - Thu, 03 Jan 2019 19:29:15 GMT
+      - Fri, 04 Jan 2019 16:55:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:15 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:09 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/volumes/detail?limit=1000
@@ -12272,27 +12272,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f16e1078d731457a9792fc3c1623b426
+      - a9c8587e6ca0499a8686b134d5d871fa
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-bcea83a8-a14c-46e3-b321-3aa643b20ab9
+      - req-005a6d5f-eff2-473f-b456-11b254e0e11d
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-bcea83a8-a14c-46e3-b321-3aa643b20ab9
+      - req-005a6d5f-eff2-473f-b456-11b254e0e11d
       Date:
-      - Thu, 03 Jan 2019 19:29:15 GMT
+      - Fri, 04 Jan 2019 16:55:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:15 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:09 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/volumes/detail?limit=1000
@@ -12307,27 +12307,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '076882700e1c413499453d732e4348ad'
+      - c0cdee71e3d54a4dbf8d933460ae73dc
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-2fdcbbc3-1265-4693-b7f3-dd73585905b3
+      - req-eee8bacf-efa7-4421-972f-5549e9bcad6f
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-2fdcbbc3-1265-4693-b7f3-dd73585905b3
+      - req-eee8bacf-efa7-4421-972f-5549e9bcad6f
       Date:
-      - Thu, 03 Jan 2019 19:29:15 GMT
+      - Fri, 04 Jan 2019 16:55:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:15 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:09 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/snapshots/detail
@@ -12342,27 +12342,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e0f67635f13845a8a9d0f40c13669e6b
+      - ae421589b77b47fa9f015fb1d0e708cd
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-9ee7dc07-7c8c-4d9e-af90-4e718812712c
+      - req-17f83bd0-3444-468a-952d-e59886628a64
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-9ee7dc07-7c8c-4d9e-af90-4e718812712c
+      - req-17f83bd0-3444-468a-952d-e59886628a64
       Date:
-      - Thu, 03 Jan 2019 19:29:15 GMT
+      - Fri, 04 Jan 2019 16:55:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:15 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:10 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/snapshots/detail?limit=1000
@@ -12377,27 +12377,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e0f67635f13845a8a9d0f40c13669e6b
+      - ae421589b77b47fa9f015fb1d0e708cd
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-2e42d48f-f38a-43fa-840c-570869e86f31
+      - req-87c5d07b-5be0-4748-a160-8633721cf8d2
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-2e42d48f-f38a-43fa-840c-570869e86f31
+      - req-87c5d07b-5be0-4748-a160-8633721cf8d2
       Date:
-      - Thu, 03 Jan 2019 19:29:15 GMT
+      - Fri, 04 Jan 2019 16:55:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:15 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:10 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/snapshots/detail
@@ -12412,27 +12412,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5b983e1168754bc89d95d4dcbbce4b0d
+      - c24caf87803e4f63a3d758d3a4e5eb89
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-cfc82317-8167-498b-b0f7-470001f22b2f
+      - req-2a9d0d3b-be2c-4a78-9e84-196a84d616ec
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-cfc82317-8167-498b-b0f7-470001f22b2f
+      - req-2a9d0d3b-be2c-4a78-9e84-196a84d616ec
       Date:
-      - Thu, 03 Jan 2019 19:29:16 GMT
+      - Fri, 04 Jan 2019 16:55:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:16 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:10 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/snapshots/detail?limit=1000
@@ -12447,27 +12447,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5b983e1168754bc89d95d4dcbbce4b0d
+      - c24caf87803e4f63a3d758d3a4e5eb89
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-8a7aa85c-2c56-4e96-bbbd-9cd1ba371d6b
+      - req-903649dd-d66c-41fa-87af-95a3e8a2fc5d
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-8a7aa85c-2c56-4e96-bbbd-9cd1ba371d6b
+      - req-903649dd-d66c-41fa-87af-95a3e8a2fc5d
       Date:
-      - Thu, 03 Jan 2019 19:29:16 GMT
+      - Fri, 04 Jan 2019 16:55:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:16 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:10 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/snapshots/detail
@@ -12482,22 +12482,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - caef88341a9942c6bb4d5120e3362481
+      - f1466ddaf2974e53ab68de7bbbfdbe34
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-81a9f9cd-3e81-4336-85e9-3644d1e645c0
+      - req-80a74f5b-14d1-4c6e-a6bd-2ff382d37238
       Content-Type:
       - application/json
       Content-Length:
       - '1053'
       X-Openstack-Request-Id:
-      - req-81a9f9cd-3e81-4336-85e9-3644d1e645c0
+      - req-80a74f5b-14d1-4c6e-a6bd-2ff382d37238
       Date:
-      - Thu, 03 Jan 2019 19:29:16 GMT
+      - Fri, 04 Jan 2019 16:55:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/snapshots/detail?marker=c44d3eb3-31fe-46ed-bfae-707920be171d",
@@ -12512,7 +12512,7 @@ http_interactions:
         "created_at": "2016-08-19T08:37:24.000000", "size": 1, "id": "c44d3eb3-31fe-46ed-bfae-707920be171d",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:16 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:10 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/snapshots/detail?limit=1000
@@ -12527,22 +12527,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - caef88341a9942c6bb4d5120e3362481
+      - f1466ddaf2974e53ab68de7bbbfdbe34
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-94d43de1-b663-4e9f-af15-b04937a554d5
+      - req-e10f5ced-f1f5-4141-9c0e-482775a2f1c2
       Content-Type:
       - application/json
       Content-Length:
       - '1064'
       X-Openstack-Request-Id:
-      - req-94d43de1-b663-4e9f-af15-b04937a554d5
+      - req-e10f5ced-f1f5-4141-9c0e-482775a2f1c2
       Date:
-      - Thu, 03 Jan 2019 19:29:16 GMT
+      - Fri, 04 Jan 2019 16:55:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/snapshots/detail?limit=1000&marker=c44d3eb3-31fe-46ed-bfae-707920be171d",
@@ -12557,7 +12557,7 @@ http_interactions:
         "created_at": "2016-08-19T08:37:24.000000", "size": 1, "id": "c44d3eb3-31fe-46ed-bfae-707920be171d",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:16 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:10 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/snapshots/detail
@@ -12572,27 +12572,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5451d2c8e0ae4636b52a84776d17426a
+      - a8ce40ab0716487a90a94791fa6386aa
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-19f0ae23-f21e-48a9-9d6a-a1629db8298e
+      - req-99747771-8db1-48f4-9528-d70e43cba688
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-19f0ae23-f21e-48a9-9d6a-a1629db8298e
+      - req-99747771-8db1-48f4-9528-d70e43cba688
       Date:
-      - Thu, 03 Jan 2019 19:29:16 GMT
+      - Fri, 04 Jan 2019 16:55:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:16 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:10 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/snapshots/detail?limit=1000
@@ -12607,27 +12607,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5451d2c8e0ae4636b52a84776d17426a
+      - a8ce40ab0716487a90a94791fa6386aa
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-74c06231-6e20-4a92-80da-3b2f34bc417e
+      - req-b6d33422-6fb0-4ca5-94c1-3a9598075e1e
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-74c06231-6e20-4a92-80da-3b2f34bc417e
+      - req-b6d33422-6fb0-4ca5-94c1-3a9598075e1e
       Date:
-      - Thu, 03 Jan 2019 19:29:16 GMT
+      - Fri, 04 Jan 2019 16:55:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:16 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:10 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/snapshots/detail
@@ -12642,27 +12642,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 578bbc2d9c2a4f3789a90e4225cc621f
+      - e0438d41c5004d29a141c08b5770ae98
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-56c6ad98-29cd-4707-8c97-023169501516
+      - req-511fbb9f-73f4-4df6-be3d-9b711ef9d7db
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-56c6ad98-29cd-4707-8c97-023169501516
+      - req-511fbb9f-73f4-4df6-be3d-9b711ef9d7db
       Date:
-      - Thu, 03 Jan 2019 19:29:16 GMT
+      - Fri, 04 Jan 2019 16:55:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:16 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:10 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/snapshots/detail?limit=1000
@@ -12677,27 +12677,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 578bbc2d9c2a4f3789a90e4225cc621f
+      - e0438d41c5004d29a141c08b5770ae98
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-39dafa5d-7e5b-48d6-8a0a-a484f92c7b4e
+      - req-4044a053-a436-4501-8bb8-efe38bfbf014
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-39dafa5d-7e5b-48d6-8a0a-a484f92c7b4e
+      - req-4044a053-a436-4501-8bb8-efe38bfbf014
       Date:
-      - Thu, 03 Jan 2019 19:29:16 GMT
+      - Fri, 04 Jan 2019 16:55:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:16 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:11 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/snapshots/detail
@@ -12712,27 +12712,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f16e1078d731457a9792fc3c1623b426
+      - a9c8587e6ca0499a8686b134d5d871fa
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-bff7904e-17d9-48ce-96f2-e56564ede552
+      - req-ac8cb9d8-cb23-4356-aeaa-4adca90bff5a
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-bff7904e-17d9-48ce-96f2-e56564ede552
+      - req-ac8cb9d8-cb23-4356-aeaa-4adca90bff5a
       Date:
-      - Thu, 03 Jan 2019 19:29:16 GMT
+      - Fri, 04 Jan 2019 16:55:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:16 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:11 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/snapshots/detail?limit=1000
@@ -12747,27 +12747,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f16e1078d731457a9792fc3c1623b426
+      - a9c8587e6ca0499a8686b134d5d871fa
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-fa6e2a55-1e14-4cbd-8615-ee99f673c029
+      - req-98cb52b2-1886-499d-a6c5-bae6c460aafc
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-fa6e2a55-1e14-4cbd-8615-ee99f673c029
+      - req-98cb52b2-1886-499d-a6c5-bae6c460aafc
       Date:
-      - Thu, 03 Jan 2019 19:29:17 GMT
+      - Fri, 04 Jan 2019 16:55:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:17 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:11 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/snapshots/detail
@@ -12782,27 +12782,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '076882700e1c413499453d732e4348ad'
+      - c0cdee71e3d54a4dbf8d933460ae73dc
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-0fe5791c-0b54-40cc-b96d-45939f4ad21a
+      - req-bc0049ee-4bc8-4f83-9f76-648d867057aa
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-0fe5791c-0b54-40cc-b96d-45939f4ad21a
+      - req-bc0049ee-4bc8-4f83-9f76-648d867057aa
       Date:
-      - Thu, 03 Jan 2019 19:29:17 GMT
+      - Fri, 04 Jan 2019 16:55:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:17 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:11 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/snapshots/detail?limit=1000
@@ -12817,27 +12817,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '076882700e1c413499453d732e4348ad'
+      - c0cdee71e3d54a4dbf8d933460ae73dc
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-a2df4837-1214-4f1b-b296-bbc35ae19746
+      - req-a0c95c6b-1413-40b3-86e8-a039be549d27
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-a2df4837-1214-4f1b-b296-bbc35ae19746
+      - req-a0c95c6b-1413-40b3-86e8-a039be549d27
       Date:
-      - Thu, 03 Jan 2019 19:29:17 GMT
+      - Fri, 04 Jan 2019 16:55:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:17 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:11 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/backups/detail
@@ -12852,27 +12852,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e0f67635f13845a8a9d0f40c13669e6b
+      - ae421589b77b47fa9f015fb1d0e708cd
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-709de22e-8e73-41ab-8c3a-c4cc0385379a
+      - req-ab3e77bb-ac79-4327-94f1-09bc91d95d82
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-709de22e-8e73-41ab-8c3a-c4cc0385379a
+      - req-ab3e77bb-ac79-4327-94f1-09bc91d95d82
       Date:
-      - Thu, 03 Jan 2019 19:29:17 GMT
+      - Fri, 04 Jan 2019 16:55:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:17 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:11 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/backups/detail?limit=1000
@@ -12887,27 +12887,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e0f67635f13845a8a9d0f40c13669e6b
+      - ae421589b77b47fa9f015fb1d0e708cd
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-ca87cd38-b3d6-42dc-ac3f-a926ab0618bb
+      - req-c59a8e16-099f-46f6-aed6-abaf32dcbd77
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-ca87cd38-b3d6-42dc-ac3f-a926ab0618bb
+      - req-c59a8e16-099f-46f6-aed6-abaf32dcbd77
       Date:
-      - Thu, 03 Jan 2019 19:29:17 GMT
+      - Fri, 04 Jan 2019 16:55:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:17 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:11 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/backups/detail
@@ -12922,27 +12922,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5b983e1168754bc89d95d4dcbbce4b0d
+      - c24caf87803e4f63a3d758d3a4e5eb89
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-1e340e0a-0a11-43ba-a4a8-4473db551919
+      - req-6f175168-61d5-4713-9919-9a6ef046fb1b
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-1e340e0a-0a11-43ba-a4a8-4473db551919
+      - req-6f175168-61d5-4713-9919-9a6ef046fb1b
       Date:
-      - Thu, 03 Jan 2019 19:29:17 GMT
+      - Fri, 04 Jan 2019 16:55:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:17 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:11 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/backups/detail?limit=1000
@@ -12957,27 +12957,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5b983e1168754bc89d95d4dcbbce4b0d
+      - c24caf87803e4f63a3d758d3a4e5eb89
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-6ef193b4-3b84-4144-9520-e5ab06ec9bbd
+      - req-17a93ff5-d0c2-41f0-a830-d686779be4c4
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-6ef193b4-3b84-4144-9520-e5ab06ec9bbd
+      - req-17a93ff5-d0c2-41f0-a830-d686779be4c4
       Date:
-      - Thu, 03 Jan 2019 19:29:17 GMT
+      - Fri, 04 Jan 2019 16:55:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:17 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:11 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/backups/detail
@@ -12992,27 +12992,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - caef88341a9942c6bb4d5120e3362481
+      - f1466ddaf2974e53ab68de7bbbfdbe34
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-107aa8f6-d3b2-406f-a1a9-e0559f23153a
+      - req-bb104028-d358-4188-bab3-d7090e14105b
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-107aa8f6-d3b2-406f-a1a9-e0559f23153a
+      - req-bb104028-d358-4188-bab3-d7090e14105b
       Date:
-      - Thu, 03 Jan 2019 19:29:17 GMT
+      - Fri, 04 Jan 2019 16:55:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:17 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:11 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/backups/detail?limit=1000
@@ -13027,27 +13027,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - caef88341a9942c6bb4d5120e3362481
+      - f1466ddaf2974e53ab68de7bbbfdbe34
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-8162c312-190c-47e9-87da-4ae4a7ef68a2
+      - req-adc56401-ca2a-49d4-9fb5-9a64f1386b21
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-8162c312-190c-47e9-87da-4ae4a7ef68a2
+      - req-adc56401-ca2a-49d4-9fb5-9a64f1386b21
       Date:
-      - Thu, 03 Jan 2019 19:29:17 GMT
+      - Fri, 04 Jan 2019 16:55:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:17 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:12 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/backups/detail
@@ -13062,27 +13062,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5451d2c8e0ae4636b52a84776d17426a
+      - a8ce40ab0716487a90a94791fa6386aa
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-d8220eb9-3d14-40ce-b4ef-06b4d355758d
+      - req-06df3b56-d40d-4fd6-b000-0daf2612ec6a
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-d8220eb9-3d14-40ce-b4ef-06b4d355758d
+      - req-06df3b56-d40d-4fd6-b000-0daf2612ec6a
       Date:
-      - Thu, 03 Jan 2019 19:29:17 GMT
+      - Fri, 04 Jan 2019 16:55:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:17 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:12 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/backups/detail?limit=1000
@@ -13097,27 +13097,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5451d2c8e0ae4636b52a84776d17426a
+      - a8ce40ab0716487a90a94791fa6386aa
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-02357dab-d083-4a3f-88dd-99225f4ca86a
+      - req-26f96f01-8726-47a3-9ca3-67335730348a
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-02357dab-d083-4a3f-88dd-99225f4ca86a
+      - req-26f96f01-8726-47a3-9ca3-67335730348a
       Date:
-      - Thu, 03 Jan 2019 19:29:18 GMT
+      - Fri, 04 Jan 2019 16:55:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:18 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:12 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/backups/detail
@@ -13132,27 +13132,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 578bbc2d9c2a4f3789a90e4225cc621f
+      - e0438d41c5004d29a141c08b5770ae98
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-365b3a57-6900-41d6-b3c4-be88646f1370
+      - req-6defcebf-d9a3-4c2e-a015-0378bb2a0266
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-365b3a57-6900-41d6-b3c4-be88646f1370
+      - req-6defcebf-d9a3-4c2e-a015-0378bb2a0266
       Date:
-      - Thu, 03 Jan 2019 19:29:18 GMT
+      - Fri, 04 Jan 2019 16:55:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:18 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:12 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/backups/detail?limit=1000
@@ -13167,27 +13167,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 578bbc2d9c2a4f3789a90e4225cc621f
+      - e0438d41c5004d29a141c08b5770ae98
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-432dd941-eee9-466f-a277-48b5cf5f10bc
+      - req-68937512-b214-4406-b85b-c0425efb8f5d
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-432dd941-eee9-466f-a277-48b5cf5f10bc
+      - req-68937512-b214-4406-b85b-c0425efb8f5d
       Date:
-      - Thu, 03 Jan 2019 19:29:18 GMT
+      - Fri, 04 Jan 2019 16:55:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:18 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:12 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/backups/detail
@@ -13202,27 +13202,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f16e1078d731457a9792fc3c1623b426
+      - a9c8587e6ca0499a8686b134d5d871fa
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-4cb6b858-42c4-479e-badc-456ca6745786
+      - req-508c8655-d8d7-4643-bded-2a5a8ea595fe
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-4cb6b858-42c4-479e-badc-456ca6745786
+      - req-508c8655-d8d7-4643-bded-2a5a8ea595fe
       Date:
-      - Thu, 03 Jan 2019 19:29:18 GMT
+      - Fri, 04 Jan 2019 16:55:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:18 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:12 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/backups/detail?limit=1000
@@ -13237,27 +13237,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f16e1078d731457a9792fc3c1623b426
+      - a9c8587e6ca0499a8686b134d5d871fa
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-b68d23c9-ffc3-42e8-acb1-6a2400675975
+      - req-4e55066f-2edc-4c73-9219-5f42cad1d6ba
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-b68d23c9-ffc3-42e8-acb1-6a2400675975
+      - req-4e55066f-2edc-4c73-9219-5f42cad1d6ba
       Date:
-      - Thu, 03 Jan 2019 19:29:18 GMT
+      - Fri, 04 Jan 2019 16:55:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:18 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:12 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/backups/detail
@@ -13272,27 +13272,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '076882700e1c413499453d732e4348ad'
+      - c0cdee71e3d54a4dbf8d933460ae73dc
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-b1962f92-4faf-4e5a-9cb7-8419a41f02be
+      - req-f30445df-937b-4e45-89f3-57deeb75d987
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-b1962f92-4faf-4e5a-9cb7-8419a41f02be
+      - req-f30445df-937b-4e45-89f3-57deeb75d987
       Date:
-      - Thu, 03 Jan 2019 19:29:18 GMT
+      - Fri, 04 Jan 2019 16:55:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:18 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:12 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/backups/detail?limit=1000
@@ -13307,27 +13307,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '076882700e1c413499453d732e4348ad'
+      - c0cdee71e3d54a4dbf8d933460ae73dc
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-121c9dcc-b3aa-4403-9f23-8a30067b0b72
+      - req-c5662bcb-e0e5-4203-99d5-dc3b6004e038
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-121c9dcc-b3aa-4403-9f23-8a30067b0b72
+      - req-c5662bcb-e0e5-4203-99d5-dc3b6004e038
       Date:
-      - Thu, 03 Jan 2019 19:29:18 GMT
+      - Fri, 04 Jan 2019 16:55:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:18 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:12 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/types?limit=1000
@@ -13342,22 +13342,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e0f67635f13845a8a9d0f40c13669e6b
+      - ae421589b77b47fa9f015fb1d0e708cd
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-45cfb690-0ed4-49dd-9486-f66eaf939c23
+      - req-931345cf-d4da-4da1-8c9f-9a29d78527e4
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-45cfb690-0ed4-49dd-9486-f66eaf939c23
+      - req-931345cf-d4da-4da1-8c9f-9a29d78527e4
       Date:
-      - Thu, 03 Jan 2019 19:29:18 GMT
+      - Fri, 04 Jan 2019 16:55:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -13369,7 +13369,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:18 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:12 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/types?limit=1000&marker=b953db40-aeea-4a55-9bd9-c08dcafd6f7e
@@ -13384,22 +13384,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e0f67635f13845a8a9d0f40c13669e6b
+      - ae421589b77b47fa9f015fb1d0e708cd
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-13535b1e-2d3c-4c70-9ce1-f0516ef131f9
+      - req-7c4ae831-39ea-4659-8129-e97b4af6b7c8
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-13535b1e-2d3c-4c70-9ce1-f0516ef131f9
+      - req-7c4ae831-39ea-4659-8129-e97b4af6b7c8
       Date:
-      - Thu, 03 Jan 2019 19:29:18 GMT
+      - Fri, 04 Jan 2019 16:55:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -13411,7 +13411,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:18 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:13 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/types?limit=1000
@@ -13426,22 +13426,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5b983e1168754bc89d95d4dcbbce4b0d
+      - c24caf87803e4f63a3d758d3a4e5eb89
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-0a25998b-5d5f-452d-8ce5-6e016fd818b9
+      - req-ec562e56-6e97-4d81-85dc-7abac4924459
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-0a25998b-5d5f-452d-8ce5-6e016fd818b9
+      - req-ec562e56-6e97-4d81-85dc-7abac4924459
       Date:
-      - Thu, 03 Jan 2019 19:29:18 GMT
+      - Fri, 04 Jan 2019 16:55:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -13453,7 +13453,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:18 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:13 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/types?limit=1000&marker=b953db40-aeea-4a55-9bd9-c08dcafd6f7e
@@ -13468,22 +13468,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5b983e1168754bc89d95d4dcbbce4b0d
+      - c24caf87803e4f63a3d758d3a4e5eb89
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-75f87645-6b24-4073-a137-7b55268fd856
+      - req-bbb2a3b2-eb2b-4886-bf07-0d58df729773
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-75f87645-6b24-4073-a137-7b55268fd856
+      - req-bbb2a3b2-eb2b-4886-bf07-0d58df729773
       Date:
-      - Thu, 03 Jan 2019 19:29:18 GMT
+      - Fri, 04 Jan 2019 16:55:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -13495,7 +13495,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:19 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:13 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/types?limit=1000
@@ -13510,22 +13510,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - caef88341a9942c6bb4d5120e3362481
+      - f1466ddaf2974e53ab68de7bbbfdbe34
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-81ce2a7b-069e-4205-b9e5-84ae066998a1
+      - req-3d5775f4-b69d-46a7-933a-8b2518914f65
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-81ce2a7b-069e-4205-b9e5-84ae066998a1
+      - req-3d5775f4-b69d-46a7-933a-8b2518914f65
       Date:
-      - Thu, 03 Jan 2019 19:29:19 GMT
+      - Fri, 04 Jan 2019 16:55:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -13537,7 +13537,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:19 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:13 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/types?limit=1000&marker=b953db40-aeea-4a55-9bd9-c08dcafd6f7e
@@ -13552,22 +13552,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - caef88341a9942c6bb4d5120e3362481
+      - f1466ddaf2974e53ab68de7bbbfdbe34
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-4b8dcc62-5a02-405e-81c7-d2ea7ebfe507
+      - req-216e84f5-269d-4451-a0a0-dff7066a974a
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-4b8dcc62-5a02-405e-81c7-d2ea7ebfe507
+      - req-216e84f5-269d-4451-a0a0-dff7066a974a
       Date:
-      - Thu, 03 Jan 2019 19:29:19 GMT
+      - Fri, 04 Jan 2019 16:55:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -13579,7 +13579,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:19 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:13 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/types?limit=1000
@@ -13594,22 +13594,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5451d2c8e0ae4636b52a84776d17426a
+      - a8ce40ab0716487a90a94791fa6386aa
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-33199f0c-8271-4b77-83df-219d23a82601
+      - req-16a5fcaa-c8c3-4332-b7f8-86a118df3dc9
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-33199f0c-8271-4b77-83df-219d23a82601
+      - req-16a5fcaa-c8c3-4332-b7f8-86a118df3dc9
       Date:
-      - Thu, 03 Jan 2019 19:29:19 GMT
+      - Fri, 04 Jan 2019 16:55:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -13621,7 +13621,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:19 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:13 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/types?limit=1000&marker=b953db40-aeea-4a55-9bd9-c08dcafd6f7e
@@ -13636,22 +13636,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5451d2c8e0ae4636b52a84776d17426a
+      - a8ce40ab0716487a90a94791fa6386aa
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-0fa3e909-5b60-4c6a-96d3-09bdeac0e3d7
+      - req-2dd8ee2e-8286-4a05-bd5f-02be7a34e5a9
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-0fa3e909-5b60-4c6a-96d3-09bdeac0e3d7
+      - req-2dd8ee2e-8286-4a05-bd5f-02be7a34e5a9
       Date:
-      - Thu, 03 Jan 2019 19:29:19 GMT
+      - Fri, 04 Jan 2019 16:55:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -13663,7 +13663,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:19 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:13 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/types?limit=1000
@@ -13678,22 +13678,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 578bbc2d9c2a4f3789a90e4225cc621f
+      - e0438d41c5004d29a141c08b5770ae98
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-6ddebc9c-1e68-4517-b0fa-20e27e338709
+      - req-23df3ca5-6ec9-4b32-8121-20fca7785619
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-6ddebc9c-1e68-4517-b0fa-20e27e338709
+      - req-23df3ca5-6ec9-4b32-8121-20fca7785619
       Date:
-      - Thu, 03 Jan 2019 19:29:19 GMT
+      - Fri, 04 Jan 2019 16:55:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -13705,7 +13705,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:19 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:13 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/types?limit=1000&marker=b953db40-aeea-4a55-9bd9-c08dcafd6f7e
@@ -13720,22 +13720,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 578bbc2d9c2a4f3789a90e4225cc621f
+      - e0438d41c5004d29a141c08b5770ae98
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-66f28c3a-14f6-46c4-8d30-a1f0e2031e69
+      - req-cda7af7c-9d62-4ceb-8d7e-3b7f45b4f801
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-66f28c3a-14f6-46c4-8d30-a1f0e2031e69
+      - req-cda7af7c-9d62-4ceb-8d7e-3b7f45b4f801
       Date:
-      - Thu, 03 Jan 2019 19:29:19 GMT
+      - Fri, 04 Jan 2019 16:55:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -13747,7 +13747,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:19 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:13 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/types?limit=1000
@@ -13762,22 +13762,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f16e1078d731457a9792fc3c1623b426
+      - a9c8587e6ca0499a8686b134d5d871fa
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-7e70438c-ea68-4d2b-9c8d-21c5309a6fff
+      - req-dc44ad13-c7de-4d99-82b1-283f3a9568d8
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-7e70438c-ea68-4d2b-9c8d-21c5309a6fff
+      - req-dc44ad13-c7de-4d99-82b1-283f3a9568d8
       Date:
-      - Thu, 03 Jan 2019 19:29:19 GMT
+      - Fri, 04 Jan 2019 16:55:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -13789,7 +13789,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:19 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:13 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/types?limit=1000&marker=b953db40-aeea-4a55-9bd9-c08dcafd6f7e
@@ -13804,22 +13804,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f16e1078d731457a9792fc3c1623b426
+      - a9c8587e6ca0499a8686b134d5d871fa
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-ac946ac6-1b88-4a10-a337-635cf4e81cbd
+      - req-724c648b-dc3b-430f-9dc6-a769ad43b22e
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-ac946ac6-1b88-4a10-a337-635cf4e81cbd
+      - req-724c648b-dc3b-430f-9dc6-a769ad43b22e
       Date:
-      - Thu, 03 Jan 2019 19:29:19 GMT
+      - Fri, 04 Jan 2019 16:55:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -13831,7 +13831,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:19 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:14 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/types?limit=1000
@@ -13846,22 +13846,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '076882700e1c413499453d732e4348ad'
+      - c0cdee71e3d54a4dbf8d933460ae73dc
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-1b7ed131-31d0-4c55-a182-8fcf92f9547a
+      - req-9852dc1e-f178-4b8c-a04f-e245a0309813
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-1b7ed131-31d0-4c55-a182-8fcf92f9547a
+      - req-9852dc1e-f178-4b8c-a04f-e245a0309813
       Date:
-      - Thu, 03 Jan 2019 19:29:19 GMT
+      - Fri, 04 Jan 2019 16:55:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -13873,7 +13873,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:19 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:14 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/types?limit=1000&marker=b953db40-aeea-4a55-9bd9-c08dcafd6f7e
@@ -13888,22 +13888,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '076882700e1c413499453d732e4348ad'
+      - c0cdee71e3d54a4dbf8d933460ae73dc
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-48206c88-d8f7-471d-b67f-565e803a6efb
+      - req-b14c7bd0-ba43-4f32-8ab0-ae934335f67f
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-48206c88-d8f7-471d-b67f-565e803a6efb
+      - req-b14c7bd0-ba43-4f32-8ab0-ae934335f67f
       Date:
-      - Thu, 03 Jan 2019 19:29:20 GMT
+      - Fri, 04 Jan 2019 16:55:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -13915,7 +13915,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:20 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:14 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -13933,15 +13933,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:29:20 GMT
+      - Fri, 04 Jan 2019 16:55:14 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 6a5befb2cc2441a5b0f783c9b8440dfe
+      - 7515676ebc854101a81fe951b7b7d847
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-90b40f9a-ed69-4b9c-a6c0-179e1b337ef0
+      - req-4d8591f5-bb48-4cac-9aa5-9e94a376d24b
       Content-Length:
       - '7311'
       Connection:
@@ -13953,7 +13953,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2019-01-03T20:29:20.309994Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2019-01-04T17:55:14.473672Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -14032,10 +14032,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["j0TgKnkjQ4GCeUsfhFkUkA"],
-        "issued_at": "2019-01-03T19:29:20.310013Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["59Kr9sO6SaaChT7XAJ7zsg"],
+        "issued_at": "2019-01-04T16:55:14.473693Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:20 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:14 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -14053,15 +14053,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:29:20 GMT
+      - Fri, 04 Jan 2019 16:55:14 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 79e51835102a45e0b37e8c611be3ce58
+      - a3f51f2b49e3482e82c148abcb5a8dc7
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-1d103d46-11b7-4244-8131-c0c49a973e7f
+      - req-0db464c4-f9a0-4d43-a0ea-2c0c1d19013e
       Content-Length:
       - '7311'
       Connection:
@@ -14073,7 +14073,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2019-01-03T20:29:20.527178Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2019-01-04T17:55:14.698214Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -14152,10 +14152,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["7jslBaXASH6ff5WHXmKUkw"],
-        "issued_at": "2019-01-03T19:29:20.527199Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["6H-8-B5sR_Clf327z_KlUA"],
+        "issued_at": "2019-01-04T16:55:14.698232Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:20 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:14 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -14173,15 +14173,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:29:20 GMT
+      - Fri, 04 Jan 2019 16:55:14 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 14bf05753662461c8d4f41570af33aa7
+      - 57a013911a8f41deaeb642a91f0ddc66
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-fa206289-e748-4062-bb42-379213a85dea
+      - req-d4e0b898-8d8d-440a-8732-6f38f1c511a5
       Content-Length:
       - '297'
       Connection:
@@ -14190,12 +14190,12 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"token": {"methods": ["password"], "expires_at": "2019-01-03T20:29:20.714372Z",
+      string: '{"token": {"methods": ["password"], "expires_at": "2019-01-04T17:55:14.872714Z",
         "extras": {}, "user": {"domain": {"id": "default", "name": "Default"}, "id":
-        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["attd2m_hRQ2NzMtrwc6JmA"],
-        "issued_at": "2019-01-03T19:29:20.714393Z"}}'
+        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["3E4CU721TBqm1TbRtsplXQ"],
+        "issued_at": "2019-01-04T16:55:14.872732Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:20 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:14 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects?domain_id=default
@@ -14210,20 +14210,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 14bf05753662461c8d4f41570af33aa7
+      - 57a013911a8f41deaeb642a91f0ddc66
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:29:20 GMT
+      - Fri, 04 Jan 2019 16:55:15 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-cec596f7-6dc9-4854-9a25-3f35a8ae3626
+      - req-67e496a0-4809-432a-a060-018413f9a0dc
       Content-Length:
       - '2475'
       Connection:
@@ -14256,7 +14256,7 @@ http_interactions:
         "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
         "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:20 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:15 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -14274,15 +14274,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:29:21 GMT
+      - Fri, 04 Jan 2019 16:55:15 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - f10308042edc4e479ee43b9b7fe5a1c0
+      - 4487548fe1884176b2dde5c1705ed31e
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-0bbc71d0-778d-491a-938b-a707bbb2d519
+      - req-5a64752b-af25-4b6c-ae9b-4150bdaf910a
       Content-Length:
       - '7278'
       Connection:
@@ -14294,7 +14294,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:29:21.073082Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:55:15.222414Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -14373,10 +14373,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["rWjSIaP5RaOIORBVm7mh5Q"],
-        "issued_at": "2019-01-03T19:29:21.073114Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["eK2pGY8SQUaQdcjIJxZrfw"],
+        "issued_at": "2019-01-04T16:55:15.222434Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:21 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:15 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -14394,15 +14394,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:29:21 GMT
+      - Fri, 04 Jan 2019 16:55:15 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 0bab4d04e69c4d1e866eea59e5f2724a
+      - bc8abdf829d54d90873483822fdaef53
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-a24c4088-3a12-4aac-90d4-1f80108ae808
+      - req-f997114f-683e-42d7-a126-78be14aec779
       Content-Length:
       - '7278'
       Connection:
@@ -14414,7 +14414,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:29:21.286196Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:55:15.440295Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -14493,10 +14493,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["9CQhBnPVSGmwZKYVDIGNew"],
-        "issued_at": "2019-01-03T19:29:21.286214Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["4znKOEzHSgCl5njp-t1xhA"],
+        "issued_at": "2019-01-04T16:55:15.440316Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:21 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:15 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -14514,15 +14514,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:29:22 GMT
+      - Fri, 04 Jan 2019 16:55:15 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 7d05ebf1c36942eb9c739bbf5afe87cd
+      - 79e55d45d7f343d2bfb8fdf386b1597b
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-daf02a70-7aee-4b31-97d8-e5c35e2ec3cc
+      - req-931c44bb-f5f4-46c4-ad5b-53fecd59a00c
       Content-Length:
       - '7264'
       Connection:
@@ -14534,7 +14534,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:29:22.519568Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:55:15.657596Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -14613,10 +14613,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["g-TzO2toRtSNTmBqRDxvWw"],
-        "issued_at": "2019-01-03T19:29:22.519587Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["NUJq0SURSQONfCkUuDXPbw"],
+        "issued_at": "2019-01-04T16:55:15.657616Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:22 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:15 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -14634,15 +14634,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:29:22 GMT
+      - Fri, 04 Jan 2019 16:55:15 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 3afb40df695e4a6597d60d258abdfa7a
+      - 76da647945d048bc8030aa67b0e4b508
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-a423df96-ce48-49af-824b-1f740ea96596
+      - req-2b309d27-1a87-490c-b4f2-f0f00e7b899d
       Content-Length:
       - '7278'
       Connection:
@@ -14654,7 +14654,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:29:22.749429Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:55:15.874998Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -14733,10 +14733,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["13Vg781GRmO5VupQVH97pg"],
-        "issued_at": "2019-01-03T19:29:22.749451Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["yzSnPWAIQzuP4s1gIaDnzw"],
+        "issued_at": "2019-01-04T16:55:15.875018Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:22 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:15 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -14754,15 +14754,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:29:22 GMT
+      - Fri, 04 Jan 2019 16:55:16 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 6b17c47f832e473596ff25bf3631fa97
+      - e058d0b80c744c908c231f432445791d
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-e0f4b032-57a0-4e5f-b77d-67fa4234ab4f
+      - req-b50f2eb2-f6a8-4c3c-98ab-6870df1d8769
       Content-Length:
       - '7265'
       Connection:
@@ -14774,7 +14774,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:29:22.958175Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:55:16.083053Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -14853,10 +14853,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["cQsQqNs8SMeTjYy_074Mcw"],
-        "issued_at": "2019-01-03T19:29:22.958193Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Wfi_CeJLSseWdtPc5nZHVw"],
+        "issued_at": "2019-01-04T16:55:16.083071Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:22 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:16 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -14874,15 +14874,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:29:24 GMT
+      - Fri, 04 Jan 2019 16:55:16 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 11b0d90c875443d2a57879a4b83588a5
+      - '08b1ab9ca6a94b7083b85f109ead7bd0'
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-ed5dd051-f9e1-495b-be52-46084a85c389
+      - req-3d3ef63d-7137-4d3e-b5e9-9a198c2a3e84
       Content-Length:
       - '7278'
       Connection:
@@ -14894,7 +14894,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:29:24.236015Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:55:16.302838Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -14973,10 +14973,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["YSQsRZ02SoOYYCgFM0HFcw"],
-        "issued_at": "2019-01-03T19:29:24.236042Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["iQTy3S8PQnGVvYxRhBYn4A"],
+        "issued_at": "2019-01-04T16:55:16.302857Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:24 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:16 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_0098405163cd4c9dbb42c2cb43eb6fd3/?format=json&limit=1000
@@ -14991,7 +14991,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f10308042edc4e479ee43b9b7fe5a1c0
+      - 4487548fe1884176b2dde5c1705ed31e
   response:
     status:
       code: 200
@@ -15004,22 +15004,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1546543764.37379'
+      - '1546620916.43234'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1546543764.37379'
+      - '1546620916.43234'
       X-Trans-Id:
-      - tx021af09490f2402eb6521-005c2e6294
+      - txf2f4dd5b2ba349afa3dbd-005c2f8ff4
       Date:
-      - Thu, 03 Jan 2019 19:29:24 GMT
+      - Fri, 04 Jan 2019 16:55:16 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:24 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:16 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_28db8f69ba9e4305b7fad82da4c86e74/?format=json&limit=1000
@@ -15034,7 +15034,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0bab4d04e69c4d1e866eea59e5f2724a
+      - bc8abdf829d54d90873483822fdaef53
   response:
     status:
       code: 200
@@ -15047,22 +15047,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1546543764.49258'
+      - '1546620916.54708'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1546543764.49258'
+      - '1546620916.54708'
       X-Trans-Id:
-      - txa5ba61866a3b4a8cb6c2e-005c2e6294
+      - tx6ed0bb2167d449a48bc29-005c2f8ff4
       Date:
-      - Thu, 03 Jan 2019 19:29:24 GMT
+      - Fri, 04 Jan 2019 16:55:16 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:24 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:16 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_4637c33fee924ebea81f8d209e452c91/?format=json&limit=1000
@@ -15077,7 +15077,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7d05ebf1c36942eb9c739bbf5afe87cd
+      - 79e55d45d7f343d2bfb8fdf386b1597b
   response:
     status:
       code: 200
@@ -15106,15 +15106,15 @@ http_interactions:
       X-Account-Project-Domain-Id:
       - default
       X-Trans-Id:
-      - tx31be829c4c4b47efa9e1a-005c2e6294
+      - txf228263a3735415abaa87-005c2f8ff4
       Date:
-      - Thu, 03 Jan 2019 19:29:24 GMT
+      - Fri, 04 Jan 2019 16:55:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '[{"count": 3, "bytes": 33, "name": "dir_1"}, {"count": 0, "bytes":
         0, "name": "dir_2"}, {"count": 0, "bytes": 0, "name": "dir_3"}]'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:24 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:16 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_4637c33fee924ebea81f8d209e452c91/?format=json&limit=1000&marker=dir_3
@@ -15129,7 +15129,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7d05ebf1c36942eb9c739bbf5afe87cd
+      - 79e55d45d7f343d2bfb8fdf386b1597b
   response:
     status:
       code: 200
@@ -15158,14 +15158,14 @@ http_interactions:
       X-Account-Project-Domain-Id:
       - default
       X-Trans-Id:
-      - tx71ebdba3fad040f7a58ac-005c2e6294
+      - tx974512668e664aaf8f6e1-005c2f8ff4
       Date:
-      - Thu, 03 Jan 2019 19:29:24 GMT
+      - Fri, 04 Jan 2019 16:55:16 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:24 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:16 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_52c452d7763a4295950527948232a3e5/?format=json&limit=1000
@@ -15180,7 +15180,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3afb40df695e4a6597d60d258abdfa7a
+      - 76da647945d048bc8030aa67b0e4b508
   response:
     status:
       code: 200
@@ -15193,22 +15193,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1546543764.81365'
+      - '1546620916.89224'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1546543764.81365'
+      - '1546620916.89224'
       X-Trans-Id:
-      - tx603e6e2897d542de92635-005c2e6294
+      - txb0f18c94d8f940e6a30bf-005c2f8ff4
       Date:
-      - Thu, 03 Jan 2019 19:29:24 GMT
+      - Fri, 04 Jan 2019 16:55:16 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:24 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:16 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_88ae57d444fd485ab2dfddd5a2615d52/?format=json&limit=1000
@@ -15223,7 +15223,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 79e51835102a45e0b37e8c611be3ce58
+      - a3f51f2b49e3482e82c148abcb5a8dc7
   response:
     status:
       code: 200
@@ -15236,22 +15236,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1546543764.92977'
+      - '1546620917.00942'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1546543764.92977'
+      - '1546620917.00942'
       X-Trans-Id:
-      - tx697e588b9ce949d382563-005c2e6294
+      - tx1494ef85f7544ee3b4f9c-005c2f8ff4
       Date:
-      - Thu, 03 Jan 2019 19:29:24 GMT
+      - Fri, 04 Jan 2019 16:55:17 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:24 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:17 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_d09cbe26295d47ff848ea73c74264e23/?format=json&limit=1000
@@ -15266,7 +15266,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6b17c47f832e473596ff25bf3631fa97
+      - e058d0b80c744c908c231f432445791d
   response:
     status:
       code: 200
@@ -15279,22 +15279,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1546543765.04671'
+      - '1546620917.14476'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1546543765.04671'
+      - '1546620917.14476'
       X-Trans-Id:
-      - tx9fbd0f684e2d45dd8bdec-005c2e6295
+      - tx27df31789f7248b0863e3-005c2f8ff5
       Date:
-      - Thu, 03 Jan 2019 19:29:25 GMT
+      - Fri, 04 Jan 2019 16:55:17 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:25 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:17 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_ef2a3405d1ef4dfd9a3616993ef46a4d/?format=json&limit=1000
@@ -15309,7 +15309,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 11b0d90c875443d2a57879a4b83588a5
+      - '08b1ab9ca6a94b7083b85f109ead7bd0'
   response:
     status:
       code: 200
@@ -15322,22 +15322,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1546543765.16443'
+      - '1546620917.27026'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1546543765.16443'
+      - '1546620917.27026'
       X-Trans-Id:
-      - tx5bce1f2cd1f146599c687-005c2e6295
+      - tx2a46bb7b848d468a8b721-005c2f8ff5
       Date:
-      - Thu, 03 Jan 2019 19:29:25 GMT
+      - Fri, 04 Jan 2019 16:55:17 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:25 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:17 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_4637c33fee924ebea81f8d209e452c91/dir_1?format=json
@@ -15352,7 +15352,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7d05ebf1c36942eb9c739bbf5afe87cd
+      - 79e55d45d7f343d2bfb8fdf386b1597b
   response:
     status:
       code: 200
@@ -15373,9 +15373,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - tx2181ae08e8114d7c8b50b-005c2e6295
+      - tx84b191e0a3c043cfad4de-005c2f8ff5
       Date:
-      - Thu, 03 Jan 2019 19:29:25 GMT
+      - Fri, 04 Jan 2019 16:55:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '[{"hash": "61257bf228e2f6802a196c9a460d19a8", "last_modified": "2016-08-19T08:37:59.564460",
@@ -15385,7 +15385,7 @@ http_interactions:
         {"hash": "1727a9b61bddf85bbe7a5710c9f45691", "last_modified": "2016-08-19T08:38:00.995870",
         "bytes": 11, "name": "file_3", "content_type": "application/octet-stream"}]'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:25 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:17 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_4637c33fee924ebea81f8d209e452c91/dir_2?format=json
@@ -15400,7 +15400,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7d05ebf1c36942eb9c739bbf5afe87cd
+      - 79e55d45d7f343d2bfb8fdf386b1597b
   response:
     status:
       code: 200
@@ -15421,14 +15421,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - tx66ebeed01c5248f3b5b44-005c2e6295
+      - tx1d402617160d4cd795012-005c2f8ff5
       Date:
-      - Thu, 03 Jan 2019 19:29:25 GMT
+      - Fri, 04 Jan 2019 16:55:17 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:25 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:17 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_4637c33fee924ebea81f8d209e452c91/dir_3?format=json
@@ -15443,7 +15443,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7d05ebf1c36942eb9c739bbf5afe87cd
+      - 79e55d45d7f343d2bfb8fdf386b1597b
   response:
     status:
       code: 200
@@ -15464,12 +15464,12 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - tx2bdefb68175947eea6405-005c2e6295
+      - tx709777ab9aba4d3ca0acb-005c2f8ff5
       Date:
-      - Thu, 03 Jan 2019 19:29:25 GMT
+      - Fri, 04 Jan 2019 16:55:17 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:29:25 GMT
+  recorded_at: Fri, 04 Jan 2019 16:55:17 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_keystone_v3_legacy_fast_refresh.yml
+++ b/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_keystone_v3_legacy_fast_refresh.yml
@@ -17,15 +17,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:26:58 GMT
+      - Fri, 04 Jan 2019 16:53:59 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - e64ac97880714db990d55c6849b7d2b2
+      - 67cd3acaa8844e6c8c3bd78e7cb333bb
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-557a9eaf-ad59-4e20-aa4f-c26a9e0966b1
+      - req-07ab7747-89bd-41ec-a85a-0531f4ee6ac5
       Content-Length:
       - '7311'
       Connection:
@@ -37,7 +37,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2019-01-03T20:26:58.372128Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2019-01-04T17:53:59.417276Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -116,10 +116,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["BlYwkB-SSCuqunlgcsT1NQ"],
-        "issued_at": "2019-01-03T19:26:58.372146Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["KYUxWPX1TzSn4IbuFl7UAQ"],
+        "issued_at": "2019-01-04T16:53:59.417296Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:58 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:59 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -134,7 +134,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e64ac97880714db990d55c6849b7d2b2
+      - 67cd3acaa8844e6c8c3bd78e7cb333bb
   response:
     status:
       code: 200
@@ -145,7 +145,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Thu, 03 Jan 2019 19:26:58 GMT
+      - Fri, 04 Jan 2019 16:53:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -154,7 +154,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:58 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:59 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -172,15 +172,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:26:58 GMT
+      - Fri, 04 Jan 2019 16:53:59 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 64447560fd5b4e2ea4dc45ca6fbbd8b3
+      - f448de60e3dc4917b6a1538959331c34
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-e52afaee-11ca-4358-b87c-7642c1b7ca8f
+      - req-a16e2406-08d4-4873-96cf-d4efa52ae905
       Content-Length:
       - '7311'
       Connection:
@@ -192,7 +192,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2019-01-03T20:26:58.668160Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2019-01-04T17:53:59.736172Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -271,10 +271,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["6GDXc0X0RKuLUz0sxEwpHw"],
-        "issued_at": "2019-01-03T19:26:58.668179Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["5kFY-ygIS9qkn6wgDFDQjw"],
+        "issued_at": "2019-01-04T16:53:59.736194Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:58 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:59 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -292,15 +292,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:26:58 GMT
+      - Fri, 04 Jan 2019 16:53:59 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 02bd474776504499b14f5bb0d64c0b56
+      - f2d2ae2dbe6846b6839107b5a6ed9dc2
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-bf8a0749-c4cf-402d-9425-56681dc0c057
+      - req-bbb66b6a-c005-4534-b2e8-afb85e2896e6
       Content-Length:
       - '7311'
       Connection:
@@ -312,7 +312,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2019-01-03T20:26:58.889967Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2019-01-04T17:53:59.943045Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -391,10 +391,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Pt_XY1QGRfCZDe9n83qhgA"],
-        "issued_at": "2019-01-03T19:26:58.889986Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["d6NUikpUSOKPKzHr2XBs4w"],
+        "issued_at": "2019-01-04T16:53:59.943065Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:58 GMT
+  recorded_at: Fri, 04 Jan 2019 16:53:59 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -412,15 +412,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:26:59 GMT
+      - Fri, 04 Jan 2019 16:54:00 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - f742775f60f743eeb8039eef82fb8677
+      - 94c550b974f04add8bac0cc9d7ffd442
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-9e397460-d058-49de-991e-a737414a9917
+      - req-defb13f9-1339-4122-a973-2baaa511e095
       Content-Length:
       - '7311'
       Connection:
@@ -432,7 +432,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2019-01-03T20:26:59.093664Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2019-01-04T17:54:00.156244Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -511,10 +511,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["XbRmshuRRS6HCHMgW-3CqA"],
-        "issued_at": "2019-01-03T19:26:59.093683Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["mvfr_CQ9Q_SDYo0YgUdYWg"],
+        "issued_at": "2019-01-04T16:54:00.156265Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:59 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:00 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -532,15 +532,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:26:59 GMT
+      - Fri, 04 Jan 2019 16:54:00 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 7385bbe287824c228c1c8be72e6ac3e7
+      - 2356feab307b48d38d1382f73c9ec206
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-ecf67453-ab4b-40a2-9018-8fd5f0173361
+      - req-fcd18632-6516-4e76-9416-ab4fe1815157
       Content-Length:
       - '7311'
       Connection:
@@ -552,7 +552,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2019-01-03T20:26:59.312702Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2019-01-04T17:54:00.376188Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -631,10 +631,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Oz-qNG88RPO3wlpeRwfggQ"],
-        "issued_at": "2019-01-03T19:26:59.312722Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Fb6NN9RbQKisu4tRbQlwNQ"],
+        "issued_at": "2019-01-04T16:54:00.376209Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:59 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:00 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -652,15 +652,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:26:59 GMT
+      - Fri, 04 Jan 2019 16:54:00 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - a2f4374d295a4df194c7d1ef93a6fcac
+      - da8fe05e6e3f4b12938804c6a774e89f
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-396327e0-75c5-49fc-84d8-86f96a31a827
+      - req-22a14fe9-a9d9-4f45-853c-f731c03ded90
       Content-Length:
       - '7311'
       Connection:
@@ -672,7 +672,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2019-01-03T20:26:59.516829Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2019-01-04T17:54:00.592369Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -751,10 +751,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["_m83X1kjQLiyee8kyDmzQg"],
-        "issued_at": "2019-01-03T19:26:59.516847Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["RKErVJxzTsO4U_my_wD6Ng"],
+        "issued_at": "2019-01-04T16:54:00.592389Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:59 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:00 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -772,15 +772,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:26:59 GMT
+      - Fri, 04 Jan 2019 16:54:00 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - fb14a174c6f04b73acaced68e1ca4ed8
+      - 58b1ba49377a47dd92b02c415db046cd
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-434e8311-c632-4020-8475-205ff4efa12a
+      - req-346b41f4-9ff8-46f7-875d-4029ffb7a057
       Content-Length:
       - '7311'
       Connection:
@@ -792,7 +792,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2019-01-03T20:26:59.887933Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2019-01-04T17:54:00.803435Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -871,10 +871,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["4ze8tgfgSUmEs9bEOUB6Mg"],
-        "issued_at": "2019-01-03T19:26:59.887961Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["3t68yjD8Qy2jLPTUXM-e0Q"],
+        "issued_at": "2019-01-04T16:54:00.803455Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:59 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:00 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -892,15 +892,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:27:00 GMT
+      - Fri, 04 Jan 2019 16:54:00 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - f96083bf1b224bce8cf7aaeefdba7653
+      - 5f6de229bf6b47159db38847b99be6fb
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-98d22b8e-af72-4ac8-8222-18959393e80f
+      - req-94d110ee-8d04-47f2-8a65-e2e00353838c
       Content-Length:
       - '7311'
       Connection:
@@ -912,7 +912,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2019-01-03T20:27:00.101142Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2019-01-04T17:54:01.017964Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -991,10 +991,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["LdEVXl1-Sxe9RsX0AXPFCA"],
-        "issued_at": "2019-01-03T19:27:00.101160Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["gKkfzrhBSMmAC6DQRUshLg"],
+        "issued_at": "2019-01-04T16:54:01.017986Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:00 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:01 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -1012,15 +1012,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:27:00 GMT
+      - Fri, 04 Jan 2019 16:54:01 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 8aef40101d034fd697ce8e464b503352
+      - '08b46ad499e8456f9b8263445f3cd58d'
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-38fc06ca-fe10-4a8e-a69f-62f36ba5c897
+      - req-3f1bea6f-edff-47a0-b017-713d61226353
       Content-Length:
       - '297'
       Connection:
@@ -1029,12 +1029,12 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"token": {"methods": ["password"], "expires_at": "2019-01-03T20:27:00.281398Z",
+      string: '{"token": {"methods": ["password"], "expires_at": "2019-01-04T17:54:01.197857Z",
         "extras": {}, "user": {"domain": {"id": "default", "name": "Default"}, "id":
-        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["El8u26cESyuOvWK_PbeW4A"],
-        "issued_at": "2019-01-03T19:27:00.281430Z"}}'
+        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["qnRUAeDzTrCTfF2dCLB1Pw"],
+        "issued_at": "2019-01-04T16:54:01.197877Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:00 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:01 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects?domain_id=default
@@ -1049,20 +1049,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8aef40101d034fd697ce8e464b503352
+      - '08b46ad499e8456f9b8263445f3cd58d'
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:27:00 GMT
+      - Fri, 04 Jan 2019 16:54:01 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-395411a0-506b-4502-abd5-2a930c950cff
+      - req-89baed23-c612-4e84-b74c-b74e8751aab9
       Content-Length:
       - '2475'
       Connection:
@@ -1095,7 +1095,7 @@ http_interactions:
         "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
         "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:00 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:01 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000
@@ -1110,7 +1110,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e64ac97880714db990d55c6849b7d2b2
+      - 67cd3acaa8844e6c8c3bd78e7cb333bb
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1123,9 +1123,9 @@ http_interactions:
       Content-Length:
       - '1010'
       X-Compute-Request-Id:
-      - req-edd06e73-8d92-4775-b0a6-64b099b89008
+      - req-7891b3b5-41f4-4239-bc21-f4af12726bbf
       Date:
-      - Thu, 03 Jan 2019 19:27:00 GMT
+      - Fri, 04 Jan 2019 16:54:01 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.tiny", "links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/1",
@@ -1139,7 +1139,7 @@ http_interactions:
         0, "disk": 20, "id": "2"}], "flavors_links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=2",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:00 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:01 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=2
@@ -1154,7 +1154,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e64ac97880714db990d55c6849b7d2b2
+      - 67cd3acaa8844e6c8c3bd78e7cb333bb
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1167,9 +1167,9 @@ http_interactions:
       Content-Length:
       - '1014'
       X-Compute-Request-Id:
-      - req-d96ef5f7-8964-44c1-a207-ee26aa8c2661
+      - req-800753a5-009a-4a89-8c67-725644d794af
       Date:
-      - Thu, 03 Jan 2019 19:27:00 GMT
+      - Fri, 04 Jan 2019 16:54:01 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.medium", "links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/3",
@@ -1183,7 +1183,7 @@ http_interactions:
         0, "disk": 80, "id": "4"}], "flavors_links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=4",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:00 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:01 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=4
@@ -1198,7 +1198,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e64ac97880714db990d55c6849b7d2b2
+      - 67cd3acaa8844e6c8c3bd78e7cb333bb
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1211,9 +1211,9 @@ http_interactions:
       Content-Length:
       - '1026'
       X-Compute-Request-Id:
-      - req-04d318d2-add9-446d-943d-505dfa6dd3a3
+      - req-605ea0a2-e27e-49ea-83d9-57530fc3417d
       Date:
-      - Thu, 03 Jan 2019 19:27:00 GMT
+      - Fri, 04 Jan 2019 16:54:01 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.xlarge", "links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/5",
@@ -1228,7 +1228,7 @@ http_interactions:
         1, "disk": 1, "id": "6"}], "flavors_links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=6",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:00 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:01 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=6
@@ -1243,7 +1243,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e64ac97880714db990d55c6849b7d2b2
+      - 67cd3acaa8844e6c8c3bd78e7cb333bb
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1256,9 +1256,9 @@ http_interactions:
       Content-Length:
       - '448'
       X-Compute-Request-Id:
-      - req-547b5f05-079b-4d70-817a-83687ecafaf2
+      - req-f91c338f-5372-4b4a-9250-297dd8d91700
       Date:
-      - Thu, 03 Jan 2019 19:27:00 GMT
+      - Fri, 04 Jan 2019 16:54:01 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.ems_refresh_spec_private", "links": [{"href":
@@ -1268,7 +1268,7 @@ http_interactions:
         8, "swap": "", "os-flavor-access:is_public": false, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         0, "disk": 160, "id": "7"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:01 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:01 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/7/os-flavor-access
@@ -1283,7 +1283,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e64ac97880714db990d55c6849b7d2b2
+      - 67cd3acaa8844e6c8c3bd78e7cb333bb
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1296,15 +1296,15 @@ http_interactions:
       Content-Length:
       - '88'
       X-Compute-Request-Id:
-      - req-d1ebe996-a88d-4f0c-a212-18a83a6f380e
+      - req-364b8f52-3490-40d3-97e0-d251462c7a01
       Date:
-      - Thu, 03 Jan 2019 19:27:01 GMT
+      - Fri, 04 Jan 2019 16:54:01 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavor_access": [{"tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "flavor_id": "7"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:01 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:01 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-availability-zone
@@ -1319,7 +1319,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e64ac97880714db990d55c6849b7d2b2
+      - 67cd3acaa8844e6c8c3bd78e7cb333bb
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1332,15 +1332,15 @@ http_interactions:
       Content-Length:
       - '97'
       X-Compute-Request-Id:
-      - req-cc66fb63-34c4-48ec-918b-015703dfae5d
+      - req-123e106e-278b-499b-8065-e9d1cb0a16f8
       Date:
-      - Thu, 03 Jan 2019 19:27:01 GMT
+      - Fri, 04 Jan 2019 16:54:02 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"availabilityZoneInfo": [{"zoneState": {"available": true}, "hosts":
         null, "zoneName": "nova"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:01 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:02 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/os-availability-zone.json
@@ -1355,28 +1355,28 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7385bbe287824c228c1c8be72e6ac3e7
+      - 2356feab307b48d38d1382f73c9ec206
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-3db455d0-9fbd-4ed6-8fbc-b615b07cb769
+      - req-0f8c4e7b-88ed-47bd-93a1-159e20b92b51
       Content-Type:
       - application/json
       Content-Length:
       - '82'
       X-Openstack-Request-Id:
-      - req-3db455d0-9fbd-4ed6-8fbc-b615b07cb769
+      - req-0f8c4e7b-88ed-47bd-93a1-159e20b92b51
       Date:
-      - Thu, 03 Jan 2019 19:27:01 GMT
+      - Fri, 04 Jan 2019 16:54:02 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"availabilityZoneInfo": [{"zoneState": {"available": true}, "zoneName":
         "nova"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:01 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:02 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-aggregates
@@ -1391,7 +1391,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e64ac97880714db990d55c6849b7d2b2
+      - 67cd3acaa8844e6c8c3bd78e7cb333bb
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1404,14 +1404,14 @@ http_interactions:
       Content-Length:
       - '18'
       X-Compute-Request-Id:
-      - req-228910c8-eeff-40ef-93e4-1b8577f2418c
+      - req-7771f261-708b-492e-ae44-b2bee1c06b69
       Date:
-      - Thu, 03 Jan 2019 19:27:01 GMT
+      - Fri, 04 Jan 2019 16:54:02 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"aggregates": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:01 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:02 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -1429,15 +1429,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:27:01 GMT
+      - Fri, 04 Jan 2019 16:54:02 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - bac2ef5dadf541f0b2c81578fc684124
+      - e2e533a188f0496491b76742d913e4e8
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-4c9354dd-f8f6-433e-bb12-6c690f0881c5
+      - req-545bd8d5-c5cd-4667-9045-cc1172b3077a
       Content-Length:
       - '7278'
       Connection:
@@ -1449,7 +1449,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:27:01.619350Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:54:02.457403Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -1528,10 +1528,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["mnmK37HmQPW6F6t-C5MyXQ"],
-        "issued_at": "2019-01-03T19:27:01.619369Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["3ZEH6zaISTCYxFAb_MpVvw"],
+        "issued_at": "2019-01-04T16:54:02.457426Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:01 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:02 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -1546,7 +1546,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bac2ef5dadf541f0b2c81578fc684124
+      - e2e533a188f0496491b76742d913e4e8
   response:
     status:
       code: 200
@@ -1557,7 +1557,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Thu, 03 Jan 2019 19:27:01 GMT
+      - Fri, 04 Jan 2019 16:54:02 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -1566,7 +1566,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:01 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:02 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -1584,15 +1584,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:27:01 GMT
+      - Fri, 04 Jan 2019 16:54:02 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 7be4a833e93746439563517ef9dca21d
+      - 4394508c0df9406aa9a1d3ebaeb53a1a
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-dc9b0124-ae7d-4a70-a00a-6f449ea45e1f
+      - req-b90f255c-72f8-44be-bc04-53c27ea783f0
       Content-Length:
       - '7278'
       Connection:
@@ -1604,7 +1604,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:27:01.915881Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:54:02.754179Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -1683,10 +1683,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["qYWWQZKWShucynjDSderRQ"],
-        "issued_at": "2019-01-03T19:27:01.915898Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["7xnE_N44SWqs4NdwgTBI9Q"],
+        "issued_at": "2019-01-04T16:54:02.754199Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:01 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:02 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -1701,7 +1701,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7be4a833e93746439563517ef9dca21d
+      - 4394508c0df9406aa9a1d3ebaeb53a1a
   response:
     status:
       code: 200
@@ -1712,7 +1712,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Thu, 03 Jan 2019 19:27:02 GMT
+      - Fri, 04 Jan 2019 16:54:02 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -1721,7 +1721,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:02 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:02 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -1739,15 +1739,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:27:02 GMT
+      - Fri, 04 Jan 2019 16:54:02 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - e04f7c4dc50f41428886395f28635e22
+      - 1bbe3c98aaf244078f0e38dceafc6af1
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-7d49d9a8-a6e7-4b55-a857-a9736e62ccc8
+      - req-0b43831d-4c99-435c-b980-51e76edcd369
       Content-Length:
       - '7264'
       Connection:
@@ -1759,7 +1759,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:27:02.205997Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:54:03.050706Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -1838,10 +1838,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["jh7KZvcJRS6KFZxcBITvtA"],
-        "issued_at": "2019-01-03T19:27:02.206017Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["xKu7iedvQI6Mtn29m1iUnA"],
+        "issued_at": "2019-01-04T16:54:03.050728Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:02 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:03 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -1856,7 +1856,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e04f7c4dc50f41428886395f28635e22
+      - 1bbe3c98aaf244078f0e38dceafc6af1
   response:
     status:
       code: 200
@@ -1867,7 +1867,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Thu, 03 Jan 2019 19:27:02 GMT
+      - Fri, 04 Jan 2019 16:54:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -1876,7 +1876,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:02 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:03 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -1894,15 +1894,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:27:02 GMT
+      - Fri, 04 Jan 2019 16:54:03 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 246db5d7783b46f4a6f9cb4771818a80
+      - 9d56efedc99842e484f90a47d49a4870
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-bbdf0d39-4646-430c-8783-0bf90bbaf2f9
+      - req-49cb91fa-a810-40c6-b953-361400d1f715
       Content-Length:
       - '7278'
       Connection:
@@ -1914,7 +1914,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:27:02.494685Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:54:03.342551Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -1993,10 +1993,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Eak90mJJQqCgrKmBf_HTsw"],
-        "issued_at": "2019-01-03T19:27:02.494706Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["1k9mFEQnS2WyBTXxFYAUTw"],
+        "issued_at": "2019-01-04T16:54:03.342574Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:02 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:03 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -2011,7 +2011,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 246db5d7783b46f4a6f9cb4771818a80
+      - 9d56efedc99842e484f90a47d49a4870
   response:
     status:
       code: 200
@@ -2022,7 +2022,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Thu, 03 Jan 2019 19:27:02 GMT
+      - Fri, 04 Jan 2019 16:54:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -2031,7 +2031,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:02 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:03 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -2049,15 +2049,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:27:02 GMT
+      - Fri, 04 Jan 2019 16:54:03 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 38045051453e47cebed4b1246ae3888d
+      - 140ed2f3ab044893ac55c401f6120b4e
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-dc436a03-ede2-4c7a-a912-6208239656a5
+      - req-b3cf8deb-fcfc-4007-8e6a-691c4a4484f2
       Content-Length:
       - '7265'
       Connection:
@@ -2069,7 +2069,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:27:02.795996Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:54:03.637218Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -2148,10 +2148,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["vfezJhNTRTWensoVOxosWg"],
-        "issued_at": "2019-01-03T19:27:02.796016Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["S3X6yqr2Q5eN2PYGUEYPhA"],
+        "issued_at": "2019-01-04T16:54:03.637240Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:02 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:03 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -2166,7 +2166,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 38045051453e47cebed4b1246ae3888d
+      - 140ed2f3ab044893ac55c401f6120b4e
   response:
     status:
       code: 200
@@ -2177,7 +2177,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Thu, 03 Jan 2019 19:27:02 GMT
+      - Fri, 04 Jan 2019 16:54:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -2186,7 +2186,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:02 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:03 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -2204,15 +2204,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:27:03 GMT
+      - Fri, 04 Jan 2019 16:54:03 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 953182a8f1084ac792ce5db2997f1117
+      - 9b17356fd83a44d491184e14be468d5b
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-6af33297-067e-47c7-8219-5efcae0d6a2b
+      - req-f9cb1f69-0f94-4377-9c0f-ee3514ebb1d7
       Content-Length:
       - '7278'
       Connection:
@@ -2224,7 +2224,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:27:03.089680Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:54:03.932179Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -2303,10 +2303,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["YyaEyzArQtefNp8OKaZ6iA"],
-        "issued_at": "2019-01-03T19:27:03.089701Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["zp2xSOw1SxmxkDmHWCC51A"],
+        "issued_at": "2019-01-04T16:54:03.932200Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:03 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:03 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -2321,7 +2321,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 953182a8f1084ac792ce5db2997f1117
+      - 9b17356fd83a44d491184e14be468d5b
   response:
     status:
       code: 200
@@ -2332,7 +2332,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Thu, 03 Jan 2019 19:27:03 GMT
+      - Fri, 04 Jan 2019 16:54:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -2341,7 +2341,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:03 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:04 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3//os-quota-sets/0098405163cd4c9dbb42c2cb43eb6fd3
@@ -2356,7 +2356,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bac2ef5dadf541f0b2c81578fc684124
+      - e2e533a188f0496491b76742d913e4e8
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2369,9 +2369,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-e3de546c-3ebb-413c-8a83-c21dec3b5dd4
+      - req-f3a77828-79c3-47f9-992c-de3e3b4086b1
       Date:
-      - Thu, 03 Jan 2019 19:27:03 GMT
+      - Fri, 04 Jan 2019 16:54:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -2380,7 +2380,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:03 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:04 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/28db8f69ba9e4305b7fad82da4c86e74//os-quota-sets/28db8f69ba9e4305b7fad82da4c86e74
@@ -2395,7 +2395,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7be4a833e93746439563517ef9dca21d
+      - 4394508c0df9406aa9a1d3ebaeb53a1a
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2408,9 +2408,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-a910f807-706d-41e1-913e-2ba2dde268da
+      - req-0cc972be-d62a-4e8e-a629-4e6d855d95c1
       Date:
-      - Thu, 03 Jan 2019 19:27:03 GMT
+      - Fri, 04 Jan 2019 16:54:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -2419,7 +2419,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:03 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:04 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91//os-quota-sets/4637c33fee924ebea81f8d209e452c91
@@ -2434,7 +2434,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e04f7c4dc50f41428886395f28635e22
+      - 1bbe3c98aaf244078f0e38dceafc6af1
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2447,9 +2447,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-b97ea01e-0258-4159-8111-810e569c89f9
+      - req-6c6450ef-9367-4e2d-9eae-93b69ce38b63
       Date:
-      - Thu, 03 Jan 2019 19:27:03 GMT
+      - Fri, 04 Jan 2019 16:54:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -2458,7 +2458,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:03 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:04 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/52c452d7763a4295950527948232a3e5//os-quota-sets/52c452d7763a4295950527948232a3e5
@@ -2473,7 +2473,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 246db5d7783b46f4a6f9cb4771818a80
+      - 9d56efedc99842e484f90a47d49a4870
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2486,9 +2486,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-ed9dcc47-b0f9-4eef-b98a-cd427fb63442
+      - req-9367d30d-72dc-4d73-a9ef-8d0059e85d00
       Date:
-      - Thu, 03 Jan 2019 19:27:03 GMT
+      - Fri, 04 Jan 2019 16:54:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -2497,7 +2497,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:03 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:04 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52//os-quota-sets/88ae57d444fd485ab2dfddd5a2615d52
@@ -2512,7 +2512,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e64ac97880714db990d55c6849b7d2b2
+      - 67cd3acaa8844e6c8c3bd78e7cb333bb
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2525,9 +2525,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-76b5659e-8642-4ea7-893c-d5ad35b78024
+      - req-748d30c2-9cc8-4ffd-addf-f851fa5c525d
       Date:
-      - Thu, 03 Jan 2019 19:27:03 GMT
+      - Fri, 04 Jan 2019 16:54:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -2536,7 +2536,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:03 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:04 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/d09cbe26295d47ff848ea73c74264e23//os-quota-sets/d09cbe26295d47ff848ea73c74264e23
@@ -2551,7 +2551,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 38045051453e47cebed4b1246ae3888d
+      - 140ed2f3ab044893ac55c401f6120b4e
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2564,9 +2564,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-018b2c7f-d276-481a-8ecd-1fa23947bf17
+      - req-8091481e-1117-44ae-9f77-680ad26a8daf
       Date:
-      - Thu, 03 Jan 2019 19:27:03 GMT
+      - Fri, 04 Jan 2019 16:54:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -2575,7 +2575,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:03 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:04 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/ef2a3405d1ef4dfd9a3616993ef46a4d//os-quota-sets/ef2a3405d1ef4dfd9a3616993ef46a4d
@@ -2590,7 +2590,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 953182a8f1084ac792ce5db2997f1117
+      - 9b17356fd83a44d491184e14be468d5b
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2603,9 +2603,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-6557bc6b-9631-4fbd-b89a-7500a1bcebb3
+      - req-61a799de-80cf-43d8-852a-e1c2c38dbda1
       Date:
-      - Thu, 03 Jan 2019 19:27:04 GMT
+      - Fri, 04 Jan 2019 16:54:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -2614,7 +2614,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:04 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:04 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -2632,15 +2632,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:27:04 GMT
+      - Fri, 04 Jan 2019 16:54:05 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - f65375c3514041229eececcb78e90cdd
+      - 39d16fb231654718bb760ea9dc5a9e72
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-9a60708c-9c5c-4f47-8de0-a88aba3a3e10
+      - req-ef498a3b-eab4-4bc2-9daf-41cef12a7a11
       Content-Length:
       - '7278'
       Connection:
@@ -2652,7 +2652,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:27:04.194352Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:54:05.106192Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -2731,10 +2731,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["CPaHaPtbR0q55T8BcEvmCw"],
-        "issued_at": "2019-01-03T19:27:04.194380Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["5c6orn7QS76Uc7quET8QXw"],
+        "issued_at": "2019-01-04T16:54:05.106213Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:04 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:05 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -2752,15 +2752,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:27:04 GMT
+      - Fri, 04 Jan 2019 16:54:05 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 5f9cabbb0af249158918b5ac3a18de04
+      - 1b489a0c31634cc7afd36bc846afa25e
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-3d5aef82-283e-4808-92ac-683c880a5dad
+      - req-79bb611b-fb21-43b8-80f3-1fba4c2eebdc
       Content-Length:
       - '7278'
       Connection:
@@ -2772,7 +2772,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:27:04.397917Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:54:05.315667Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -2851,10 +2851,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["nH-7NRyyTgO-lXQ-I5opDA"],
-        "issued_at": "2019-01-03T19:27:04.397937Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["-4XEjwfBQY2yuSmWgAayIw"],
+        "issued_at": "2019-01-04T16:54:05.315689Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:04 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:05 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -2872,15 +2872,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:27:04 GMT
+      - Fri, 04 Jan 2019 16:54:05 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - e8bc82bcae2c4776aa51e786a90fd15e
+      - cc2e580e92a240c89086c8fbd3ea1518
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-8b04a23d-3830-4239-a569-b2f2b488ffb1
+      - req-0963cb4d-a78c-4535-937e-beb74994bf75
       Content-Length:
       - '7264'
       Connection:
@@ -2892,7 +2892,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:27:04.603113Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:54:05.523191Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -2971,10 +2971,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["wnEUan2OTc2ICPdltqvefw"],
-        "issued_at": "2019-01-03T19:27:04.603134Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["-1btr1dfTl67h1NUxW534Q"],
+        "issued_at": "2019-01-04T16:54:05.523212Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:04 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:05 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -2992,15 +2992,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:27:04 GMT
+      - Fri, 04 Jan 2019 16:54:05 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - d53af302a9d84612a5e8ca3115cdef5c
+      - d6201d03759242a3a2d11abbf3093bb6
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-10eb2f50-36e6-4e22-b6aa-687e0634d17a
+      - req-4fe70e47-644a-40de-b212-8cb395a0a9ce
       Content-Length:
       - '7278'
       Connection:
@@ -3012,7 +3012,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:27:04.813929Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:54:05.741128Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -3091,10 +3091,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["4F_qQCClS8uQiTPowH324A"],
-        "issued_at": "2019-01-03T19:27:04.813964Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["ywKiHfykS2GTxFjb-XTOXA"],
+        "issued_at": "2019-01-04T16:54:05.741150Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:04 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:05 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -3112,15 +3112,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:27:04 GMT
+      - Fri, 04 Jan 2019 16:54:05 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - dd8c92ca2e7148a0a7db36fa140b14a1
+      - 7b1b1c82cdfc434fbbf5099fe7624c84
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-f91decd7-1543-453e-bd80-fb2c07d77909
+      - req-44069832-bd19-49c1-bb41-dc77579153d1
       Content-Length:
       - '7265'
       Connection:
@@ -3132,7 +3132,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:27:05.025599Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:54:05.954240Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -3211,10 +3211,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["dLWjwYwMQwiYjBAsvs6s4Q"],
-        "issued_at": "2019-01-03T19:27:05.025618Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["44l3F5qxRbSrsKWXnuLCVg"],
+        "issued_at": "2019-01-04T16:54:05.954279Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:05 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:05 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -3232,15 +3232,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:27:05 GMT
+      - Fri, 04 Jan 2019 16:54:06 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - b3ba5816f18e45ecb4fb6203ecf025a4
+      - 6cbcddbe498c42b7b515b13a05eb1f4a
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-0c33958a-5b3b-4602-94ef-533c75fb0143
+      - req-f4b39e03-7838-4cff-a9c3-4c702ec0cf04
       Content-Length:
       - '7278'
       Connection:
@@ -3252,7 +3252,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:27:05.235719Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:54:06.164906Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -3331,10 +3331,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["BLQkfvybRMK7ifG7PzXmtw"],
-        "issued_at": "2019-01-03T19:27:05.235739Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["D2tXD74lRaiat_qbFMIWUA"],
+        "issued_at": "2019-01-04T16:54:06.164927Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:05 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:06 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3//os-quota-sets/0098405163cd4c9dbb42c2cb43eb6fd3
@@ -3349,22 +3349,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f65375c3514041229eececcb78e90cdd
+      - 39d16fb231654718bb760ea9dc5a9e72
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-ab31d438-2221-4ac5-8b85-29026d4853e4
+      - req-103e0145-efdd-4c5a-a54a-fe415811ba73
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-ab31d438-2221-4ac5-8b85-29026d4853e4
+      - req-103e0145-efdd-4c5a-a54a-fe415811ba73
       Date:
-      - Thu, 03 Jan 2019 19:27:05 GMT
+      - Fri, 04 Jan 2019 16:54:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -3374,7 +3374,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "0098405163cd4c9dbb42c2cb43eb6fd3"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:05 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:06 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74//os-quota-sets/28db8f69ba9e4305b7fad82da4c86e74
@@ -3389,22 +3389,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5f9cabbb0af249158918b5ac3a18de04
+      - 1b489a0c31634cc7afd36bc846afa25e
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-b68a7007-efc8-487a-888a-26db8ee3a654
+      - req-53f61c92-c8a9-42d7-b396-20dc7eac8450
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-b68a7007-efc8-487a-888a-26db8ee3a654
+      - req-53f61c92-c8a9-42d7-b396-20dc7eac8450
       Date:
-      - Thu, 03 Jan 2019 19:27:05 GMT
+      - Fri, 04 Jan 2019 16:54:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -3414,7 +3414,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "28db8f69ba9e4305b7fad82da4c86e74"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:05 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:06 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91//os-quota-sets/4637c33fee924ebea81f8d209e452c91
@@ -3429,22 +3429,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e8bc82bcae2c4776aa51e786a90fd15e
+      - cc2e580e92a240c89086c8fbd3ea1518
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-1016f691-e26b-404f-affe-0a3e779e9dde
+      - req-38831b5e-077a-4042-9d76-322bd3441eee
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-1016f691-e26b-404f-affe-0a3e779e9dde
+      - req-38831b5e-077a-4042-9d76-322bd3441eee
       Date:
-      - Thu, 03 Jan 2019 19:27:06 GMT
+      - Fri, 04 Jan 2019 16:54:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -3454,7 +3454,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "4637c33fee924ebea81f8d209e452c91"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:06 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:07 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5//os-quota-sets/52c452d7763a4295950527948232a3e5
@@ -3469,22 +3469,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d53af302a9d84612a5e8ca3115cdef5c
+      - d6201d03759242a3a2d11abbf3093bb6
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-41742bfd-a7bb-48b7-9a5e-59e74d11f315
+      - req-39d0fb79-2cdb-416a-a6d5-a9b0f35c6f43
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-41742bfd-a7bb-48b7-9a5e-59e74d11f315
+      - req-39d0fb79-2cdb-416a-a6d5-a9b0f35c6f43
       Date:
-      - Thu, 03 Jan 2019 19:27:06 GMT
+      - Fri, 04 Jan 2019 16:54:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -3494,7 +3494,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "52c452d7763a4295950527948232a3e5"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:06 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:07 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52//os-quota-sets/88ae57d444fd485ab2dfddd5a2615d52
@@ -3509,22 +3509,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7385bbe287824c228c1c8be72e6ac3e7
+      - 2356feab307b48d38d1382f73c9ec206
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-d2d5b70d-a7d1-4288-9ec9-24b3e86eac07
+      - req-052eb6e5-0c95-424b-9701-24e0cfbc1d59
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-d2d5b70d-a7d1-4288-9ec9-24b3e86eac07
+      - req-052eb6e5-0c95-424b-9701-24e0cfbc1d59
       Date:
-      - Thu, 03 Jan 2019 19:27:06 GMT
+      - Fri, 04 Jan 2019 16:54:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -3534,7 +3534,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "88ae57d444fd485ab2dfddd5a2615d52"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:06 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:07 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23//os-quota-sets/d09cbe26295d47ff848ea73c74264e23
@@ -3549,22 +3549,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - dd8c92ca2e7148a0a7db36fa140b14a1
+      - 7b1b1c82cdfc434fbbf5099fe7624c84
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-468a9ce2-d083-4b65-87ad-6b23764bf8cd
+      - req-32b606df-15b8-4530-8b8b-498ff5144aaf
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-468a9ce2-d083-4b65-87ad-6b23764bf8cd
+      - req-32b606df-15b8-4530-8b8b-498ff5144aaf
       Date:
-      - Thu, 03 Jan 2019 19:27:06 GMT
+      - Fri, 04 Jan 2019 16:54:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -3574,7 +3574,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "d09cbe26295d47ff848ea73c74264e23"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:06 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:07 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d//os-quota-sets/ef2a3405d1ef4dfd9a3616993ef46a4d
@@ -3589,22 +3589,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b3ba5816f18e45ecb4fb6203ecf025a4
+      - 6cbcddbe498c42b7b515b13a05eb1f4a
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-5c489124-a4e0-4dd2-9377-5e03731b54ce
+      - req-f6aa4cc8-2f74-4b78-a339-5ed8e3a74920
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-5c489124-a4e0-4dd2-9377-5e03731b54ce
+      - req-f6aa4cc8-2f74-4b78-a339-5ed8e3a74920
       Date:
-      - Thu, 03 Jan 2019 19:27:07 GMT
+      - Fri, 04 Jan 2019 16:54:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -3614,7 +3614,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:07 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:08 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -3632,15 +3632,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:27:07 GMT
+      - Fri, 04 Jan 2019 16:54:08 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - fe8c8afa252c499cbf923969538e0437
+      - 95cf048e354f4cdcbbdeddc1a6713cfd
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-4839254c-34c0-4e75-ad97-8702e89b6be6
+      - req-6aeab0de-bfd7-492c-b649-da544ba25deb
       Content-Length:
       - '7278'
       Connection:
@@ -3652,7 +3652,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:27:07.283717Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:54:08.301757Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -3731,10 +3731,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["3Jj4z3AWQ42v4_djPMfHfQ"],
-        "issued_at": "2019-01-03T19:27:07.283748Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["QAZkP5WSQai_Wex_nB-VHw"],
+        "issued_at": "2019-01-04T16:54:08.301794Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:07 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:08 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -3752,15 +3752,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:27:07 GMT
+      - Fri, 04 Jan 2019 16:54:08 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 5da79aa3ceca4ad5b36db4d6df8e4ced
+      - 20d3695c5fcb4286a1fc93bd6f20b4de
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-29377eee-a273-49ad-8299-bece6ff3a1d5
+      - req-c0aa8ec8-739c-4f7d-810b-b30347d31492
       Content-Length:
       - '7278'
       Connection:
@@ -3772,7 +3772,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:27:07.487895Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:54:08.504019Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -3851,10 +3851,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["16kYl8sbQHyb-BI_E0aBlQ"],
-        "issued_at": "2019-01-03T19:27:07.487915Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["xffDjZsxQNykH7eC2zUNdg"],
+        "issued_at": "2019-01-04T16:54:08.504040Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:07 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:08 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -3872,15 +3872,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:27:07 GMT
+      - Fri, 04 Jan 2019 16:54:08 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 0b4fed5dbf73458e825506d2ef46b389
+      - a39c95493d8941a98f9b6f71f0425fbe
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-d7b28302-59fa-47e9-a44d-5cff0097db50
+      - req-acd975ce-dc53-4bc3-a578-d0c103d81a9f
       Content-Length:
       - '7264'
       Connection:
@@ -3892,7 +3892,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:27:07.692888Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:54:08.716023Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -3971,10 +3971,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["btNeqim-R5mSLocHW1YqLw"],
-        "issued_at": "2019-01-03T19:27:07.692907Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["GAFkwr7iTN6ak1wNfXvz3g"],
+        "issued_at": "2019-01-04T16:54:08.716044Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:07 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:08 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -3992,15 +3992,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:27:08 GMT
+      - Fri, 04 Jan 2019 16:54:08 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - b927183bbde54e87bee6f3dc7cb87423
+      - 2febc2672659405cb1462343f5049781
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-3ed25738-79f0-4852-94fe-346cb0ada0ab
+      - req-1a232bdc-7b3b-4497-a335-07a57ebc368e
       Content-Length:
       - '7278'
       Connection:
@@ -4012,7 +4012,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:27:08.134569Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:54:08.957918Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -4091,10 +4091,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["qKuRzL0WROeaxR9DOIOs_A"],
-        "issued_at": "2019-01-03T19:27:08.134588Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["4uX3-mnSS4aBnbtE1s9Lkw"],
+        "issued_at": "2019-01-04T16:54:08.957943Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:08 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:08 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -4112,15 +4112,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:27:08 GMT
+      - Fri, 04 Jan 2019 16:54:09 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - c4fc224a60064ba2b155d2aefd48a335
+      - e3d7acf2d8534ac88913448df3caba02
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-fccfae49-4e84-46be-8cf5-95029b887f9d
+      - req-91deb331-e99b-45bd-a480-104f67a63005
       Content-Length:
       - '7265'
       Connection:
@@ -4132,7 +4132,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:27:08.341638Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:54:09.170348Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -4211,10 +4211,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["hV2EgOkYTGGXatRR-KQbTQ"],
-        "issued_at": "2019-01-03T19:27:08.341657Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["cWjzKmrjSOm76-VxMBOCzg"],
+        "issued_at": "2019-01-04T16:54:09.170369Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:08 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:09 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -4232,15 +4232,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:27:08 GMT
+      - Fri, 04 Jan 2019 16:54:09 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - a147f98c038b4a238aace32cd467efb9
+      - 8f08a52b152f4c1a81c9eb3f21a634dd
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-1ba1a7ff-844e-4f6f-9aab-704645fb8006
+      - req-7b7c4c1f-7fb3-4e7f-b9cc-fafee1ee724f
       Content-Length:
       - '7278'
       Connection:
@@ -4252,7 +4252,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:27:08.539379Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:54:09.381393Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -4331,10 +4331,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Q-UwBzoyRdG_vK46ybRCPw"],
-        "issued_at": "2019-01-03T19:27:08.539397Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["kOxZrLesTg-5kpWWkXxRiQ"],
+        "issued_at": "2019-01-04T16:54:09.381421Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:08 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:09 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/0098405163cd4c9dbb42c2cb43eb6fd3
@@ -4349,7 +4349,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fe8c8afa252c499cbf923969538e0437
+      - 95cf048e354f4cdcbbdeddc1a6713cfd
   response:
     status:
       code: 200
@@ -4360,16 +4360,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-397fdbe3-cee4-4451-8dfc-61415008735b
+      - req-5bd3405c-6224-4bd9-8efe-bd1f64350cb7
       Date:
-      - Thu, 03 Jan 2019 19:27:08 GMT
+      - Fri, 04 Jan 2019 16:54:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:08 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:09 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/28db8f69ba9e4305b7fad82da4c86e74
@@ -4384,7 +4384,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5da79aa3ceca4ad5b36db4d6df8e4ced
+      - 20d3695c5fcb4286a1fc93bd6f20b4de
   response:
     status:
       code: 200
@@ -4395,16 +4395,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-645b4839-b444-414b-9301-0f9cf23ddb02
+      - req-e833695d-0089-4f99-b6e3-2cb5b2b8c4a5
       Date:
-      - Thu, 03 Jan 2019 19:27:08 GMT
+      - Fri, 04 Jan 2019 16:54:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:08 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:09 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/4637c33fee924ebea81f8d209e452c91
@@ -4419,7 +4419,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0b4fed5dbf73458e825506d2ef46b389
+      - a39c95493d8941a98f9b6f71f0425fbe
   response:
     status:
       code: 200
@@ -4430,16 +4430,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-b810db0b-9e0c-449d-8b01-2e49487ed2a6
+      - req-6a57de5f-00c5-43a7-960c-3b182fd96c9d
       Date:
-      - Thu, 03 Jan 2019 19:27:08 GMT
+      - Fri, 04 Jan 2019 16:54:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 20, "network": 20, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:08 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:09 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/52c452d7763a4295950527948232a3e5
@@ -4454,7 +4454,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b927183bbde54e87bee6f3dc7cb87423
+      - 2febc2672659405cb1462343f5049781
   response:
     status:
       code: 200
@@ -4465,16 +4465,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-0ed52fcd-c662-4f77-9fc5-61fb3607d961
+      - req-a8321cd1-ac64-4093-9457-47204efcd800
       Date:
-      - Thu, 03 Jan 2019 19:27:09 GMT
+      - Fri, 04 Jan 2019 16:54:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:09 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:09 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/88ae57d444fd485ab2dfddd5a2615d52
@@ -4489,7 +4489,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 64447560fd5b4e2ea4dc45ca6fbbd8b3
+      - f448de60e3dc4917b6a1538959331c34
   response:
     status:
       code: 200
@@ -4500,16 +4500,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-2a6acffe-2e41-4dbd-9711-919ea2126be3
+      - req-69b46f8a-eb95-4057-be12-db9b1f38b99c
       Date:
-      - Thu, 03 Jan 2019 19:27:09 GMT
+      - Fri, 04 Jan 2019 16:54:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:09 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:09 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/d09cbe26295d47ff848ea73c74264e23
@@ -4524,7 +4524,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c4fc224a60064ba2b155d2aefd48a335
+      - e3d7acf2d8534ac88913448df3caba02
   response:
     status:
       code: 200
@@ -4535,16 +4535,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-2fadd172-b907-4c08-8060-152b81b30e6d
+      - req-16569426-938d-424e-aa86-c53599771346
       Date:
-      - Thu, 03 Jan 2019 19:27:09 GMT
+      - Fri, 04 Jan 2019 16:54:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:09 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:10 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/ef2a3405d1ef4dfd9a3616993ef46a4d
@@ -4559,7 +4559,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a147f98c038b4a238aace32cd467efb9
+      - 8f08a52b152f4c1a81c9eb3f21a634dd
   response:
     status:
       code: 200
@@ -4570,16 +4570,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-1f4ce4e3-ec99-452c-8215-3287a1d259d9
+      - req-7518c726-53ee-4b6a-8fb8-9ce2bea9b7b0
       Date:
-      - Thu, 03 Jan 2019 19:27:09 GMT
+      - Fri, 04 Jan 2019 16:54:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:09 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:10 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-keypairs?all_tenants=True&limit=1000
@@ -4594,7 +4594,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e64ac97880714db990d55c6849b7d2b2
+      - 67cd3acaa8844e6c8c3bd78e7cb333bb
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4607,9 +4607,9 @@ http_interactions:
       Content-Length:
       - '1611'
       X-Compute-Request-Id:
-      - req-9ef6ea8f-cdc3-4b0b-8579-cc385fbdb127
+      - req-084a636e-b994-4825-be15-98c2e580c1fa
       Date:
-      - Thu, 03 Jan 2019 19:27:09 GMT
+      - Fri, 04 Jan 2019 16:54:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKQyhM0ECmYmB8mI4vfeTEaY90skgHYgA/5apgT+cHhKzZX59Go+LGfb98dOCYEjnV3XKdO5dy7MrSdI5QSvGJmJIQPsH4WZNpRNuEhHzcHS1fEPe9zMceRlLafkTeUKhUGMIi1gOmBRdyZtz6fJw37AK6ioM4+16IhXjNVLV09jHn2PsUjh2RsGX5TzA3eHivptzINBD8eMBkyQwS2uejY42FlIg9qBpa8KEMgyo4KLvd/99kw9wLg1D9Y5+3OxA/J6hLfjSBv7Vd7Xvwd4ZmDlkU5+yH88b2ZOte8MyfAnlVA4v8bMdSsAf1e5NvUuZsoZC8goZCHjXmTDSI+yen
@@ -4619,7 +4619,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:09 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:10 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-keypairs?all_tenants=True&limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -4634,7 +4634,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e64ac97880714db990d55c6849b7d2b2
+      - 67cd3acaa8844e6c8c3bd78e7cb333bb
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4647,9 +4647,9 @@ http_interactions:
       Content-Length:
       - '1611'
       X-Compute-Request-Id:
-      - req-fbba9351-3261-4907-9cfd-93c4778fc937
+      - req-2446e42f-84ea-44b8-9669-d0b0476c5615
       Date:
-      - Thu, 03 Jan 2019 19:27:09 GMT
+      - Fri, 04 Jan 2019 16:54:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKQyhM0ECmYmB8mI4vfeTEaY90skgHYgA/5apgT+cHhKzZX59Go+LGfb98dOCYEjnV3XKdO5dy7MrSdI5QSvGJmJIQPsH4WZNpRNuEhHzcHS1fEPe9zMceRlLafkTeUKhUGMIi1gOmBRdyZtz6fJw37AK6ioM4+16IhXjNVLV09jHn2PsUjh2RsGX5TzA3eHivptzINBD8eMBkyQwS2uejY42FlIg9qBpa8KEMgyo4KLvd/99kw9wLg1D9Y5+3OxA/J6hLfjSBv7Vd7Xvwd4ZmDlkU5+yH88b2ZOte8MyfAnlVA4v8bMdSsAf1e5NvUuZsoZC8goZCHjXmTDSI+yen
@@ -4659,7 +4659,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:09 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:10 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -4677,15 +4677,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:27:09 GMT
+      - Fri, 04 Jan 2019 16:54:10 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 26e8f5ba7974439b987fd475bdf86583
+      - 217024f1fa1e426e8305def2dec741a7
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-f6e864f5-808f-43eb-b2be-bb66ca3775d7
+      - req-048ba813-7e6b-4113-aa64-26e21ba819d6
       Content-Length:
       - '7278'
       Connection:
@@ -4697,7 +4697,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:27:09.746240Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:54:10.583715Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -4776,10 +4776,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["SDto4qdXT3yIXDKy3SLIjA"],
-        "issued_at": "2019-01-03T19:27:09.746262Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["cvrj5zWqTAKSpJYAgAVAYw"],
+        "issued_at": "2019-01-04T16:54:10.583739Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:09 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:10 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -4797,15 +4797,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:27:09 GMT
+      - Fri, 04 Jan 2019 16:54:10 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - e7d63918235b464f8c163c0a2a076943
+      - d63cdb9d3c564b01ac78268d0165bad9
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-183d8450-8d6a-4d61-ae0e-008e5336a0a6
+      - req-e30445da-476f-4c3c-94e8-23a4862293bb
       Content-Length:
       - '7278'
       Connection:
@@ -4817,7 +4817,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:27:09.952035Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:54:10.800460Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -4896,10 +4896,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Hn7Szy6eSzmh_G-QLg7cuA"],
-        "issued_at": "2019-01-03T19:27:09.952054Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["D3jeVqlZRz-tC89CIvaa2A"],
+        "issued_at": "2019-01-04T16:54:10.800490Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:09 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:10 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -4917,15 +4917,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:27:10 GMT
+      - Fri, 04 Jan 2019 16:54:10 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 0f42ca67363640dab0eec2ec7cd03b06
+      - 1233a7e28ffa4626aa264eb01124e2b3
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-5fad00ae-efe2-4199-aa88-a41cd92090ea
+      - req-d4e06528-ad38-4b13-b201-030009df7b7c
       Content-Length:
       - '7264'
       Connection:
@@ -4937,7 +4937,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:27:10.159427Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:54:11.055443Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -5016,10 +5016,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["5PNtBjhCQamlXn4QpVUj5g"],
-        "issued_at": "2019-01-03T19:27:10.159446Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["kEGjYZv7TiquMK--M67pyQ"],
+        "issued_at": "2019-01-04T16:54:11.055465Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:10 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:11 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -5037,15 +5037,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:27:10 GMT
+      - Fri, 04 Jan 2019 16:54:11 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 65debc5a45d44e79980d332998d059fb
+      - b515aafa6a1744a1acc65b74e79bb3a0
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-7afec9c9-4e3c-494b-9363-2551003a60f2
+      - req-5d29c882-72d2-4833-a5ac-4b505a9b19ed
       Content-Length:
       - '7278'
       Connection:
@@ -5057,7 +5057,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:27:10.363139Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:54:11.270611Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -5136,10 +5136,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["4ayns8z6QUmWZiLZP5pEMQ"],
-        "issued_at": "2019-01-03T19:27:10.363156Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["1WXPESSdRYykbucaQJCOdw"],
+        "issued_at": "2019-01-04T16:54:11.270634Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:10 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:11 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -5157,15 +5157,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:27:10 GMT
+      - Fri, 04 Jan 2019 16:54:11 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 00a4ee979d54489890751ef5a4791251
+      - 870e1e40b1c64a6598c7900105e8e0b0
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-d6806e85-3163-4f9a-a518-6506cb3e31c5
+      - req-37dcd347-397f-4d62-8841-84646614c59f
       Content-Length:
       - '7265'
       Connection:
@@ -5177,7 +5177,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:27:10.573218Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:54:11.487932Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -5256,10 +5256,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["CKp7ZKvBSdi55nL4vS8pfQ"],
-        "issued_at": "2019-01-03T19:27:10.573237Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["6ZBKcpnHQxmHboOHw_BiHA"],
+        "issued_at": "2019-01-04T16:54:11.487969Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:10 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:11 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -5277,15 +5277,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:27:10 GMT
+      - Fri, 04 Jan 2019 16:54:11 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 11c9e631a42743afaed573516410f1d2
+      - d71c5d7724a9412da94c9e7b391f9c11
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-4329758f-1f1a-495d-9819-4750a2d88b53
+      - req-49a75d99-56c9-4b70-8614-2ae78c0ca661
       Content-Length:
       - '7278'
       Connection:
@@ -5297,7 +5297,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:27:10.795732Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:54:11.704248Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -5376,10 +5376,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["svMRf-b0RtmZYpgrl-k7CA"],
-        "issued_at": "2019-01-03T19:27:10.795752Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["OzZdMLTwSNKLVSFPOfaDhQ"],
+        "issued_at": "2019-01-04T16:54:11.704269Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:10 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:11 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/0098405163cd4c9dbb42c2cb43eb6fd3/stacks?limit=1000&show_nested=true
@@ -5394,7 +5394,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 26e8f5ba7974439b987fd475bdf86583
+      - 217024f1fa1e426e8305def2dec741a7
   response:
     status:
       code: 200
@@ -5405,14 +5405,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-432df408-a041-4797-8e0a-399cc30845f8
+      - req-cf231926-a205-4b53-ae42-1420061f15f2
       Date:
-      - Thu, 03 Jan 2019 19:27:10 GMT
+      - Fri, 04 Jan 2019 16:54:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:10 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:11 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/28db8f69ba9e4305b7fad82da4c86e74/stacks?limit=1000&show_nested=true
@@ -5427,7 +5427,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e7d63918235b464f8c163c0a2a076943
+      - d63cdb9d3c564b01ac78268d0165bad9
   response:
     status:
       code: 200
@@ -5438,14 +5438,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-f9ca1119-6f32-4885-b3fe-27d1234b555b
+      - req-6fb0bac7-4e88-4531-9177-8ae9b2caf2ad
       Date:
-      - Thu, 03 Jan 2019 19:27:11 GMT
+      - Fri, 04 Jan 2019 16:54:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:11 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:11 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks?limit=1000&show_nested=true
@@ -5460,7 +5460,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0f42ca67363640dab0eec2ec7cd03b06
+      - 1233a7e28ffa4626aa264eb01124e2b3
   response:
     status:
       code: 200
@@ -5471,9 +5471,9 @@ http_interactions:
       Content-Length:
       - '2559'
       X-Openstack-Request-Id:
-      - req-f10658eb-455b-4642-957a-2426c773623c
+      - req-0230541e-dcd4-47f0-96c2-5ad157086c0a
       Date:
-      - Thu, 03 Jan 2019 19:27:11 GMT
+      - Fri, 04 Jan 2019 16:54:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": [{"description": "Heat WordPress template to support F20,
@@ -5507,7 +5507,7 @@ http_interactions:
         "rel": "self"}], "updated_time": null, "stack_owner": null, "stack_status":
         "CREATE_COMPLETE", "id": "7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:11 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:12 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks?limit=1000&marker=7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0&show_nested=true
@@ -5522,7 +5522,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0f42ca67363640dab0eec2ec7cd03b06
+      - 1233a7e28ffa4626aa264eb01124e2b3
   response:
     status:
       code: 200
@@ -5533,14 +5533,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-8a1c5519-c4fb-4f91-9ef7-551ccc499722
+      - req-cfd95f68-9cf1-424a-bb3b-c6d903407ca0
       Date:
-      - Thu, 03 Jan 2019 19:27:11 GMT
+      - Fri, 04 Jan 2019 16:54:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:11 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:12 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/52c452d7763a4295950527948232a3e5/stacks?limit=1000&show_nested=true
@@ -5555,7 +5555,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 65debc5a45d44e79980d332998d059fb
+      - b515aafa6a1744a1acc65b74e79bb3a0
   response:
     status:
       code: 200
@@ -5566,14 +5566,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-c2ef68be-8a60-4232-a9cc-b449eb934b11
+      - req-eac6bdc9-d480-47d0-8a2c-c81abc274f07
       Date:
-      - Thu, 03 Jan 2019 19:27:11 GMT
+      - Fri, 04 Jan 2019 16:54:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:11 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:12 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/88ae57d444fd485ab2dfddd5a2615d52/stacks?limit=1000&show_nested=true
@@ -5588,7 +5588,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f96083bf1b224bce8cf7aaeefdba7653
+      - 5f6de229bf6b47159db38847b99be6fb
   response:
     status:
       code: 200
@@ -5599,14 +5599,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-b6519f81-3685-4b2a-9b04-601077aca141
+      - req-32248129-c66b-4d53-a00b-1b7d8a94f543
       Date:
-      - Thu, 03 Jan 2019 19:27:11 GMT
+      - Fri, 04 Jan 2019 16:54:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:11 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:12 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/d09cbe26295d47ff848ea73c74264e23/stacks?limit=1000&show_nested=true
@@ -5621,7 +5621,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 00a4ee979d54489890751ef5a4791251
+      - 870e1e40b1c64a6598c7900105e8e0b0
   response:
     status:
       code: 200
@@ -5632,14 +5632,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-14c5773e-c6ee-477d-94bb-f927d6d97019
+      - req-66d02c0b-1b29-4be5-a401-740dc7337671
       Date:
-      - Thu, 03 Jan 2019 19:27:11 GMT
+      - Fri, 04 Jan 2019 16:54:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:11 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:12 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/ef2a3405d1ef4dfd9a3616993ef46a4d/stacks?limit=1000&show_nested=true
@@ -5654,7 +5654,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 11c9e631a42743afaed573516410f1d2
+      - d71c5d7724a9412da94c9e7b391f9c11
   response:
     status:
       code: 200
@@ -5665,14 +5665,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-c5d6c137-6f12-4984-a22a-81e5c4e535f1
+      - req-1fb32888-7fe1-44df-8320-aa7b48cd8ea9
       Date:
-      - Thu, 03 Jan 2019 19:27:11 GMT
+      - Fri, 04 Jan 2019 16:54:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:11 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:12 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack3/00c5dc04-2c94-48d2-8031-db08934e9a44
@@ -5687,7 +5687,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0f42ca67363640dab0eec2ec7cd03b06
+      - 1233a7e28ffa4626aa264eb01124e2b3
   response:
     status:
       code: 200
@@ -5698,9 +5698,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-322a71db-5236-4a13-83b3-573194c9ba43
+      - req-70c09aa9-a0dc-4578-8ba1-5f4ec249c9f3
       Date:
-      - Thu, 03 Jan 2019 19:27:12 GMT
+      - Fri, 04 Jan 2019 16:54:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -5727,7 +5727,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:12 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:13 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack2/d6eba2a2-7b0d-4213-afbb-69c8f6dddd8d
@@ -5742,7 +5742,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0f42ca67363640dab0eec2ec7cd03b06
+      - 1233a7e28ffa4626aa264eb01124e2b3
   response:
     status:
       code: 200
@@ -5753,9 +5753,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-73bceb99-8e59-47aa-a3de-56cd3c74076c
+      - req-1b0f2853-c971-411b-b515-9d3d12cd90c3
       Date:
-      - Thu, 03 Jan 2019 19:27:12 GMT
+      - Fri, 04 Jan 2019 16:54:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -5782,7 +5782,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:12 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:13 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack1/7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0
@@ -5797,7 +5797,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0f42ca67363640dab0eec2ec7cd03b06
+      - 1233a7e28ffa4626aa264eb01124e2b3
   response:
     status:
       code: 200
@@ -5808,9 +5808,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-228d07c8-a974-4f92-82d8-9cb7053bee8c
+      - req-3d371efd-5729-4367-8e43-05a95162f036
       Date:
-      - Thu, 03 Jan 2019 19:27:12 GMT
+      - Fri, 04 Jan 2019 16:54:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -5837,7 +5837,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:12 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:13 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack3/00c5dc04-2c94-48d2-8031-db08934e9a44/resources
@@ -5852,7 +5852,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0f42ca67363640dab0eec2ec7cd03b06
+      - 1233a7e28ffa4626aa264eb01124e2b3
   response:
     status:
       code: 200
@@ -5863,9 +5863,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-32068e62-5737-44f4-98e8-2aa586fad9cd
+      - req-783a3a3f-52bc-42a8-8808-b5904889fd58
       Date:
-      - Thu, 03 Jan 2019 19:27:12 GMT
+      - Fri, 04 Jan 2019 16:54:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -5877,7 +5877,7 @@ http_interactions:
         changed", "physical_resource_id": "40989f26-9c38-4f72-b739-afccb44397cf",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:12 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:13 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack3/00c5dc04-2c94-48d2-8031-db08934e9a44/template
@@ -5892,7 +5892,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0f42ca67363640dab0eec2ec7cd03b06
+      - 1233a7e28ffa4626aa264eb01124e2b3
   response:
     status:
       code: 200
@@ -5903,9 +5903,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-8074faaf-00cd-476e-9e1c-55c2bcfa12ad
+      - req-9b369d51-2304-4718-900d-f144bacfb45a
       Date:
-      - Thu, 03 Jan 2019 19:27:13 GMT
+      - Fri, 04 Jan 2019 16:54:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -5961,7 +5961,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:13 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:13 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack2/d6eba2a2-7b0d-4213-afbb-69c8f6dddd8d/resources
@@ -5976,7 +5976,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0f42ca67363640dab0eec2ec7cd03b06
+      - 1233a7e28ffa4626aa264eb01124e2b3
   response:
     status:
       code: 200
@@ -5987,9 +5987,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-4730cfce-6d62-4c00-a8cd-1140bd550638
+      - req-e16cedb3-bdc6-41fa-9550-c6f7445c6710
       Date:
-      - Thu, 03 Jan 2019 19:27:13 GMT
+      - Fri, 04 Jan 2019 16:54:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -6001,7 +6001,7 @@ http_interactions:
         changed", "physical_resource_id": "ad4f7eb0-9122-41a6-a0f7-55c1d4ca5e02",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:13 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:14 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack2/d6eba2a2-7b0d-4213-afbb-69c8f6dddd8d/template
@@ -6016,7 +6016,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0f42ca67363640dab0eec2ec7cd03b06
+      - 1233a7e28ffa4626aa264eb01124e2b3
   response:
     status:
       code: 200
@@ -6027,9 +6027,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-4dcfcfe9-e30e-494a-9988-ccf601f94b0d
+      - req-e1377942-4347-43e9-a5ba-b7ce3e32240e
       Date:
-      - Thu, 03 Jan 2019 19:27:13 GMT
+      - Fri, 04 Jan 2019 16:54:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -6085,7 +6085,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:13 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:14 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack1/7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0/resources
@@ -6100,7 +6100,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0f42ca67363640dab0eec2ec7cd03b06
+      - 1233a7e28ffa4626aa264eb01124e2b3
   response:
     status:
       code: 200
@@ -6111,9 +6111,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-627a438f-5b9d-4fbf-9d0d-46d5ae8d2dc0
+      - req-0c2f5786-68cb-4826-aaa7-e3f6a8fc67d7
       Date:
-      - Thu, 03 Jan 2019 19:27:13 GMT
+      - Fri, 04 Jan 2019 16:54:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -6125,7 +6125,7 @@ http_interactions:
         changed", "physical_resource_id": "8022b967-813a-4e3b-8ff4-7c036957a8a0",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:13 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:14 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack1/7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0/template
@@ -6140,7 +6140,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0f42ca67363640dab0eec2ec7cd03b06
+      - 1233a7e28ffa4626aa264eb01124e2b3
   response:
     status:
       code: 200
@@ -6151,9 +6151,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-1f899288-7713-4366-b1d6-978d9d720e82
+      - req-66bdb934-eb32-4d35-a2eb-9cd94f3f9e4f
       Date:
-      - Thu, 03 Jan 2019 19:27:13 GMT
+      - Fri, 04 Jan 2019 16:54:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -6209,7 +6209,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:13 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:14 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images?all_tenants=True&limit=1000
@@ -6224,7 +6224,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f742775f60f743eeb8039eef82fb8677
+      - 94c550b974f04add8bac0cc9d7ffd442
   response:
     status:
       code: 200
@@ -6235,14 +6235,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-72318495-ded5-40b4-9887-13aa1a5467b6
+      - req-55d193c0-2181-4c31-953b-5418441d479d
       Date:
-      - Thu, 03 Jan 2019 19:27:13 GMT
+      - Fri, 04 Jan 2019 16:54:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000&all_tenants=True"}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:13 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:14 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images
@@ -6257,7 +6257,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f742775f60f743eeb8039eef82fb8677
+      - 94c550b974f04add8bac0cc9d7ffd442
   response:
     status:
       code: 200
@@ -6268,9 +6268,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-2d5a3ca8-93cc-40b7-95cc-9bd26fc6b2d4
+      - req-80542622-40cb-4035-9aa1-edf4511ae675
       Date:
-      - Thu, 03 Jan 2019 19:27:13 GMT
+      - Fri, 04 Jan 2019 16:54:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -6312,7 +6312,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images"}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:13 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:14 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images/f17ed5a2-4e34-4140-a634-0d56b2e564b5/members
@@ -6327,7 +6327,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f742775f60f743eeb8039eef82fb8677
+      - 94c550b974f04add8bac0cc9d7ffd442
   response:
     status:
       code: 200
@@ -6338,14 +6338,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-a8eb874f-47d3-4439-bb13-78930117e10e
+      - req-8d69f72b-9a2b-4929-ae1f-54171c76d0e9
       Date:
-      - Thu, 03 Jan 2019 19:27:13 GMT
+      - Fri, 04 Jan 2019 16:54:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"members": [], "schema": "/v2/schemas/members"}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:13 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:14 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images/afa19b9e-6375-431a-9ef0-07723a338c64/members
@@ -6360,7 +6360,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f742775f60f743eeb8039eef82fb8677
+      - 94c550b974f04add8bac0cc9d7ffd442
   response:
     status:
       code: 200
@@ -6371,14 +6371,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-5642f558-06e4-4c98-8bfc-d315b5751f95
+      - req-ca665501-2f01-4953-a9f3-e9722cd128ac
       Date:
-      - Thu, 03 Jan 2019 19:27:14 GMT
+      - Fri, 04 Jan 2019 16:54:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"members": [], "schema": "/v2/schemas/members"}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:14 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:14 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images/f5a1950f-a8e8-4485-9e51-a49ee40ae42e/members
@@ -6393,7 +6393,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f742775f60f743eeb8039eef82fb8677
+      - 94c550b974f04add8bac0cc9d7ffd442
   response:
     status:
       code: 200
@@ -6404,14 +6404,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-70769b75-9510-432c-8b2c-3a76f82e9d58
+      - req-28f153d1-0a23-4ffc-9056-c60c4b64f00a
       Date:
-      - Thu, 03 Jan 2019 19:27:14 GMT
+      - Fri, 04 Jan 2019 16:54:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"members": [], "schema": "/v2/schemas/members"}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:14 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:15 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images/b672acdb-654b-41d7-963c-44a0349bd285/members
@@ -6426,7 +6426,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f742775f60f743eeb8039eef82fb8677
+      - 94c550b974f04add8bac0cc9d7ffd442
   response:
     status:
       code: 200
@@ -6437,14 +6437,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-0542dbfb-7b63-4343-9b61-2f09c9dffd6f
+      - req-e68c6c45-1e8f-4bad-9203-7a7d4e2cff69
       Date:
-      - Thu, 03 Jan 2019 19:27:14 GMT
+      - Fri, 04 Jan 2019 16:54:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"members": [], "schema": "/v2/schemas/members"}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:14 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:15 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?all_tenants=True&limit=1000
@@ -6459,7 +6459,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e64ac97880714db990d55c6849b7d2b2
+      - 67cd3acaa8844e6c8c3bd78e7cb333bb
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6472,9 +6472,9 @@ http_interactions:
       Content-Length:
       - '3998'
       X-Compute-Request-Id:
-      - req-9b831fdc-58ea-46c1-a612-da8d2eb09ea3
+      - req-fddf8f24-e0b7-4ebd-9796-3ec366fda3e2
       Date:
-      - Thu, 03 Jan 2019 19:27:14 GMT
+      - Fri, 04 Jan 2019 16:54:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?all_tenants=True&limit=1000&marker=43f23d3a-fe8d-4bbb-9d23-fe1c437c7813",
@@ -6520,7 +6520,7 @@ http_interactions:
         [], "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:14 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:15 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?all_tenants=True&limit=1000&marker=43f23d3a-fe8d-4bbb-9d23-fe1c437c7813
@@ -6535,7 +6535,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e64ac97880714db990d55c6849b7d2b2
+      - 67cd3acaa8844e6c8c3bd78e7cb333bb
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6548,9 +6548,9 @@ http_interactions:
       Content-Length:
       - '4062'
       X-Compute-Request-Id:
-      - req-6d493c53-96be-44be-b971-67c7e6e26423
+      - req-f7f4bb0c-1d0c-4fa1-945f-da6aa48ef2c5
       Date:
-      - Thu, 03 Jan 2019 19:27:14 GMT
+      - Fri, 04 Jan 2019 16:54:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?all_tenants=True&limit=1000&marker=5d121f19-3e04-4743-8ed7-c5dfaa6ef71f",
@@ -6596,7 +6596,7 @@ http_interactions:
         [], "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 3, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:14 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:15 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?all_tenants=True&limit=1000&marker=5d121f19-3e04-4743-8ed7-c5dfaa6ef71f
@@ -6611,7 +6611,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e64ac97880714db990d55c6849b7d2b2
+      - 67cd3acaa8844e6c8c3bd78e7cb333bb
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6624,9 +6624,9 @@ http_interactions:
       Content-Length:
       - '4144'
       X-Compute-Request-Id:
-      - req-adc0e0c6-9e9d-4183-b9bf-02c4bafc9535
+      - req-e62c7a9f-879a-4d39-8290-999499d2ebcd
       Date:
-      - Thu, 03 Jan 2019 19:27:15 GMT
+      - Fri, 04 Jan 2019 16:54:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?all_tenants=True&limit=1000&marker=7edb7855-d974-4e45-8ad2-88491541ab91",
@@ -6674,7 +6674,7 @@ http_interactions:
         "", "progress": 0, "OS-EXT-STS:power_state": 1, "config_drive": "", "metadata":
         {}}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:15 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:16 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?all_tenants=True&limit=1000&marker=7edb7855-d974-4e45-8ad2-88491541ab91
@@ -6689,7 +6689,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e64ac97880714db990d55c6849b7d2b2
+      - 67cd3acaa8844e6c8c3bd78e7cb333bb
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6702,9 +6702,9 @@ http_interactions:
       Content-Length:
       - '3813'
       X-Compute-Request-Id:
-      - req-80dd9969-ebce-44f4-b941-8fa71c41b309
+      - req-86ac5c6a-767a-419a-b283-ab19f3476a83
       Date:
-      - Thu, 03 Jan 2019 19:27:15 GMT
+      - Fri, 04 Jan 2019 16:54:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?all_tenants=True&limit=1000&marker=ad4f7eb0-9122-41a6-a0f7-55c1d4ca5e02",
@@ -6746,7 +6746,7 @@ http_interactions:
         "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:15 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:16 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?all_tenants=True&limit=1000&marker=ad4f7eb0-9122-41a6-a0f7-55c1d4ca5e02
@@ -6761,7 +6761,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e64ac97880714db990d55c6849b7d2b2
+      - 67cd3acaa8844e6c8c3bd78e7cb333bb
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6774,9 +6774,9 @@ http_interactions:
       Content-Length:
       - '1816'
       X-Compute-Request-Id:
-      - req-68a510a2-91fd-494b-a949-f868f7af3454
+      - req-995ce6e5-7fd3-43a3-8097-0d14dfa4e67d
       Date:
-      - Thu, 03 Jan 2019 19:27:15 GMT
+      - Fri, 04 Jan 2019 16:54:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": [{"status": "SHUTOFF", "updated": "2017-05-22T16:01:49Z",
@@ -6799,7 +6799,7 @@ http_interactions:
         "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:15 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:16 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-floating-ips
@@ -6814,7 +6814,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e64ac97880714db990d55c6849b7d2b2
+      - 67cd3acaa8844e6c8c3bd78e7cb333bb
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6827,14 +6827,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-c9d863a6-ec30-42e5-bb07-26d1e5f01bbc
+      - req-660584e6-cbf3-4e0f-a2bf-52adcdd4be48
       Date:
-      - Thu, 03 Jan 2019 19:27:15 GMT
+      - Fri, 04 Jan 2019 16:54:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:15 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:16 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-floating-ips
@@ -6849,7 +6849,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e64ac97880714db990d55c6849b7d2b2
+      - 67cd3acaa8844e6c8c3bd78e7cb333bb
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6862,14 +6862,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-126f055d-a728-4b7d-9800-10822ca78cbe
+      - req-58481948-aa81-4c61-9027-20eb664afde9
       Date:
-      - Thu, 03 Jan 2019 19:27:15 GMT
+      - Fri, 04 Jan 2019 16:54:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:15 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:17 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-floating-ips
@@ -6884,7 +6884,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e64ac97880714db990d55c6849b7d2b2
+      - 67cd3acaa8844e6c8c3bd78e7cb333bb
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6897,14 +6897,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-37b4a11a-2f1a-4d56-985d-6b822299dd8b
+      - req-d792d748-2c37-4b44-8bcb-e684326ca023
       Date:
-      - Thu, 03 Jan 2019 19:27:16 GMT
+      - Fri, 04 Jan 2019 16:54:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:16 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:17 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-floating-ips
@@ -6919,7 +6919,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e64ac97880714db990d55c6849b7d2b2
+      - 67cd3acaa8844e6c8c3bd78e7cb333bb
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6932,14 +6932,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-ff54d644-4148-4f0d-9654-c4f732a8f385
+      - req-66af8520-9b9d-4869-9ba1-318774b777b4
       Date:
-      - Thu, 03 Jan 2019 19:27:16 GMT
+      - Fri, 04 Jan 2019 16:54:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:16 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:17 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-floating-ips
@@ -6954,7 +6954,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e64ac97880714db990d55c6849b7d2b2
+      - 67cd3acaa8844e6c8c3bd78e7cb333bb
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6967,14 +6967,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-5998d0f6-b932-4cbc-922f-c847a5ac5851
+      - req-395ab86d-875c-4b39-a584-104a94cd9bee
       Date:
-      - Thu, 03 Jan 2019 19:27:16 GMT
+      - Fri, 04 Jan 2019 16:54:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:16 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:17 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-floating-ips
@@ -6989,7 +6989,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e64ac97880714db990d55c6849b7d2b2
+      - 67cd3acaa8844e6c8c3bd78e7cb333bb
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -7002,14 +7002,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-25eba026-6e7a-4bfa-bb72-9bc71cec7e9b
+      - req-5ab5bf29-4640-41dc-926b-c66e31266a91
       Date:
-      - Thu, 03 Jan 2019 19:27:16 GMT
+      - Fri, 04 Jan 2019 16:54:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:16 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:17 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-floating-ips
@@ -7024,7 +7024,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e64ac97880714db990d55c6849b7d2b2
+      - 67cd3acaa8844e6c8c3bd78e7cb333bb
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -7037,14 +7037,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-bb03b3a8-dad1-4e3e-9e1c-c75e63e7419d
+      - req-72a54680-fe5c-4a1b-900e-4106a2462c04
       Date:
-      - Thu, 03 Jan 2019 19:27:16 GMT
+      - Fri, 04 Jan 2019 16:54:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:16 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:17 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-floating-ips
@@ -7059,7 +7059,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e64ac97880714db990d55c6849b7d2b2
+      - 67cd3acaa8844e6c8c3bd78e7cb333bb
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -7072,14 +7072,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-a443b617-7275-4466-8f9e-6524c2590dc6
+      - req-fd185d0a-9e27-40b4-b700-b222bed5a6a6
       Date:
-      - Thu, 03 Jan 2019 19:27:16 GMT
+      - Fri, 04 Jan 2019 16:54:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:16 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:18 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-floating-ips
@@ -7094,7 +7094,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e64ac97880714db990d55c6849b7d2b2
+      - 67cd3acaa8844e6c8c3bd78e7cb333bb
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -7107,14 +7107,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-72accff5-9676-45f1-9279-df1d9c94653a
+      - req-a594bee4-5959-462b-b7a5-9d15dbba856f
       Date:
-      - Thu, 03 Jan 2019 19:27:16 GMT
+      - Fri, 04 Jan 2019 16:54:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:16 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:18 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-services?all_tenants=True&limit=1000
@@ -7129,7 +7129,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e64ac97880714db990d55c6849b7d2b2
+      - 67cd3acaa8844e6c8c3bd78e7cb333bb
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -7142,26 +7142,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-81e4a27f-fb20-4f5b-872b-0ce498cdde70
+      - req-3210cf65-0416-4f76-8d33-c56420f74afe
       Date:
-      - Thu, 03 Jan 2019 19:27:16 GMT
+      - Fri, 04 Jan 2019 16:54:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-01-03T19:27:08.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-01-04T16:54:10.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2019-01-03T19:27:13.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2019-01-04T16:54:15.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-01-03T19:27:15.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-01-04T16:54:18.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 5, "updated_at":
-        "2019-01-03T19:27:07.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2019-01-04T16:54:10.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2019-01-03T19:27:11.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2019-01-04T16:54:14.000000"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:16 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:18 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-services?all_tenants=True&limit=1000&marker=6
@@ -7176,7 +7176,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e64ac97880714db990d55c6849b7d2b2
+      - 67cd3acaa8844e6c8c3bd78e7cb333bb
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -7189,26 +7189,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-43f6c183-a975-4fd6-bbf5-9949b29bf596
+      - req-fa20559f-5127-4c44-8b31-5844caa9e502
       Date:
-      - Thu, 03 Jan 2019 19:27:17 GMT
+      - Fri, 04 Jan 2019 16:54:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-01-03T19:27:08.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-01-04T16:54:10.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2019-01-03T19:27:13.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2019-01-04T16:54:15.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-01-03T19:27:15.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-01-04T16:54:18.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 5, "updated_at":
-        "2019-01-03T19:27:07.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2019-01-04T16:54:10.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2019-01-03T19:27:11.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2019-01-04T16:54:14.000000"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:17 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:18 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -7226,15 +7226,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:27:18 GMT
+      - Fri, 04 Jan 2019 16:54:19 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 736692f0e1c649d28909581d69c091b6
+      - cf8ac9fba9094a828c6f1ed179606b0b
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-e1895663-38d4-4572-b470-4303389e253c
+      - req-7dd11fe1-3375-4912-a3ec-e2fa1c8058c0
       Content-Length:
       - '7311'
       Connection:
@@ -7246,7 +7246,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2019-01-03T20:27:18.311280Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2019-01-04T17:54:19.722975Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -7325,10 +7325,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["XxM6W1xqSXihNS3OIDJwcw"],
-        "issued_at": "2019-01-03T19:27:18.311300Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["hj-6lj_PRNWLwXDFfHS4Pw"],
+        "issued_at": "2019-01-04T16:54:19.722997Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:18 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:19 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -7346,15 +7346,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:27:18 GMT
+      - Fri, 04 Jan 2019 16:54:19 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 10b19d6972d64effaff52918f6731423
+      - 75a1f57eb32f40019f7601d170f26d41
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-50d77406-69ba-47fe-969e-9b3b76c3b1ed
+      - req-6711cd68-ec82-4979-89f5-26d5f68cf27a
       Content-Length:
       - '7311'
       Connection:
@@ -7366,7 +7366,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2019-01-03T20:27:18.514328Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2019-01-04T17:54:19.937791Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -7445,10 +7445,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["UbJ_iCCsSziz8mNPqmc3OQ"],
-        "issued_at": "2019-01-03T19:27:18.514346Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["OuSpWKPlTi2_ImBn62XHhg"],
+        "issued_at": "2019-01-04T16:54:19.937813Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:18 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:19 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000
@@ -7463,7 +7463,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 10b19d6972d64effaff52918f6731423
+      - 75a1f57eb32f40019f7601d170f26d41
   response:
     status:
       code: 200
@@ -7474,9 +7474,9 @@ http_interactions:
       Content-Length:
       - '2751'
       X-Openstack-Request-Id:
-      - req-7e085d06-bdc3-4bce-bd27-3f11af6db1fa
+      - req-2c21c291-5562-4cdf-bafc-39de7db3d3d7
       Date:
-      - Thu, 03 Jan 2019 19:27:18 GMT
+      - Fri, 04 Jan 2019 16:54:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=2e57d382-aeb2-4107-85cd-9dbde325f8f7",
@@ -7511,7 +7511,7 @@ http_interactions:
         null, "port_range_min": null, "id": "7e354503-9d45-4cc4-a742-4ff9501ba396",
         "security_group_id": "2e57d382-aeb2-4107-85cd-9dbde325f8f7"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:18 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:20 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=2e57d382-aeb2-4107-85cd-9dbde325f8f7
@@ -7526,7 +7526,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 10b19d6972d64effaff52918f6731423
+      - 75a1f57eb32f40019f7601d170f26d41
   response:
     status:
       code: 200
@@ -7537,9 +7537,9 @@ http_interactions:
       Content-Length:
       - '3418'
       X-Openstack-Request-Id:
-      - req-bd4c68a4-1415-44fe-b73f-01508d367bc0
+      - req-cbf72930-a946-42e8-9db8-9d0e948b1518
       Date:
-      - Thu, 03 Jan 2019 19:27:18 GMT
+      - Fri, 04 Jan 2019 16:54:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=42bcab35-fe98-49f3-ba0e-705a2737b81d",
@@ -7582,7 +7582,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "f87c3733-0682-46d9-8df1-05f1207541d1",
         "security_group_id": "42bcab35-fe98-49f3-ba0e-705a2737b81d"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:18 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:20 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=42bcab35-fe98-49f3-ba0e-705a2737b81d
@@ -7597,7 +7597,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 10b19d6972d64effaff52918f6731423
+      - 75a1f57eb32f40019f7601d170f26d41
   response:
     status:
       code: 200
@@ -7608,9 +7608,9 @@ http_interactions:
       Content-Length:
       - '3418'
       X-Openstack-Request-Id:
-      - req-af466228-e754-45a2-8277-7fd9e27dd1ab
+      - req-bd3905d4-332d-4b3b-8f42-67cd0a59ab5e
       Date:
-      - Thu, 03 Jan 2019 19:27:18 GMT
+      - Fri, 04 Jan 2019 16:54:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=7250f04f-facd-4731-b072-f346b1cc7a80",
@@ -7653,7 +7653,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "d0ee1562-3ff7-4ad5-b29f-8dd350ed221f",
         "security_group_id": "7250f04f-facd-4731-b072-f346b1cc7a80"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:18 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:20 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=7250f04f-facd-4731-b072-f346b1cc7a80
@@ -7668,7 +7668,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 10b19d6972d64effaff52918f6731423
+      - 75a1f57eb32f40019f7601d170f26d41
   response:
     status:
       code: 200
@@ -7679,9 +7679,9 @@ http_interactions:
       Content-Length:
       - '8771'
       X-Openstack-Request-Id:
-      - req-7d19dbce-5e13-496f-a681-2de8437dc9ba
+      - req-62cccb0b-0c40-4512-b517-543c60b935a7
       Date:
-      - Thu, 03 Jan 2019 19:27:19 GMT
+      - Fri, 04 Jan 2019 16:54:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d",
@@ -7788,7 +7788,7 @@ http_interactions:
         "port_range_max": 65535, "port_range_min": 1, "id": "e483857b-5eb5-4cb0-94d6-b431a2f0cb10",
         "security_group_id": "8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:19 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:20 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d
@@ -7803,7 +7803,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 10b19d6972d64effaff52918f6731423
+      - 75a1f57eb32f40019f7601d170f26d41
   response:
     status:
       code: 200
@@ -7814,9 +7814,9 @@ http_interactions:
       Content-Length:
       - '3418'
       X-Openstack-Request-Id:
-      - req-ae3efc6d-de54-43e2-990b-6cfd0a2e29db
+      - req-2cd76ad8-bc19-4432-a6c3-e42b550388d6
       Date:
-      - Thu, 03 Jan 2019 19:27:19 GMT
+      - Fri, 04 Jan 2019 16:54:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=bab65d2f-4717-47eb-bfb2-95100b254563",
@@ -7858,7 +7858,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "e1aa03c0-0758-42ca-b030-a3d62800e578",
         "security_group_id": "bab65d2f-4717-47eb-bfb2-95100b254563"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:19 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:20 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=bab65d2f-4717-47eb-bfb2-95100b254563
@@ -7873,7 +7873,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 10b19d6972d64effaff52918f6731423
+      - 75a1f57eb32f40019f7601d170f26d41
   response:
     status:
       code: 200
@@ -7884,15 +7884,15 @@ http_interactions:
       Content-Length:
       - '173'
       X-Openstack-Request-Id:
-      - req-b983a8ad-8832-4525-9ce6-1de397cc3e5c
+      - req-564305c0-9cea-4229-93ef-b86e1d63389b
       Date:
-      - Thu, 03 Jan 2019 19:27:19 GMT
+      - Fri, 04 Jan 2019 16:54:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&page_reverse=True",
         "rel": "previous"}], "security_groups": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:19 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:20 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/networks
@@ -7907,7 +7907,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 10b19d6972d64effaff52918f6731423
+      - 75a1f57eb32f40019f7601d170f26d41
   response:
     status:
       code: 200
@@ -7918,9 +7918,9 @@ http_interactions:
       Content-Length:
       - '5330'
       X-Openstack-Request-Id:
-      - req-3a867f15-fd2f-4d12-943d-70838dcb1ab6
+      - req-9b96493c-4e5e-489e-b277-9e0e75c954f0
       Date:
-      - Thu, 03 Jan 2019 19:27:19 GMT
+      - Fri, 04 Jan 2019 16:54:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"networks": [{"status": "ACTIVE", "subnets": ["75e7a9c8-eeaf-4cd0-80da-05165f897e69"],
@@ -7990,7 +7990,7 @@ http_interactions:
         "vxlan", "id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "provider:segmentation_id":
         11}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:19 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:20 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/subnets?all_tenants=True&limit=1000
@@ -8005,7 +8005,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 10b19d6972d64effaff52918f6731423
+      - 75a1f57eb32f40019f7601d170f26d41
   response:
     status:
       code: 200
@@ -8016,9 +8016,9 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-511dfd5a-554d-48b1-9893-3c6a08c2fb34
+      - req-271950c8-75d5-4cb1-9056-3cdd7add25ae
       Date:
-      - Thu, 03 Jan 2019 19:27:19 GMT
+      - Fri, 04 Jan 2019 16:54:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
@@ -8109,23 +8109,23 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
         "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.8", "end": "192.168.0.8"},
-        {"start": "192.168.0.3", "end": "192.168.0.5"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
         null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}]}'
+        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:19 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:21 GMT
 - request:
     method: get
-    uri: http://10.8.99.206:9696/v2.0/subnets?all_tenants=True&limit=1000&marker=f4c17602-9618-4604-b3c9-9e4801d094d3
+    uri: http://10.8.99.206:9696/v2.0/subnets?all_tenants=True&limit=1000&marker=24c83610-eab6-4f68-99dd-ab22a638b4a0
     body:
       encoding: US-ASCII
       string: ''
@@ -8137,7 +8137,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 10b19d6972d64effaff52918f6731423
+      - 75a1f57eb32f40019f7601d170f26d41
   response:
     status:
       code: 200
@@ -8148,45 +8148,28 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-5752e6c8-774a-4a8e-a841-bc6d51f6d599
+      - req-c4eff69a-5f85-40c2-ba73-e0ee719644f9
       Date:
-      - Thu, 03 Jan 2019 19:27:19 GMT
+      - Fri, 04 Jan 2019 16:54:21 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
-        true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
-        "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
-        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
         false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
         "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
         "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
+        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
         true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
@@ -8241,20 +8224,37 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
         "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
+        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
         "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
         "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "f4c17602-9618-4604-b3c9-9e4801d094d3",
-        "subnetpool_id": null}]}'
+        "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:19 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:21 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/routers?all_tenants=True&limit=1000
@@ -8269,7 +8269,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 10b19d6972d64effaff52918f6731423
+      - 75a1f57eb32f40019f7601d170f26d41
   response:
     status:
       code: 200
@@ -8280,9 +8280,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-23cc43e3-b108-4c3a-acbe-fd4c0f6f646b
+      - req-1fc6961e-111d-46cd-82a4-a7701d9453a6
       Date:
-      - Thu, 03 Jan 2019 19:27:19 GMT
+      - Fri, 04 Jan 2019 16:54:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -8314,7 +8314,7 @@ http_interactions:
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:19 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:21 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/routers?all_tenants=True&limit=1000&marker=e49f1a18-9fd8-4130-9e9f-f13b5190f9fd
@@ -8329,7 +8329,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 10b19d6972d64effaff52918f6731423
+      - 75a1f57eb32f40019f7601d170f26d41
   response:
     status:
       code: 200
@@ -8340,9 +8340,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-11237f98-6d6e-4ce4-89a3-64c0273ba44b
+      - req-33e46666-103d-4dea-b839-7941f3a12a73
       Date:
-      - Thu, 03 Jan 2019 19:27:20 GMT
+      - Fri, 04 Jan 2019 16:54:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -8374,7 +8374,7 @@ http_interactions:
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:20 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:21 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/ports?all_tenants=True&limit=1000
@@ -8389,7 +8389,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 10b19d6972d64effaff52918f6731423
+      - 75a1f57eb32f40019f7601d170f26d41
   response:
     status:
       code: 200
@@ -8400,9 +8400,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-95fea7e7-9574-4cc0-ab75-423dfef9449a
+      - req-cdbd0daa-731f-4ae0-b774-08ebd53ffe95
       Date:
-      - Thu, 03 Jan 2019 19:27:20 GMT
+      - Fri, 04 Jan 2019 16:54:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -8805,7 +8805,7 @@ http_interactions:
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:20 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:21 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/ports?all_tenants=True&limit=1000&marker=fb9152f8-5f19-4171-9b8e-f1e594c24d64
@@ -8820,7 +8820,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 10b19d6972d64effaff52918f6731423
+      - 75a1f57eb32f40019f7601d170f26d41
   response:
     status:
       code: 200
@@ -8831,9 +8831,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-af1739e3-5a17-4f9a-b806-e9ec00592d0d
+      - req-029ad6aa-9280-486f-9c5b-3effc1bcfb13
       Date:
-      - Thu, 03 Jan 2019 19:27:20 GMT
+      - Fri, 04 Jan 2019 16:54:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -9236,7 +9236,7 @@ http_interactions:
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:20 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:21 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/floatingips?all_tenants=True&limit=1000
@@ -9251,7 +9251,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 10b19d6972d64effaff52918f6731423
+      - 75a1f57eb32f40019f7601d170f26d41
   response:
     status:
       code: 200
@@ -9262,9 +9262,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-515abefc-e6bb-4d06-aa26-8a6d7a97f51e
+      - req-20fbe43b-b541-4a94-a191-bb93e4f3cbf1
       Date:
-      - Thu, 03 Jan 2019 19:27:20 GMT
+      - Fri, 04 Jan 2019 16:54:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
@@ -9306,7 +9306,7 @@ http_interactions:
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:20 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:22 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/floatingips?all_tenants=True&limit=1000&marker=e5a4a7fd-b2c7-4a38-b725-a666d4f90f60
@@ -9321,7 +9321,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 10b19d6972d64effaff52918f6731423
+      - 75a1f57eb32f40019f7601d170f26d41
   response:
     status:
       code: 200
@@ -9332,9 +9332,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-5e4fef9e-cc42-4fbd-912b-31d7652a8355
+      - req-071009a4-787c-4028-8041-06eede1ce150
       Date:
-      - Thu, 03 Jan 2019 19:27:20 GMT
+      - Fri, 04 Jan 2019 16:54:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
@@ -9376,7 +9376,7 @@ http_interactions:
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:20 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:22 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -9394,15 +9394,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:27:21 GMT
+      - Fri, 04 Jan 2019 16:54:22 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 673039721edd4608a13d61d21c613fcb
+      - 32cce70d6eac422dae1e15cb249d4a78
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-ce4d2b20-da4f-4fa9-bb1b-c4e4b2702d7c
+      - req-ed7e11e3-f66c-4a0e-926b-cf3ca15b335e
       Content-Length:
       - '7311'
       Connection:
@@ -9414,7 +9414,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2019-01-03T20:27:21.540465Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2019-01-04T17:54:22.967434Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -9493,10 +9493,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["TMfXm2kuT7K8KytaUibV5Q"],
-        "issued_at": "2019-01-03T19:27:21.540483Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["siYkV-A-Q86R8PX3jAS1Aw"],
+        "issued_at": "2019-01-04T16:54:22.967458Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:21 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:22 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -9514,15 +9514,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:27:21 GMT
+      - Fri, 04 Jan 2019 16:54:23 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - a0d42d645b1b455baa0971c73a53543c
+      - 84e69123ccd04494a04a28b62f9a9f05
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-edb0c024-2b44-4c4f-ba72-47d20dcd587f
+      - req-c72b31ac-691a-4a35-8e29-b586cb656f04
       Content-Length:
       - '7311'
       Connection:
@@ -9534,7 +9534,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2019-01-03T20:27:21.745631Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2019-01-04T17:54:23.182362Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -9613,10 +9613,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["OlopEIRATn2yjmi9uG-d4A"],
-        "issued_at": "2019-01-03T19:27:21.745652Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["6mdzZRFxQkON8j1TgDRjag"],
+        "issued_at": "2019-01-04T16:54:23.182383Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:21 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:23 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -9634,15 +9634,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:27:21 GMT
+      - Fri, 04 Jan 2019 16:54:23 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 438d8c88f08441678751d1c3712f6dd6
+      - 424f48e3e30a40e685280f469fa04e04
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-333938f3-d7e7-4bb5-b889-1b5804acc172
+      - req-e98cc3df-387c-4245-9427-ff8e042b2f5d
       Content-Length:
       - '297'
       Connection:
@@ -9651,12 +9651,12 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"token": {"methods": ["password"], "expires_at": "2019-01-03T20:27:21.922168Z",
+      string: '{"token": {"methods": ["password"], "expires_at": "2019-01-04T17:54:23.361609Z",
         "extras": {}, "user": {"domain": {"id": "default", "name": "Default"}, "id":
-        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["SnEvPF4mQmi2MZmZFJO_jQ"],
-        "issued_at": "2019-01-03T19:27:21.922187Z"}}'
+        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["OxqG_uEbS0KZJT8dWyg5pQ"],
+        "issued_at": "2019-01-04T16:54:23.361630Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:21 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:23 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects?domain_id=default
@@ -9671,20 +9671,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 438d8c88f08441678751d1c3712f6dd6
+      - 424f48e3e30a40e685280f469fa04e04
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:27:22 GMT
+      - Fri, 04 Jan 2019 16:54:23 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-8bd49549-3406-45dd-b529-d1b7c63f25c8
+      - req-42dc5632-28b2-4f3a-95d6-a7266ef6b1fd
       Content-Length:
       - '2475'
       Connection:
@@ -9717,7 +9717,7 @@ http_interactions:
         "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
         "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:22 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:23 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -9735,15 +9735,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:27:22 GMT
+      - Fri, 04 Jan 2019 16:54:23 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - ad4e757583f940129c8dbdcbeaee2628
+      - c6aa4612933943a08ea281b9cc23755d
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-b0d5ed92-372a-45a3-bb5b-ce3e936bf78f
+      - req-1b40a418-c3af-4214-8d64-07a16100161d
       Content-Length:
       - '7278'
       Connection:
@@ -9755,7 +9755,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:27:22.254820Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:54:23.708553Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -9834,10 +9834,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["fziqLb6yQqadBDSQQE-LCw"],
-        "issued_at": "2019-01-03T19:27:22.254838Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["SzhLEhqvRDuJ2WoqOLeBaw"],
+        "issued_at": "2019-01-04T16:54:23.708574Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:22 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:23 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -9855,15 +9855,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:27:22 GMT
+      - Fri, 04 Jan 2019 16:54:23 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 80d3f3c526414a1d8d71afbe3ad49f88
+      - 819e27dd31c34352800addb4fbb02bdd
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-8633371c-3989-401b-8af2-315fbe98abc9
+      - req-f41c4391-c36f-434e-959c-618ce80bfde1
       Content-Length:
       - '7278'
       Connection:
@@ -9875,7 +9875,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:27:22.454901Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:54:23.916231Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -9954,10 +9954,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["a7b6IVe2QbGgDtvIW66miQ"],
-        "issued_at": "2019-01-03T19:27:22.454918Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["MTtsWy0-SpeAWhF-QxYgzg"],
+        "issued_at": "2019-01-04T16:54:23.916251Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:22 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:23 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -9975,15 +9975,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:27:22 GMT
+      - Fri, 04 Jan 2019 16:54:24 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 36eb1bd4c97d4fe99c92f694b5d07f94
+      - 7a7482f760ec493fae6e13fc61c5a315
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-ecfe1041-d5cd-4134-8f75-c3534c874131
+      - req-e8c2275d-f0b9-4a44-801a-f07bad4d2e39
       Content-Length:
       - '7264'
       Connection:
@@ -9995,7 +9995,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:27:22.671197Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:54:24.130467Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -10074,10 +10074,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["JfsIjH8uSrSs5Foc2YjSpQ"],
-        "issued_at": "2019-01-03T19:27:22.671220Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Lw_-j2InQ0W9rs8RYYhbew"],
+        "issued_at": "2019-01-04T16:54:24.130488Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:22 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:24 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -10095,15 +10095,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:27:22 GMT
+      - Fri, 04 Jan 2019 16:54:24 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - '04499dbcd81144289327c48a77bdda94'
+      - 95c094ff62c441e5926ce9cad6ab4da9
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-2384f095-c2ce-4f4d-9225-c3a26fa33e6d
+      - req-7ca01cf9-275b-4c94-8245-02d8dd820f97
       Content-Length:
       - '7278'
       Connection:
@@ -10115,7 +10115,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:27:22.891418Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:54:24.348624Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -10194,10 +10194,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["r9hCPNonRhWJf0TSNALvgA"],
-        "issued_at": "2019-01-03T19:27:22.891443Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["w7vKcU-kTjCE33ob0b6wAw"],
+        "issued_at": "2019-01-04T16:54:24.348647Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:22 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:24 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -10215,15 +10215,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:27:23 GMT
+      - Fri, 04 Jan 2019 16:54:24 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - c2b030eebb7a4365b2c59673c40a71ef
+      - dafca91b6dcb45ec8044c53aa5ec8ba7
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-c1f43d44-ebbf-4ce7-8458-ddc288d55983
+      - req-6a0a1c54-1611-41e7-9f93-ab41e42e3cde
       Content-Length:
       - '7265'
       Connection:
@@ -10235,7 +10235,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:27:23.099273Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:54:24.555383Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -10314,10 +10314,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["bDINfhCGSBG6FjyOseI89Q"],
-        "issued_at": "2019-01-03T19:27:23.099292Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["z55hgmOBTtCe-B9ti1jzsQ"],
+        "issued_at": "2019-01-04T16:54:24.555411Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:23 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:24 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -10335,15 +10335,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:27:23 GMT
+      - Fri, 04 Jan 2019 16:54:24 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 3e949517bf86460d9946177bd8024f06
+      - 5eec6ffa9cde4bffa5800d922577a083
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-79d9698a-b904-4a92-92e8-f9eff5836c98
+      - req-b1e17c28-d34d-4790-8732-b6eb2cd8e42e
       Content-Length:
       - '7278'
       Connection:
@@ -10355,7 +10355,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:27:23.299494Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:54:24.805257Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -10434,10 +10434,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["nMcLBxycTj-ZkJ2D49vCKw"],
-        "issued_at": "2019-01-03T19:27:23.299513Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Lo60-CNORO6F3GVlUDSZFw"],
+        "issued_at": "2019-01-04T16:54:24.805281Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:23 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:24 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/volumes/detail?limit=1000
@@ -10452,27 +10452,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ad4e757583f940129c8dbdcbeaee2628
+      - c6aa4612933943a08ea281b9cc23755d
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-9a5270f6-8ac1-4a48-84be-daa33f0b496e
+      - req-dc00f633-fa0c-4e0d-ba77-72a4ad12d14d
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-9a5270f6-8ac1-4a48-84be-daa33f0b496e
+      - req-dc00f633-fa0c-4e0d-ba77-72a4ad12d14d
       Date:
-      - Thu, 03 Jan 2019 19:27:23 GMT
+      - Fri, 04 Jan 2019 16:54:24 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:23 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:25 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/volumes/detail?limit=1000
@@ -10487,27 +10487,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 80d3f3c526414a1d8d71afbe3ad49f88
+      - 819e27dd31c34352800addb4fbb02bdd
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-6f10e7d0-7356-405b-a4d7-60c7f7ecd854
+      - req-1edaf487-3578-493c-9c2a-a1f6201abdc6
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-6f10e7d0-7356-405b-a4d7-60c7f7ecd854
+      - req-1edaf487-3578-493c-9c2a-a1f6201abdc6
       Date:
-      - Thu, 03 Jan 2019 19:27:23 GMT
+      - Fri, 04 Jan 2019 16:54:25 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:23 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:25 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000
@@ -10522,22 +10522,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 36eb1bd4c97d4fe99c92f694b5d07f94
+      - 7a7482f760ec493fae6e13fc61c5a315
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-2ce4cc19-a0f2-49e2-8170-991064eed42c
+      - req-8caccac2-74d3-4c38-ab42-87d40240e244
       Content-Type:
       - application/json
       Content-Length:
       - '2706'
       X-Openstack-Request-Id:
-      - req-2ce4cc19-a0f2-49e2-8170-991064eed42c
+      - req-8caccac2-74d3-4c38-ab42-87d40240e244
       Date:
-      - Thu, 03 Jan 2019 19:27:23 GMT
+      - Fri, 04 Jan 2019 16:54:25 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=f46458aa-309d-4f47-b996-a39db065030a",
@@ -10570,7 +10570,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-4", "bootable": "true", "created_at":
         "2016-08-19T08:37:45.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:23 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:25 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=f46458aa-309d-4f47-b996-a39db065030a
@@ -10585,22 +10585,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 36eb1bd4c97d4fe99c92f694b5d07f94
+      - 7a7482f760ec493fae6e13fc61c5a315
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-ad7754f8-49ce-46bb-825c-7d1d3f918ea4
+      - req-017282c5-6852-442a-bdd0-e1aeb773e51b
       Content-Type:
       - application/json
       Content-Length:
       - '3284'
       X-Openstack-Request-Id:
-      - req-ad7754f8-49ce-46bb-825c-7d1d3f918ea4
+      - req-017282c5-6852-442a-bdd0-e1aeb773e51b
       Date:
-      - Thu, 03 Jan 2019 19:27:23 GMT
+      - Fri, 04 Jan 2019 16:54:25 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=476a0c89-4322-42aa-b7ce-3ac21be55af7",
@@ -10641,7 +10641,7 @@ http_interactions:
         "name": "EmsRefreshSpec-Volume-2", "bootable": "false", "created_at": "2016-08-19T08:37:33.000000",
         "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:23 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:25 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=476a0c89-4322-42aa-b7ce-3ac21be55af7
@@ -10656,22 +10656,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 36eb1bd4c97d4fe99c92f694b5d07f94
+      - 7a7482f760ec493fae6e13fc61c5a315
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-71bd2761-1747-42e2-be69-b3f974a9d58d
+      - req-81aac566-1014-452c-8caa-29eaa0be8194
       Content-Type:
       - application/json
       Content-Length:
       - '2753'
       X-Openstack-Request-Id:
-      - req-71bd2761-1747-42e2-be69-b3f974a9d58d
+      - req-81aac566-1014-452c-8caa-29eaa0be8194
       Date:
-      - Thu, 03 Jan 2019 19:27:24 GMT
+      - Fri, 04 Jan 2019 16:54:25 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=8791e24f-874d-4f1e-99ec-75fdb9d48ca5",
@@ -10705,7 +10705,7 @@ http_interactions:
         "bootable": "false", "created_at": "2016-08-19T08:37:05.000000", "volume_type":
         "iscsi"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:24 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:25 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=8791e24f-874d-4f1e-99ec-75fdb9d48ca5
@@ -10720,27 +10720,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 36eb1bd4c97d4fe99c92f694b5d07f94
+      - 7a7482f760ec493fae6e13fc61c5a315
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-28eef5c1-7944-44ad-926d-0a4ba59b1451
+      - req-441d593a-d60a-4fd8-b5cf-084c72e46096
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-28eef5c1-7944-44ad-926d-0a4ba59b1451
+      - req-441d593a-d60a-4fd8-b5cf-084c72e46096
       Date:
-      - Thu, 03 Jan 2019 19:27:24 GMT
+      - Fri, 04 Jan 2019 16:54:25 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:24 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:25 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/volumes/detail?limit=1000
@@ -10755,27 +10755,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '04499dbcd81144289327c48a77bdda94'
+      - 95c094ff62c441e5926ce9cad6ab4da9
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-87d29cc5-9a7f-4595-b8d1-3999b15c36b5
+      - req-ea3257ec-c93a-44c1-80ee-b1ca52542dd4
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-87d29cc5-9a7f-4595-b8d1-3999b15c36b5
+      - req-ea3257ec-c93a-44c1-80ee-b1ca52542dd4
       Date:
-      - Thu, 03 Jan 2019 19:27:24 GMT
+      - Fri, 04 Jan 2019 16:54:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:24 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:26 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/volumes/detail?limit=1000
@@ -10790,27 +10790,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a0d42d645b1b455baa0971c73a53543c
+      - 84e69123ccd04494a04a28b62f9a9f05
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-21e11cb1-f81d-4465-91d8-57c6e8fedc67
+      - req-23765d9d-95c9-4e78-9706-5deeb43720b3
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-21e11cb1-f81d-4465-91d8-57c6e8fedc67
+      - req-23765d9d-95c9-4e78-9706-5deeb43720b3
       Date:
-      - Thu, 03 Jan 2019 19:27:24 GMT
+      - Fri, 04 Jan 2019 16:54:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:24 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:26 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/volumes/detail?limit=1000
@@ -10825,27 +10825,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c2b030eebb7a4365b2c59673c40a71ef
+      - dafca91b6dcb45ec8044c53aa5ec8ba7
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-909e8484-32ef-4380-a31c-61602419cde7
+      - req-436af4a8-20b6-4ada-927d-dabc3f2ebd48
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-909e8484-32ef-4380-a31c-61602419cde7
+      - req-436af4a8-20b6-4ada-927d-dabc3f2ebd48
       Date:
-      - Thu, 03 Jan 2019 19:27:24 GMT
+      - Fri, 04 Jan 2019 16:54:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:24 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:26 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/volumes/detail?limit=1000
@@ -10860,27 +10860,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3e949517bf86460d9946177bd8024f06
+      - 5eec6ffa9cde4bffa5800d922577a083
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-db7cb496-d25c-4bb3-a6ae-f3c067991494
+      - req-b01002da-c03b-432b-8bed-b573508462e0
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-db7cb496-d25c-4bb3-a6ae-f3c067991494
+      - req-b01002da-c03b-432b-8bed-b573508462e0
       Date:
-      - Thu, 03 Jan 2019 19:27:24 GMT
+      - Fri, 04 Jan 2019 16:54:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:24 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:26 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/snapshots/detail
@@ -10895,27 +10895,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ad4e757583f940129c8dbdcbeaee2628
+      - c6aa4612933943a08ea281b9cc23755d
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-4532bc8a-807f-40a6-b1c0-742c354e0b2a
+      - req-f8a214ec-c33b-48da-9f66-13219312ad70
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-4532bc8a-807f-40a6-b1c0-742c354e0b2a
+      - req-f8a214ec-c33b-48da-9f66-13219312ad70
       Date:
-      - Thu, 03 Jan 2019 19:27:24 GMT
+      - Fri, 04 Jan 2019 16:54:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:24 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:26 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/snapshots/detail?limit=1000
@@ -10930,27 +10930,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ad4e757583f940129c8dbdcbeaee2628
+      - c6aa4612933943a08ea281b9cc23755d
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-ca993ac2-be7f-4d0d-a0b0-62121df66f69
+      - req-0f11719a-8305-466e-8ef7-66d94cbe3016
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-ca993ac2-be7f-4d0d-a0b0-62121df66f69
+      - req-0f11719a-8305-466e-8ef7-66d94cbe3016
       Date:
-      - Thu, 03 Jan 2019 19:27:25 GMT
+      - Fri, 04 Jan 2019 16:54:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:25 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:26 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/snapshots/detail
@@ -10965,27 +10965,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 80d3f3c526414a1d8d71afbe3ad49f88
+      - 819e27dd31c34352800addb4fbb02bdd
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-d26b92f9-c8d6-48eb-9715-c043cc8f9c04
+      - req-255c5387-5bbf-4ec5-b99d-90015e301783
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-d26b92f9-c8d6-48eb-9715-c043cc8f9c04
+      - req-255c5387-5bbf-4ec5-b99d-90015e301783
       Date:
-      - Thu, 03 Jan 2019 19:27:25 GMT
+      - Fri, 04 Jan 2019 16:54:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:25 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:26 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/snapshots/detail?limit=1000
@@ -11000,27 +11000,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 80d3f3c526414a1d8d71afbe3ad49f88
+      - 819e27dd31c34352800addb4fbb02bdd
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-d8ef7aa7-dc7a-4e42-8011-0466719e0a01
+      - req-818b8290-7af9-40f5-a5d3-3f2cab1fef6b
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-d8ef7aa7-dc7a-4e42-8011-0466719e0a01
+      - req-818b8290-7af9-40f5-a5d3-3f2cab1fef6b
       Date:
-      - Thu, 03 Jan 2019 19:27:25 GMT
+      - Fri, 04 Jan 2019 16:54:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:25 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:26 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/snapshots/detail
@@ -11035,22 +11035,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 36eb1bd4c97d4fe99c92f694b5d07f94
+      - 7a7482f760ec493fae6e13fc61c5a315
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-e272d7bd-6169-475a-8375-569268c901b9
+      - req-a0b692ff-0fb5-4258-892e-f1789468ac25
       Content-Type:
       - application/json
       Content-Length:
       - '1053'
       X-Openstack-Request-Id:
-      - req-e272d7bd-6169-475a-8375-569268c901b9
+      - req-a0b692ff-0fb5-4258-892e-f1789468ac25
       Date:
-      - Thu, 03 Jan 2019 19:27:25 GMT
+      - Fri, 04 Jan 2019 16:54:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/snapshots/detail?marker=c44d3eb3-31fe-46ed-bfae-707920be171d",
@@ -11065,7 +11065,7 @@ http_interactions:
         "created_at": "2016-08-19T08:37:24.000000", "size": 1, "id": "c44d3eb3-31fe-46ed-bfae-707920be171d",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:25 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:27 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/snapshots/detail?limit=1000
@@ -11080,22 +11080,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 36eb1bd4c97d4fe99c92f694b5d07f94
+      - 7a7482f760ec493fae6e13fc61c5a315
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-6463fba2-ccfe-44f2-902f-c69f81bbddd0
+      - req-1c176c26-fa1b-4928-86d4-ff673df1077b
       Content-Type:
       - application/json
       Content-Length:
       - '1064'
       X-Openstack-Request-Id:
-      - req-6463fba2-ccfe-44f2-902f-c69f81bbddd0
+      - req-1c176c26-fa1b-4928-86d4-ff673df1077b
       Date:
-      - Thu, 03 Jan 2019 19:27:25 GMT
+      - Fri, 04 Jan 2019 16:54:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/snapshots/detail?limit=1000&marker=c44d3eb3-31fe-46ed-bfae-707920be171d",
@@ -11110,7 +11110,7 @@ http_interactions:
         "created_at": "2016-08-19T08:37:24.000000", "size": 1, "id": "c44d3eb3-31fe-46ed-bfae-707920be171d",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:25 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:27 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/snapshots/detail
@@ -11125,27 +11125,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '04499dbcd81144289327c48a77bdda94'
+      - 95c094ff62c441e5926ce9cad6ab4da9
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-87848e2a-d0a0-4c93-8e57-fe3b9eb86340
+      - req-35505ae4-c9b1-4f56-a97e-72a8327bb4a2
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-87848e2a-d0a0-4c93-8e57-fe3b9eb86340
+      - req-35505ae4-c9b1-4f56-a97e-72a8327bb4a2
       Date:
-      - Thu, 03 Jan 2019 19:27:25 GMT
+      - Fri, 04 Jan 2019 16:54:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:25 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:27 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/snapshots/detail?limit=1000
@@ -11160,27 +11160,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '04499dbcd81144289327c48a77bdda94'
+      - 95c094ff62c441e5926ce9cad6ab4da9
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-e2c2bf46-31d9-475c-bc7a-a13b517c5593
+      - req-3eff4e50-0a15-42d7-8665-af4cbf79ea0d
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-e2c2bf46-31d9-475c-bc7a-a13b517c5593
+      - req-3eff4e50-0a15-42d7-8665-af4cbf79ea0d
       Date:
-      - Thu, 03 Jan 2019 19:27:25 GMT
+      - Fri, 04 Jan 2019 16:54:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:25 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:27 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/snapshots/detail
@@ -11195,27 +11195,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a0d42d645b1b455baa0971c73a53543c
+      - 84e69123ccd04494a04a28b62f9a9f05
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-1d39eb31-9618-4e93-a781-34e92c93e219
+      - req-0909d511-2036-42fe-a233-ed83c628eee9
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-1d39eb31-9618-4e93-a781-34e92c93e219
+      - req-0909d511-2036-42fe-a233-ed83c628eee9
       Date:
-      - Thu, 03 Jan 2019 19:27:25 GMT
+      - Fri, 04 Jan 2019 16:54:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:25 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:27 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/snapshots/detail?limit=1000
@@ -11230,27 +11230,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a0d42d645b1b455baa0971c73a53543c
+      - 84e69123ccd04494a04a28b62f9a9f05
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-7bf7b2f7-1928-4a10-9012-94c2de225296
+      - req-5cf3a1d5-1421-44b7-a48d-2281f3095748
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-7bf7b2f7-1928-4a10-9012-94c2de225296
+      - req-5cf3a1d5-1421-44b7-a48d-2281f3095748
       Date:
-      - Thu, 03 Jan 2019 19:27:25 GMT
+      - Fri, 04 Jan 2019 16:54:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:25 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:27 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/snapshots/detail
@@ -11265,27 +11265,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c2b030eebb7a4365b2c59673c40a71ef
+      - dafca91b6dcb45ec8044c53aa5ec8ba7
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-c7133e87-b118-4627-bed9-2d01613bae70
+      - req-95c29c01-cd75-4f8b-91d6-6cc7bdd09dee
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-c7133e87-b118-4627-bed9-2d01613bae70
+      - req-95c29c01-cd75-4f8b-91d6-6cc7bdd09dee
       Date:
-      - Thu, 03 Jan 2019 19:27:26 GMT
+      - Fri, 04 Jan 2019 16:54:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:26 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:27 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/snapshots/detail?limit=1000
@@ -11300,27 +11300,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c2b030eebb7a4365b2c59673c40a71ef
+      - dafca91b6dcb45ec8044c53aa5ec8ba7
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-6abecf97-90ae-4c0d-aa83-d93a09b5b8e6
+      - req-ed3cb75e-a194-42bb-bf63-92802a7c326e
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-6abecf97-90ae-4c0d-aa83-d93a09b5b8e6
+      - req-ed3cb75e-a194-42bb-bf63-92802a7c326e
       Date:
-      - Thu, 03 Jan 2019 19:27:26 GMT
+      - Fri, 04 Jan 2019 16:54:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:26 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:27 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/snapshots/detail
@@ -11335,27 +11335,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3e949517bf86460d9946177bd8024f06
+      - 5eec6ffa9cde4bffa5800d922577a083
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-702bcc15-2105-480f-81cf-2cd4958b5f27
+      - req-dd8b727b-44f0-4c81-9780-b7ebc208fbc9
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-702bcc15-2105-480f-81cf-2cd4958b5f27
+      - req-dd8b727b-44f0-4c81-9780-b7ebc208fbc9
       Date:
-      - Thu, 03 Jan 2019 19:27:26 GMT
+      - Fri, 04 Jan 2019 16:54:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:26 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:27 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/snapshots/detail?limit=1000
@@ -11370,27 +11370,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3e949517bf86460d9946177bd8024f06
+      - 5eec6ffa9cde4bffa5800d922577a083
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-b3e68255-265f-42cf-838a-3f1b9a5760dc
+      - req-c350663a-befb-407b-9816-dfd13ee12974
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-b3e68255-265f-42cf-838a-3f1b9a5760dc
+      - req-c350663a-befb-407b-9816-dfd13ee12974
       Date:
-      - Thu, 03 Jan 2019 19:27:26 GMT
+      - Fri, 04 Jan 2019 16:54:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:26 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:28 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/backups/detail
@@ -11405,27 +11405,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ad4e757583f940129c8dbdcbeaee2628
+      - c6aa4612933943a08ea281b9cc23755d
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-f060c85f-f58c-4b9f-a2ea-8784aa08c718
+      - req-df57ed92-ac57-4626-9bc5-94febfd4a170
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-f060c85f-f58c-4b9f-a2ea-8784aa08c718
+      - req-df57ed92-ac57-4626-9bc5-94febfd4a170
       Date:
-      - Thu, 03 Jan 2019 19:27:26 GMT
+      - Fri, 04 Jan 2019 16:54:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:26 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:28 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/backups/detail?limit=1000
@@ -11440,27 +11440,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ad4e757583f940129c8dbdcbeaee2628
+      - c6aa4612933943a08ea281b9cc23755d
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-13e5f9ee-183d-41f3-8d8c-12e87d87117f
+      - req-43bbb011-0c33-4556-ad49-3421522a5cda
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-13e5f9ee-183d-41f3-8d8c-12e87d87117f
+      - req-43bbb011-0c33-4556-ad49-3421522a5cda
       Date:
-      - Thu, 03 Jan 2019 19:27:26 GMT
+      - Fri, 04 Jan 2019 16:54:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:26 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:28 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/backups/detail
@@ -11475,27 +11475,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 80d3f3c526414a1d8d71afbe3ad49f88
+      - 819e27dd31c34352800addb4fbb02bdd
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-b6ea31f4-b09d-4fbf-9d9b-e8249028a98c
+      - req-d452d6d2-2248-4a62-b9b6-c94cc8e63a4f
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-b6ea31f4-b09d-4fbf-9d9b-e8249028a98c
+      - req-d452d6d2-2248-4a62-b9b6-c94cc8e63a4f
       Date:
-      - Thu, 03 Jan 2019 19:27:26 GMT
+      - Fri, 04 Jan 2019 16:54:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:26 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:28 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/backups/detail?limit=1000
@@ -11510,27 +11510,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 80d3f3c526414a1d8d71afbe3ad49f88
+      - 819e27dd31c34352800addb4fbb02bdd
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-b34366e7-b797-42eb-ab9e-32355a29d61e
+      - req-7875e89f-f99d-46cb-bab9-e34a5da7191f
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-b34366e7-b797-42eb-ab9e-32355a29d61e
+      - req-7875e89f-f99d-46cb-bab9-e34a5da7191f
       Date:
-      - Thu, 03 Jan 2019 19:27:26 GMT
+      - Fri, 04 Jan 2019 16:54:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:26 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:28 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/backups/detail
@@ -11545,27 +11545,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 36eb1bd4c97d4fe99c92f694b5d07f94
+      - 7a7482f760ec493fae6e13fc61c5a315
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-f0841e10-bc4e-4188-8d46-1c2e6e228d93
+      - req-2c10ab61-93ab-4ca7-86d4-91e692e6bef6
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-f0841e10-bc4e-4188-8d46-1c2e6e228d93
+      - req-2c10ab61-93ab-4ca7-86d4-91e692e6bef6
       Date:
-      - Thu, 03 Jan 2019 19:27:26 GMT
+      - Fri, 04 Jan 2019 16:54:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:26 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:28 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/backups/detail?limit=1000
@@ -11580,27 +11580,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 36eb1bd4c97d4fe99c92f694b5d07f94
+      - 7a7482f760ec493fae6e13fc61c5a315
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-6dba93a8-8c9b-4533-be6b-9193de0ba4b0
+      - req-1fcdc52b-4422-41de-9bae-641dd4ec329d
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-6dba93a8-8c9b-4533-be6b-9193de0ba4b0
+      - req-1fcdc52b-4422-41de-9bae-641dd4ec329d
       Date:
-      - Thu, 03 Jan 2019 19:27:26 GMT
+      - Fri, 04 Jan 2019 16:54:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:26 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:28 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/backups/detail
@@ -11615,27 +11615,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '04499dbcd81144289327c48a77bdda94'
+      - 95c094ff62c441e5926ce9cad6ab4da9
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-df5af440-68e9-4faf-b7cf-da585e3fa60d
+      - req-cd594d40-4fc4-43c8-815f-2901cff50211
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-df5af440-68e9-4faf-b7cf-da585e3fa60d
+      - req-cd594d40-4fc4-43c8-815f-2901cff50211
       Date:
-      - Thu, 03 Jan 2019 19:27:26 GMT
+      - Fri, 04 Jan 2019 16:54:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:27 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:28 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/backups/detail?limit=1000
@@ -11650,27 +11650,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '04499dbcd81144289327c48a77bdda94'
+      - 95c094ff62c441e5926ce9cad6ab4da9
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-1986d717-cb22-4d6e-a882-88cd24ce69e2
+      - req-11ac9464-a4d7-45a4-a8be-5c782d5559f6
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-1986d717-cb22-4d6e-a882-88cd24ce69e2
+      - req-11ac9464-a4d7-45a4-a8be-5c782d5559f6
       Date:
-      - Thu, 03 Jan 2019 19:27:27 GMT
+      - Fri, 04 Jan 2019 16:54:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:27 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:28 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/backups/detail
@@ -11685,27 +11685,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a0d42d645b1b455baa0971c73a53543c
+      - 84e69123ccd04494a04a28b62f9a9f05
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-48743a67-4db2-4c52-ab2c-470fe34c65c9
+      - req-385527e9-9264-40ee-8925-9165d8b0530d
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-48743a67-4db2-4c52-ab2c-470fe34c65c9
+      - req-385527e9-9264-40ee-8925-9165d8b0530d
       Date:
-      - Thu, 03 Jan 2019 19:27:27 GMT
+      - Fri, 04 Jan 2019 16:54:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:27 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:28 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/backups/detail?limit=1000
@@ -11720,27 +11720,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a0d42d645b1b455baa0971c73a53543c
+      - 84e69123ccd04494a04a28b62f9a9f05
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-acd46848-f7e9-41c2-af79-aceea5f8e2d0
+      - req-f75a7d38-ee33-45bc-9b17-0b5c8b0abd66
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-acd46848-f7e9-41c2-af79-aceea5f8e2d0
+      - req-f75a7d38-ee33-45bc-9b17-0b5c8b0abd66
       Date:
-      - Thu, 03 Jan 2019 19:27:27 GMT
+      - Fri, 04 Jan 2019 16:54:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:27 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:28 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/backups/detail
@@ -11755,27 +11755,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c2b030eebb7a4365b2c59673c40a71ef
+      - dafca91b6dcb45ec8044c53aa5ec8ba7
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-4486d978-8c8c-436a-a47b-6ea3dc6b1dd4
+      - req-3391e528-d600-4b57-b703-9bc9772d468f
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-4486d978-8c8c-436a-a47b-6ea3dc6b1dd4
+      - req-3391e528-d600-4b57-b703-9bc9772d468f
       Date:
-      - Thu, 03 Jan 2019 19:27:27 GMT
+      - Fri, 04 Jan 2019 16:54:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:27 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:29 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/backups/detail?limit=1000
@@ -11790,27 +11790,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c2b030eebb7a4365b2c59673c40a71ef
+      - dafca91b6dcb45ec8044c53aa5ec8ba7
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-360826ff-76f9-4196-bcb8-f444b7911342
+      - req-23eed66e-b11e-4ea0-a75b-aa122a2f8946
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-360826ff-76f9-4196-bcb8-f444b7911342
+      - req-23eed66e-b11e-4ea0-a75b-aa122a2f8946
       Date:
-      - Thu, 03 Jan 2019 19:27:27 GMT
+      - Fri, 04 Jan 2019 16:54:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:27 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:29 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/backups/detail
@@ -11825,27 +11825,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3e949517bf86460d9946177bd8024f06
+      - 5eec6ffa9cde4bffa5800d922577a083
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-1e911620-8a17-4e9f-98d9-792328ed0f69
+      - req-7fd5a463-cc6e-4def-a720-233739a568df
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-1e911620-8a17-4e9f-98d9-792328ed0f69
+      - req-7fd5a463-cc6e-4def-a720-233739a568df
       Date:
-      - Thu, 03 Jan 2019 19:27:27 GMT
+      - Fri, 04 Jan 2019 16:54:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:27 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:29 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/backups/detail?limit=1000
@@ -11860,27 +11860,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3e949517bf86460d9946177bd8024f06
+      - 5eec6ffa9cde4bffa5800d922577a083
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-31e8b174-aa4b-4dc3-9eac-0737ade88821
+      - req-b338275f-be5f-4942-a2ea-b03739f42955
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-31e8b174-aa4b-4dc3-9eac-0737ade88821
+      - req-b338275f-be5f-4942-a2ea-b03739f42955
       Date:
-      - Thu, 03 Jan 2019 19:27:27 GMT
+      - Fri, 04 Jan 2019 16:54:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:27 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:29 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/types?limit=1000
@@ -11895,22 +11895,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ad4e757583f940129c8dbdcbeaee2628
+      - c6aa4612933943a08ea281b9cc23755d
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-4d3a8a5f-dd8a-43a8-ac63-b32455b92d32
+      - req-7f2b1c3a-fbba-4b8e-ab65-44a44fa9de61
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-4d3a8a5f-dd8a-43a8-ac63-b32455b92d32
+      - req-7f2b1c3a-fbba-4b8e-ab65-44a44fa9de61
       Date:
-      - Thu, 03 Jan 2019 19:27:27 GMT
+      - Fri, 04 Jan 2019 16:54:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -11922,7 +11922,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:27 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:29 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/types?limit=1000&marker=b953db40-aeea-4a55-9bd9-c08dcafd6f7e
@@ -11937,22 +11937,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ad4e757583f940129c8dbdcbeaee2628
+      - c6aa4612933943a08ea281b9cc23755d
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-06e602b5-d88b-4f39-8909-3a5aa043b3e8
+      - req-0520e571-716f-4ad0-8758-99dc9e38252f
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-06e602b5-d88b-4f39-8909-3a5aa043b3e8
+      - req-0520e571-716f-4ad0-8758-99dc9e38252f
       Date:
-      - Thu, 03 Jan 2019 19:27:27 GMT
+      - Fri, 04 Jan 2019 16:54:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -11964,7 +11964,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:27 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:29 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/types?limit=1000
@@ -11979,22 +11979,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 80d3f3c526414a1d8d71afbe3ad49f88
+      - 819e27dd31c34352800addb4fbb02bdd
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-9a4083aa-3c3e-4663-aeb6-e55db782e72e
+      - req-65184693-ecb0-42a1-90a3-47f3af61980b
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-9a4083aa-3c3e-4663-aeb6-e55db782e72e
+      - req-65184693-ecb0-42a1-90a3-47f3af61980b
       Date:
-      - Thu, 03 Jan 2019 19:27:27 GMT
+      - Fri, 04 Jan 2019 16:54:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -12006,7 +12006,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:27 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:29 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/types?limit=1000&marker=b953db40-aeea-4a55-9bd9-c08dcafd6f7e
@@ -12021,22 +12021,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 80d3f3c526414a1d8d71afbe3ad49f88
+      - 819e27dd31c34352800addb4fbb02bdd
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-75b2d67c-a15f-4aa0-833a-6b0420a84302
+      - req-b123be27-0539-427c-890d-a3b9a74b2738
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-75b2d67c-a15f-4aa0-833a-6b0420a84302
+      - req-b123be27-0539-427c-890d-a3b9a74b2738
       Date:
-      - Thu, 03 Jan 2019 19:27:28 GMT
+      - Fri, 04 Jan 2019 16:54:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -12048,7 +12048,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:28 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:29 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/types?limit=1000
@@ -12063,22 +12063,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 36eb1bd4c97d4fe99c92f694b5d07f94
+      - 7a7482f760ec493fae6e13fc61c5a315
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-fb5837bf-4938-422d-a810-43993dded9bb
+      - req-30ae3d30-035d-4c60-b6f5-3541b1c0b21f
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-fb5837bf-4938-422d-a810-43993dded9bb
+      - req-30ae3d30-035d-4c60-b6f5-3541b1c0b21f
       Date:
-      - Thu, 03 Jan 2019 19:27:28 GMT
+      - Fri, 04 Jan 2019 16:54:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -12090,7 +12090,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:28 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:29 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/types?limit=1000&marker=b953db40-aeea-4a55-9bd9-c08dcafd6f7e
@@ -12105,22 +12105,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 36eb1bd4c97d4fe99c92f694b5d07f94
+      - 7a7482f760ec493fae6e13fc61c5a315
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-adecdb9b-16d6-46fe-8ece-6d37e00ef5de
+      - req-acb232b9-49d8-41a9-9458-9a97d6f7e9b4
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-adecdb9b-16d6-46fe-8ece-6d37e00ef5de
+      - req-acb232b9-49d8-41a9-9458-9a97d6f7e9b4
       Date:
-      - Thu, 03 Jan 2019 19:27:28 GMT
+      - Fri, 04 Jan 2019 16:54:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -12132,7 +12132,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:28 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:29 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/types?limit=1000
@@ -12147,22 +12147,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '04499dbcd81144289327c48a77bdda94'
+      - 95c094ff62c441e5926ce9cad6ab4da9
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-d6e6cd12-6355-4ef5-96d6-e4b8e6da6a9e
+      - req-63df911d-6b3b-40ab-bd37-e0a1852acf06
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-d6e6cd12-6355-4ef5-96d6-e4b8e6da6a9e
+      - req-63df911d-6b3b-40ab-bd37-e0a1852acf06
       Date:
-      - Thu, 03 Jan 2019 19:27:28 GMT
+      - Fri, 04 Jan 2019 16:54:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -12174,7 +12174,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:28 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:30 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/types?limit=1000&marker=b953db40-aeea-4a55-9bd9-c08dcafd6f7e
@@ -12189,22 +12189,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '04499dbcd81144289327c48a77bdda94'
+      - 95c094ff62c441e5926ce9cad6ab4da9
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-59c19cb5-57bc-4d09-ba8e-4ba6dbb6c0d4
+      - req-27737db0-4fd3-4cb5-a3a7-453df419c176
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-59c19cb5-57bc-4d09-ba8e-4ba6dbb6c0d4
+      - req-27737db0-4fd3-4cb5-a3a7-453df419c176
       Date:
-      - Thu, 03 Jan 2019 19:27:28 GMT
+      - Fri, 04 Jan 2019 16:54:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -12216,7 +12216,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:28 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:30 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/types?limit=1000
@@ -12231,22 +12231,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a0d42d645b1b455baa0971c73a53543c
+      - 84e69123ccd04494a04a28b62f9a9f05
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-00b51300-c63f-42be-bff3-80193dc819cf
+      - req-0c69d8a8-3527-4df4-9ba6-e98fe05f4077
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-00b51300-c63f-42be-bff3-80193dc819cf
+      - req-0c69d8a8-3527-4df4-9ba6-e98fe05f4077
       Date:
-      - Thu, 03 Jan 2019 19:27:28 GMT
+      - Fri, 04 Jan 2019 16:54:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -12258,7 +12258,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:28 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:30 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/types?limit=1000&marker=b953db40-aeea-4a55-9bd9-c08dcafd6f7e
@@ -12273,22 +12273,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a0d42d645b1b455baa0971c73a53543c
+      - 84e69123ccd04494a04a28b62f9a9f05
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-c856de0c-57ae-4f7d-8d15-db0ecb4ef1b6
+      - req-c8ca217a-5afb-4b87-baef-2d9813a22d22
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-c856de0c-57ae-4f7d-8d15-db0ecb4ef1b6
+      - req-c8ca217a-5afb-4b87-baef-2d9813a22d22
       Date:
-      - Thu, 03 Jan 2019 19:27:28 GMT
+      - Fri, 04 Jan 2019 16:54:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -12300,7 +12300,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:28 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:30 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/types?limit=1000
@@ -12315,22 +12315,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c2b030eebb7a4365b2c59673c40a71ef
+      - dafca91b6dcb45ec8044c53aa5ec8ba7
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-b03c27cc-653c-4185-8a38-0db43b9af719
+      - req-84a6ba3a-628c-4dea-a69a-0838a43509f9
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-b03c27cc-653c-4185-8a38-0db43b9af719
+      - req-84a6ba3a-628c-4dea-a69a-0838a43509f9
       Date:
-      - Thu, 03 Jan 2019 19:27:28 GMT
+      - Fri, 04 Jan 2019 16:54:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -12342,7 +12342,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:28 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:30 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/types?limit=1000&marker=b953db40-aeea-4a55-9bd9-c08dcafd6f7e
@@ -12357,22 +12357,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c2b030eebb7a4365b2c59673c40a71ef
+      - dafca91b6dcb45ec8044c53aa5ec8ba7
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-dbf24050-3c1a-460f-87e7-e0642fff86dc
+      - req-86e0596a-a9a1-42a1-94cd-0592f57a23ee
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-dbf24050-3c1a-460f-87e7-e0642fff86dc
+      - req-86e0596a-a9a1-42a1-94cd-0592f57a23ee
       Date:
-      - Thu, 03 Jan 2019 19:27:28 GMT
+      - Fri, 04 Jan 2019 16:54:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -12384,7 +12384,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:28 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:30 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/types?limit=1000
@@ -12399,22 +12399,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3e949517bf86460d9946177bd8024f06
+      - 5eec6ffa9cde4bffa5800d922577a083
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-af644dea-43a0-47d1-945a-b884fa0599cf
+      - req-d754edaa-3565-4354-8d12-826f5d8e2e63
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-af644dea-43a0-47d1-945a-b884fa0599cf
+      - req-d754edaa-3565-4354-8d12-826f5d8e2e63
       Date:
-      - Thu, 03 Jan 2019 19:27:29 GMT
+      - Fri, 04 Jan 2019 16:54:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -12426,7 +12426,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:29 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:30 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/types?limit=1000&marker=b953db40-aeea-4a55-9bd9-c08dcafd6f7e
@@ -12441,22 +12441,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3e949517bf86460d9946177bd8024f06
+      - 5eec6ffa9cde4bffa5800d922577a083
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-2a924622-0a6e-40f7-89b4-e4ba3eebe096
+      - req-382cbc3c-5868-45ab-b216-79acf72fada7
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-2a924622-0a6e-40f7-89b4-e4ba3eebe096
+      - req-382cbc3c-5868-45ab-b216-79acf72fada7
       Date:
-      - Thu, 03 Jan 2019 19:27:29 GMT
+      - Fri, 04 Jan 2019 16:54:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -12468,7 +12468,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:29 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:30 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -12486,15 +12486,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:27:29 GMT
+      - Fri, 04 Jan 2019 16:54:30 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 0fb2df59f09048cfb16e695150d12bf2
+      - b08e1a5c29ec4673a6498d2a553e9c43
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-56692b12-b8e4-4cac-8059-e71d89ad5710
+      - req-d5a2eb0e-8351-4428-8b6d-c11f74d334aa
       Content-Length:
       - '7311'
       Connection:
@@ -12506,7 +12506,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2019-01-03T20:27:29.385199Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2019-01-04T17:54:31.054401Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -12585,10 +12585,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["KVwa5dSVS6aiCzmiP-HKew"],
-        "issued_at": "2019-01-03T19:27:29.385218Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["frFm9BVORM-ysIdUhcjMbg"],
+        "issued_at": "2019-01-04T16:54:31.054427Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:29 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:31 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -12606,15 +12606,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:27:29 GMT
+      - Fri, 04 Jan 2019 16:54:31 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 47b1e4593c9b412b98c54f7078c277ea
+      - 39523c746419496ba15e54ec5f21673c
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-ca61192d-0227-4ad2-93a5-6b7aeed900c9
+      - req-d7d766a8-6e32-44bd-a8fc-94ef1832cbb7
       Content-Length:
       - '7311'
       Connection:
@@ -12626,7 +12626,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2019-01-03T20:27:29.597444Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2019-01-04T17:54:31.300195Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -12705,10 +12705,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["4hQXm3nRSVK2ScrFO5h6Yw"],
-        "issued_at": "2019-01-03T19:27:29.597464Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["K1SnsOmqR1-1t2gYRB-c6w"],
+        "issued_at": "2019-01-04T16:54:31.300219Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:29 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:31 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -12726,15 +12726,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:27:29 GMT
+      - Fri, 04 Jan 2019 16:54:31 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - '091e241e52564c9a93510ee21a8467b4'
+      - b74a9059432f4f7192e97322664f7992
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-29d11e12-4b89-4812-b1e3-8053ccd6e64e
+      - req-07de856c-5c75-4093-97de-cc4dde9f577f
       Content-Length:
       - '297'
       Connection:
@@ -12743,12 +12743,12 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"token": {"methods": ["password"], "expires_at": "2019-01-03T20:27:29.771155Z",
+      string: '{"token": {"methods": ["password"], "expires_at": "2019-01-04T17:54:31.476294Z",
         "extras": {}, "user": {"domain": {"id": "default", "name": "Default"}, "id":
-        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Hprvq56aQJObtCSymqA6OQ"],
-        "issued_at": "2019-01-03T19:27:29.771172Z"}}'
+        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["8lWN9r1ATKedHLBW7TIdtw"],
+        "issued_at": "2019-01-04T16:54:31.476315Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:29 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:31 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects?domain_id=default
@@ -12763,20 +12763,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '091e241e52564c9a93510ee21a8467b4'
+      - b74a9059432f4f7192e97322664f7992
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:27:29 GMT
+      - Fri, 04 Jan 2019 16:54:31 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-b5582627-dfc8-4bc2-8822-897f66b2dd5d
+      - req-9167600d-4be7-4778-a45c-4f11370e8c60
       Content-Length:
       - '2475'
       Connection:
@@ -12809,7 +12809,7 @@ http_interactions:
         "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
         "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:29 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:31 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -12827,15 +12827,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:27:30 GMT
+      - Fri, 04 Jan 2019 16:54:31 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 6e08439cea8641dfb1ea74f5eb104774
+      - c521ff55fe6f4dfdae4387ae0a808907
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-0e062d99-3872-445e-b734-91d6527e5231
+      - req-6407b181-1741-4250-a369-68a0989c4e3c
       Content-Length:
       - '7278'
       Connection:
@@ -12847,7 +12847,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:27:30.107418Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:54:31.831436Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -12926,10 +12926,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Vgg_3LNeS2uKGxo3iQth_g"],
-        "issued_at": "2019-01-03T19:27:30.107435Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["pPUS0jEmSHmKidebFrzR8w"],
+        "issued_at": "2019-01-04T16:54:31.831459Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:30 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:31 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -12947,15 +12947,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:27:30 GMT
+      - Fri, 04 Jan 2019 16:54:31 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 5ae4e34180664132a79d88b52a4b5376
+      - e048dd317462446d91bd424e395e079d
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-74f13779-98de-4e8e-a78b-0b99653207f3
+      - req-37887623-1fa0-4c16-998f-00ceffa549a3
       Content-Length:
       - '7278'
       Connection:
@@ -12967,7 +12967,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:27:30.311744Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:54:32.043889Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -13046,10 +13046,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["hTk86J9aQFyr1jl3RhzIhA"],
-        "issued_at": "2019-01-03T19:27:30.311761Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["R5o9-8mbR8O2J3XZP82vjw"],
+        "issued_at": "2019-01-04T16:54:32.043909Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:30 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:32 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -13067,15 +13067,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:27:30 GMT
+      - Fri, 04 Jan 2019 16:54:32 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - e72c292936af4229b886d246f4b523b8
+      - 2f23d7493d2a4258bc538eecd467f751
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-4a1f4979-47b5-401c-81ce-4e4a47055a97
+      - req-e58b4075-fb27-4efd-85be-47e399646f06
       Content-Length:
       - '7264'
       Connection:
@@ -13087,7 +13087,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:27:30.516389Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:54:32.265344Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -13166,10 +13166,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["_viA4I2MRaWu6cl3okRoZg"],
-        "issued_at": "2019-01-03T19:27:30.516406Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["XFsuEyK7S16qmkKTMIDaSw"],
+        "issued_at": "2019-01-04T16:54:32.265371Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:30 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:32 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -13187,15 +13187,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:27:30 GMT
+      - Fri, 04 Jan 2019 16:54:32 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 195aaa47a195409297bbe40d11732d99
+      - b509495ad04846e4a2dead51d5e5cde7
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-3da0404a-f634-4b49-a99f-d2d86375ac54
+      - req-f0bb54f0-da78-438b-ba23-7e9cf2534f96
       Content-Length:
       - '7278'
       Connection:
@@ -13207,7 +13207,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:27:30.752350Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:54:32.475914Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -13286,10 +13286,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["QvTNgq_MTQ2Q3wGw6BN-Pg"],
-        "issued_at": "2019-01-03T19:27:30.752371Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["N2x23MIKSxOXt8jW-gzDaw"],
+        "issued_at": "2019-01-04T16:54:32.475940Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:30 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:32 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -13307,15 +13307,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:27:30 GMT
+      - Fri, 04 Jan 2019 16:54:32 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 69e7239fb77540b5851b5d04e57e319c
+      - 6e36dffc33d8430dbeb1e9a46acab159
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-eae706f0-cbed-4dba-bbf2-e310874b2832
+      - req-d3bdf48b-80be-4d80-8f81-001ce1c53faf
       Content-Length:
       - '7265'
       Connection:
@@ -13327,7 +13327,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:27:30.973931Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:54:32.692047Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -13406,10 +13406,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Q1urYJ9kR1WT5k03aUqtUQ"],
-        "issued_at": "2019-01-03T19:27:30.973960Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["4M2Z8U1hSjaJPNvEQ7pfFw"],
+        "issued_at": "2019-01-04T16:54:32.692068Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:31 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:32 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -13427,15 +13427,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:27:31 GMT
+      - Fri, 04 Jan 2019 16:54:32 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - a3bb52bedd1242adb0a6aa51bd4f4006
+      - ab032a15d08747b0aee7910a498ccd29
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-deef42bc-a22b-41ab-a23f-950ea0ef68d1
+      - req-c2d722e0-bad4-4aa0-8519-5c44275e9410
       Content-Length:
       - '7278'
       Connection:
@@ -13447,7 +13447,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-03T20:27:31.187150Z", "project": {"domain": {"id":
+        "expires_at": "2019-01-04T17:54:32.939532Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -13526,10 +13526,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["UCdpk2mMQnOU60V3ZlXdUA"],
-        "issued_at": "2019-01-03T19:27:31.187169Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["bR6_6-XkQWebqt6jNrFrCQ"],
+        "issued_at": "2019-01-04T16:54:32.939560Z"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:31 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:32 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_0098405163cd4c9dbb42c2cb43eb6fd3/?format=json&limit=1000
@@ -13544,7 +13544,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6e08439cea8641dfb1ea74f5eb104774
+      - c521ff55fe6f4dfdae4387ae0a808907
   response:
     status:
       code: 200
@@ -13557,22 +13557,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1546543651.32139'
+      - '1546620873.07071'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1546543651.32139'
+      - '1546620873.07071'
       X-Trans-Id:
-      - tx26e967a5ca5c46d1b4bd6-005c2e6223
+      - tx458563ec956149d683a11-005c2f8fc9
       Date:
-      - Thu, 03 Jan 2019 19:27:31 GMT
+      - Fri, 04 Jan 2019 16:54:33 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:31 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:33 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_28db8f69ba9e4305b7fad82da4c86e74/?format=json&limit=1000
@@ -13587,7 +13587,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5ae4e34180664132a79d88b52a4b5376
+      - e048dd317462446d91bd424e395e079d
   response:
     status:
       code: 200
@@ -13600,22 +13600,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1546543651.43716'
+      - '1546620873.18317'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1546543651.43716'
+      - '1546620873.18317'
       X-Trans-Id:
-      - txb55dcfbe89404746a6127-005c2e6223
+      - tx26a9f631faba4570bfc97-005c2f8fc9
       Date:
-      - Thu, 03 Jan 2019 19:27:31 GMT
+      - Fri, 04 Jan 2019 16:54:33 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:31 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:33 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_4637c33fee924ebea81f8d209e452c91/?format=json&limit=1000
@@ -13630,7 +13630,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e72c292936af4229b886d246f4b523b8
+      - 2f23d7493d2a4258bc538eecd467f751
   response:
     status:
       code: 200
@@ -13659,15 +13659,15 @@ http_interactions:
       X-Account-Project-Domain-Id:
       - default
       X-Trans-Id:
-      - txe8968f454cbd47a5b74a3-005c2e6223
+      - tx860047b5262f451eb8b5f-005c2f8fc9
       Date:
-      - Thu, 03 Jan 2019 19:27:31 GMT
+      - Fri, 04 Jan 2019 16:54:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '[{"count": 3, "bytes": 33, "name": "dir_1"}, {"count": 0, "bytes":
         0, "name": "dir_2"}, {"count": 0, "bytes": 0, "name": "dir_3"}]'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:31 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:33 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_4637c33fee924ebea81f8d209e452c91/?format=json&limit=1000&marker=dir_3
@@ -13682,7 +13682,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e72c292936af4229b886d246f4b523b8
+      - 2f23d7493d2a4258bc538eecd467f751
   response:
     status:
       code: 200
@@ -13711,14 +13711,14 @@ http_interactions:
       X-Account-Project-Domain-Id:
       - default
       X-Trans-Id:
-      - txb6648fd06b8b4856b3a2a-005c2e6223
+      - txb717bd30703044e08ec5d-005c2f8fc9
       Date:
-      - Thu, 03 Jan 2019 19:27:31 GMT
+      - Fri, 04 Jan 2019 16:54:33 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:31 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:33 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_52c452d7763a4295950527948232a3e5/?format=json&limit=1000
@@ -13733,7 +13733,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 195aaa47a195409297bbe40d11732d99
+      - b509495ad04846e4a2dead51d5e5cde7
   response:
     status:
       code: 200
@@ -13746,22 +13746,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1546543651.78003'
+      - '1546620873.50772'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1546543651.78003'
+      - '1546620873.50772'
       X-Trans-Id:
-      - txce09d72429704b67b62ce-005c2e6223
+      - txe0935129de724876a296e-005c2f8fc9
       Date:
-      - Thu, 03 Jan 2019 19:27:31 GMT
+      - Fri, 04 Jan 2019 16:54:33 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:31 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:33 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_88ae57d444fd485ab2dfddd5a2615d52/?format=json&limit=1000
@@ -13776,7 +13776,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 47b1e4593c9b412b98c54f7078c277ea
+      - 39523c746419496ba15e54ec5f21673c
   response:
     status:
       code: 200
@@ -13789,22 +13789,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1546543651.90045'
+      - '1546620873.62548'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1546543651.90045'
+      - '1546620873.62548'
       X-Trans-Id:
-      - tx9020f0fc8d044c92b720c-005c2e6223
+      - tx0eb18d2db5e0497085a78-005c2f8fc9
       Date:
-      - Thu, 03 Jan 2019 19:27:31 GMT
+      - Fri, 04 Jan 2019 16:54:33 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:31 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:33 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_d09cbe26295d47ff848ea73c74264e23/?format=json&limit=1000
@@ -13819,7 +13819,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 69e7239fb77540b5851b5d04e57e319c
+      - 6e36dffc33d8430dbeb1e9a46acab159
   response:
     status:
       code: 200
@@ -13832,22 +13832,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1546543652.01239'
+      - '1546620873.74290'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1546543652.01239'
+      - '1546620873.74290'
       X-Trans-Id:
-      - txf0479a8dbcbc4c2983c0d-005c2e6223
+      - tx88ff9de3034e45c5a2e5c-005c2f8fc9
       Date:
-      - Thu, 03 Jan 2019 19:27:32 GMT
+      - Fri, 04 Jan 2019 16:54:33 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:32 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:33 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_ef2a3405d1ef4dfd9a3616993ef46a4d/?format=json&limit=1000
@@ -13862,7 +13862,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a3bb52bedd1242adb0a6aa51bd4f4006
+      - ab032a15d08747b0aee7910a498ccd29
   response:
     status:
       code: 200
@@ -13875,22 +13875,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1546543652.12454'
+      - '1546620873.85836'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1546543652.12454'
+      - '1546620873.85836'
       X-Trans-Id:
-      - txf813108f126b440a9487d-005c2e6224
+      - tx80bad320d32d461895a61-005c2f8fc9
       Date:
-      - Thu, 03 Jan 2019 19:27:32 GMT
+      - Fri, 04 Jan 2019 16:54:33 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:32 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:33 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_4637c33fee924ebea81f8d209e452c91/dir_1?format=json
@@ -13905,7 +13905,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e72c292936af4229b886d246f4b523b8
+      - 2f23d7493d2a4258bc538eecd467f751
   response:
     status:
       code: 200
@@ -13926,9 +13926,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - tx286b6940843540738d0eb-005c2e6224
+      - tx8f2f9c26067647919e249-005c2f8fc9
       Date:
-      - Thu, 03 Jan 2019 19:27:32 GMT
+      - Fri, 04 Jan 2019 16:54:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '[{"hash": "61257bf228e2f6802a196c9a460d19a8", "last_modified": "2016-08-19T08:37:59.564460",
@@ -13938,7 +13938,7 @@ http_interactions:
         {"hash": "1727a9b61bddf85bbe7a5710c9f45691", "last_modified": "2016-08-19T08:38:00.995870",
         "bytes": 11, "name": "file_3", "content_type": "application/octet-stream"}]'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:32 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:33 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_4637c33fee924ebea81f8d209e452c91/dir_2?format=json
@@ -13953,7 +13953,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e72c292936af4229b886d246f4b523b8
+      - 2f23d7493d2a4258bc538eecd467f751
   response:
     status:
       code: 200
@@ -13974,14 +13974,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - txd55e683f17df4dd7a0af0-005c2e6224
+      - tx52ada6fb018f4329b1cc4-005c2f8fca
       Date:
-      - Thu, 03 Jan 2019 19:27:32 GMT
+      - Fri, 04 Jan 2019 16:54:34 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:32 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:34 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_4637c33fee924ebea81f8d209e452c91/dir_3?format=json
@@ -13996,7 +13996,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e72c292936af4229b886d246f4b523b8
+      - 2f23d7493d2a4258bc538eecd467f751
   response:
     status:
       code: 200
@@ -14017,12 +14017,12 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - txee3419f311d143e6a3e97-005c2e6224
+      - tx44a7200b4d9e44549f5c2-005c2f8fca
       Date:
-      - Thu, 03 Jan 2019 19:27:32 GMT
+      - Fri, 04 Jan 2019 16:54:34 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:27:32 GMT
+  recorded_at: Fri, 04 Jan 2019 16:54:34 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_legacy_fast_refresh.yml
+++ b/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_legacy_fast_refresh.yml
@@ -17,13 +17,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:23:24 GMT
+      - Fri, 04 Jan 2019 16:56:13 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-3532fa5d-505c-4b5a-9a3a-76589e55aad4
+      - req-6fc025a8-1a03-4823-8ce9-7f4601a7976b
       Content-Length:
       - '4170'
       Connection:
@@ -32,10 +32,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:23:24.094187", "expires":
-        "2019-01-03T20:23:24Z", "id": "de544df98dea49b0ba517c6665b46042", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:56:13.593450", "expires":
+        "2019-01-04T17:56:13Z", "id": "4dd6d85d1dad4a8581bd582e82489653", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["4JW7yiT8RCaDpO3k-b9qkQ"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["aGmdlosmQZ67MW_BuO02_Q"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -80,7 +80,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:24 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:13 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -95,7 +95,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - de544df98dea49b0ba517c6665b46042
+      - 4dd6d85d1dad4a8581bd582e82489653
   response:
     status:
       code: 200
@@ -106,7 +106,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Thu, 03 Jan 2019 19:23:24 GMT
+      - Fri, 04 Jan 2019 16:56:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -115,7 +115,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:24 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:13 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -133,13 +133,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:23:24 GMT
+      - Fri, 04 Jan 2019 16:56:13 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-a4db288c-6551-427c-a33e-c26882db2499
+      - req-7157359a-dd9e-4f8d-a2ac-4a7eb9d478ba
       Content-Length:
       - '4170'
       Connection:
@@ -148,10 +148,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:23:24.674308", "expires":
-        "2019-01-03T20:23:24Z", "id": "81ed6be4b2c14b6b97f04c759c60c6c6", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:56:13.873223", "expires":
+        "2019-01-04T17:56:13Z", "id": "220751180e094d9bb52bde77f7a15b82", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["IqSzAO1ZQ_GnCZEN-Chz-w"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["LUb1MiAgR5i7mPfzobg5cw"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -196,7 +196,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:24 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:13 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -214,13 +214,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:23:24 GMT
+      - Fri, 04 Jan 2019 16:56:14 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-af8fd805-84e1-40bd-8b0a-adde065020cf
+      - req-b876f8ea-3863-41cf-a27a-e5854d0492aa
       Content-Length:
       - '4170'
       Connection:
@@ -229,10 +229,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:23:24.883423", "expires":
-        "2019-01-03T20:23:24Z", "id": "c0f1e3786d974bcd9e3bce4bebf4f4f9", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:56:14.061823", "expires":
+        "2019-01-04T17:56:14Z", "id": "7e9c7174c3a746ffa4fbb8450e9c13e8", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["_JuOnnElRBysjEiT0M5f4g"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["KUTq8IZATi6C3RFieRqGTA"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -277,7 +277,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:24 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:14 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -295,13 +295,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:23:25 GMT
+      - Fri, 04 Jan 2019 16:56:14 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-38d9b485-fd98-4830-9f32-449103986eb9
+      - req-a0d9a7c6-2a5d-4656-bd6d-78d2209d3221
       Content-Length:
       - '4170'
       Connection:
@@ -310,10 +310,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:23:25.108443", "expires":
-        "2019-01-03T20:23:25Z", "id": "b7b65cf5deb94e3f8571e518de52c533", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:56:14.268665", "expires":
+        "2019-01-04T17:56:14Z", "id": "f5997510ac014e33914baa695bf37faa", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["D-jZydljS5-NE9LA3XGLbw"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["MpXBH71DSOapzPKRVHwtzQ"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -358,7 +358,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:25 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:14 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -376,13 +376,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:23:25 GMT
+      - Fri, 04 Jan 2019 16:56:14 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-57ed3029-8c2c-48d2-9476-c172688efe4f
+      - req-37db8534-6ba1-4564-9517-bd092f4e2fd7
       Content-Length:
       - '4170'
       Connection:
@@ -391,10 +391,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:23:25.560727", "expires":
-        "2019-01-03T20:23:25Z", "id": "2bbcbd30c5eb48d8ab9edb887955896c", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:56:14.466397", "expires":
+        "2019-01-04T17:56:14Z", "id": "1ba1708a86db40f2951dd2c951698cf1", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["2CCwcR4JQUayFY_blKQ3ZQ"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["21g6ROH3SmqfUK-lDG2znA"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -439,7 +439,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:25 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:14 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -457,13 +457,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:23:25 GMT
+      - Fri, 04 Jan 2019 16:56:14 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-60323003-dd67-4eae-ae64-132baa35020e
+      - req-62c9357a-dc4e-491b-a976-ed131e8adba9
       Content-Length:
       - '4170'
       Connection:
@@ -472,10 +472,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:23:25.815485", "expires":
-        "2019-01-03T20:23:25Z", "id": "3f72382ce47e43898e73be7dd8f2cdfc", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:56:14.661441", "expires":
+        "2019-01-04T17:56:14Z", "id": "54afe4457ed942e7855ce15b09d5081d", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["YEl55oq2QNCp_FStqkgkPg"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["CgT7V1DyTomZilGqHU03BA"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -520,7 +520,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:25 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:14 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -538,13 +538,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:23:26 GMT
+      - Fri, 04 Jan 2019 16:56:14 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-2a89e28b-3e96-47f3-8f4a-be0b752be735
+      - req-33f79af6-f758-4a5d-b1d2-054d7683e823
       Content-Length:
       - '4170'
       Connection:
@@ -553,10 +553,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:23:26.067798", "expires":
-        "2019-01-03T20:23:26Z", "id": "2e9ae483567842c3b00ba552eb059ecc", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:56:14.848200", "expires":
+        "2019-01-04T17:56:14Z", "id": "30dbec12cbf84820a75a64eb8e6b1ad5", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["sPYqInxGQxupEWEEicBVQw"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["IdUo3Ku5SamhDdUmuvvEpA"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -601,7 +601,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:26 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:14 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -619,13 +619,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:23:26 GMT
+      - Fri, 04 Jan 2019 16:56:14 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-f684fdf4-9718-4ec8-9b79-eeb60d785526
+      - req-521a70a4-1d69-4943-b434-77ec5976666a
       Content-Length:
       - '4170'
       Connection:
@@ -634,10 +634,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:23:26.311778", "expires":
-        "2019-01-03T20:23:26Z", "id": "bb6dca3637384bca8c21ebddbcdd6f7a", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:56:15.090162", "expires":
+        "2019-01-04T17:56:15Z", "id": "a86ea300989346d191777d0e7198cc3f", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["X1rPo6m_RcmoX6mJfW36JQ"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["IdZD5yWdTiiKO70i0PZR2Q"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -682,7 +682,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:26 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:15 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -700,13 +700,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:23:26 GMT
+      - Fri, 04 Jan 2019 16:56:15 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-6c6eeb9c-1f3b-484b-82e8-4fdfa89d9640
+      - req-bbec6dcf-0b64-4067-8c1c-1db9dfdef0a6
       Content-Length:
       - '370'
       Connection:
@@ -715,13 +715,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:23:26.475172", "expires":
-        "2019-01-03T20:23:26Z", "id": "3c5d83d1ec0c4436871fae831ba83ebb", "audit_ids":
-        ["2yz_tExOTkm6SP3iS9u_yA"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:56:15.255438", "expires":
+        "2019-01-04T17:56:15Z", "id": "39cb464115b1434c973b907db7a047dc", "audit_ids":
+        ["pIoFp6-QRgesC0n03sjPjQ"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:26 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:15 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -736,20 +736,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3c5d83d1ec0c4436871fae831ba83ebb
+      - 39cb464115b1434c973b907db7a047dc
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:23:26 GMT
+      - Fri, 04 Jan 2019 16:56:15 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-b81c8287-6db5-498e-bee2-df5b297dcd50
+      - req-7aaa1cf9-39ea-4b1b-903f-a357c90d7a3b
       Content-Length:
       - '500'
       Connection:
@@ -766,7 +766,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:26 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:15 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000
@@ -781,7 +781,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - de544df98dea49b0ba517c6665b46042
+      - 4dd6d85d1dad4a8581bd582e82489653
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -794,9 +794,9 @@ http_interactions:
       Content-Length:
       - '1010'
       X-Compute-Request-Id:
-      - req-0256778a-7c69-4b11-a1d8-da3a0857fcd6
+      - req-346d8448-331e-4c14-936d-6322dc52b07d
       Date:
-      - Thu, 03 Jan 2019 19:23:26 GMT
+      - Fri, 04 Jan 2019 16:56:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.tiny", "links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/1",
@@ -810,7 +810,7 @@ http_interactions:
         0, "disk": 20, "id": "2"}], "flavors_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=2",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:26 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:15 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=2
@@ -825,7 +825,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - de544df98dea49b0ba517c6665b46042
+      - 4dd6d85d1dad4a8581bd582e82489653
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -838,9 +838,9 @@ http_interactions:
       Content-Length:
       - '1014'
       X-Compute-Request-Id:
-      - req-8bfa2cfc-6951-411c-8dcc-7039d50dfb78
+      - req-c4c3c42c-488f-4b96-9557-a606025fa93d
       Date:
-      - Thu, 03 Jan 2019 19:23:26 GMT
+      - Fri, 04 Jan 2019 16:56:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.medium", "links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/3",
@@ -854,7 +854,7 @@ http_interactions:
         0, "disk": 80, "id": "4"}], "flavors_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=4",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:27 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:15 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=4
@@ -869,7 +869,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - de544df98dea49b0ba517c6665b46042
+      - 4dd6d85d1dad4a8581bd582e82489653
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -882,9 +882,9 @@ http_interactions:
       Content-Length:
       - '1026'
       X-Compute-Request-Id:
-      - req-87fa19b5-48ed-4593-996b-e7531263e818
+      - req-ee459506-471b-46fd-92fa-5aa3992446e1
       Date:
-      - Thu, 03 Jan 2019 19:23:27 GMT
+      - Fri, 04 Jan 2019 16:56:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.xlarge", "links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/5",
@@ -899,7 +899,7 @@ http_interactions:
         1, "disk": 1, "id": "6"}], "flavors_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=6",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:27 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:15 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=6
@@ -914,7 +914,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - de544df98dea49b0ba517c6665b46042
+      - 4dd6d85d1dad4a8581bd582e82489653
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -927,9 +927,9 @@ http_interactions:
       Content-Length:
       - '448'
       X-Compute-Request-Id:
-      - req-5424ffd5-7012-4875-b493-bc7a32edaae3
+      - req-1113cfa8-8878-4013-a3bd-760378534cd8
       Date:
-      - Thu, 03 Jan 2019 19:23:27 GMT
+      - Fri, 04 Jan 2019 16:56:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.ems_refresh_spec_private", "links": [{"href":
@@ -939,7 +939,7 @@ http_interactions:
         8, "swap": "", "os-flavor-access:is_public": false, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         0, "disk": 160, "id": "7"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:27 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:15 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/7/os-flavor-access
@@ -954,7 +954,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - de544df98dea49b0ba517c6665b46042
+      - 4dd6d85d1dad4a8581bd582e82489653
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -967,15 +967,15 @@ http_interactions:
       Content-Length:
       - '88'
       X-Compute-Request-Id:
-      - req-7764e317-9098-4968-9ce9-ce63f30da6bb
+      - req-580ff769-9056-42ea-997e-a74b435e050b
       Date:
-      - Thu, 03 Jan 2019 19:23:27 GMT
+      - Fri, 04 Jan 2019 16:56:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavor_access": [{"tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "flavor_id": "7"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:27 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:16 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-availability-zone
@@ -990,7 +990,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - de544df98dea49b0ba517c6665b46042
+      - 4dd6d85d1dad4a8581bd582e82489653
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1003,15 +1003,15 @@ http_interactions:
       Content-Length:
       - '97'
       X-Compute-Request-Id:
-      - req-6b9a80f1-03b8-4d8e-b02c-ae28bb09ba10
+      - req-94e13ded-093c-4ab5-9a32-3f650e4ea8ed
       Date:
-      - Thu, 03 Jan 2019 19:23:27 GMT
+      - Fri, 04 Jan 2019 16:56:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"availabilityZoneInfo": [{"zoneState": {"available": true}, "hosts":
         null, "zoneName": "nova"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:27 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:16 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-availability-zone.json
@@ -1026,28 +1026,28 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2bbcbd30c5eb48d8ab9edb887955896c
+      - 1ba1708a86db40f2951dd2c951698cf1
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-08a49e6f-2ec2-401f-8590-75c961baf9eb
+      - req-2fd34702-68db-4041-b0b2-36da5e8755ea
       Content-Type:
       - application/json
       Content-Length:
       - '82'
       X-Openstack-Request-Id:
-      - req-08a49e6f-2ec2-401f-8590-75c961baf9eb
+      - req-2fd34702-68db-4041-b0b2-36da5e8755ea
       Date:
-      - Thu, 03 Jan 2019 19:23:27 GMT
+      - Fri, 04 Jan 2019 16:56:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"availabilityZoneInfo": [{"zoneState": {"available": true}, "zoneName":
         "nova"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:27 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:16 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-aggregates
@@ -1062,7 +1062,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - de544df98dea49b0ba517c6665b46042
+      - 4dd6d85d1dad4a8581bd582e82489653
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1075,14 +1075,14 @@ http_interactions:
       Content-Length:
       - '18'
       X-Compute-Request-Id:
-      - req-6ab58e7f-aa62-4fc2-b179-ec1df3a290f7
+      - req-c88f29f0-eefd-41ca-84e5-934f1eac7e19
       Date:
-      - Thu, 03 Jan 2019 19:23:27 GMT
+      - Fri, 04 Jan 2019 16:56:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"aggregates": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:27 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:16 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1100,13 +1100,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:23:27 GMT
+      - Fri, 04 Jan 2019 16:56:16 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-30526ccf-c9d0-4409-ba7f-9cba1c01379b
+      - req-6c682816-4fc1-4f5c-97c4-4768a51612e0
       Content-Length:
       - '4117'
       Connection:
@@ -1115,10 +1115,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:23:27.891336", "expires":
-        "2019-01-03T20:23:27Z", "id": "b0e67fe89091464784ba392d3c6c7027", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:56:16.656105", "expires":
+        "2019-01-04T17:56:16Z", "id": "6a418d833aea4b13831fbfc1dd7d6733", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["GpLxM4piSP-88n6h6WlrXg"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["jwaDwFAHTfaVwU2RfgEnbg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -1162,7 +1162,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:27 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:16 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -1177,7 +1177,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b0e67fe89091464784ba392d3c6c7027
+      - 6a418d833aea4b13831fbfc1dd7d6733
   response:
     status:
       code: 200
@@ -1188,7 +1188,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Thu, 03 Jan 2019 19:23:27 GMT
+      - Fri, 04 Jan 2019 16:56:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -1197,7 +1197,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:28 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:16 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1215,13 +1215,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:23:28 GMT
+      - Fri, 04 Jan 2019 16:56:16 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-30eda489-1f6f-49ae-bbb0-6c91c7d442ff
+      - req-095563fb-4536-41a2-8cf6-23371d077dc8
       Content-Length:
       - '4131'
       Connection:
@@ -1230,10 +1230,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:23:28.165319", "expires":
-        "2019-01-03T20:23:28Z", "id": "90bfa33b960b4342b8bd4ea28f4b944a", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:56:16.939604", "expires":
+        "2019-01-04T17:56:16Z", "id": "78262f38305345dd9f366c79808f9553", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["vz_N-QKYShuEv5JFhSbPEQ"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["9fruieuKS0KlmN9HMKpXaw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -1277,7 +1277,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:28 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:16 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -1292,7 +1292,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 90bfa33b960b4342b8bd4ea28f4b944a
+      - 78262f38305345dd9f366c79808f9553
   response:
     status:
       code: 200
@@ -1303,7 +1303,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Thu, 03 Jan 2019 19:23:28 GMT
+      - Fri, 04 Jan 2019 16:56:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -1312,7 +1312,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:28 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:17 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1330,13 +1330,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:23:28 GMT
+      - Fri, 04 Jan 2019 16:56:17 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-c275c515-2931-404a-877d-9c7edde73987
+      - req-d2ff1bdb-3670-4c88-910d-ea98b9487795
       Content-Length:
       - '4118'
       Connection:
@@ -1345,10 +1345,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:23:28.459412", "expires":
-        "2019-01-03T20:23:28Z", "id": "d65d8152c2bf43e6a89b9976752c64fc", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:56:17.220376", "expires":
+        "2019-01-04T17:56:17Z", "id": "f88d0aad52c442d5a9d91137ded39dc4", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["gwklCOGvSUK_EBBIs7AbVQ"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["Rm_n6oy0TVKYYjrHb6Dt-A"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -1392,7 +1392,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:28 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:17 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -1407,7 +1407,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d65d8152c2bf43e6a89b9976752c64fc
+      - f88d0aad52c442d5a9d91137ded39dc4
   response:
     status:
       code: 200
@@ -1418,7 +1418,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Thu, 03 Jan 2019 19:23:28 GMT
+      - Fri, 04 Jan 2019 16:56:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -1427,7 +1427,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:28 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:17 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a//os-quota-sets/69f8f7205ade4aa59084c32c83e60b5a
@@ -1442,7 +1442,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b0e67fe89091464784ba392d3c6c7027
+      - 6a418d833aea4b13831fbfc1dd7d6733
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1455,9 +1455,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-ffd30d5d-9d8e-44f6-9cd3-69394beebf4c
+      - req-6c5d9a8a-1a5e-4d22-b263-9bc285484843
       Date:
-      - Thu, 03 Jan 2019 19:23:28 GMT
+      - Fri, 04 Jan 2019 16:56:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -1466,7 +1466,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:28 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:17 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8//os-quota-sets/b458a5c25c3749758f4c0661940b3ba8
@@ -1481,7 +1481,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 90bfa33b960b4342b8bd4ea28f4b944a
+      - 78262f38305345dd9f366c79808f9553
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1494,9 +1494,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-5f965462-e057-473c-a439-66afa29557e2
+      - req-d2587cf7-5de7-47f2-8482-2df33e972a70
       Date:
-      - Thu, 03 Jan 2019 19:23:28 GMT
+      - Fri, 04 Jan 2019 16:56:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -1505,7 +1505,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:28 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:17 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a//os-quota-sets/e54e5c3c19e34720b05661f2ea1ea00a
@@ -1520,7 +1520,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - de544df98dea49b0ba517c6665b46042
+      - 4dd6d85d1dad4a8581bd582e82489653
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1533,9 +1533,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-492a98c6-a445-4773-a687-8ff60767c259
+      - req-c36ed1c5-7902-4ef8-8e13-80c96e7bd1ed
       Date:
-      - Thu, 03 Jan 2019 19:23:28 GMT
+      - Fri, 04 Jan 2019 16:56:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -1544,7 +1544,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:29 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:17 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608//os-quota-sets/e8f744b1fc6a487681d35fb275252608
@@ -1559,7 +1559,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d65d8152c2bf43e6a89b9976752c64fc
+      - f88d0aad52c442d5a9d91137ded39dc4
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1572,9 +1572,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-5f8e5783-4ad8-4d17-83da-ccb778f8190a
+      - req-b82cb429-fbe9-4f6f-b2b7-16d86d391792
       Date:
-      - Thu, 03 Jan 2019 19:23:29 GMT
+      - Fri, 04 Jan 2019 16:56:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -1583,7 +1583,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:29 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:17 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1601,13 +1601,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:23:29 GMT
+      - Fri, 04 Jan 2019 16:56:18 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-9cfd4f87-ffe2-4245-88be-ff09d57fa32c
+      - req-f0fee8dc-8160-40a5-9677-999793ec2035
       Content-Length:
       - '4117'
       Connection:
@@ -1616,10 +1616,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:23:29.331205", "expires":
-        "2019-01-03T20:23:29Z", "id": "780b7ebc4c8d4f508d152bf1e100d74a", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:56:18.073656", "expires":
+        "2019-01-04T17:56:18Z", "id": "65618a4b35814bf6abe3e5ec43485318", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["WIobW5XDSka_B4m_50KqqQ"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["ajb-1d3oTxa1luVeBw0DUw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -1663,7 +1663,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:29 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:18 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1681,13 +1681,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:23:29 GMT
+      - Fri, 04 Jan 2019 16:56:18 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-822f07bb-6e43-4e13-a91e-2bb61c761212
+      - req-2d7dafb7-b909-4499-9dd5-1e860fc65b53
       Content-Length:
       - '4131'
       Connection:
@@ -1696,10 +1696,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:23:29.550570", "expires":
-        "2019-01-03T20:23:29Z", "id": "75cf762aef4d4f79921731dee24e1b28", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:56:18.286946", "expires":
+        "2019-01-04T17:56:18Z", "id": "58f1281b90d44c8b948de52d5ef3f089", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["iruS9XyaRVKUFUVqkJtYpA"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["C58CpUtQQXGR_xzIuTtVfg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -1743,7 +1743,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:29 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:18 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1761,13 +1761,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:23:29 GMT
+      - Fri, 04 Jan 2019 16:56:18 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-d0f9614e-b3d9-464a-aba2-fdae47fc75f1
+      - req-e778de91-b231-4a7b-80af-7041fef7ea90
       Content-Length:
       - '4118'
       Connection:
@@ -1776,10 +1776,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:23:29.737979", "expires":
-        "2019-01-03T20:23:29Z", "id": "a6a6dcfdda1c444184eeed540a6a567c", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:56:18.471805", "expires":
+        "2019-01-04T17:56:18Z", "id": "ea6670ee7ce5416d82029ce412ed2795", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["i1B_XSvFSkaAStEEhKcSsg"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["9B-jN137T_GILPwsFBnlPw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -1823,7 +1823,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:29 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:18 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a//os-quota-sets/69f8f7205ade4aa59084c32c83e60b5a
@@ -1838,22 +1838,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 780b7ebc4c8d4f508d152bf1e100d74a
+      - 65618a4b35814bf6abe3e5ec43485318
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-cc3864d9-bd97-4604-bd6d-edd03de83c9b
+      - req-2ac32ec1-f469-4d3f-bae7-e58e3b74e4d9
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-cc3864d9-bd97-4604-bd6d-edd03de83c9b
+      - req-2ac32ec1-f469-4d3f-bae7-e58e3b74e4d9
       Date:
-      - Thu, 03 Jan 2019 19:23:30 GMT
+      - Fri, 04 Jan 2019 16:56:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -1863,7 +1863,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "69f8f7205ade4aa59084c32c83e60b5a"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:30 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:18 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8//os-quota-sets/b458a5c25c3749758f4c0661940b3ba8
@@ -1878,22 +1878,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 75cf762aef4d4f79921731dee24e1b28
+      - 58f1281b90d44c8b948de52d5ef3f089
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-d569a586-f8c9-4a69-9a91-024fccaec9f4
+      - req-642319b2-c728-48de-8435-40a180ebc096
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-d569a586-f8c9-4a69-9a91-024fccaec9f4
+      - req-642319b2-c728-48de-8435-40a180ebc096
       Date:
-      - Thu, 03 Jan 2019 19:23:30 GMT
+      - Fri, 04 Jan 2019 16:56:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -1903,7 +1903,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "b458a5c25c3749758f4c0661940b3ba8"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:30 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:19 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a//os-quota-sets/e54e5c3c19e34720b05661f2ea1ea00a
@@ -1918,22 +1918,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2bbcbd30c5eb48d8ab9edb887955896c
+      - 1ba1708a86db40f2951dd2c951698cf1
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-f36ccc2a-4937-451b-be85-da70b31605af
+      - req-7cdd137a-0947-4cc1-aa8f-86627fe22d7e
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-f36ccc2a-4937-451b-be85-da70b31605af
+      - req-7cdd137a-0947-4cc1-aa8f-86627fe22d7e
       Date:
-      - Thu, 03 Jan 2019 19:23:30 GMT
+      - Fri, 04 Jan 2019 16:56:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -1943,7 +1943,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "e54e5c3c19e34720b05661f2ea1ea00a"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:30 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:19 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608//os-quota-sets/e8f744b1fc6a487681d35fb275252608
@@ -1958,22 +1958,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a6a6dcfdda1c444184eeed540a6a567c
+      - ea6670ee7ce5416d82029ce412ed2795
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-b8e2d895-f8ab-47a9-8475-503626198432
+      - req-d5c417e2-a7c4-4590-abeb-3ffdc55c891e
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-b8e2d895-f8ab-47a9-8475-503626198432
+      - req-d5c417e2-a7c4-4590-abeb-3ffdc55c891e
       Date:
-      - Thu, 03 Jan 2019 19:23:30 GMT
+      - Fri, 04 Jan 2019 16:56:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -1983,7 +1983,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "e8f744b1fc6a487681d35fb275252608"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:30 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:19 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -2001,13 +2001,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:23:31 GMT
+      - Fri, 04 Jan 2019 16:56:20 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-1c5cc6c7-ee6e-4456-8641-8ab1774ceb2a
+      - req-f09d3b29-a99a-4bea-bbf0-84996fe1880d
       Content-Length:
       - '4117'
       Connection:
@@ -2016,10 +2016,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:23:31.155445", "expires":
-        "2019-01-03T20:23:31Z", "id": "dd2446a236464be08b9cbe1081ccde8a", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:56:20.133202", "expires":
+        "2019-01-04T17:56:20Z", "id": "44dfd905589542ee91b63cf7335979f8", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["mVN0oHKER02VfKo-L2k7Ww"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["iFitrRuhS-6xVjWKziOFWA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -2063,7 +2063,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:31 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:20 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -2081,13 +2081,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:23:31 GMT
+      - Fri, 04 Jan 2019 16:56:20 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-a4402b5f-27c4-400a-9d03-b68977a1e5ff
+      - req-e3f2501a-cd76-4a73-a89b-ff504e025ca4
       Content-Length:
       - '4131'
       Connection:
@@ -2096,10 +2096,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:23:31.338772", "expires":
-        "2019-01-03T20:23:31Z", "id": "9f16a0ed0ce7455a872be4cb78b8e847", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:56:20.324730", "expires":
+        "2019-01-04T17:56:20Z", "id": "3bd8bedcbed047b29822800f314ac1cf", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["eQKqstl1QA-ElycgfPvOLw"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["Gxllfc3yRyWqn3rUtqqsYg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -2143,7 +2143,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:31 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:20 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -2161,13 +2161,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:23:31 GMT
+      - Fri, 04 Jan 2019 16:56:20 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-6af84c0a-436a-44e0-be51-b8e7e22d25ce
+      - req-9a544a1c-0a5b-414d-b778-6257ebf2636d
       Content-Length:
       - '4118'
       Connection:
@@ -2176,10 +2176,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:23:31.542948", "expires":
-        "2019-01-03T20:23:31Z", "id": "9661b0fff11e4d85bad7f982c7e1ff03", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:56:20.511773", "expires":
+        "2019-01-04T17:56:20Z", "id": "dd22a2e0580a411f83bf2f57c8436a5f", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["E3PTCClfRKCxmInsYgjVug"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["WLSi3mpaQzO2ZpZhTA5qIA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -2223,7 +2223,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:31 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:20 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0//quotas/69f8f7205ade4aa59084c32c83e60b5a
@@ -2238,7 +2238,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - dd2446a236464be08b9cbe1081ccde8a
+      - 44dfd905589542ee91b63cf7335979f8
   response:
     status:
       code: 200
@@ -2249,16 +2249,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-e4b88b9b-f45b-46e4-a90a-5bb6efba6c25
+      - req-862f3695-51c8-41e7-81e0-7b3a6f6b2811
       Date:
-      - Thu, 03 Jan 2019 19:23:31 GMT
+      - Fri, 04 Jan 2019 16:56:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 20, "network": 20, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:31 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:20 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0//quotas/b458a5c25c3749758f4c0661940b3ba8
@@ -2273,7 +2273,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9f16a0ed0ce7455a872be4cb78b8e847
+      - 3bd8bedcbed047b29822800f314ac1cf
   response:
     status:
       code: 200
@@ -2284,16 +2284,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-afee0971-2c7b-45cc-ab2b-6ae7269b1930
+      - req-17135168-bd4b-4754-aed8-0f7991dbc366
       Date:
-      - Thu, 03 Jan 2019 19:23:31 GMT
+      - Fri, 04 Jan 2019 16:56:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:31 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:20 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0//quotas/e54e5c3c19e34720b05661f2ea1ea00a
@@ -2308,7 +2308,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 81ed6be4b2c14b6b97f04c759c60c6c6
+      - 220751180e094d9bb52bde77f7a15b82
   response:
     status:
       code: 200
@@ -2319,16 +2319,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-a2ac89d4-a684-427b-ba23-c2711e1ffde2
+      - req-1dc36bcc-d130-41ce-b556-5e344fd6d118
       Date:
-      - Thu, 03 Jan 2019 19:23:32 GMT
+      - Fri, 04 Jan 2019 16:56:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:32 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:20 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0//quotas/e8f744b1fc6a487681d35fb275252608
@@ -2343,7 +2343,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9661b0fff11e4d85bad7f982c7e1ff03
+      - dd22a2e0580a411f83bf2f57c8436a5f
   response:
     status:
       code: 200
@@ -2354,16 +2354,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-014668dd-d41b-4c65-8305-70620e0d7f23
+      - req-bb5b2acd-10e2-48e8-a9b9-e63e9752a612
       Date:
-      - Thu, 03 Jan 2019 19:23:32 GMT
+      - Fri, 04 Jan 2019 16:56:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:32 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:21 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-keypairs?all_tenants=True&limit=1000
@@ -2378,7 +2378,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - de544df98dea49b0ba517c6665b46042
+      - 4dd6d85d1dad4a8581bd582e82489653
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2391,9 +2391,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-2112fbbb-87c1-44d6-84f7-23bcc298ab0c
+      - req-5ee26d67-2c28-41e1-8f60-ee5093c635cc
       Date:
-      - Thu, 03 Jan 2019 19:23:32 GMT
+      - Fri, 04 Jan 2019 16:56:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -2403,7 +2403,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:32 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:21 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-keypairs?all_tenants=True&limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -2418,7 +2418,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - de544df98dea49b0ba517c6665b46042
+      - 4dd6d85d1dad4a8581bd582e82489653
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2431,9 +2431,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-7fdea1e2-40ea-48ba-bb37-5a17d9031d64
+      - req-1269a521-073c-4688-9563-f7ad8f749af1
       Date:
-      - Thu, 03 Jan 2019 19:23:32 GMT
+      - Fri, 04 Jan 2019 16:56:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -2443,7 +2443,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:32 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:21 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -2461,13 +2461,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:23:32 GMT
+      - Fri, 04 Jan 2019 16:56:21 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-c41f9072-be5a-4247-bad0-d60152ff5ddf
+      - req-9cd519a3-9fa2-4fc6-8341-7da3fd5a056b
       Content-Length:
       - '4117'
       Connection:
@@ -2476,10 +2476,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:23:32.524340", "expires":
-        "2019-01-03T20:23:32Z", "id": "fe6cf3f6adb74cfeb68683ebfb91beb7", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:56:21.499192", "expires":
+        "2019-01-04T17:56:21Z", "id": "69d35cf55ba44576a11469feb5af83e2", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["R1cHL6ZsRLuxfpr8_D2dOA"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["vco9JC9URFGq-mjj-scvHA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -2523,7 +2523,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:32 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:21 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -2541,13 +2541,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:23:32 GMT
+      - Fri, 04 Jan 2019 16:56:21 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-bbe87814-dfed-4c8f-aa5b-cc09d6425f6a
+      - req-b680f163-78cf-49f2-9df7-b714d39554f6
       Content-Length:
       - '4131'
       Connection:
@@ -2556,10 +2556,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:23:32.715847", "expires":
-        "2019-01-03T20:23:32Z", "id": "3215fdf85c0e4bee823ca558ea73b82f", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:56:21.679695", "expires":
+        "2019-01-04T17:56:21Z", "id": "9a2d72c095c84abc86d0d0d964857555", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["TptnVQeHSLe_hjZb7s2WRQ"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["CkonbJ-vSpmGhkcVrARfdA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -2603,7 +2603,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:32 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:21 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -2621,13 +2621,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:23:32 GMT
+      - Fri, 04 Jan 2019 16:56:21 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-1786b18c-2d58-4413-bb3d-1f77dc6c7e10
+      - req-3a08a492-91e8-4df9-9184-4d763938c787
       Content-Length:
       - '4118'
       Connection:
@@ -2636,10 +2636,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:23:32.904887", "expires":
-        "2019-01-03T20:23:32Z", "id": "c80c30d1aa6c453fa1ea638fd196d680", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:56:21.861681", "expires":
+        "2019-01-04T17:56:21Z", "id": "2b36c4a0bc66450f9ee3a636aa3a6cd3", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["CNYXBya9Q0u8ixr7peBntg"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["dckaIlxERy-veOfhU_YIeg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -2683,7 +2683,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:32 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:21 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks?limit=1000&show_nested=true
@@ -2698,7 +2698,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fe6cf3f6adb74cfeb68683ebfb91beb7
+      - 69d35cf55ba44576a11469feb5af83e2
   response:
     status:
       code: 200
@@ -2709,9 +2709,9 @@ http_interactions:
       Content-Length:
       - '2559'
       X-Openstack-Request-Id:
-      - req-a21209f5-2b65-4a5c-bbc0-807104afc32a
+      - req-11111edb-c6e7-4385-9b61-d1947d8e6b62
       Date:
-      - Thu, 03 Jan 2019 19:23:33 GMT
+      - Fri, 04 Jan 2019 16:56:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": [{"description": "Heat WordPress template to support F20,
@@ -2745,7 +2745,7 @@ http_interactions:
         "rel": "self"}], "updated_time": null, "stack_owner": null, "stack_status":
         "CREATE_COMPLETE", "id": "091e1e54-e01c-4ec5-a0ab-b00bee4d425c"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:33 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:22 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks?limit=1000&marker=091e1e54-e01c-4ec5-a0ab-b00bee4d425c&show_nested=true
@@ -2760,7 +2760,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fe6cf3f6adb74cfeb68683ebfb91beb7
+      - 69d35cf55ba44576a11469feb5af83e2
   response:
     status:
       code: 200
@@ -2771,14 +2771,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-23d5be36-58a2-4373-9f1f-e5ee5c3da319
+      - req-e2ba391f-d05f-4d46-a020-1b7f88e2f147
       Date:
-      - Thu, 03 Jan 2019 19:23:33 GMT
+      - Fri, 04 Jan 2019 16:56:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:33 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:22 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/b458a5c25c3749758f4c0661940b3ba8/stacks?limit=1000&show_nested=true
@@ -2793,7 +2793,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3215fdf85c0e4bee823ca558ea73b82f
+      - 9a2d72c095c84abc86d0d0d964857555
   response:
     status:
       code: 200
@@ -2804,14 +2804,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-2f4d66cf-8f9a-4a80-9863-1583f4b54d32
+      - req-f11baa44-0a6b-49bb-be4d-f307ca9aecda
       Date:
-      - Thu, 03 Jan 2019 19:23:33 GMT
+      - Fri, 04 Jan 2019 16:56:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:33 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:22 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/e54e5c3c19e34720b05661f2ea1ea00a/stacks?limit=1000&show_nested=true
@@ -2826,7 +2826,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bb6dca3637384bca8c21ebddbcdd6f7a
+      - a86ea300989346d191777d0e7198cc3f
   response:
     status:
       code: 200
@@ -2837,14 +2837,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-f7502eee-3fc6-42b0-a431-bdf4f7a7bc4b
+      - req-f7b3aa15-cf46-4db5-ba37-7973549c9d6c
       Date:
-      - Thu, 03 Jan 2019 19:23:33 GMT
+      - Fri, 04 Jan 2019 16:56:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:33 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:22 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/e8f744b1fc6a487681d35fb275252608/stacks?limit=1000&show_nested=true
@@ -2859,7 +2859,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c80c30d1aa6c453fa1ea638fd196d680
+      - 2b36c4a0bc66450f9ee3a636aa3a6cd3
   response:
     status:
       code: 200
@@ -2870,14 +2870,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-7b3a116c-5f09-4cb4-bddf-e43d5bafa0c3
+      - req-83b8f819-bfa5-483d-881d-244a1984c644
       Date:
-      - Thu, 03 Jan 2019 19:23:33 GMT
+      - Fri, 04 Jan 2019 16:56:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:33 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:22 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack3/45d2af82-eff9-4483-a1f0-f19c44d96146
@@ -2892,7 +2892,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fe6cf3f6adb74cfeb68683ebfb91beb7
+      - 69d35cf55ba44576a11469feb5af83e2
   response:
     status:
       code: 200
@@ -2903,9 +2903,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-fb3f2ffb-adcb-4cbc-b775-a45371adb935
+      - req-7a10654a-80cb-4537-9fea-78fc6c7eb7df
       Date:
-      - Thu, 03 Jan 2019 19:23:34 GMT
+      - Fri, 04 Jan 2019 16:56:23 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -2932,7 +2932,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:34 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:23 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack2/4cf24b12-29fc-4529-a8ed-6b079dea7c17
@@ -2947,7 +2947,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fe6cf3f6adb74cfeb68683ebfb91beb7
+      - 69d35cf55ba44576a11469feb5af83e2
   response:
     status:
       code: 200
@@ -2958,9 +2958,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-83979d80-2a5a-48b8-83a8-b1d0aea49708
+      - req-9dfeaf50-59d7-4721-8d27-257c9d2a94f9
       Date:
-      - Thu, 03 Jan 2019 19:23:34 GMT
+      - Fri, 04 Jan 2019 16:56:23 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -2987,7 +2987,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:34 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:23 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c
@@ -3002,7 +3002,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fe6cf3f6adb74cfeb68683ebfb91beb7
+      - 69d35cf55ba44576a11469feb5af83e2
   response:
     status:
       code: 200
@@ -3013,9 +3013,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-83418ee3-56b7-426e-8c3f-bcce343340bf
+      - req-0bb2fedf-ba41-4efe-804b-e75e2d6b18be
       Date:
-      - Thu, 03 Jan 2019 19:23:34 GMT
+      - Fri, 04 Jan 2019 16:56:23 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -3042,7 +3042,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:34 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:23 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack3/45d2af82-eff9-4483-a1f0-f19c44d96146/resources
@@ -3057,7 +3057,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fe6cf3f6adb74cfeb68683ebfb91beb7
+      - 69d35cf55ba44576a11469feb5af83e2
   response:
     status:
       code: 200
@@ -3068,9 +3068,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-c1200213-238b-4238-af92-0344ff405ccc
+      - req-9469a81b-945b-4670-9cd5-1db7572e7b11
       Date:
-      - Thu, 03 Jan 2019 19:23:34 GMT
+      - Fri, 04 Jan 2019 16:56:23 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -3082,7 +3082,7 @@ http_interactions:
         changed", "physical_resource_id": "aa5907f3-8209-4dd0-b3ef-600431d85bac",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:35 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:23 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack3/45d2af82-eff9-4483-a1f0-f19c44d96146/template
@@ -3097,7 +3097,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fe6cf3f6adb74cfeb68683ebfb91beb7
+      - 69d35cf55ba44576a11469feb5af83e2
   response:
     status:
       code: 200
@@ -3108,9 +3108,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-ea7c0897-e0a5-4f44-b71a-86afe6da2012
+      - req-35d5e3cf-ec05-47f5-9c54-e9c234daee23
       Date:
-      - Thu, 03 Jan 2019 19:23:35 GMT
+      - Fri, 04 Jan 2019 16:56:23 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -3166,7 +3166,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:35 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:23 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack2/4cf24b12-29fc-4529-a8ed-6b079dea7c17/resources
@@ -3181,7 +3181,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fe6cf3f6adb74cfeb68683ebfb91beb7
+      - 69d35cf55ba44576a11469feb5af83e2
   response:
     status:
       code: 200
@@ -3192,9 +3192,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-53acde93-21ab-455b-8eff-4802c60bfa8c
+      - req-acc15253-697c-4118-812d-08bbc996c207
       Date:
-      - Thu, 03 Jan 2019 19:23:35 GMT
+      - Fri, 04 Jan 2019 16:56:24 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -3206,7 +3206,7 @@ http_interactions:
         changed", "physical_resource_id": "219a737c-b4ad-430d-944a-a92a4834b12d",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:35 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:24 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack2/4cf24b12-29fc-4529-a8ed-6b079dea7c17/template
@@ -3221,7 +3221,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fe6cf3f6adb74cfeb68683ebfb91beb7
+      - 69d35cf55ba44576a11469feb5af83e2
   response:
     status:
       code: 200
@@ -3232,9 +3232,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-5f94ca07-a637-4dc6-9aca-4439cdba51ae
+      - req-e14e78d9-1edd-4adf-acce-396509d1b76e
       Date:
-      - Thu, 03 Jan 2019 19:23:35 GMT
+      - Fri, 04 Jan 2019 16:56:24 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -3290,7 +3290,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:35 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:24 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c/resources
@@ -3305,7 +3305,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fe6cf3f6adb74cfeb68683ebfb91beb7
+      - 69d35cf55ba44576a11469feb5af83e2
   response:
     status:
       code: 200
@@ -3316,9 +3316,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-4212ec5e-f377-4e47-abb6-89766398fdad
+      - req-e73b5d7a-53ec-4099-bef4-c84320c715b4
       Date:
-      - Thu, 03 Jan 2019 19:23:35 GMT
+      - Fri, 04 Jan 2019 16:56:24 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -3330,7 +3330,7 @@ http_interactions:
         changed", "physical_resource_id": "b686353f-0da0-48bf-bc35-8ea411a67dfd",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:35 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:24 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c/template
@@ -3345,7 +3345,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fe6cf3f6adb74cfeb68683ebfb91beb7
+      - 69d35cf55ba44576a11469feb5af83e2
   response:
     status:
       code: 200
@@ -3356,9 +3356,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-321bfa5e-5d4d-4060-986e-91fbad327c30
+      - req-bba20b3b-78ff-4181-86a1-29e2213bf74d
       Date:
-      - Thu, 03 Jan 2019 19:23:35 GMT
+      - Fri, 04 Jan 2019 16:56:24 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -3414,7 +3414,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:35 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:24 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images?all_tenants=True&limit=1000
@@ -3429,7 +3429,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b7b65cf5deb94e3f8571e518de52c533
+      - f5997510ac014e33914baa695bf37faa
   response:
     status:
       code: 200
@@ -3440,14 +3440,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-39dfd607-ed38-48aa-9011-c883ce2c9497
+      - req-faf06d01-c682-4574-b6b8-31074b2a0e5e
       Date:
-      - Thu, 03 Jan 2019 19:23:35 GMT
+      - Fri, 04 Jan 2019 16:56:24 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000&all_tenants=True"}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:35 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:24 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images
@@ -3462,7 +3462,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b7b65cf5deb94e3f8571e518de52c533
+      - f5997510ac014e33914baa695bf37faa
   response:
     status:
       code: 200
@@ -3473,9 +3473,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-bbbbbfb0-f9dd-42e2-86fe-bbf23d649ff4
+      - req-571d387a-d8b1-494e-8ab7-c8b4a73baaf4
       Date:
-      - Thu, 03 Jan 2019 19:23:35 GMT
+      - Fri, 04 Jan 2019 16:56:24 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -3517,7 +3517,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images"}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:35 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:24 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images/78ab353a-8b32-4cb9-b00b-60a70bacae08/members
@@ -3532,7 +3532,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b7b65cf5deb94e3f8571e518de52c533
+      - f5997510ac014e33914baa695bf37faa
   response:
     status:
       code: 200
@@ -3543,14 +3543,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-0f0ec9a3-6880-4ed4-8349-6af4d8197d10
+      - req-e055931f-e3e5-4aff-8723-4fbda490bd44
       Date:
-      - Thu, 03 Jan 2019 19:23:36 GMT
+      - Fri, 04 Jan 2019 16:56:24 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"members": [], "schema": "/v2/schemas/members"}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:36 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:24 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images/c9e7d983-c1a3-45f5-be89-3cfa4d7d9c0f/members
@@ -3565,7 +3565,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b7b65cf5deb94e3f8571e518de52c533
+      - f5997510ac014e33914baa695bf37faa
   response:
     status:
       code: 200
@@ -3576,14 +3576,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-1038f6d7-9a80-4d63-92dd-cf5c35591b2f
+      - req-8bcdf1cb-1b43-4414-93ec-ed8070c1c929
       Date:
-      - Thu, 03 Jan 2019 19:23:36 GMT
+      - Fri, 04 Jan 2019 16:56:25 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"members": [], "schema": "/v2/schemas/members"}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:36 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:25 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images/2f6b4eb7-8fc2-4439-9dc2-560d7457c706/members
@@ -3598,7 +3598,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b7b65cf5deb94e3f8571e518de52c533
+      - f5997510ac014e33914baa695bf37faa
   response:
     status:
       code: 200
@@ -3609,14 +3609,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-008fa691-6e63-4331-a91f-abcd366b1754
+      - req-8ecd3697-6050-4fee-b129-2accba418965
       Date:
-      - Thu, 03 Jan 2019 19:23:36 GMT
+      - Fri, 04 Jan 2019 16:56:25 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"members": [], "schema": "/v2/schemas/members"}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:36 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:25 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images/bb799f70-5e02-461b-8324-17ee88259c7b/members
@@ -3631,7 +3631,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b7b65cf5deb94e3f8571e518de52c533
+      - f5997510ac014e33914baa695bf37faa
   response:
     status:
       code: 200
@@ -3642,14 +3642,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-5f673495-684d-48a8-8a9f-523988123773
+      - req-34df9418-f63f-43f7-b9ab-c927982e4e25
       Date:
-      - Thu, 03 Jan 2019 19:23:36 GMT
+      - Fri, 04 Jan 2019 16:56:25 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"members": [], "schema": "/v2/schemas/members"}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:36 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:25 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?all_tenants=True&limit=1000
@@ -3664,7 +3664,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - de544df98dea49b0ba517c6665b46042
+      - 4dd6d85d1dad4a8581bd582e82489653
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3677,9 +3677,9 @@ http_interactions:
       Content-Length:
       - '3998'
       X-Compute-Request-Id:
-      - req-0728b4dc-9c3f-4467-abcc-776f89b2882e
+      - req-0b56bdcb-72cb-421c-8303-091348d77261
       Date:
-      - Thu, 03 Jan 2019 19:23:36 GMT
+      - Fri, 04 Jan 2019 16:56:25 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?all_tenants=True&limit=1000&marker=96fef14f-5338-4d58-8b89-58b627b27b9b",
@@ -3725,7 +3725,7 @@ http_interactions:
         [], "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:36 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:25 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?all_tenants=True&limit=1000&marker=96fef14f-5338-4d58-8b89-58b627b27b9b
@@ -3740,7 +3740,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - de544df98dea49b0ba517c6665b46042
+      - 4dd6d85d1dad4a8581bd582e82489653
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3753,9 +3753,9 @@ http_interactions:
       Content-Length:
       - '4062'
       X-Compute-Request-Id:
-      - req-2356cc36-dbe0-4bd3-a289-115a7871d26f
+      - req-94e87c9d-24a1-4424-855c-cd6de966985f
       Date:
-      - Thu, 03 Jan 2019 19:23:36 GMT
+      - Fri, 04 Jan 2019 16:56:25 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?all_tenants=True&limit=1000&marker=ca1fc357-ee31-45e9-a38d-98723d6c8876",
@@ -3801,7 +3801,7 @@ http_interactions:
         [], "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 3, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:36 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:25 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?all_tenants=True&limit=1000&marker=ca1fc357-ee31-45e9-a38d-98723d6c8876
@@ -3816,7 +3816,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - de544df98dea49b0ba517c6665b46042
+      - 4dd6d85d1dad4a8581bd582e82489653
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3829,9 +3829,9 @@ http_interactions:
       Content-Length:
       - '4144'
       X-Compute-Request-Id:
-      - req-3adc4cfc-9e94-41fc-bf78-b85c3586c8cc
+      - req-e0191ff8-a5e8-4172-921b-3f44aaff7738
       Date:
-      - Thu, 03 Jan 2019 19:23:37 GMT
+      - Fri, 04 Jan 2019 16:56:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?all_tenants=True&limit=1000&marker=ca4f3a16-bae3-4407-83e9-f77b28af0f2b",
@@ -3879,7 +3879,7 @@ http_interactions:
         "", "progress": 0, "OS-EXT-STS:power_state": 1, "config_drive": "", "metadata":
         {}}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:37 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:26 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?all_tenants=True&limit=1000&marker=ca4f3a16-bae3-4407-83e9-f77b28af0f2b
@@ -3894,7 +3894,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - de544df98dea49b0ba517c6665b46042
+      - 4dd6d85d1dad4a8581bd582e82489653
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3907,9 +3907,9 @@ http_interactions:
       Content-Length:
       - '3813'
       X-Compute-Request-Id:
-      - req-f6ae1254-a499-4c5c-b8d7-0b973c2d2bb2
+      - req-3c99697d-0978-4b3f-82c4-ae09fd0ecf13
       Date:
-      - Thu, 03 Jan 2019 19:23:37 GMT
+      - Fri, 04 Jan 2019 16:56:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?all_tenants=True&limit=1000&marker=aa5907f3-8209-4dd0-b3ef-600431d85bac",
@@ -3951,7 +3951,7 @@ http_interactions:
         "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:37 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:26 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?all_tenants=True&limit=1000&marker=aa5907f3-8209-4dd0-b3ef-600431d85bac
@@ -3966,7 +3966,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - de544df98dea49b0ba517c6665b46042
+      - 4dd6d85d1dad4a8581bd582e82489653
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3979,9 +3979,9 @@ http_interactions:
       Content-Length:
       - '1816'
       X-Compute-Request-Id:
-      - req-b725fccc-ddd2-4299-89c6-d752552cf1d4
+      - req-83275e7e-a5a8-4212-91e6-75ff627363a6
       Date:
-      - Thu, 03 Jan 2019 19:23:37 GMT
+      - Fri, 04 Jan 2019 16:56:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": [{"status": "SHUTOFF", "updated": "2018-01-17T14:49:17Z",
@@ -4004,7 +4004,7 @@ http_interactions:
         "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:37 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:26 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-floating-ips
@@ -4019,7 +4019,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - de544df98dea49b0ba517c6665b46042
+      - 4dd6d85d1dad4a8581bd582e82489653
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4032,14 +4032,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-7e1b30ee-9870-46c4-8249-c5d4c8463efe
+      - req-54463a01-3128-4583-9057-4bf606ae789e
       Date:
-      - Thu, 03 Jan 2019 19:23:37 GMT
+      - Fri, 04 Jan 2019 16:56:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:37 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:26 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-floating-ips
@@ -4054,7 +4054,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - de544df98dea49b0ba517c6665b46042
+      - 4dd6d85d1dad4a8581bd582e82489653
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4067,14 +4067,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-de7f633e-ed8f-4ca1-ab9c-877e74faf0e8
+      - req-f30a615c-096d-4d68-a285-e509233c8688
       Date:
-      - Thu, 03 Jan 2019 19:23:38 GMT
+      - Fri, 04 Jan 2019 16:56:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:38 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:26 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-floating-ips
@@ -4089,7 +4089,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - de544df98dea49b0ba517c6665b46042
+      - 4dd6d85d1dad4a8581bd582e82489653
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4102,14 +4102,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-92238aa5-b07d-4c96-ab88-dbaff5699f80
+      - req-3e7a1dec-96d4-4504-a9fc-8980cf25e8f1
       Date:
-      - Thu, 03 Jan 2019 19:23:38 GMT
+      - Fri, 04 Jan 2019 16:56:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:38 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:27 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-floating-ips
@@ -4124,7 +4124,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - de544df98dea49b0ba517c6665b46042
+      - 4dd6d85d1dad4a8581bd582e82489653
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4137,14 +4137,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-83b88223-b285-4e2a-89c8-f1a4616b560c
+      - req-c783cd21-5cb9-4554-97b7-3cd721318f56
       Date:
-      - Thu, 03 Jan 2019 19:23:38 GMT
+      - Fri, 04 Jan 2019 16:56:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:38 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:27 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-floating-ips
@@ -4159,7 +4159,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - de544df98dea49b0ba517c6665b46042
+      - 4dd6d85d1dad4a8581bd582e82489653
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4172,14 +4172,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-2c0f9437-0b03-43d0-b334-fb1762a99a1c
+      - req-8c5f9bb5-4c74-4aa2-840c-ec44d719759b
       Date:
-      - Thu, 03 Jan 2019 19:23:38 GMT
+      - Fri, 04 Jan 2019 16:56:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:38 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:27 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-floating-ips
@@ -4194,7 +4194,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - de544df98dea49b0ba517c6665b46042
+      - 4dd6d85d1dad4a8581bd582e82489653
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4207,14 +4207,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-578f091d-3b7f-4d2b-b966-df498786423f
+      - req-95c563b1-d2eb-432f-8e95-5bda1986af48
       Date:
-      - Thu, 03 Jan 2019 19:23:38 GMT
+      - Fri, 04 Jan 2019 16:56:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:38 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:27 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-floating-ips
@@ -4229,7 +4229,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - de544df98dea49b0ba517c6665b46042
+      - 4dd6d85d1dad4a8581bd582e82489653
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4242,14 +4242,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-4e8d7f52-d3ed-43d1-b736-026848e9c13f
+      - req-bc925819-d732-41c9-9686-265f8f142fb3
       Date:
-      - Thu, 03 Jan 2019 19:23:38 GMT
+      - Fri, 04 Jan 2019 16:56:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:38 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:27 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-floating-ips
@@ -4264,7 +4264,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - de544df98dea49b0ba517c6665b46042
+      - 4dd6d85d1dad4a8581bd582e82489653
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4277,14 +4277,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-6151a35a-2cc0-4b50-b66d-ed2f8b222d7f
+      - req-91b27901-bd6c-4497-95ee-28202c3bac70
       Date:
-      - Thu, 03 Jan 2019 19:23:38 GMT
+      - Fri, 04 Jan 2019 16:56:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:38 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:27 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-floating-ips
@@ -4299,7 +4299,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - de544df98dea49b0ba517c6665b46042
+      - 4dd6d85d1dad4a8581bd582e82489653
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4312,14 +4312,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-cbaaf5c6-1e63-46b1-bbca-2faf98c909ae
+      - req-bd5a27bf-e8f0-43ac-8230-fe7e9ae22022
       Date:
-      - Thu, 03 Jan 2019 19:23:39 GMT
+      - Fri, 04 Jan 2019 16:56:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:39 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:27 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-services?all_tenants=True&limit=1000
@@ -4334,7 +4334,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - de544df98dea49b0ba517c6665b46042
+      - 4dd6d85d1dad4a8581bd582e82489653
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4347,26 +4347,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-8640e92a-4f93-42e9-a2c7-204342df770c
+      - req-02042082-096a-4e71-9f3e-03841d60fd57
       Date:
-      - Thu, 03 Jan 2019 19:23:39 GMT
+      - Fri, 04 Jan 2019 16:56:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-01-03T19:23:35.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-01-04T16:56:18.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2019-01-03T19:23:33.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2019-01-04T16:56:27.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-01-03T19:23:35.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-01-04T16:56:18.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2019-01-03T19:23:29.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2019-01-04T16:56:22.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2019-01-03T19:23:38.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2019-01-04T16:56:22.000000"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:39 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:28 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-services?all_tenants=True&limit=1000&marker=5
@@ -4381,7 +4381,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - de544df98dea49b0ba517c6665b46042
+      - 4dd6d85d1dad4a8581bd582e82489653
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4394,26 +4394,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-a971e910-1085-4f16-8149-8b3da9caa25a
+      - req-ab701b92-b5d0-4fc6-b690-6a094b05ccd4
       Date:
-      - Thu, 03 Jan 2019 19:23:39 GMT
+      - Fri, 04 Jan 2019 16:56:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-01-03T19:23:35.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-01-04T16:56:18.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2019-01-03T19:23:33.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2019-01-04T16:56:27.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-01-03T19:23:35.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-01-04T16:56:18.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2019-01-03T19:23:29.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2019-01-04T16:56:22.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2019-01-03T19:23:38.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2019-01-04T16:56:22.000000"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:39 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:28 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4431,13 +4431,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:23:43 GMT
+      - Fri, 04 Jan 2019 16:56:29 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-9f330bf4-44c8-48ed-abbc-c5189820304e
+      - req-8d7b7e2f-2be6-4b02-b09d-9498087b8358
       Content-Length:
       - '4170'
       Connection:
@@ -4446,10 +4446,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:23:43.499147", "expires":
-        "2019-01-03T20:23:43Z", "id": "f5554321b7004bf5a362301e52d8389c", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:56:29.265057", "expires":
+        "2019-01-04T17:56:29Z", "id": "bc82d01afebe4c54af1df75e9f2c995d", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["naU7DUKcTnutH8nudiCsTg"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["uzHdWPGgRQuoVfVF7rPFGg"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -4494,7 +4494,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:43 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:29 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4512,13 +4512,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:23:43 GMT
+      - Fri, 04 Jan 2019 16:56:29 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-9c48d1e8-6a8f-427b-b2c8-38e5abbf1c70
+      - req-e18984d4-92f0-44f3-90fb-90a4e087e9c7
       Content-Length:
       - '4170'
       Connection:
@@ -4527,10 +4527,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:23:43.693543", "expires":
-        "2019-01-03T20:23:43Z", "id": "0bdfa51e69d34719aa4b73c9d21f3875", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:56:29.473343", "expires":
+        "2019-01-04T17:56:29Z", "id": "469822f9ed8e4536aa2e8ffc062209a2", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["gdjz9of7SaWPdKgTq7Bg9g"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["s2PyUI1cQEeg0JZ35KryxQ"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -4575,7 +4575,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:43 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:29 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?all_tenants=True&limit=1000
@@ -4590,7 +4590,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0bdfa51e69d34719aa4b73c9d21f3875
+      - 469822f9ed8e4536aa2e8ffc062209a2
   response:
     status:
       code: 200
@@ -4601,9 +4601,9 @@ http_interactions:
       Content-Length:
       - '3418'
       X-Openstack-Request-Id:
-      - req-f8afcac6-5fe2-492d-9d27-d79da35efc02
+      - req-80522479-d0eb-4419-a1be-fc8a3dcae8fd
       Date:
-      - Thu, 03 Jan 2019 19:23:43 GMT
+      - Fri, 04 Jan 2019 16:56:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef",
@@ -4645,7 +4645,7 @@ http_interactions:
         null, "port_range_min": null, "id": "ff24dfac-169a-4238-b78b-ed1536a0bf06",
         "security_group_id": "5b2b42a6-1271-4c4a-b062-8e8ba299acef"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:43 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:29 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef
@@ -4660,7 +4660,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0bdfa51e69d34719aa4b73c9d21f3875
+      - 469822f9ed8e4536aa2e8ffc062209a2
   response:
     status:
       code: 200
@@ -4671,9 +4671,9 @@ http_interactions:
       Content-Length:
       - '3418'
       X-Openstack-Request-Id:
-      - req-a923f7e8-df4e-44b7-bb8c-3d11fcbf6894
+      - req-08170d5c-d541-4938-9480-8db7c84ed886
       Date:
-      - Thu, 03 Jan 2019 19:23:44 GMT
+      - Fri, 04 Jan 2019 16:56:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab",
@@ -4716,7 +4716,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "c06c0e71-2c18-43a9-ace9-91242f0251e2",
         "security_group_id": "98bfc20c-a897-42c5-b33c-f0d8317667ab"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:44 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:29 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab
@@ -4731,7 +4731,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0bdfa51e69d34719aa4b73c9d21f3875
+      - 469822f9ed8e4536aa2e8ffc062209a2
   response:
     status:
       code: 200
@@ -4742,9 +4742,9 @@ http_interactions:
       Content-Length:
       - '2751'
       X-Openstack-Request-Id:
-      - req-855658b7-064b-405e-a9d7-1b85691028e1
+      - req-4f944832-f4ac-4a81-b401-162b11297210
       Date:
-      - Thu, 03 Jan 2019 19:23:44 GMT
+      - Fri, 04 Jan 2019 16:56:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4",
@@ -4779,7 +4779,7 @@ http_interactions:
         null, "port_range_min": null, "id": "75924ebc-4758-4042-ad04-4ef3c9189098",
         "security_group_id": "e4836528-d0df-425e-a117-ae8ec6f356d4"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:44 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:29 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4
@@ -4794,7 +4794,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0bdfa51e69d34719aa4b73c9d21f3875
+      - 469822f9ed8e4536aa2e8ffc062209a2
   response:
     status:
       code: 200
@@ -4805,9 +4805,9 @@ http_interactions:
       Content-Length:
       - '7097'
       X-Openstack-Request-Id:
-      - req-b4db0a60-833f-490c-ad06-ce8220de0318
+      - req-5cb367c7-6eae-4ba4-adb8-ed0db9c0ece6
       Date:
-      - Thu, 03 Jan 2019 19:23:44 GMT
+      - Fri, 04 Jan 2019 16:56:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=fd147cb7-7456-43d9-a01f-c06e21b4e6fb&page_reverse=True",
@@ -4894,7 +4894,7 @@ http_interactions:
         "port_range_max": 80, "port_range_min": 80, "id": "f79f0e32-b186-4778-952e-20827a60ef73",
         "security_group_id": "fd147cb7-7456-43d9-a01f-c06e21b4e6fb"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:44 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:30 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/networks
@@ -4909,7 +4909,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0bdfa51e69d34719aa4b73c9d21f3875
+      - 469822f9ed8e4536aa2e8ffc062209a2
   response:
     status:
       code: 200
@@ -4920,17 +4920,12 @@ http_interactions:
       Content-Length:
       - '5330'
       X-Openstack-Request-Id:
-      - req-9f03632e-7135-437e-9ee4-06af740034c4
+      - req-f0519f2d-eae8-41f4-8e13-27d8847f88f5
       Date:
-      - Thu, 03 Jan 2019 19:23:44 GMT
+      - Fri, 04 Jan 2019 16:56:30 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"networks": [{"status": "ACTIVE", "subnets": ["bb23bb48-804d-4416-bac3-231db23841e8"],
-        "name": "EmsRefreshSpec-NetworkPrivate_2", "provider:physical_network": null,
-        "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
-        0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
-        "id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "provider:segmentation_id":
-        53}, {"status": "ACTIVE", "subnets": ["841b5584-f86f-4abd-9bc2-f445b8bc860b",
+      string: '{"networks": [{"status": "ACTIVE", "subnets": ["841b5584-f86f-4abd-9bc2-f445b8bc860b",
         "39628ee0-d5ff-4a88-ae66-80442e5feefd"], "name": "EmsRefreshSpec-NetworkPrivate_30",
         "provider:physical_network": null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
@@ -4985,14 +4980,19 @@ http_interactions:
         null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
         "vxlan", "id": "560b4210-2b5a-4439-8d24-203e09478f48", "provider:segmentation_id":
-        54}, {"status": "ACTIVE", "subnets": ["104c081f-97dd-42b7-8930-98abbd015c74",
+        54}, {"status": "ACTIVE", "subnets": ["bb23bb48-804d-4416-bac3-231db23841e8"],
+        "name": "EmsRefreshSpec-NetworkPrivate_2", "provider:physical_network": null,
+        "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
+        0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
+        "id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "provider:segmentation_id":
+        53}, {"status": "ACTIVE", "subnets": ["104c081f-97dd-42b7-8930-98abbd015c74",
         "d53802a5-f0f6-48ba-9207-dbd9b13acac3"], "name": "EmsRefreshSpec-NetworkPrivate",
         "provider:physical_network": null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
         "vxlan", "id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "provider:segmentation_id":
         14}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:44 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:30 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?all_tenants=True&limit=1000
@@ -5007,7 +5007,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0bdfa51e69d34719aa4b73c9d21f3875
+      - 469822f9ed8e4536aa2e8ffc062209a2
   response:
     status:
       code: 200
@@ -5018,41 +5018,12 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-b753e011-199a-481a-a061-68e559873eeb
+      - req-32380ea8-660f-4a63-9a93-892c6348455a
       Date:
-      - Thu, 03 Jan 2019 19:23:44 GMT
+      - Fri, 04 Jan 2019 16:56:30 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
-        true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
@@ -5111,23 +5082,52 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
         "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
         "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:44 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:30 GMT
 - request:
     method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?all_tenants=True&limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
+    uri: http://10.8.99.233:9696/v2.0/subnets?all_tenants=True&limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
     body:
       encoding: US-ASCII
       string: ''
@@ -5139,7 +5139,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0bdfa51e69d34719aa4b73c9d21f3875
+      - 469822f9ed8e4536aa2e8ffc062209a2
   response:
     status:
       code: 200
@@ -5150,41 +5150,12 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-4a8c799c-591e-403b-83ba-cd0f962403ef
+      - req-c18a97eb-90e4-478d-9051-999b9724d471
       Date:
-      - Thu, 03 Jan 2019 19:23:44 GMT
+      - Fri, 04 Jan 2019 16:56:30 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
-        true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
@@ -5243,20 +5214,49 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
         "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
         "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:44 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:30 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?all_tenants=True&limit=1000
@@ -5271,7 +5271,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0bdfa51e69d34719aa4b73c9d21f3875
+      - 469822f9ed8e4536aa2e8ffc062209a2
   response:
     status:
       code: 200
@@ -5282,9 +5282,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-0cbc1fa5-7e96-4fac-852f-8567f81fb26e
+      - req-ee085d6a-2166-436c-b6ed-f9729f22f9bf
       Date:
-      - Thu, 03 Jan 2019 19:23:44 GMT
+      - Fri, 04 Jan 2019 16:56:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -5316,7 +5316,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:44 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:30 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?all_tenants=True&limit=1000&marker=a41c036a-c34e-454b-851d-5eefd03888cb
@@ -5331,7 +5331,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0bdfa51e69d34719aa4b73c9d21f3875
+      - 469822f9ed8e4536aa2e8ffc062209a2
   response:
     status:
       code: 200
@@ -5342,9 +5342,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-cfdead27-703e-457e-9406-93cff19d6357
+      - req-8b1b78e6-40bb-4de3-afc8-92ac6a16aa1e
       Date:
-      - Thu, 03 Jan 2019 19:23:45 GMT
+      - Fri, 04 Jan 2019 16:56:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -5376,7 +5376,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:45 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:30 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?all_tenants=True&limit=1000
@@ -5391,7 +5391,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0bdfa51e69d34719aa4b73c9d21f3875
+      - 469822f9ed8e4536aa2e8ffc062209a2
   response:
     status:
       code: 200
@@ -5402,9 +5402,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-ee52efd3-50df-4a1a-a99d-032411574003
+      - req-3f9aeb86-2597-4bcc-bd0f-b8612953ed9a
       Date:
-      - Thu, 03 Jan 2019 19:23:45 GMT
+      - Fri, 04 Jan 2019 16:56:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -5807,7 +5807,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:45 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:30 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?all_tenants=True&limit=1000&marker=dee8791c-23b3-4e65-846d-49aeaba18036
@@ -5822,7 +5822,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0bdfa51e69d34719aa4b73c9d21f3875
+      - 469822f9ed8e4536aa2e8ffc062209a2
   response:
     status:
       code: 200
@@ -5833,9 +5833,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-6adef03f-91c8-422d-a35a-1de3ffe944fc
+      - req-eb3d9d67-5d75-4b50-bcf0-f501522c420f
       Date:
-      - Thu, 03 Jan 2019 19:23:45 GMT
+      - Fri, 04 Jan 2019 16:56:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -6238,7 +6238,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:45 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:31 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?all_tenants=True&limit=1000
@@ -6253,7 +6253,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0bdfa51e69d34719aa4b73c9d21f3875
+      - 469822f9ed8e4536aa2e8ffc062209a2
   response:
     status:
       code: 200
@@ -6264,9 +6264,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-bb8990bf-19b2-4a83-b3a5-4d5b0933df5b
+      - req-b3aa75a7-b89a-4aa7-8d47-46a64ddb1c57
       Date:
-      - Thu, 03 Jan 2019 19:23:45 GMT
+      - Fri, 04 Jan 2019 16:56:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -6308,7 +6308,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:45 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:31 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?all_tenants=True&limit=1000&marker=ee601a91-f6ac-4a46-a599-87cfd83094a3
@@ -6323,7 +6323,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0bdfa51e69d34719aa4b73c9d21f3875
+      - 469822f9ed8e4536aa2e8ffc062209a2
   response:
     status:
       code: 200
@@ -6334,9 +6334,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-8ec4e4f9-8f54-4c5f-bb15-ae3670c95941
+      - req-e6571ee5-7d3c-4525-a02e-a88026b341ad
       Date:
-      - Thu, 03 Jan 2019 19:23:45 GMT
+      - Fri, 04 Jan 2019 16:56:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -6378,7 +6378,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:45 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:31 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -6396,13 +6396,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:23:46 GMT
+      - Fri, 04 Jan 2019 16:56:32 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-2c67e3a1-6eed-4bd1-9b55-ede60ccf843f
+      - req-00091167-3332-4f54-a6df-7a53041afd40
       Content-Length:
       - '4170'
       Connection:
@@ -6411,10 +6411,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:23:46.876128", "expires":
-        "2019-01-03T20:23:46Z", "id": "c13da2d60e154d3f96654f3d378ae650", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:56:32.285459", "expires":
+        "2019-01-04T17:56:32Z", "id": "1242c2eca5094496886984a92cc0fd06", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["fEiuIp4YSRCzRyMN5qW1ow"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["iGkiquViTAaDE1wRdvatIw"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -6459,7 +6459,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:46 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:32 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -6477,13 +6477,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:23:47 GMT
+      - Fri, 04 Jan 2019 16:56:32 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-2740f9b4-fcff-4d3e-bd59-8fd23f1e33a6
+      - req-564f4c3a-30b4-4280-8874-441cc64f1f1f
       Content-Length:
       - '4170'
       Connection:
@@ -6492,10 +6492,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:23:47.058583", "expires":
-        "2019-01-03T20:23:47Z", "id": "9f3b700b58e44bc1b3e2dd0c5be292bd", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:56:32.479765", "expires":
+        "2019-01-04T17:56:32Z", "id": "f257a59a730c45389146f9939f76288f", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["t5S8eNS8QO-aoqwqMz2B5w"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["DYKK7XmoTGOPYnG8s4hTSw"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -6540,7 +6540,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:47 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:32 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -6558,13 +6558,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:23:47 GMT
+      - Fri, 04 Jan 2019 16:56:32 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-b7b18d7f-975f-4c4c-bdb3-451eeed39b68
+      - req-bd97ad8d-7018-41b8-a1df-be5e33fc4cc3
       Content-Length:
       - '370'
       Connection:
@@ -6573,13 +6573,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:23:47.231843", "expires":
-        "2019-01-03T20:23:47Z", "id": "f43be3ab999e47c387527524e7f4af26", "audit_ids":
-        ["vIjCPz-QTvuVrVawZPhbFw"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:56:32.651964", "expires":
+        "2019-01-04T17:56:32Z", "id": "f50fa305602e47b7a2b8e8f493262dbd", "audit_ids":
+        ["dPQ6chiuSkSUre6mC-xbow"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:47 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:32 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -6594,20 +6594,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f43be3ab999e47c387527524e7f4af26
+      - f50fa305602e47b7a2b8e8f493262dbd
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:23:47 GMT
+      - Fri, 04 Jan 2019 16:56:32 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-7a0bfefe-c672-4c08-bc7d-ac8fe38b90ba
+      - req-995b3629-a37e-44a1-abce-5e584efbfc69
       Content-Length:
       - '500'
       Connection:
@@ -6624,7 +6624,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:47 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:32 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -6642,13 +6642,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:23:47 GMT
+      - Fri, 04 Jan 2019 16:56:32 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-712f415f-c026-454a-b375-9e82a7130a9d
+      - req-44e8e8ba-48d1-444d-b0d2-c7695bc0fc20
       Content-Length:
       - '4117'
       Connection:
@@ -6657,10 +6657,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:23:47.583417", "expires":
-        "2019-01-03T20:23:47Z", "id": "d3770bcd0be6494ba5f3810141a34ec3", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:56:32.975703", "expires":
+        "2019-01-04T17:56:32Z", "id": "60a428bdfbdf4737bdb909a30b0fa209", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["kZnkMrSnR_6vndfOxGuFNA"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["EFX6rKI3RruHhwvDRZWRAQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -6704,7 +6704,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:47 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:33 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -6722,13 +6722,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:23:47 GMT
+      - Fri, 04 Jan 2019 16:56:33 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-61ea0f8e-ecf2-4570-a351-049936a03354
+      - req-ba1c0b21-5aa7-4247-89bf-73db0cc4ea65
       Content-Length:
       - '4131'
       Connection:
@@ -6737,10 +6737,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:23:47.770872", "expires":
-        "2019-01-03T20:23:47Z", "id": "6dc38cbad1f8411eb2101f8eecffb724", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:56:33.163774", "expires":
+        "2019-01-04T17:56:33Z", "id": "e9c041ee7584454aad43fe10a4bba8da", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["UnwHhbapSDeQmsC15l_gPw"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["ZEqVk8MDQLacDt3xOlxm5A"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -6784,7 +6784,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:47 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:33 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -6802,13 +6802,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:23:47 GMT
+      - Fri, 04 Jan 2019 16:56:33 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-5d8a5fc4-f25e-4e96-903a-2e11451086ed
+      - req-9dd44889-8f57-4ba0-8053-070760c1c9ea
       Content-Length:
       - '4118'
       Connection:
@@ -6817,10 +6817,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:23:47.969685", "expires":
-        "2019-01-03T20:23:47Z", "id": "4ffa0ed4d4c1484b8e0cd29fed1cd13a", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:56:33.351213", "expires":
+        "2019-01-04T17:56:33Z", "id": "c103569076ed4abc9d6ca89e9c33f193", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["EjoWlMyDSUetaOx1_D0BrQ"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["xED4w0_AS2eBwq0-6icvyw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -6864,7 +6864,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:47 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:33 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000
@@ -6879,22 +6879,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d3770bcd0be6494ba5f3810141a34ec3
+      - 60a428bdfbdf4737bdb909a30b0fa209
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-6b2e5019-21e9-4be6-8dec-81aae132a704
+      - req-0ab615c0-61d5-4143-bab3-0bc949db17fa
       Content-Type:
       - application/json
       Content-Length:
       - '2706'
       X-Openstack-Request-Id:
-      - req-6b2e5019-21e9-4be6-8dec-81aae132a704
+      - req-0ab615c0-61d5-4143-bab3-0bc949db17fa
       Date:
-      - Thu, 03 Jan 2019 19:23:48 GMT
+      - Fri, 04 Jan 2019 16:56:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=9bb99818-b339-4e31-b87f-e4181ec48acd",
@@ -6927,7 +6927,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-4", "bootable": "true", "created_at":
         "2016-11-11T13:49:53.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:48 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:33 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=9bb99818-b339-4e31-b87f-e4181ec48acd
@@ -6942,22 +6942,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d3770bcd0be6494ba5f3810141a34ec3
+      - 60a428bdfbdf4737bdb909a30b0fa209
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-5ab59e10-1960-4abb-804d-1930b692a349
+      - req-e9d788da-cccc-42da-8c92-59ad386220d2
       Content-Type:
       - application/json
       Content-Length:
       - '3284'
       X-Openstack-Request-Id:
-      - req-5ab59e10-1960-4abb-804d-1930b692a349
+      - req-e9d788da-cccc-42da-8c92-59ad386220d2
       Date:
-      - Thu, 03 Jan 2019 19:23:48 GMT
+      - Fri, 04 Jan 2019 16:56:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=2c774148-c11a-434c-aabb-7fa9c82c37ce",
@@ -6998,7 +6998,7 @@ http_interactions:
         "name": "EmsRefreshSpec-Volume-2", "bootable": "false", "created_at": "2016-11-11T13:49:43.000000",
         "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:48 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:33 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=2c774148-c11a-434c-aabb-7fa9c82c37ce
@@ -7013,22 +7013,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d3770bcd0be6494ba5f3810141a34ec3
+      - 60a428bdfbdf4737bdb909a30b0fa209
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-0b7c9f78-a683-4e6f-afd0-1aed7da38db9
+      - req-350be71d-0a25-46b5-a325-3ad27f974414
       Content-Type:
       - application/json
       Content-Length:
       - '2753'
       X-Openstack-Request-Id:
-      - req-0b7c9f78-a683-4e6f-afd0-1aed7da38db9
+      - req-350be71d-0a25-46b5-a325-3ad27f974414
       Date:
-      - Thu, 03 Jan 2019 19:23:48 GMT
+      - Fri, 04 Jan 2019 16:56:34 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=0a55c0d5-c780-4e7d-9d09-47f5520c7448",
@@ -7062,7 +7062,7 @@ http_interactions:
         "bootable": "false", "created_at": "2016-11-11T13:49:20.000000", "volume_type":
         "iscsi"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:48 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:34 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=0a55c0d5-c780-4e7d-9d09-47f5520c7448
@@ -7077,27 +7077,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d3770bcd0be6494ba5f3810141a34ec3
+      - 60a428bdfbdf4737bdb909a30b0fa209
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-a84efb8e-ec8e-4da8-a3bc-db4c96252557
+      - req-332437b9-c9ab-4769-8ab9-55b92c7f42b3
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-a84efb8e-ec8e-4da8-a3bc-db4c96252557
+      - req-332437b9-c9ab-4769-8ab9-55b92c7f42b3
       Date:
-      - Thu, 03 Jan 2019 19:23:48 GMT
+      - Fri, 04 Jan 2019 16:56:34 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:48 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:34 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/volumes/detail?limit=1000
@@ -7112,27 +7112,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6dc38cbad1f8411eb2101f8eecffb724
+      - e9c041ee7584454aad43fe10a4bba8da
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-bad6e748-0ebc-4a8d-9570-34febedeeb36
+      - req-6f1fbc37-1bec-4756-9778-81ddd8f5e16b
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-bad6e748-0ebc-4a8d-9570-34febedeeb36
+      - req-6f1fbc37-1bec-4756-9778-81ddd8f5e16b
       Date:
-      - Thu, 03 Jan 2019 19:23:48 GMT
+      - Fri, 04 Jan 2019 16:56:34 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:49 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:34 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/volumes/detail?limit=1000
@@ -7147,27 +7147,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9f3b700b58e44bc1b3e2dd0c5be292bd
+      - f257a59a730c45389146f9939f76288f
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-91bfc2ab-c7af-47d1-9baa-b0b674fbeae7
+      - req-1b21fe24-4cbc-42c8-ab76-7d6330a98d0c
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-91bfc2ab-c7af-47d1-9baa-b0b674fbeae7
+      - req-1b21fe24-4cbc-42c8-ab76-7d6330a98d0c
       Date:
-      - Thu, 03 Jan 2019 19:23:49 GMT
+      - Fri, 04 Jan 2019 16:56:34 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:49 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:34 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/volumes/detail?limit=1000
@@ -7182,27 +7182,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4ffa0ed4d4c1484b8e0cd29fed1cd13a
+      - c103569076ed4abc9d6ca89e9c33f193
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-cf45af48-197f-4603-8994-ebdbb6e0d3d7
+      - req-e3e1c5a6-3c01-436c-805d-43defc5feda4
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-cf45af48-197f-4603-8994-ebdbb6e0d3d7
+      - req-e3e1c5a6-3c01-436c-805d-43defc5feda4
       Date:
-      - Thu, 03 Jan 2019 19:23:49 GMT
+      - Fri, 04 Jan 2019 16:56:34 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:49 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:34 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail
@@ -7217,22 +7217,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d3770bcd0be6494ba5f3810141a34ec3
+      - 60a428bdfbdf4737bdb909a30b0fa209
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-c56996cb-c55c-4698-99d0-cf0a3a705b9a
+      - req-58899175-2f16-4f47-bd34-e5f42374deb9
       Content-Type:
       - application/json
       Content-Length:
       - '1053'
       X-Openstack-Request-Id:
-      - req-c56996cb-c55c-4698-99d0-cf0a3a705b9a
+      - req-58899175-2f16-4f47-bd34-e5f42374deb9
       Date:
-      - Thu, 03 Jan 2019 19:23:49 GMT
+      - Fri, 04 Jan 2019 16:56:34 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?marker=76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
@@ -7247,7 +7247,7 @@ http_interactions:
         "created_at": "2016-11-11T13:49:36.000000", "size": 1, "id": "76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:49 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:34 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?limit=1000
@@ -7262,22 +7262,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d3770bcd0be6494ba5f3810141a34ec3
+      - 60a428bdfbdf4737bdb909a30b0fa209
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-4067632d-a47a-491e-8c50-90f3e9599989
+      - req-a2e47347-62a7-425f-bda5-9397e96fc351
       Content-Type:
       - application/json
       Content-Length:
       - '1064'
       X-Openstack-Request-Id:
-      - req-4067632d-a47a-491e-8c50-90f3e9599989
+      - req-a2e47347-62a7-425f-bda5-9397e96fc351
       Date:
-      - Thu, 03 Jan 2019 19:23:49 GMT
+      - Fri, 04 Jan 2019 16:56:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?limit=1000&marker=76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
@@ -7292,7 +7292,7 @@ http_interactions:
         "created_at": "2016-11-11T13:49:36.000000", "size": 1, "id": "76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:49 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:35 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/snapshots/detail
@@ -7307,27 +7307,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6dc38cbad1f8411eb2101f8eecffb724
+      - e9c041ee7584454aad43fe10a4bba8da
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-578a574f-c965-49aa-ae9b-7089b37985b6
+      - req-9561b11e-f18e-4813-8f79-0d79b5d950e4
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-578a574f-c965-49aa-ae9b-7089b37985b6
+      - req-9561b11e-f18e-4813-8f79-0d79b5d950e4
       Date:
-      - Thu, 03 Jan 2019 19:23:49 GMT
+      - Fri, 04 Jan 2019 16:56:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:49 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:35 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/snapshots/detail?limit=1000
@@ -7342,27 +7342,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6dc38cbad1f8411eb2101f8eecffb724
+      - e9c041ee7584454aad43fe10a4bba8da
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-80eb9fdf-6d6b-472b-87e4-919f30d408b4
+      - req-9bc003c4-7357-4ab3-b231-556bd1479b79
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-80eb9fdf-6d6b-472b-87e4-919f30d408b4
+      - req-9bc003c4-7357-4ab3-b231-556bd1479b79
       Date:
-      - Thu, 03 Jan 2019 19:23:49 GMT
+      - Fri, 04 Jan 2019 16:56:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:49 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:35 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/snapshots/detail
@@ -7377,27 +7377,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9f3b700b58e44bc1b3e2dd0c5be292bd
+      - f257a59a730c45389146f9939f76288f
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-504dec82-8fd4-476c-a929-5cceb2381fd6
+      - req-ebc2e62e-5973-4f39-acc5-a04b4fd1e454
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-504dec82-8fd4-476c-a929-5cceb2381fd6
+      - req-ebc2e62e-5973-4f39-acc5-a04b4fd1e454
       Date:
-      - Thu, 03 Jan 2019 19:23:49 GMT
+      - Fri, 04 Jan 2019 16:56:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:49 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:35 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/snapshots/detail?limit=1000
@@ -7412,27 +7412,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9f3b700b58e44bc1b3e2dd0c5be292bd
+      - f257a59a730c45389146f9939f76288f
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-e87350c5-a20e-43c9-ac81-207c15b4001b
+      - req-e985c6f6-680c-4430-a3d8-33c2e1152fc2
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-e87350c5-a20e-43c9-ac81-207c15b4001b
+      - req-e985c6f6-680c-4430-a3d8-33c2e1152fc2
       Date:
-      - Thu, 03 Jan 2019 19:23:50 GMT
+      - Fri, 04 Jan 2019 16:56:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:50 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:35 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/snapshots/detail
@@ -7447,27 +7447,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4ffa0ed4d4c1484b8e0cd29fed1cd13a
+      - c103569076ed4abc9d6ca89e9c33f193
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-c85112e3-fd67-4bd3-94a9-1838021fafc7
+      - req-40f89e9d-2bd4-413a-8cc3-9f5b609ff2fc
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-c85112e3-fd67-4bd3-94a9-1838021fafc7
+      - req-40f89e9d-2bd4-413a-8cc3-9f5b609ff2fc
       Date:
-      - Thu, 03 Jan 2019 19:23:50 GMT
+      - Fri, 04 Jan 2019 16:56:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:50 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:35 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/snapshots/detail?limit=1000
@@ -7482,27 +7482,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4ffa0ed4d4c1484b8e0cd29fed1cd13a
+      - c103569076ed4abc9d6ca89e9c33f193
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-43b5009d-cd8a-4510-a4c2-b03492d3a1d9
+      - req-ed57b89c-e102-44d8-b15f-28b19964944f
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-43b5009d-cd8a-4510-a4c2-b03492d3a1d9
+      - req-ed57b89c-e102-44d8-b15f-28b19964944f
       Date:
-      - Thu, 03 Jan 2019 19:23:50 GMT
+      - Fri, 04 Jan 2019 16:56:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:50 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:35 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/backups/detail
@@ -7517,27 +7517,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d3770bcd0be6494ba5f3810141a34ec3
+      - 60a428bdfbdf4737bdb909a30b0fa209
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-d8310952-720b-4b40-b727-9a4bd1281db0
+      - req-39712bce-e01e-4e98-bad1-0c9522d3fa9e
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-d8310952-720b-4b40-b727-9a4bd1281db0
+      - req-39712bce-e01e-4e98-bad1-0c9522d3fa9e
       Date:
-      - Thu, 03 Jan 2019 19:23:50 GMT
+      - Fri, 04 Jan 2019 16:56:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:50 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:35 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/backups/detail?limit=1000
@@ -7552,27 +7552,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d3770bcd0be6494ba5f3810141a34ec3
+      - 60a428bdfbdf4737bdb909a30b0fa209
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-2bad3dc2-45c1-48dc-901a-1dff261916a9
+      - req-9c16b489-8644-469d-9789-d88c843ef04a
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-2bad3dc2-45c1-48dc-901a-1dff261916a9
+      - req-9c16b489-8644-469d-9789-d88c843ef04a
       Date:
-      - Thu, 03 Jan 2019 19:23:50 GMT
+      - Fri, 04 Jan 2019 16:56:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:50 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:35 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/backups/detail
@@ -7587,27 +7587,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6dc38cbad1f8411eb2101f8eecffb724
+      - e9c041ee7584454aad43fe10a4bba8da
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-d29e8f98-9427-4e70-a5fe-edde1d796474
+      - req-158f2e52-81e9-45d7-a443-69f2dfff8fd5
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-d29e8f98-9427-4e70-a5fe-edde1d796474
+      - req-158f2e52-81e9-45d7-a443-69f2dfff8fd5
       Date:
-      - Thu, 03 Jan 2019 19:23:50 GMT
+      - Fri, 04 Jan 2019 16:56:36 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:50 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:36 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/backups/detail?limit=1000
@@ -7622,27 +7622,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6dc38cbad1f8411eb2101f8eecffb724
+      - e9c041ee7584454aad43fe10a4bba8da
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-307f6f77-3855-4f5c-9b9e-9c803b9d2013
+      - req-2228462f-cd4d-44b9-b2b7-ddc704ad62dc
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-307f6f77-3855-4f5c-9b9e-9c803b9d2013
+      - req-2228462f-cd4d-44b9-b2b7-ddc704ad62dc
       Date:
-      - Thu, 03 Jan 2019 19:23:50 GMT
+      - Fri, 04 Jan 2019 16:56:36 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:50 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:36 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/backups/detail
@@ -7657,27 +7657,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9f3b700b58e44bc1b3e2dd0c5be292bd
+      - f257a59a730c45389146f9939f76288f
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-c8db4f58-f6b1-4773-a6b8-da60896de0cc
+      - req-31753e6c-ad5b-48ab-acb2-9be8d4973b27
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-c8db4f58-f6b1-4773-a6b8-da60896de0cc
+      - req-31753e6c-ad5b-48ab-acb2-9be8d4973b27
       Date:
-      - Thu, 03 Jan 2019 19:23:50 GMT
+      - Fri, 04 Jan 2019 16:56:36 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:50 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:36 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/backups/detail?limit=1000
@@ -7692,27 +7692,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9f3b700b58e44bc1b3e2dd0c5be292bd
+      - f257a59a730c45389146f9939f76288f
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-29bd1669-fbe1-4291-a5ea-579236a00bb3
+      - req-56f80072-1fc1-4c00-9228-2868d7be1077
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-29bd1669-fbe1-4291-a5ea-579236a00bb3
+      - req-56f80072-1fc1-4c00-9228-2868d7be1077
       Date:
-      - Thu, 03 Jan 2019 19:23:50 GMT
+      - Fri, 04 Jan 2019 16:56:36 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:50 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:36 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/backups/detail
@@ -7727,27 +7727,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4ffa0ed4d4c1484b8e0cd29fed1cd13a
+      - c103569076ed4abc9d6ca89e9c33f193
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-abee91be-2dc0-4730-bc42-ad3aab719f07
+      - req-84ea6881-5dbd-4070-94c9-38312348ae4c
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-abee91be-2dc0-4730-bc42-ad3aab719f07
+      - req-84ea6881-5dbd-4070-94c9-38312348ae4c
       Date:
-      - Thu, 03 Jan 2019 19:23:50 GMT
+      - Fri, 04 Jan 2019 16:56:36 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:51 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:36 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/backups/detail?limit=1000
@@ -7762,27 +7762,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4ffa0ed4d4c1484b8e0cd29fed1cd13a
+      - c103569076ed4abc9d6ca89e9c33f193
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-d5f12231-fb7c-4edb-b24a-456971ae5ba7
+      - req-88bf60dd-29ef-4655-ade8-96c891b14f72
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-d5f12231-fb7c-4edb-b24a-456971ae5ba7
+      - req-88bf60dd-29ef-4655-ade8-96c891b14f72
       Date:
-      - Thu, 03 Jan 2019 19:23:51 GMT
+      - Fri, 04 Jan 2019 16:56:36 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:51 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:36 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -7800,13 +7800,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:23:51 GMT
+      - Fri, 04 Jan 2019 16:56:37 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-178125a6-97f6-47d3-9cc3-4a24c489d73b
+      - req-14d1df0c-cd6a-4aea-9911-3f4500d7adfe
       Content-Length:
       - '4170'
       Connection:
@@ -7815,10 +7815,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:23:51.395045", "expires":
-        "2019-01-03T20:23:51Z", "id": "3ee4bab88124408f84861bee912de234", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:56:37.198268", "expires":
+        "2019-01-04T17:56:37Z", "id": "f1afd0360b9e4b8f82650ec4a8331ba0", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["xyCM0SbYSRGtp80RB0a6zA"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["QvbkDvKXTsOTfEHcxMKftA"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -7863,7 +7863,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:51 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:37 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -7881,13 +7881,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:23:51 GMT
+      - Fri, 04 Jan 2019 16:56:37 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-36dcd545-ccdd-4505-a5b0-92d7a3d8a95a
+      - req-0b434580-f3fc-4cb7-b21d-ecee28a1db71
       Content-Length:
       - '4170'
       Connection:
@@ -7896,10 +7896,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:23:51.595036", "expires":
-        "2019-01-03T20:23:51Z", "id": "7786ea6d1da14080b913eb817f19845f", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:56:37.408683", "expires":
+        "2019-01-04T17:56:37Z", "id": "d57918c01c3d4a44b62efee1d7cf9371", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["NnqHe4EFSmaISTOW8zP_Uw"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["gmYsagi_RGe1TY7qWyXVvA"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -7944,7 +7944,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:51 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:37 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -7962,13 +7962,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:23:51 GMT
+      - Fri, 04 Jan 2019 16:56:37 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-bf95b71e-3f17-4bc7-b6dd-ff08d3f1ea29
+      - req-00bf61d9-5511-441c-95f5-58da8e6c4ace
       Content-Length:
       - '370'
       Connection:
@@ -7977,13 +7977,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:23:51.756409", "expires":
-        "2019-01-03T20:23:51Z", "id": "8450337f08cb46829afeacf7b181df3e", "audit_ids":
-        ["doJGCNg7S2CPXOoIaQ-MMg"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:56:37.572704", "expires":
+        "2019-01-04T17:56:37Z", "id": "cae20d5fa7a04a9eaedab530b8f0d16d", "audit_ids":
+        ["FRR1YC0XRxK2EIsB8JnAkg"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:51 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:37 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -7998,20 +7998,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8450337f08cb46829afeacf7b181df3e
+      - cae20d5fa7a04a9eaedab530b8f0d16d
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:23:51 GMT
+      - Fri, 04 Jan 2019 16:56:37 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-b9af6d1d-c6b0-49bf-9a8e-d00a9603eb89
+      - req-7929dcf4-fa3a-4a4e-80e0-55422893ac78
       Content-Length:
       - '500'
       Connection:
@@ -8028,7 +8028,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:51 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:37 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -8046,13 +8046,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:23:52 GMT
+      - Fri, 04 Jan 2019 16:56:37 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-608a8612-a3c8-4852-8743-fa50503d955a
+      - req-ba43caac-2324-41fd-826b-46378dea857d
       Content-Length:
       - '4117'
       Connection:
@@ -8061,10 +8061,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:23:52.081574", "expires":
-        "2019-01-03T20:23:52Z", "id": "0ae7a911da9f405690bd6825c597cc89", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:56:37.913036", "expires":
+        "2019-01-04T17:56:37Z", "id": "2fe8cdeb0cad4eb88a5272a61428db71", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["vUZiU9BhSVe7YwrA2-D88Q"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["LdfveJw0RbGETwxj3lLgDw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -8108,7 +8108,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:52 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:37 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -8126,13 +8126,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:23:52 GMT
+      - Fri, 04 Jan 2019 16:56:38 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-6d891a7d-15b8-4027-bcdc-d712a482c630
+      - req-ae46d520-7eec-4757-bce9-991016672b52
       Content-Length:
       - '4131'
       Connection:
@@ -8141,10 +8141,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:23:52.268647", "expires":
-        "2019-01-03T20:23:52Z", "id": "63573cf29167483d953c9cf26d845d5e", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:56:38.111276", "expires":
+        "2019-01-04T17:56:38Z", "id": "02621620d2064a618251a17396422401", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["2wmD_yCCTmS4ZQFwKyHxJg"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["hhqMF8oiTCyPO4Hl0QCHlg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -8188,7 +8188,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:52 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:38 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -8206,13 +8206,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:23:52 GMT
+      - Fri, 04 Jan 2019 16:56:38 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-85fbcc36-0364-4e6e-8e6e-e914bfa312f8
+      - req-9b30546b-a78e-4d18-b6d7-8509bcaff1d0
       Content-Length:
       - '4118'
       Connection:
@@ -8221,10 +8221,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:23:52.458730", "expires":
-        "2019-01-03T20:23:52Z", "id": "0441cc9c7a30497693c01a670abc42d5", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:56:38.313211", "expires":
+        "2019-01-04T17:56:38Z", "id": "7518042cac67451a83610e1b67419f01", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["LuYotFdURbupD5ubegBj5A"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["Zy7UbvE5SJSVjzFVvA8fSA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -8268,7 +8268,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:52 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:38 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/?format=json&limit=1000
@@ -8283,7 +8283,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0ae7a911da9f405690bd6825c597cc89
+      - 2fe8cdeb0cad4eb88a5272a61428db71
   response:
     status:
       code: 200
@@ -8312,15 +8312,15 @@ http_interactions:
       X-Account-Project-Domain-Id:
       - default
       X-Trans-Id:
-      - tx4e386370b1ea41788c8ee-005c2e6148
+      - txaf1ce9a376104970afb38-005c2f9046
       Date:
-      - Thu, 03 Jan 2019 19:23:52 GMT
+      - Fri, 04 Jan 2019 16:56:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '[{"count": 3, "bytes": 33, "name": "dir_1"}, {"count": 0, "bytes":
         0, "name": "dir_2"}, {"count": 0, "bytes": 0, "name": "dir_3"}]'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:52 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:38 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/?format=json&limit=1000&marker=dir_3
@@ -8335,7 +8335,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0ae7a911da9f405690bd6825c597cc89
+      - 2fe8cdeb0cad4eb88a5272a61428db71
   response:
     status:
       code: 200
@@ -8364,14 +8364,14 @@ http_interactions:
       X-Account-Project-Domain-Id:
       - default
       X-Trans-Id:
-      - txd9662fe0ccdd45ab96355-005c2e6148
+      - txdd1f12c148b74842b1bec-005c2f9046
       Date:
-      - Thu, 03 Jan 2019 19:23:52 GMT
+      - Fri, 04 Jan 2019 16:56:38 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:52 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:38 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_b458a5c25c3749758f4c0661940b3ba8/?format=json&limit=1000
@@ -8386,7 +8386,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 63573cf29167483d953c9cf26d845d5e
+      - 02621620d2064a618251a17396422401
   response:
     status:
       code: 200
@@ -8399,22 +8399,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1546543432.89587'
+      - '1546620998.73767'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1546543432.89587'
+      - '1546620998.73767'
       X-Trans-Id:
-      - tx9b0d9bfea4bb4273b7e36-005c2e6148
+      - tx5cab8547b2004005929cd-005c2f9046
       Date:
-      - Thu, 03 Jan 2019 19:23:52 GMT
+      - Fri, 04 Jan 2019 16:56:38 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:52 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:38 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_e54e5c3c19e34720b05661f2ea1ea00a/?format=json&limit=1000
@@ -8429,7 +8429,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7786ea6d1da14080b913eb817f19845f
+      - d57918c01c3d4a44b62efee1d7cf9371
   response:
     status:
       code: 200
@@ -8442,22 +8442,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1546543433.05194'
+      - '1546620998.89178'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1546543433.05194'
+      - '1546620998.89178'
       X-Trans-Id:
-      - tx8d3be41a8bb343bb88113-005c2e6148
+      - tx75c4d18ce38c4503b0ac8-005c2f9046
       Date:
-      - Thu, 03 Jan 2019 19:23:53 GMT
+      - Fri, 04 Jan 2019 16:56:38 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:53 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:38 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_e8f744b1fc6a487681d35fb275252608/?format=json&limit=1000
@@ -8472,7 +8472,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0441cc9c7a30497693c01a670abc42d5
+      - 7518042cac67451a83610e1b67419f01
   response:
     status:
       code: 200
@@ -8485,22 +8485,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1546543433.20778'
+      - '1546620999.04412'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1546543433.20778'
+      - '1546620999.04412'
       X-Trans-Id:
-      - txbba0417bb3844295967e8-005c2e6149
+      - txf0e970e81449485190ad7-005c2f9046
       Date:
-      - Thu, 03 Jan 2019 19:23:53 GMT
+      - Fri, 04 Jan 2019 16:56:39 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:53 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:39 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/dir_1?format=json
@@ -8515,7 +8515,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0ae7a911da9f405690bd6825c597cc89
+      - 2fe8cdeb0cad4eb88a5272a61428db71
   response:
     status:
       code: 200
@@ -8536,9 +8536,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - txcbe9a647c5ef4d46bee39-005c2e6149
+      - txb93ab11d243442f782703-005c2f9047
       Date:
-      - Thu, 03 Jan 2019 19:23:53 GMT
+      - Fri, 04 Jan 2019 16:56:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '[{"hash": "61257bf228e2f6802a196c9a460d19a8", "last_modified": "2016-11-11T13:50:03.869630",
@@ -8548,7 +8548,7 @@ http_interactions:
         {"hash": "1727a9b61bddf85bbe7a5710c9f45691", "last_modified": "2016-11-11T13:50:04.495640",
         "bytes": 11, "name": "file_3", "content_type": "application/octet-stream"}]'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:53 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:39 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/dir_2?format=json
@@ -8563,7 +8563,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0ae7a911da9f405690bd6825c597cc89
+      - 2fe8cdeb0cad4eb88a5272a61428db71
   response:
     status:
       code: 200
@@ -8584,14 +8584,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - txa74c716965b14008a0a84-005c2e6149
+      - tx52bccc98a1eb4a5889d85-005c2f9047
       Date:
-      - Thu, 03 Jan 2019 19:23:53 GMT
+      - Fri, 04 Jan 2019 16:56:39 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:53 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:39 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/dir_3?format=json
@@ -8606,7 +8606,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0ae7a911da9f405690bd6825c597cc89
+      - 2fe8cdeb0cad4eb88a5272a61428db71
   response:
     status:
       code: 200
@@ -8627,12 +8627,12 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - tx5888cc4153874cbe9d784-005c2e6149
+      - txd3a7fe0cfdae444dbe60c-005c2f9047
       Date:
-      - Thu, 03 Jan 2019 19:23:53 GMT
+      - Fri, 04 Jan 2019 16:56:39 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:23:53 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:39 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_network_targeted_refresh.yml
+++ b/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_network_targeted_refresh.yml
@@ -17,13 +17,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:25:42 GMT
+      - Fri, 04 Jan 2019 16:57:27 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-66ea1864-638d-4cd7-a06f-34f3039bc568
+      - req-2c1f77a1-650f-4ba0-b4cb-075b29400e1a
       Content-Length:
       - '4170'
       Connection:
@@ -32,10 +32,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:25:42.219383", "expires":
-        "2019-01-03T20:25:42Z", "id": "b6eece1f9bd542f69fa920091e9f7d94", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:57:27.097457", "expires":
+        "2019-01-04T17:57:27Z", "id": "fcc16d07651c4e77809bf7c9e8743b05", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["hUUj_9l8RkahN1OiGYfrug"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["HIJH2zh5TgKHPPM5wRb62g"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -80,7 +80,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:42 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:27 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -95,7 +95,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b6eece1f9bd542f69fa920091e9f7d94
+      - fcc16d07651c4e77809bf7c9e8743b05
   response:
     status:
       code: 200
@@ -106,7 +106,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Thu, 03 Jan 2019 19:25:42 GMT
+      - Fri, 04 Jan 2019 16:57:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -115,7 +115,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:42 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:27 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-availability-zone
@@ -130,7 +130,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b6eece1f9bd542f69fa920091e9f7d94
+      - fcc16d07651c4e77809bf7c9e8743b05
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -143,15 +143,15 @@ http_interactions:
       Content-Length:
       - '97'
       X-Compute-Request-Id:
-      - req-6dd3137d-c56d-43a8-96dc-43c4dddff7af
+      - req-d775d76a-e869-46f8-a8b2-5679ec091dbe
       Date:
-      - Thu, 03 Jan 2019 19:25:42 GMT
+      - Fri, 04 Jan 2019 16:57:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"availabilityZoneInfo": [{"zoneState": {"available": true}, "hosts":
         null, "zoneName": "nova"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:42 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:27 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -169,13 +169,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:25:42 GMT
+      - Fri, 04 Jan 2019 16:57:27 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-30041626-8cf8-46b6-8247-8daac298d789
+      - req-8ecc41ff-991a-400b-8cb1-a433927da61c
       Content-Length:
       - '4170'
       Connection:
@@ -184,10 +184,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:25:42.707446", "expires":
-        "2019-01-03T20:25:42Z", "id": "ddb3b8e038164a93a8ea3bc6966bfac1", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:57:27.580254", "expires":
+        "2019-01-04T17:57:27Z", "id": "850b9cc1260946ba8adf189fd4158dbd", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["Mr6p9VQaQluGUWDjjJ-Pvw"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["ScsVgp74QWmG7aWYh0xdTA"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -232,7 +232,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:42 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:27 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-availability-zone.json
@@ -247,28 +247,28 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ddb3b8e038164a93a8ea3bc6966bfac1
+      - 850b9cc1260946ba8adf189fd4158dbd
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-a4a22cee-e855-43da-9c7a-b0355ea3eaff
+      - req-78770491-e258-48dc-9c77-bc0e5c7b8c8f
       Content-Type:
       - application/json
       Content-Length:
       - '82'
       X-Openstack-Request-Id:
-      - req-a4a22cee-e855-43da-9c7a-b0355ea3eaff
+      - req-78770491-e258-48dc-9c77-bc0e5c7b8c8f
       Date:
-      - Thu, 03 Jan 2019 19:25:42 GMT
+      - Fri, 04 Jan 2019 16:57:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"availabilityZoneInfo": [{"zoneState": {"available": true}, "zoneName":
         "nova"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:42 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:27 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -286,13 +286,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:25:43 GMT
+      - Fri, 04 Jan 2019 16:57:27 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-3fe4d888-08dd-4b8d-bc9c-10b259518469
+      - req-dd51db09-eb9e-41c8-8935-f909a83374d3
       Content-Length:
       - '370'
       Connection:
@@ -301,13 +301,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:25:43.029250", "expires":
-        "2019-01-03T20:25:43Z", "id": "6b3c14cc91eb44388979f2460b54a3b9", "audit_ids":
-        ["V7bV42PJSZ65Dz_RKDEiaA"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:57:27.910513", "expires":
+        "2019-01-04T17:57:27Z", "id": "e2f96b5e483949dc9c2ed507e0677ba2", "audit_ids":
+        ["OhhkuQd_RsGSlZTAEsggLg"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:43 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:27 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -322,20 +322,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6b3c14cc91eb44388979f2460b54a3b9
+      - e2f96b5e483949dc9c2ed507e0677ba2
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:25:43 GMT
+      - Fri, 04 Jan 2019 16:57:28 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-bb5b48cc-5e05-408c-a222-f9e677a607dc
+      - req-3d7b5ff9-1a59-4d77-8c05-711d073cbfbe
       Content-Length:
       - '500'
       Connection:
@@ -352,7 +352,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:43 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:28 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -370,13 +370,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:25:43 GMT
+      - Fri, 04 Jan 2019 16:57:28 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-0bbb82f9-ce52-4d0c-a7d0-575de3636aca
+      - req-05358f16-8903-468b-9a68-161d178d965c
       Content-Length:
       - '4117'
       Connection:
@@ -385,10 +385,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:25:43.378725", "expires":
-        "2019-01-03T20:25:43Z", "id": "ed4080aaabbf4527b32becedf2a21c1a", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:57:28.237527", "expires":
+        "2019-01-04T17:57:28Z", "id": "fc7768f9f49f425a8e51f0d7657c2c54", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["mW9wWg1YRISuf7YgCWtHCQ"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["v9_j0iLcQmy8rzZiKewG2Q"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -432,7 +432,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:43 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:28 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -447,7 +447,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ed4080aaabbf4527b32becedf2a21c1a
+      - fc7768f9f49f425a8e51f0d7657c2c54
   response:
     status:
       code: 200
@@ -458,7 +458,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Thu, 03 Jan 2019 19:25:43 GMT
+      - Fri, 04 Jan 2019 16:57:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -467,7 +467,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:43 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:28 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -485,13 +485,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:25:43 GMT
+      - Fri, 04 Jan 2019 16:57:28 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-aee3239a-3e27-45b3-8f19-b2c8adfd7f70
+      - req-6afe96d1-ea1a-4273-81ad-a5e90479b0a2
       Content-Length:
       - '4131'
       Connection:
@@ -500,10 +500,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:25:43.651676", "expires":
-        "2019-01-03T20:25:43Z", "id": "8d2570738443453cb3a9b614ec9967df", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:57:28.512291", "expires":
+        "2019-01-04T17:57:28Z", "id": "8f1b1d267cfe44aab330da1ceaf2873f", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["SoW-61hyR16QTmzKKCVETA"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["nGXNduLxSmyV_JPHXVc3oQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -547,7 +547,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:43 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:28 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -562,7 +562,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8d2570738443453cb3a9b614ec9967df
+      - 8f1b1d267cfe44aab330da1ceaf2873f
   response:
     status:
       code: 200
@@ -573,7 +573,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Thu, 03 Jan 2019 19:25:43 GMT
+      - Fri, 04 Jan 2019 16:57:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -582,7 +582,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:43 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:28 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -600,13 +600,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:25:43 GMT
+      - Fri, 04 Jan 2019 16:57:28 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-c1b485cf-af53-4c2a-a734-16ce40a6fcb7
+      - req-3f77e621-f2c2-4450-9df5-b19ea8d77fd8
       Content-Length:
       - '4118'
       Connection:
@@ -615,10 +615,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:25:43.925872", "expires":
-        "2019-01-03T20:25:43Z", "id": "d8cd8a89e2ef42a998a81a6e7030868a", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:57:28.785301", "expires":
+        "2019-01-04T17:57:28Z", "id": "8d0c384a3a9e44dcad04710b51c85784", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["Qsr1DCTLQ2aIYhUh_guADA"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["NRxt3ZHCRji8oatkkq0gNg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -662,7 +662,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:43 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:28 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -677,7 +677,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d8cd8a89e2ef42a998a81a6e7030868a
+      - 8d0c384a3a9e44dcad04710b51c85784
   response:
     status:
       code: 200
@@ -688,7 +688,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Thu, 03 Jan 2019 19:25:44 GMT
+      - Fri, 04 Jan 2019 16:57:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -697,7 +697,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:44 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:28 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-services?limit=1000
@@ -712,7 +712,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ed4080aaabbf4527b32becedf2a21c1a
+      - fc7768f9f49f425a8e51f0d7657c2c54
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -725,26 +725,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-47822fba-d5c8-459e-9644-769655479712
+      - req-8867a227-e882-427e-ab6c-3a17d080f83f
       Date:
-      - Thu, 03 Jan 2019 19:25:44 GMT
+      - Fri, 04 Jan 2019 16:57:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-01-03T19:25:35.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-01-04T16:57:28.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2019-01-03T19:25:43.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2019-01-04T16:57:27.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-01-03T19:25:35.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-01-04T16:57:28.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2019-01-03T19:25:39.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2019-01-04T16:57:22.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2019-01-03T19:25:38.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2019-01-04T16:57:22.000000"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:44 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:29 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-services?limit=1000&marker=5
@@ -759,7 +759,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ed4080aaabbf4527b32becedf2a21c1a
+      - fc7768f9f49f425a8e51f0d7657c2c54
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -772,26 +772,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-4da0edd5-4401-4a12-989e-a3d382126d85
+      - req-d11721be-46f0-4d2b-94d8-c4a6c0826b11
       Date:
-      - Thu, 03 Jan 2019 19:25:44 GMT
+      - Fri, 04 Jan 2019 16:57:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-01-03T19:25:35.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-01-04T16:57:28.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2019-01-03T19:25:43.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2019-01-04T16:57:27.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-01-03T19:25:35.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-01-04T16:57:28.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2019-01-03T19:25:39.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2019-01-04T16:57:22.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2019-01-03T19:25:38.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2019-01-04T16:57:22.000000"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:44 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:29 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8/os-services?limit=1000
@@ -806,7 +806,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8d2570738443453cb3a9b614ec9967df
+      - 8f1b1d267cfe44aab330da1ceaf2873f
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -819,26 +819,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-2905ad92-7afc-423f-966e-cd91c048d02c
+      - req-22feb8d4-86fe-41bb-982c-a2932e664a95
       Date:
-      - Thu, 03 Jan 2019 19:25:44 GMT
+      - Fri, 04 Jan 2019 16:57:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-01-03T19:25:35.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-01-04T16:57:28.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2019-01-03T19:25:43.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2019-01-04T16:57:27.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-01-03T19:25:35.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-01-04T16:57:28.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2019-01-03T19:25:39.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2019-01-04T16:57:22.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2019-01-03T19:25:38.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2019-01-04T16:57:22.000000"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:44 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:29 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8/os-services?limit=1000&marker=5
@@ -853,7 +853,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8d2570738443453cb3a9b614ec9967df
+      - 8f1b1d267cfe44aab330da1ceaf2873f
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -866,26 +866,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-1e8d88c1-e157-46ca-9685-1a33f0e6e99e
+      - req-45ac6c56-e088-437c-b943-fef6bf548ad5
       Date:
-      - Thu, 03 Jan 2019 19:25:44 GMT
+      - Fri, 04 Jan 2019 16:57:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-01-03T19:25:35.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-01-04T16:57:28.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2019-01-03T19:25:43.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2019-01-04T16:57:27.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-01-03T19:25:35.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-01-04T16:57:28.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2019-01-03T19:25:39.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2019-01-04T16:57:22.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2019-01-03T19:25:38.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2019-01-04T16:57:22.000000"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:44 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:29 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-services?limit=1000
@@ -900,7 +900,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b6eece1f9bd542f69fa920091e9f7d94
+      - fcc16d07651c4e77809bf7c9e8743b05
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -913,26 +913,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-3667a8d3-961f-4922-9c91-9c753e8ccb30
+      - req-8ab751e7-4736-46e5-b2f0-b2025fe10e3a
       Date:
-      - Thu, 03 Jan 2019 19:25:44 GMT
+      - Fri, 04 Jan 2019 16:57:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-01-03T19:25:35.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-01-04T16:57:28.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2019-01-03T19:25:43.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2019-01-04T16:57:27.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-01-03T19:25:35.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-01-04T16:57:28.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2019-01-03T19:25:39.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2019-01-04T16:57:22.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2019-01-03T19:25:38.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2019-01-04T16:57:22.000000"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:44 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:29 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-services?limit=1000&marker=5
@@ -947,7 +947,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b6eece1f9bd542f69fa920091e9f7d94
+      - fcc16d07651c4e77809bf7c9e8743b05
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -960,26 +960,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-3595ddf4-ed02-476c-98b0-2e2fb5a1229f
+      - req-eea639aa-8498-4c3b-9806-573ae1a2999b
       Date:
-      - Thu, 03 Jan 2019 19:25:44 GMT
+      - Fri, 04 Jan 2019 16:57:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-01-03T19:25:35.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-01-04T16:57:28.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2019-01-03T19:25:43.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2019-01-04T16:57:27.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-01-03T19:25:35.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-01-04T16:57:28.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2019-01-03T19:25:39.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2019-01-04T16:57:22.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2019-01-03T19:25:38.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2019-01-04T16:57:22.000000"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:44 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:29 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608/os-services?limit=1000
@@ -994,7 +994,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d8cd8a89e2ef42a998a81a6e7030868a
+      - 8d0c384a3a9e44dcad04710b51c85784
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1007,26 +1007,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-72063775-6d1f-4b7c-9aa5-79692fe98b3e
+      - req-1c84acc2-710c-4856-9269-284c06d39628
       Date:
-      - Thu, 03 Jan 2019 19:25:45 GMT
+      - Fri, 04 Jan 2019 16:57:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-01-03T19:25:35.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-01-04T16:57:28.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2019-01-03T19:25:43.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2019-01-04T16:57:27.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-01-03T19:25:45.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-01-04T16:57:28.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2019-01-03T19:25:39.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2019-01-04T16:57:22.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2019-01-03T19:25:38.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2019-01-04T16:57:22.000000"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:45 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:29 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608/os-services?limit=1000&marker=5
@@ -1041,7 +1041,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d8cd8a89e2ef42a998a81a6e7030868a
+      - 8d0c384a3a9e44dcad04710b51c85784
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1054,26 +1054,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-db25502d-414e-44a8-a8ba-6386f4b3fb11
+      - req-33cf223c-7679-4e8f-80bf-e35fc464b4d9
       Date:
-      - Thu, 03 Jan 2019 19:25:45 GMT
+      - Fri, 04 Jan 2019 16:57:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-01-03T19:25:35.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-01-04T16:57:28.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2019-01-03T19:25:43.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2019-01-04T16:57:27.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-01-03T19:25:45.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-01-04T16:57:28.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2019-01-03T19:25:39.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2019-01-04T16:57:22.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2019-01-03T19:25:38.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2019-01-04T16:57:22.000000"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:45 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:30 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000
@@ -1088,7 +1088,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b6eece1f9bd542f69fa920091e9f7d94
+      - fcc16d07651c4e77809bf7c9e8743b05
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1101,9 +1101,9 @@ http_interactions:
       Content-Length:
       - '1010'
       X-Compute-Request-Id:
-      - req-f1298c5b-95be-43ba-b064-1a7930ef8457
+      - req-f624c28f-7288-4953-bcb9-b3a21a80d24a
       Date:
-      - Thu, 03 Jan 2019 19:25:45 GMT
+      - Fri, 04 Jan 2019 16:57:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.tiny", "links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/1",
@@ -1117,7 +1117,7 @@ http_interactions:
         0, "disk": 20, "id": "2"}], "flavors_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=2",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:45 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:30 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=2
@@ -1132,7 +1132,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b6eece1f9bd542f69fa920091e9f7d94
+      - fcc16d07651c4e77809bf7c9e8743b05
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1145,9 +1145,9 @@ http_interactions:
       Content-Length:
       - '1014'
       X-Compute-Request-Id:
-      - req-957b9c66-d4f8-4c65-bb2c-35a5a0306d04
+      - req-7593eb5a-e345-4d25-9814-b10c096a4d26
       Date:
-      - Thu, 03 Jan 2019 19:25:45 GMT
+      - Fri, 04 Jan 2019 16:57:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.medium", "links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/3",
@@ -1161,7 +1161,7 @@ http_interactions:
         0, "disk": 80, "id": "4"}], "flavors_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=4",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:45 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:30 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=4
@@ -1176,7 +1176,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b6eece1f9bd542f69fa920091e9f7d94
+      - fcc16d07651c4e77809bf7c9e8743b05
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1189,9 +1189,9 @@ http_interactions:
       Content-Length:
       - '1026'
       X-Compute-Request-Id:
-      - req-e527c3fb-b933-4b1e-8cee-a47c85059cc7
+      - req-71a58ef3-f048-4b86-9681-eec85b3dea60
       Date:
-      - Thu, 03 Jan 2019 19:25:45 GMT
+      - Fri, 04 Jan 2019 16:57:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.xlarge", "links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/5",
@@ -1206,7 +1206,7 @@ http_interactions:
         1, "disk": 1, "id": "6"}], "flavors_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=6",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:45 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:30 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=6
@@ -1221,7 +1221,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b6eece1f9bd542f69fa920091e9f7d94
+      - fcc16d07651c4e77809bf7c9e8743b05
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1234,9 +1234,9 @@ http_interactions:
       Content-Length:
       - '448'
       X-Compute-Request-Id:
-      - req-a02820fc-09ad-4359-aef7-8202106cc48b
+      - req-0bc1b3f6-7189-4030-a5ab-6a04ca3998b2
       Date:
-      - Thu, 03 Jan 2019 19:25:45 GMT
+      - Fri, 04 Jan 2019 16:57:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.ems_refresh_spec_private", "links": [{"href":
@@ -1246,7 +1246,7 @@ http_interactions:
         8, "swap": "", "os-flavor-access:is_public": false, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         0, "disk": 160, "id": "7"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:45 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:30 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/7/os-flavor-access
@@ -1261,7 +1261,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b6eece1f9bd542f69fa920091e9f7d94
+      - fcc16d07651c4e77809bf7c9e8743b05
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1274,15 +1274,15 @@ http_interactions:
       Content-Length:
       - '88'
       X-Compute-Request-Id:
-      - req-abe7cb13-e1eb-4a44-a0db-704fc98523b6
+      - req-f05e84c2-0e49-4c6f-b965-e939490fdffc
       Date:
-      - Thu, 03 Jan 2019 19:25:45 GMT
+      - Fri, 04 Jan 2019 16:57:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavor_access": [{"tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "flavor_id": "7"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:45 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:30 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1300,13 +1300,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:25:46 GMT
+      - Fri, 04 Jan 2019 16:57:30 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-2629dbf3-c2eb-4207-99af-eb7ec7347a4f
+      - req-a3e9e2a2-3a8a-4db6-9e64-a9536c5f0e09
       Content-Length:
       - '4170'
       Connection:
@@ -1315,10 +1315,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:25:46.139702", "expires":
-        "2019-01-03T20:25:46Z", "id": "c189dbb3a2b64a0883cd3c84361418d2", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:57:30.772394", "expires":
+        "2019-01-04T17:57:30Z", "id": "0bc80cb02fe24f7d9a209db56ffa3e23", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["evPM9r2MTN2Pqzz0a_OdIQ"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["CtAU5wv3SvGu5qBIXZHCSw"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -1363,7 +1363,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:46 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:30 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1381,13 +1381,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:25:46 GMT
+      - Fri, 04 Jan 2019 16:57:30 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-9086bf58-2b78-4aee-a870-2674b6dcdf6a
+      - req-709abbe2-bb30-49cf-88aa-5762110df572
       Content-Length:
       - '4117'
       Connection:
@@ -1396,10 +1396,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:25:46.337421", "expires":
-        "2019-01-03T20:25:46Z", "id": "531393c5d81942f98edfe506b4202dd3", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:57:30.976026", "expires":
+        "2019-01-04T17:57:30Z", "id": "15e0e1bc1c6b47bd962c591832b58898", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["4AJrHJX1ToqG4Pjv2fPKBQ"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["lDIOQ45vRcuevHhRpZBhvg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -1443,7 +1443,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:46 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:31 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1461,13 +1461,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:25:46 GMT
+      - Fri, 04 Jan 2019 16:57:31 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-2bed4df4-e1af-4ca3-b225-5f52bc4c4f6f
+      - req-9966d642-5f3a-45a9-8784-d592fe41b17c
       Content-Length:
       - '4131'
       Connection:
@@ -1476,10 +1476,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:25:46.532344", "expires":
-        "2019-01-03T20:25:46Z", "id": "ec71123e882f4066a8764e7d30af781f", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:57:31.166675", "expires":
+        "2019-01-04T17:57:31Z", "id": "604e0988e71548cdae01db977e73fadf", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["MrCErBifSnm2UG7MmAxsbg"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["vIFzJhJ7TC6eWUchijvNIw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -1523,7 +1523,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:46 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:31 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1541,13 +1541,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:25:46 GMT
+      - Fri, 04 Jan 2019 16:57:31 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-23b0feb2-b724-4a8d-8458-98a7929990c5
+      - req-a404b073-7424-47e0-b36f-ad1104be3fa4
       Content-Length:
       - '4118'
       Connection:
@@ -1556,10 +1556,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:25:46.719146", "expires":
-        "2019-01-03T20:25:46Z", "id": "7177618e9966411c8a40e4b1dc24bf68", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:57:31.358528", "expires":
+        "2019-01-04T17:57:31Z", "id": "9ad4e1add6b34c3da771c88cd3c1e70c", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["8RgwiZozRsC1ieqRWO1s4Q"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["IYlRrnecRGCXcIVzDcATnA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -1603,7 +1603,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:46 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:31 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images?limit=1000
@@ -1618,7 +1618,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 531393c5d81942f98edfe506b4202dd3
+      - 15e0e1bc1c6b47bd962c591832b58898
   response:
     status:
       code: 200
@@ -1629,9 +1629,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-53b8f1f4-961d-409f-bdc9-b8c584bca1fb
+      - req-d4827caf-5b5e-40da-b73b-f890defb0194
       Date:
-      - Thu, 03 Jan 2019 19:25:46 GMT
+      - Fri, 04 Jan 2019 16:57:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -1673,7 +1673,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:46 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:31 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images?limit=1000&marker=bb799f70-5e02-461b-8324-17ee88259c7b
@@ -1688,7 +1688,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 531393c5d81942f98edfe506b4202dd3
+      - 15e0e1bc1c6b47bd962c591832b58898
   response:
     status:
       code: 200
@@ -1699,14 +1699,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-11d58792-b6e6-4b2e-8b0f-f0d758920394
+      - req-1c64863a-1845-495f-a79b-5bae9ef48433
       Date:
-      - Thu, 03 Jan 2019 19:25:47 GMT
+      - Fri, 04 Jan 2019 16:57:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:47 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:31 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images?limit=1000
@@ -1721,7 +1721,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ec71123e882f4066a8764e7d30af781f
+      - 604e0988e71548cdae01db977e73fadf
   response:
     status:
       code: 200
@@ -1732,9 +1732,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-15f080cc-6fcc-4764-ae2f-c874dd80489c
+      - req-01e7a952-efa4-4bb8-ad82-82d6af7f43e9
       Date:
-      - Thu, 03 Jan 2019 19:25:47 GMT
+      - Fri, 04 Jan 2019 16:57:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -1776,7 +1776,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:47 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:31 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images?limit=1000&marker=bb799f70-5e02-461b-8324-17ee88259c7b
@@ -1791,7 +1791,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ec71123e882f4066a8764e7d30af781f
+      - 604e0988e71548cdae01db977e73fadf
   response:
     status:
       code: 200
@@ -1802,14 +1802,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-a601c8cd-c155-4e52-9069-14cafbc962a1
+      - req-876f7029-e2e0-43c7-922c-f026ecd9f57c
       Date:
-      - Thu, 03 Jan 2019 19:25:47 GMT
+      - Fri, 04 Jan 2019 16:57:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:47 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:32 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images?limit=1000
@@ -1824,7 +1824,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c189dbb3a2b64a0883cd3c84361418d2
+      - 0bc80cb02fe24f7d9a209db56ffa3e23
   response:
     status:
       code: 200
@@ -1835,9 +1835,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-25f8e63f-478f-4d79-85ea-6953d48c75b5
+      - req-b72b410c-e62e-4f18-8360-6d3fcee54360
       Date:
-      - Thu, 03 Jan 2019 19:25:47 GMT
+      - Fri, 04 Jan 2019 16:57:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -1879,7 +1879,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:47 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:32 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images?limit=1000&marker=bb799f70-5e02-461b-8324-17ee88259c7b
@@ -1894,7 +1894,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c189dbb3a2b64a0883cd3c84361418d2
+      - 0bc80cb02fe24f7d9a209db56ffa3e23
   response:
     status:
       code: 200
@@ -1905,14 +1905,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-e12c2fa4-0744-4ea2-8548-b1776d58682f
+      - req-e594d389-3bfc-47ca-bdab-8ab8762cc245
       Date:
-      - Thu, 03 Jan 2019 19:25:47 GMT
+      - Fri, 04 Jan 2019 16:57:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:47 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:32 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images?limit=1000
@@ -1927,7 +1927,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7177618e9966411c8a40e4b1dc24bf68
+      - 9ad4e1add6b34c3da771c88cd3c1e70c
   response:
     status:
       code: 200
@@ -1938,9 +1938,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-cdff2d76-354d-47d7-bee4-1b889fca1a59
+      - req-9b82a80f-438c-46b3-9059-283432ba3b3f
       Date:
-      - Thu, 03 Jan 2019 19:25:47 GMT
+      - Fri, 04 Jan 2019 16:57:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -1982,7 +1982,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:47 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:32 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images?limit=1000&marker=bb799f70-5e02-461b-8324-17ee88259c7b
@@ -1997,7 +1997,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7177618e9966411c8a40e4b1dc24bf68
+      - 9ad4e1add6b34c3da771c88cd3c1e70c
   response:
     status:
       code: 200
@@ -2008,14 +2008,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-47339d39-ea2a-4fd9-b6cb-2e1e7884d06f
+      - req-4f7ef6ce-36b7-477c-ac96-f583ce49738d
       Date:
-      - Thu, 03 Jan 2019 19:25:47 GMT
+      - Fri, 04 Jan 2019 16:57:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:48 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:32 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-keypairs?limit=1000
@@ -2030,7 +2030,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ed4080aaabbf4527b32becedf2a21c1a
+      - fc7768f9f49f425a8e51f0d7657c2c54
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2043,9 +2043,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-5d78fb75-8c62-442c-ad94-6f75cc39062b
+      - req-827a8d12-f028-4f14-8291-21268eaddd48
       Date:
-      - Thu, 03 Jan 2019 19:25:48 GMT
+      - Fri, 04 Jan 2019 16:57:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -2055,7 +2055,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:48 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:32 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -2070,7 +2070,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ed4080aaabbf4527b32becedf2a21c1a
+      - fc7768f9f49f425a8e51f0d7657c2c54
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2083,9 +2083,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-de55c81c-d672-4849-b619-fb0c8f5f5d03
+      - req-cea54a96-d2d1-44c6-bf08-d93a09e96d5b
       Date:
-      - Thu, 03 Jan 2019 19:25:48 GMT
+      - Fri, 04 Jan 2019 16:57:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -2095,7 +2095,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:48 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:33 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8/os-keypairs?limit=1000
@@ -2110,7 +2110,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8d2570738443453cb3a9b614ec9967df
+      - 8f1b1d267cfe44aab330da1ceaf2873f
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2123,9 +2123,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-6109187d-22c0-45e4-b1e9-8cb517b38373
+      - req-f7020fc3-5742-43f4-9dcf-4a4e5786069c
       Date:
-      - Thu, 03 Jan 2019 19:25:48 GMT
+      - Fri, 04 Jan 2019 16:57:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -2135,7 +2135,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:48 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:33 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -2150,7 +2150,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8d2570738443453cb3a9b614ec9967df
+      - 8f1b1d267cfe44aab330da1ceaf2873f
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2163,9 +2163,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-e303e3c7-2173-4ce8-b93d-bedcbcd46b77
+      - req-4c3b7aa2-6e95-4798-80b1-73e902121dd8
       Date:
-      - Thu, 03 Jan 2019 19:25:48 GMT
+      - Fri, 04 Jan 2019 16:57:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -2175,7 +2175,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:48 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:33 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-keypairs?limit=1000
@@ -2190,7 +2190,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b6eece1f9bd542f69fa920091e9f7d94
+      - fcc16d07651c4e77809bf7c9e8743b05
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2203,9 +2203,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-738585b5-7b3c-42db-a19d-1ee1e0170998
+      - req-0524e366-6a97-4778-8b92-951a118f5744
       Date:
-      - Thu, 03 Jan 2019 19:25:48 GMT
+      - Fri, 04 Jan 2019 16:57:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -2215,7 +2215,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:48 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:33 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -2230,7 +2230,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b6eece1f9bd542f69fa920091e9f7d94
+      - fcc16d07651c4e77809bf7c9e8743b05
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2243,9 +2243,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-4a55005f-a1a0-418e-a9dc-1de674571aba
+      - req-04fccb1b-e63b-4607-bced-6e2ea6a16484
       Date:
-      - Thu, 03 Jan 2019 19:25:48 GMT
+      - Fri, 04 Jan 2019 16:57:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -2255,7 +2255,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:48 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:33 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608/os-keypairs?limit=1000
@@ -2270,7 +2270,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d8cd8a89e2ef42a998a81a6e7030868a
+      - 8d0c384a3a9e44dcad04710b51c85784
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2283,9 +2283,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-25adcba8-8430-4410-9a6a-d2c2c375c461
+      - req-4e3954af-17eb-4b75-a0ae-39df1438488e
       Date:
-      - Thu, 03 Jan 2019 19:25:48 GMT
+      - Fri, 04 Jan 2019 16:57:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -2295,7 +2295,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:48 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:33 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -2310,7 +2310,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d8cd8a89e2ef42a998a81a6e7030868a
+      - 8d0c384a3a9e44dcad04710b51c85784
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2323,9 +2323,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-5a0d8d57-86d2-42df-a291-26f24e08c254
+      - req-97b12411-24aa-484b-bf0a-17d21412c606
       Date:
-      - Thu, 03 Jan 2019 19:25:48 GMT
+      - Fri, 04 Jan 2019 16:57:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -2335,7 +2335,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:48 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:33 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -2353,13 +2353,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:25:48 GMT
+      - Fri, 04 Jan 2019 16:57:33 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-854b75e9-0ae3-4aa4-8423-d8937f755c2d
+      - req-f5014d66-cc3d-4e44-9155-b422fb3356f4
       Content-Length:
       - '4170'
       Connection:
@@ -2368,10 +2368,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:25:48.922385", "expires":
-        "2019-01-03T20:25:48Z", "id": "9af2caddc2dc4ad68de781dbdcc4930c", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:57:33.921694", "expires":
+        "2019-01-04T17:57:33Z", "id": "e5ff5b6865a34078910fc3ff7f852d33", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["9wapYN_8RRSCMv7LCTI3Zg"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["_e56RcZoR_G-aqsUSM9qHw"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -2416,7 +2416,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:48 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:33 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -2434,13 +2434,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:25:49 GMT
+      - Fri, 04 Jan 2019 16:57:34 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-686bc4d4-ef5f-4c8e-9918-35e70a131aff
+      - req-4f4ce787-5ac6-4f84-ad25-2a5d9ae9bd9c
       Content-Length:
       - '4117'
       Connection:
@@ -2449,10 +2449,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:25:49.105366", "expires":
-        "2019-01-03T20:25:49Z", "id": "4e4c1d91228f44f7a4744631f62c9877", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:57:34.113986", "expires":
+        "2019-01-04T17:57:34Z", "id": "1c9ca403bad8466882aa3979ac1d1406", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["-V7DQL8PSFK8NwE_WGeo4Q"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["tpR4qiMaSmmV9iZpt_vghg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -2496,7 +2496,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:49 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:34 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -2514,13 +2514,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:25:49 GMT
+      - Fri, 04 Jan 2019 16:57:34 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-2b696da2-9c22-4984-ac55-a68e22bcceb9
+      - req-9509d90b-ec3e-4d64-b7ef-cbea73423dcc
       Content-Length:
       - '4131'
       Connection:
@@ -2529,10 +2529,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:25:49.295579", "expires":
-        "2019-01-03T20:25:49Z", "id": "16fb3b9ce2504be4866abfd88d9f3c05", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:57:34.307916", "expires":
+        "2019-01-04T17:57:34Z", "id": "460cd4b4a8dc44c6a68eb5d7b1761e19", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["B1Krj9tHTKyrQMubpN12ow"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["R4E92MfdQbyBvP_re_T9Rg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -2576,7 +2576,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:49 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:34 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -2594,13 +2594,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:25:49 GMT
+      - Fri, 04 Jan 2019 16:57:34 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-5411f056-51e2-45ed-8373-c178c5ed6d64
+      - req-bb107c4b-523a-47e4-aff6-4a86e01804c1
       Content-Length:
       - '4118'
       Connection:
@@ -2609,10 +2609,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:25:49.481196", "expires":
-        "2019-01-03T20:25:49Z", "id": "69eef217ec8147d49e7f38d2bbe09a48", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:57:34.498044", "expires":
+        "2019-01-04T17:57:34Z", "id": "aef4a66263fb4b6d95653782edb0f4c9", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["0GuV2mfoSBC1YYuh6RfPbQ"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["awZwwuUvTIWNmNpd6otVGQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -2656,7 +2656,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:49 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:34 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks?limit=1000&show_nested=true
@@ -2671,7 +2671,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4e4c1d91228f44f7a4744631f62c9877
+      - 1c9ca403bad8466882aa3979ac1d1406
   response:
     status:
       code: 200
@@ -2682,9 +2682,9 @@ http_interactions:
       Content-Length:
       - '2559'
       X-Openstack-Request-Id:
-      - req-bfbbc5fb-e15b-4422-822d-485e71526113
+      - req-6614a7f2-8598-4f51-8dcd-c0ff76cbee69
       Date:
-      - Thu, 03 Jan 2019 19:25:49 GMT
+      - Fri, 04 Jan 2019 16:57:34 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": [{"description": "Heat WordPress template to support F20,
@@ -2718,7 +2718,7 @@ http_interactions:
         "rel": "self"}], "updated_time": null, "stack_owner": null, "stack_status":
         "CREATE_COMPLETE", "id": "091e1e54-e01c-4ec5-a0ab-b00bee4d425c"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:49 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:34 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks?limit=1000&marker=091e1e54-e01c-4ec5-a0ab-b00bee4d425c&show_nested=true
@@ -2733,7 +2733,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4e4c1d91228f44f7a4744631f62c9877
+      - 1c9ca403bad8466882aa3979ac1d1406
   response:
     status:
       code: 200
@@ -2744,14 +2744,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-4baa56af-2656-42c7-9916-7f8e6570697e
+      - req-7a516b99-d0dd-4dca-a0cd-8ce4034b6f66
       Date:
-      - Thu, 03 Jan 2019 19:25:49 GMT
+      - Fri, 04 Jan 2019 16:57:36 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:49 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:36 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/b458a5c25c3749758f4c0661940b3ba8/stacks?limit=1000&show_nested=true
@@ -2766,7 +2766,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 16fb3b9ce2504be4866abfd88d9f3c05
+      - 460cd4b4a8dc44c6a68eb5d7b1761e19
   response:
     status:
       code: 200
@@ -2777,14 +2777,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-14a38c3f-2536-49e5-bc8e-c600da8d60e0
+      - req-426530b0-4340-4695-80d2-865a0d69a5b5
       Date:
-      - Thu, 03 Jan 2019 19:25:49 GMT
+      - Fri, 04 Jan 2019 16:57:36 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:50 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:36 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/e54e5c3c19e34720b05661f2ea1ea00a/stacks?limit=1000&show_nested=true
@@ -2799,7 +2799,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9af2caddc2dc4ad68de781dbdcc4930c
+      - e5ff5b6865a34078910fc3ff7f852d33
   response:
     status:
       code: 200
@@ -2810,14 +2810,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-23ebf039-0cc9-4802-90a4-42bff2239be4
+      - req-7dc86b2a-9bd3-4a1e-abc1-509670fb5268
       Date:
-      - Thu, 03 Jan 2019 19:25:50 GMT
+      - Fri, 04 Jan 2019 16:57:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:50 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:37 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/e8f744b1fc6a487681d35fb275252608/stacks?limit=1000&show_nested=true
@@ -2832,7 +2832,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 69eef217ec8147d49e7f38d2bbe09a48
+      - aef4a66263fb4b6d95653782edb0f4c9
   response:
     status:
       code: 200
@@ -2843,14 +2843,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-ae451c05-3fc3-4ffc-80af-5174dedf950f
+      - req-5883dc04-dc0a-4ea1-b5d7-81eee77598b6
       Date:
-      - Thu, 03 Jan 2019 19:25:50 GMT
+      - Fri, 04 Jan 2019 16:57:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:50 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:37 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack3/45d2af82-eff9-4483-a1f0-f19c44d96146
@@ -2865,7 +2865,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4e4c1d91228f44f7a4744631f62c9877
+      - 1c9ca403bad8466882aa3979ac1d1406
   response:
     status:
       code: 200
@@ -2876,9 +2876,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-272f8869-0735-4a0f-b2ce-6442b5a176bb
+      - req-2505597a-0851-444a-b208-4c522490e9e2
       Date:
-      - Thu, 03 Jan 2019 19:25:50 GMT
+      - Fri, 04 Jan 2019 16:57:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -2905,7 +2905,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:50 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:37 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack2/4cf24b12-29fc-4529-a8ed-6b079dea7c17
@@ -2920,7 +2920,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4e4c1d91228f44f7a4744631f62c9877
+      - 1c9ca403bad8466882aa3979ac1d1406
   response:
     status:
       code: 200
@@ -2931,9 +2931,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-ddb69063-65dd-45ce-b124-b18d269b2104
+      - req-e166259f-84ab-4df9-b662-a9a5c83f5ee1
       Date:
-      - Thu, 03 Jan 2019 19:25:50 GMT
+      - Fri, 04 Jan 2019 16:57:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -2960,7 +2960,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:51 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:37 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c
@@ -2975,7 +2975,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4e4c1d91228f44f7a4744631f62c9877
+      - 1c9ca403bad8466882aa3979ac1d1406
   response:
     status:
       code: 200
@@ -2986,9 +2986,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-f6585be9-a83e-4965-a8fd-d616377dec96
+      - req-ca931788-6bc0-4080-ac91-1eb3e1496011
       Date:
-      - Thu, 03 Jan 2019 19:25:51 GMT
+      - Fri, 04 Jan 2019 16:57:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -3015,7 +3015,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:51 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:38 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack3/45d2af82-eff9-4483-a1f0-f19c44d96146/template
@@ -3030,7 +3030,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4e4c1d91228f44f7a4744631f62c9877
+      - 1c9ca403bad8466882aa3979ac1d1406
   response:
     status:
       code: 200
@@ -3041,9 +3041,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-8a591520-8a6d-4f0e-ad29-e360755edee7
+      - req-0a4043cd-cb23-421f-969b-b67d1cf72fde
       Date:
-      - Thu, 03 Jan 2019 19:25:51 GMT
+      - Fri, 04 Jan 2019 16:57:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -3099,7 +3099,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:51 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:38 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack3/45d2af82-eff9-4483-a1f0-f19c44d96146/resources
@@ -3114,7 +3114,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4e4c1d91228f44f7a4744631f62c9877
+      - 1c9ca403bad8466882aa3979ac1d1406
   response:
     status:
       code: 200
@@ -3125,9 +3125,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-eb5ce842-f0dd-449c-a231-e2749930bc6d
+      - req-2c4b2266-0d26-4d70-991e-beac4617e5c7
       Date:
-      - Thu, 03 Jan 2019 19:25:51 GMT
+      - Fri, 04 Jan 2019 16:57:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -3139,7 +3139,7 @@ http_interactions:
         changed", "physical_resource_id": "aa5907f3-8209-4dd0-b3ef-600431d85bac",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:51 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:38 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/detail?limit=1000
@@ -3154,7 +3154,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ed4080aaabbf4527b32becedf2a21c1a
+      - fc7768f9f49f425a8e51f0d7657c2c54
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3167,9 +3167,9 @@ http_interactions:
       Content-Length:
       - '3981'
       X-Compute-Request-Id:
-      - req-9e600a45-2aba-4ba0-bee7-d54fc38e3f16
+      - req-69b5a487-f649-43af-a7b1-2c5a696bd3ac
       Date:
-      - Thu, 03 Jan 2019 19:25:52 GMT
+      - Fri, 04 Jan 2019 16:57:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/detail?limit=1000&marker=96fef14f-5338-4d58-8b89-58b627b27b9b",
@@ -3215,7 +3215,7 @@ http_interactions:
         [], "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:52 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:38 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/detail?limit=1000&marker=96fef14f-5338-4d58-8b89-58b627b27b9b
@@ -3230,7 +3230,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ed4080aaabbf4527b32becedf2a21c1a
+      - fc7768f9f49f425a8e51f0d7657c2c54
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3243,9 +3243,9 @@ http_interactions:
       Content-Length:
       - '4045'
       X-Compute-Request-Id:
-      - req-bbc401a3-54e4-46c2-a05d-a32af7f12be4
+      - req-1131b8ce-e40b-4ef4-9263-afbe1500e968
       Date:
-      - Thu, 03 Jan 2019 19:25:52 GMT
+      - Fri, 04 Jan 2019 16:57:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/detail?limit=1000&marker=ca1fc357-ee31-45e9-a38d-98723d6c8876",
@@ -3291,7 +3291,7 @@ http_interactions:
         [], "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 3, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:52 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:39 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/detail?limit=1000&marker=ca1fc357-ee31-45e9-a38d-98723d6c8876
@@ -3306,7 +3306,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ed4080aaabbf4527b32becedf2a21c1a
+      - fc7768f9f49f425a8e51f0d7657c2c54
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3319,9 +3319,9 @@ http_interactions:
       Content-Length:
       - '4127'
       X-Compute-Request-Id:
-      - req-2193fe7f-76e6-4b53-82bc-60401546f579
+      - req-1b3e6abb-3422-4bc6-afa5-ec36b0eca18b
       Date:
-      - Thu, 03 Jan 2019 19:25:52 GMT
+      - Fri, 04 Jan 2019 16:57:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/detail?limit=1000&marker=ca4f3a16-bae3-4407-83e9-f77b28af0f2b",
@@ -3369,7 +3369,7 @@ http_interactions:
         "", "progress": 0, "OS-EXT-STS:power_state": 1, "config_drive": "", "metadata":
         {}}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:52 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:39 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/detail?limit=1000&marker=ca4f3a16-bae3-4407-83e9-f77b28af0f2b
@@ -3384,7 +3384,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ed4080aaabbf4527b32becedf2a21c1a
+      - fc7768f9f49f425a8e51f0d7657c2c54
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3397,9 +3397,9 @@ http_interactions:
       Content-Length:
       - '3796'
       X-Compute-Request-Id:
-      - req-5d8ba299-cc18-42e4-bae3-c3282921a6b4
+      - req-76e93c2f-6eca-4e11-b968-a287b08c6a2d
       Date:
-      - Thu, 03 Jan 2019 19:25:52 GMT
+      - Fri, 04 Jan 2019 16:57:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/detail?limit=1000&marker=aa5907f3-8209-4dd0-b3ef-600431d85bac",
@@ -3441,7 +3441,7 @@ http_interactions:
         "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:52 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:39 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/detail?limit=1000&marker=aa5907f3-8209-4dd0-b3ef-600431d85bac
@@ -3456,7 +3456,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ed4080aaabbf4527b32becedf2a21c1a
+      - fc7768f9f49f425a8e51f0d7657c2c54
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3469,9 +3469,9 @@ http_interactions:
       Content-Length:
       - '1816'
       X-Compute-Request-Id:
-      - req-733704d0-690f-4f9f-b118-31acd0b503fb
+      - req-247d8089-7e37-4cf8-9862-2ea73de6ad6f
       Date:
-      - Thu, 03 Jan 2019 19:25:53 GMT
+      - Fri, 04 Jan 2019 16:57:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": [{"status": "SHUTOFF", "updated": "2018-01-17T14:49:17Z",
@@ -3494,7 +3494,7 @@ http_interactions:
         "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:53 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:40 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8/servers/detail?limit=1000
@@ -3509,7 +3509,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8d2570738443453cb3a9b614ec9967df
+      - 8f1b1d267cfe44aab330da1ceaf2873f
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3522,14 +3522,14 @@ http_interactions:
       Content-Length:
       - '15'
       X-Compute-Request-Id:
-      - req-ba9994ce-28ff-4a00-8425-afcf16240623
+      - req-7e471b82-1d1a-44a4-83e4-af49b9d72bb6
       Date:
-      - Thu, 03 Jan 2019 19:25:53 GMT
+      - Fri, 04 Jan 2019 16:57:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:53 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:40 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?limit=1000
@@ -3544,7 +3544,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b6eece1f9bd542f69fa920091e9f7d94
+      - fcc16d07651c4e77809bf7c9e8743b05
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3557,14 +3557,14 @@ http_interactions:
       Content-Length:
       - '15'
       X-Compute-Request-Id:
-      - req-7b94fe3d-7957-4236-bb98-b8616d8217d9
+      - req-44e81f91-7428-4a8a-8c79-4ffaf5331531
       Date:
-      - Thu, 03 Jan 2019 19:25:53 GMT
+      - Fri, 04 Jan 2019 16:57:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:53 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:40 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608/servers/detail?limit=1000
@@ -3579,7 +3579,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d8cd8a89e2ef42a998a81a6e7030868a
+      - 8d0c384a3a9e44dcad04710b51c85784
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3592,14 +3592,14 @@ http_interactions:
       Content-Length:
       - '15'
       X-Compute-Request-Id:
-      - req-11783cb5-7381-4bfe-aeee-5bd2c66da457
+      - req-c329b438-4c99-4f42-acaf-763123e2bafe
       Date:
-      - Thu, 03 Jan 2019 19:25:53 GMT
+      - Fri, 04 Jan 2019 16:57:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:53 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:40 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack2/4cf24b12-29fc-4529-a8ed-6b079dea7c17/template
@@ -3614,7 +3614,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4e4c1d91228f44f7a4744631f62c9877
+      - 1c9ca403bad8466882aa3979ac1d1406
   response:
     status:
       code: 200
@@ -3625,9 +3625,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-7d9dde2f-71a2-48e9-bdd6-ffe1fe2268ff
+      - req-a701bd51-fd78-48be-af8c-3a054af1c779
       Date:
-      - Thu, 03 Jan 2019 19:25:53 GMT
+      - Fri, 04 Jan 2019 16:57:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -3683,7 +3683,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:53 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:40 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack2/4cf24b12-29fc-4529-a8ed-6b079dea7c17/resources
@@ -3698,7 +3698,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4e4c1d91228f44f7a4744631f62c9877
+      - 1c9ca403bad8466882aa3979ac1d1406
   response:
     status:
       code: 200
@@ -3709,9 +3709,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-0716bd5a-45fc-4244-a0b6-a1793b21612c
+      - req-9babd046-16b0-4d3d-9f63-709773295ace
       Date:
-      - Thu, 03 Jan 2019 19:25:53 GMT
+      - Fri, 04 Jan 2019 16:57:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -3723,7 +3723,7 @@ http_interactions:
         changed", "physical_resource_id": "219a737c-b4ad-430d-944a-a92a4834b12d",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:53 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:40 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c/template
@@ -3738,7 +3738,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4e4c1d91228f44f7a4744631f62c9877
+      - 1c9ca403bad8466882aa3979ac1d1406
   response:
     status:
       code: 200
@@ -3749,9 +3749,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-122d9480-99f7-4f32-8ae0-0d34e8025d67
+      - req-2a72e77f-0948-42de-95a9-dea916eba182
       Date:
-      - Thu, 03 Jan 2019 19:25:53 GMT
+      - Fri, 04 Jan 2019 16:57:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -3807,7 +3807,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:53 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:40 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c/resources
@@ -3822,7 +3822,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4e4c1d91228f44f7a4744631f62c9877
+      - 1c9ca403bad8466882aa3979ac1d1406
   response:
     status:
       code: 200
@@ -3833,9 +3833,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-17b1466a-4e4a-4ed3-aaeb-40f34461bffc
+      - req-8f105b8e-bc90-4a7c-9f79-7cede736187d
       Date:
-      - Thu, 03 Jan 2019 19:25:54 GMT
+      - Fri, 04 Jan 2019 16:57:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -3847,7 +3847,7 @@ http_interactions:
         changed", "physical_resource_id": "b686353f-0da0-48bf-bc35-8ea411a67dfd",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:54 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:40 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a//os-quota-sets/69f8f7205ade4aa59084c32c83e60b5a
@@ -3862,7 +3862,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ed4080aaabbf4527b32becedf2a21c1a
+      - fc7768f9f49f425a8e51f0d7657c2c54
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3875,9 +3875,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-f8c8d9ff-c4a2-4768-9154-d654273558a9
+      - req-cfb78567-b492-4c0f-a5d1-f8ac58b5418f
       Date:
-      - Thu, 03 Jan 2019 19:25:54 GMT
+      - Fri, 04 Jan 2019 16:57:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -3886,7 +3886,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:54 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:40 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8//os-quota-sets/b458a5c25c3749758f4c0661940b3ba8
@@ -3901,7 +3901,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8d2570738443453cb3a9b614ec9967df
+      - 8f1b1d267cfe44aab330da1ceaf2873f
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3914,9 +3914,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-db0658b2-4cb7-4f7a-8f9f-426376318203
+      - req-7a41e7eb-63fb-470a-8b5d-597bf37c4ac3
       Date:
-      - Thu, 03 Jan 2019 19:25:54 GMT
+      - Fri, 04 Jan 2019 16:57:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -3925,7 +3925,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:54 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:42 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a//os-quota-sets/e54e5c3c19e34720b05661f2ea1ea00a
@@ -3940,7 +3940,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b6eece1f9bd542f69fa920091e9f7d94
+      - fcc16d07651c4e77809bf7c9e8743b05
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3953,9 +3953,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-a1561421-82cd-4518-80d1-9593bb631d8e
+      - req-125c18b0-6b4a-41cd-8d5d-7982a50b589f
       Date:
-      - Thu, 03 Jan 2019 19:25:54 GMT
+      - Fri, 04 Jan 2019 16:57:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -3964,7 +3964,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:54 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:42 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608//os-quota-sets/e8f744b1fc6a487681d35fb275252608
@@ -3979,7 +3979,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d8cd8a89e2ef42a998a81a6e7030868a
+      - 8d0c384a3a9e44dcad04710b51c85784
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3992,9 +3992,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-213b7f61-4797-4f07-93d9-ca26fb0292a4
+      - req-a22a4fa8-6135-41f7-8f91-e9b1c00d8021
       Date:
-      - Thu, 03 Jan 2019 19:25:54 GMT
+      - Fri, 04 Jan 2019 16:57:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -4003,7 +4003,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:54 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:42 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4021,13 +4021,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:25:54 GMT
+      - Fri, 04 Jan 2019 16:57:42 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-8b72aaf4-24f4-4f26-a28e-051e9e6c1838
+      - req-4a7c9ed6-f385-4ec5-bd5c-76d6d2cdfc87
       Content-Length:
       - '4117'
       Connection:
@@ -4036,10 +4036,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:25:54.633769", "expires":
-        "2019-01-03T20:25:54Z", "id": "9ca79dbce6724a63bc5a43a7c7db3c5d", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:57:42.467776", "expires":
+        "2019-01-04T17:57:42Z", "id": "024e41417f6949cc89281b21234f91b7", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["m9cD3wLDSsuE7tySvLGvmg"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["GsrZK8rbQ16oRV2jbc2grg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -4083,7 +4083,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:54 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:42 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4101,13 +4101,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:25:54 GMT
+      - Fri, 04 Jan 2019 16:57:42 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-7d504eca-b329-4705-a544-7c510fb1c80e
+      - req-e62208b5-d496-47ca-b19c-72e48ce400d4
       Content-Length:
       - '4131'
       Connection:
@@ -4116,10 +4116,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:25:54.843077", "expires":
-        "2019-01-03T20:25:54Z", "id": "7caff75714e24eaf932288c3a2b627c6", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:57:42.664425", "expires":
+        "2019-01-04T17:57:42Z", "id": "0a614ee4b0fd433588809616606c3097", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["-o50nqA7QzqC1ESuyD7Zfg"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["XlKOX-NfT_avUARz42prqA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -4163,7 +4163,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:54 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:42 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4181,13 +4181,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:25:54 GMT
+      - Fri, 04 Jan 2019 16:57:47 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-f806e9fc-5c2a-4b88-ba07-01aa626f0b0c
+      - req-97acf311-c24a-41a4-9922-f243340fd6f9
       Content-Length:
       - '4118'
       Connection:
@@ -4196,10 +4196,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:25:55.048996", "expires":
-        "2019-01-03T20:25:55Z", "id": "783e0dd4185f4ef1bbec0dca1a8f1765", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:57:47.919401", "expires":
+        "2019-01-04T17:57:47Z", "id": "a359a67e90b4427b85157b75e0d92575", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["hDJ-mKKGQFaN9a6p730B3Q"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["X910glTMQpK8KiNUQ0PXkQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -4243,7 +4243,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:55 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:47 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a//os-quota-sets/69f8f7205ade4aa59084c32c83e60b5a
@@ -4258,22 +4258,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9ca79dbce6724a63bc5a43a7c7db3c5d
+      - 024e41417f6949cc89281b21234f91b7
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-da0765a6-29c3-46ef-b30f-883f4c5f5314
+      - req-8b83105b-49d5-4b8c-b7fc-1e724138f5eb
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-da0765a6-29c3-46ef-b30f-883f4c5f5314
+      - req-8b83105b-49d5-4b8c-b7fc-1e724138f5eb
       Date:
-      - Thu, 03 Jan 2019 19:25:55 GMT
+      - Fri, 04 Jan 2019 16:57:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -4283,7 +4283,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "69f8f7205ade4aa59084c32c83e60b5a"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:55 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:48 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8//os-quota-sets/b458a5c25c3749758f4c0661940b3ba8
@@ -4298,22 +4298,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7caff75714e24eaf932288c3a2b627c6
+      - 0a614ee4b0fd433588809616606c3097
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-9616ba42-b7ed-4b0e-bbc6-aeb056586473
+      - req-28e7087b-7541-4186-818d-d2ceffab2c17
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-9616ba42-b7ed-4b0e-bbc6-aeb056586473
+      - req-28e7087b-7541-4186-818d-d2ceffab2c17
       Date:
-      - Thu, 03 Jan 2019 19:25:55 GMT
+      - Fri, 04 Jan 2019 16:57:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -4323,7 +4323,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "b458a5c25c3749758f4c0661940b3ba8"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:55 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:48 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a//os-quota-sets/e54e5c3c19e34720b05661f2ea1ea00a
@@ -4338,22 +4338,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ddb3b8e038164a93a8ea3bc6966bfac1
+      - 850b9cc1260946ba8adf189fd4158dbd
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-03684336-77ac-4a92-8a16-6e4d6633d897
+      - req-f230d2ec-c7d7-4181-bf87-651915d65abc
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-03684336-77ac-4a92-8a16-6e4d6633d897
+      - req-f230d2ec-c7d7-4181-bf87-651915d65abc
       Date:
-      - Thu, 03 Jan 2019 19:25:55 GMT
+      - Fri, 04 Jan 2019 16:57:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -4363,7 +4363,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "e54e5c3c19e34720b05661f2ea1ea00a"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:55 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:48 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608//os-quota-sets/e8f744b1fc6a487681d35fb275252608
@@ -4378,22 +4378,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 783e0dd4185f4ef1bbec0dca1a8f1765
+      - a359a67e90b4427b85157b75e0d92575
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-6b41e18b-1739-4e10-abdb-6851e7fddd8e
+      - req-e1e94073-4087-4df5-aae0-e5b45bd472c6
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-6b41e18b-1739-4e10-abdb-6851e7fddd8e
+      - req-e1e94073-4087-4df5-aae0-e5b45bd472c6
       Date:
-      - Thu, 03 Jan 2019 19:25:56 GMT
+      - Fri, 04 Jan 2019 16:57:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -4403,7 +4403,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "e8f744b1fc6a487681d35fb275252608"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:56 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:49 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4421,13 +4421,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:25:56 GMT
+      - Fri, 04 Jan 2019 16:57:49 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-ed4f3eac-6424-4031-a4f5-b9036d0ba4a0
+      - req-ed6b7da5-645a-4fe1-9c49-a5c9d7a573e7
       Content-Length:
       - '4170'
       Connection:
@@ -4436,10 +4436,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:25:56.412448", "expires":
-        "2019-01-03T20:25:56Z", "id": "376552830778498eb2217225cf33f31c", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:57:49.443891", "expires":
+        "2019-01-04T17:57:49Z", "id": "7652a698c18248aa891dbcf62beb1f43", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["uAJkhtc3QkC7EZI3VZ0wuw"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["nS5A0GGDTmaz9g47HVNc7g"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -4484,7 +4484,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:56 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:49 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4502,13 +4502,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:25:56 GMT
+      - Fri, 04 Jan 2019 16:57:49 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-68603eeb-5597-4589-981f-f4113d242f88
+      - req-1965bf36-b1a5-421a-9e9d-9321d6a83e11
       Content-Length:
       - '4117'
       Connection:
@@ -4517,10 +4517,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:25:56.606399", "expires":
-        "2019-01-03T20:25:56Z", "id": "8ebfa48b16c14e85815bba18ad1fac5c", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:57:49.633594", "expires":
+        "2019-01-04T17:57:49Z", "id": "11754ea894fd4f0a99b6c0ca075ce4e3", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["m5y_ZuPtREqpRbCcdzWjbA"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["DnjFIe-6Qmi4tsQMDJnZUA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -4564,7 +4564,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:56 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:49 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4582,13 +4582,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:25:56 GMT
+      - Fri, 04 Jan 2019 16:57:49 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-e665bee6-0707-48a9-b548-fa6cbd63423d
+      - req-9873994f-a44d-43b3-aba8-2be41a836cea
       Content-Length:
       - '4131'
       Connection:
@@ -4597,10 +4597,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:25:56.793718", "expires":
-        "2019-01-03T20:25:56Z", "id": "adadc4eb7ecf4c329792b437f359cae4", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:57:49.831605", "expires":
+        "2019-01-04T17:57:49Z", "id": "e293ae9eb4e44d3dae28f8eef1912c29", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["qpqLwSa5QyGqpVVospvcng"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["v3Y34ITRTg6XAt_s3uTkcA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -4644,7 +4644,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:56 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:49 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4662,13 +4662,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:25:56 GMT
+      - Fri, 04 Jan 2019 16:57:50 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-0790a728-afab-44f8-92db-574c447e534d
+      - req-b5c63cfe-c530-4556-9aeb-a66a0f2f3a61
       Content-Length:
       - '4118'
       Connection:
@@ -4677,10 +4677,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:25:56.976422", "expires":
-        "2019-01-03T20:25:56Z", "id": "e0fcb08193154676a894281b6737bf26", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:57:50.393117", "expires":
+        "2019-01-04T17:57:50Z", "id": "ce439edfd73d4a4f8827b922fefc45f8", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["BbzQ8KnIT1StXTYphFG6FA"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["XvEwDGDrR2qUietnzAzB6w"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -4724,7 +4724,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:57 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:50 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0//quotas/69f8f7205ade4aa59084c32c83e60b5a
@@ -4739,7 +4739,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8ebfa48b16c14e85815bba18ad1fac5c
+      - 11754ea894fd4f0a99b6c0ca075ce4e3
   response:
     status:
       code: 200
@@ -4750,16 +4750,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-486dd185-46d0-4d9b-beb8-1fcb95e44f25
+      - req-420ba2de-2ae8-4120-83a7-01f05a111216
       Date:
-      - Thu, 03 Jan 2019 19:25:57 GMT
+      - Fri, 04 Jan 2019 16:57:50 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 20, "network": 20, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:57 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:50 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0//quotas/b458a5c25c3749758f4c0661940b3ba8
@@ -4774,7 +4774,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - adadc4eb7ecf4c329792b437f359cae4
+      - e293ae9eb4e44d3dae28f8eef1912c29
   response:
     status:
       code: 200
@@ -4785,16 +4785,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-de6fc97a-6040-4efb-a047-2d4f013c5f47
+      - req-8e69d0ce-38ea-4334-aeed-a2f0322d9f33
       Date:
-      - Thu, 03 Jan 2019 19:25:57 GMT
+      - Fri, 04 Jan 2019 16:57:50 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:57 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:50 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0//quotas/e54e5c3c19e34720b05661f2ea1ea00a
@@ -4809,7 +4809,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 376552830778498eb2217225cf33f31c
+      - 7652a698c18248aa891dbcf62beb1f43
   response:
     status:
       code: 200
@@ -4820,16 +4820,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-0bc75d51-ad63-4398-a0fc-5bfb592489ac
+      - req-a07f4175-cf5c-4f05-9b74-6c555532cfb3
       Date:
-      - Thu, 03 Jan 2019 19:25:57 GMT
+      - Fri, 04 Jan 2019 16:57:50 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:57 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:50 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0//quotas/e8f744b1fc6a487681d35fb275252608
@@ -4844,7 +4844,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e0fcb08193154676a894281b6737bf26
+      - ce439edfd73d4a4f8827b922fefc45f8
   response:
     status:
       code: 200
@@ -4855,16 +4855,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-3aa9585a-1ef8-400f-9d8c-f947ffa9d9b8
+      - req-2ea12c1f-ad93-427c-b034-0ebf831465b3
       Date:
-      - Thu, 03 Jan 2019 19:25:57 GMT
+      - Fri, 04 Jan 2019 16:57:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:57 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:51 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/4bb36934-fd61-4a19-ab9d-28fbbda0c7f0/os-volume_attachments
@@ -4879,7 +4879,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ed4080aaabbf4527b32becedf2a21c1a
+      - fc7768f9f49f425a8e51f0d7657c2c54
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4892,15 +4892,15 @@ http_interactions:
       Content-Length:
       - '197'
       X-Compute-Request-Id:
-      - req-9ea3085e-147c-4055-9c09-d58f595bd232
+      - req-d9efd264-c4f9-4f60-b6d6-bb021a515be2
       Date:
-      - Thu, 03 Jan 2019 19:25:57 GMT
+      - Fri, 04 Jan 2019 16:57:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumeAttachments": [{"device": "/dev/vda", "serverId": "4bb36934-fd61-4a19-ab9d-28fbbda0c7f0",
         "id": "b124469d-a857-4b39-abe9-d0e63985f834", "volumeId": "b124469d-a857-4b39-abe9-d0e63985f834"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:57 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:51 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/ca4f3a16-bae3-4407-83e9-f77b28af0f2b/os-volume_attachments
@@ -4915,7 +4915,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ed4080aaabbf4527b32becedf2a21c1a
+      - fc7768f9f49f425a8e51f0d7657c2c54
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4928,15 +4928,15 @@ http_interactions:
       Content-Length:
       - '197'
       X-Compute-Request-Id:
-      - req-b324194d-a65b-4902-a918-02ba51fa1499
+      - req-f594ded5-e364-41e0-b316-772819653fd0
       Date:
-      - Thu, 03 Jan 2019 19:25:57 GMT
+      - Fri, 04 Jan 2019 16:57:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumeAttachments": [{"device": "/dev/vdd", "serverId": "ca4f3a16-bae3-4407-83e9-f77b28af0f2b",
         "id": "0a55c0d5-c780-4e7d-9d09-47f5520c7448", "volumeId": "0a55c0d5-c780-4e7d-9d09-47f5520c7448"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:57 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:51 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4954,13 +4954,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:25:58 GMT
+      - Fri, 04 Jan 2019 16:57:51 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-7a8034ed-b3de-4147-87be-a391a3d2de4f
+      - req-3fc9364b-2985-4701-bde3-afd2a3f164fe
       Content-Length:
       - '4170'
       Connection:
@@ -4969,10 +4969,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:25:58.051515", "expires":
-        "2019-01-03T20:25:58Z", "id": "d2a5629418a142d0b9a68f29fc6c931f", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:57:51.485576", "expires":
+        "2019-01-04T17:57:51Z", "id": "0f9131f5fe8847a396b36e7fced19b4f", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["o6T5Rh_CTpug24OiPxE_TQ"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["o_h0TYq2RR2m9u5wkQmoSA"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -5017,7 +5017,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:58 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:51 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -5035,13 +5035,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:25:58 GMT
+      - Fri, 04 Jan 2019 16:57:51 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-ae764986-2914-4c2f-8f1e-101ca65d1587
+      - req-a12a315d-c71c-47a0-b973-83c326272ed3
       Content-Length:
       - '4170'
       Connection:
@@ -5050,10 +5050,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:25:58.250478", "expires":
-        "2019-01-03T20:25:58Z", "id": "020344fa8f6a4c34b7368eb5a6bf74e9", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:57:51.680297", "expires":
+        "2019-01-04T17:57:51Z", "id": "98ed806dfb744033bbadce7dd2c043fb", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["pNpUEHuwRIm92jrUxaE-tA"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["e6hRcUwLT2qZJcNzRYDTig"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -5098,7 +5098,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:58 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:51 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-aggregates
@@ -5113,7 +5113,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b6eece1f9bd542f69fa920091e9f7d94
+      - fcc16d07651c4e77809bf7c9e8743b05
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5126,14 +5126,14 @@ http_interactions:
       Content-Length:
       - '18'
       X-Compute-Request-Id:
-      - req-64cbde59-116f-4ead-a9e6-d1b1fa49513b
+      - req-d6f3a290-1756-43b3-a84f-33a2ee34c477
       Date:
-      - Thu, 03 Jan 2019 19:25:58 GMT
+      - Fri, 04 Jan 2019 16:57:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"aggregates": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:58 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:51 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&status=available
@@ -5148,22 +5148,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9ca79dbce6724a63bc5a43a7c7db3c5d
+      - 024e41417f6949cc89281b21234f91b7
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-888bd8b5-2633-425a-88f1-202e1c97d9ff
+      - req-e66180d3-970f-449c-9368-9c4a1c273146
       Content-Type:
       - application/json
       Content-Length:
       - '2723'
       X-Openstack-Request-Id:
-      - req-888bd8b5-2633-425a-88f1-202e1c97d9ff
+      - req-e66180d3-970f-449c-9368-9c4a1c273146
       Date:
-      - Thu, 03 Jan 2019 19:25:58 GMT
+      - Fri, 04 Jan 2019 16:57:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&status=available&marker=9bb99818-b339-4e31-b87f-e4181ec48acd",
@@ -5196,7 +5196,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-4", "bootable": "true", "created_at":
         "2016-11-11T13:49:53.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:58 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:52 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=9bb99818-b339-4e31-b87f-e4181ec48acd&status=available
@@ -5211,22 +5211,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9ca79dbce6724a63bc5a43a7c7db3c5d
+      - 024e41417f6949cc89281b21234f91b7
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-f3721929-1fa3-4ef9-ad60-4cca4f7569ec
+      - req-62e55888-0d62-4240-b883-f8ebd5814015
       Content-Type:
       - application/json
       Content-Length:
       - '1180'
       X-Openstack-Request-Id:
-      - req-f3721929-1fa3-4ef9-ad60-4cca4f7569ec
+      - req-62e55888-0d62-4240-b883-f8ebd5814015
       Date:
-      - Thu, 03 Jan 2019 19:25:58 GMT
+      - Fri, 04 Jan 2019 16:57:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": [{"migration_status": null, "attachments": [], "links":
@@ -5243,7 +5243,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-FromSnapshot", "bootable": "false", "created_at":
         "2016-11-11T13:49:26.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:58 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:52 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/volumes/detail?limit=1000&status=available
@@ -5258,27 +5258,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7caff75714e24eaf932288c3a2b627c6
+      - 0a614ee4b0fd433588809616606c3097
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-9cf0a2e0-0c84-44b5-90ce-6e492b25dfdf
+      - req-abf3f286-0132-40bf-9d32-5db0d866fddd
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-9cf0a2e0-0c84-44b5-90ce-6e492b25dfdf
+      - req-abf3f286-0132-40bf-9d32-5db0d866fddd
       Date:
-      - Thu, 03 Jan 2019 19:25:58 GMT
+      - Fri, 04 Jan 2019 16:57:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:58 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:52 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/volumes/detail?limit=1000&status=available
@@ -5293,27 +5293,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ddb3b8e038164a93a8ea3bc6966bfac1
+      - 850b9cc1260946ba8adf189fd4158dbd
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-e1270f73-4ee3-4178-bbf1-8ddbd2924833
+      - req-79e61af0-2032-4ce7-9d9b-474536ad08f3
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-e1270f73-4ee3-4178-bbf1-8ddbd2924833
+      - req-79e61af0-2032-4ce7-9d9b-474536ad08f3
       Date:
-      - Thu, 03 Jan 2019 19:25:59 GMT
+      - Fri, 04 Jan 2019 16:57:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:59 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:52 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/volumes/detail?limit=1000&status=available
@@ -5328,27 +5328,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 783e0dd4185f4ef1bbec0dca1a8f1765
+      - a359a67e90b4427b85157b75e0d92575
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-78df706e-fc1d-4546-ad7b-4ba493a650ad
+      - req-5f8c3338-8603-4538-8cd5-5bb6b36c6eae
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-78df706e-fc1d-4546-ad7b-4ba493a650ad
+      - req-5f8c3338-8603-4538-8cd5-5bb6b36c6eae
       Date:
-      - Thu, 03 Jan 2019 19:25:59 GMT
+      - Fri, 04 Jan 2019 16:57:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:59 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:52 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail
@@ -5363,22 +5363,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9ca79dbce6724a63bc5a43a7c7db3c5d
+      - 024e41417f6949cc89281b21234f91b7
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-58e1c331-8118-4c79-a480-008dacacdc14
+      - req-3e854df2-89dd-4c09-9100-fb8b82c96e8d
       Content-Type:
       - application/json
       Content-Length:
       - '1053'
       X-Openstack-Request-Id:
-      - req-58e1c331-8118-4c79-a480-008dacacdc14
+      - req-3e854df2-89dd-4c09-9100-fb8b82c96e8d
       Date:
-      - Thu, 03 Jan 2019 19:25:59 GMT
+      - Fri, 04 Jan 2019 16:57:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?marker=76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
@@ -5393,7 +5393,7 @@ http_interactions:
         "created_at": "2016-11-11T13:49:36.000000", "size": 1, "id": "76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:59 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:52 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?limit=1000&status=available
@@ -5408,22 +5408,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9ca79dbce6724a63bc5a43a7c7db3c5d
+      - 024e41417f6949cc89281b21234f91b7
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-9b995a9e-b265-4308-80d7-2e3317a64132
+      - req-bbd34e0c-8a7d-4e4f-abbb-9b7c127fa291
       Content-Type:
       - application/json
       Content-Length:
       - '1081'
       X-Openstack-Request-Id:
-      - req-9b995a9e-b265-4308-80d7-2e3317a64132
+      - req-bbd34e0c-8a7d-4e4f-abbb-9b7c127fa291
       Date:
-      - Thu, 03 Jan 2019 19:25:59 GMT
+      - Fri, 04 Jan 2019 16:57:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?limit=1000&status=available&marker=76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
@@ -5438,7 +5438,7 @@ http_interactions:
         "created_at": "2016-11-11T13:49:36.000000", "size": 1, "id": "76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:59 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:52 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/snapshots/detail
@@ -5453,27 +5453,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7caff75714e24eaf932288c3a2b627c6
+      - 0a614ee4b0fd433588809616606c3097
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-6e1acd77-ef6c-4415-a125-4257ae65899b
+      - req-d6379720-e969-4bf4-8c46-db5ab699fd87
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-6e1acd77-ef6c-4415-a125-4257ae65899b
+      - req-d6379720-e969-4bf4-8c46-db5ab699fd87
       Date:
-      - Thu, 03 Jan 2019 19:25:59 GMT
+      - Fri, 04 Jan 2019 16:57:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:59 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:52 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/snapshots/detail?limit=1000&status=available
@@ -5488,27 +5488,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7caff75714e24eaf932288c3a2b627c6
+      - 0a614ee4b0fd433588809616606c3097
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-7634c72e-e74f-4c88-bf34-29d4c5d72f7e
+      - req-a158c06e-a448-4e68-b9e6-7b37282c7749
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-7634c72e-e74f-4c88-bf34-29d4c5d72f7e
+      - req-a158c06e-a448-4e68-b9e6-7b37282c7749
       Date:
-      - Thu, 03 Jan 2019 19:25:59 GMT
+      - Fri, 04 Jan 2019 16:57:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:59 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:53 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/snapshots/detail
@@ -5523,27 +5523,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ddb3b8e038164a93a8ea3bc6966bfac1
+      - 850b9cc1260946ba8adf189fd4158dbd
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-f0b28495-350b-4de3-bde7-2984a057b81b
+      - req-22b267d2-8644-4400-a071-9573320260e8
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-f0b28495-350b-4de3-bde7-2984a057b81b
+      - req-22b267d2-8644-4400-a071-9573320260e8
       Date:
-      - Thu, 03 Jan 2019 19:25:59 GMT
+      - Fri, 04 Jan 2019 16:57:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:59 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:53 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/snapshots/detail?limit=1000&status=available
@@ -5558,27 +5558,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ddb3b8e038164a93a8ea3bc6966bfac1
+      - 850b9cc1260946ba8adf189fd4158dbd
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-00a17d93-1d6e-4d85-9a6c-c612c6960718
+      - req-f802b39a-e4be-4981-bacf-ea736c7f248f
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-00a17d93-1d6e-4d85-9a6c-c612c6960718
+      - req-f802b39a-e4be-4981-bacf-ea736c7f248f
       Date:
-      - Thu, 03 Jan 2019 19:25:59 GMT
+      - Fri, 04 Jan 2019 16:57:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:59 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:53 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/snapshots/detail
@@ -5593,27 +5593,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 783e0dd4185f4ef1bbec0dca1a8f1765
+      - a359a67e90b4427b85157b75e0d92575
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-610c1938-7d1a-4f5d-a7c9-a303df67cd19
+      - req-0db12090-8552-44f4-b72f-3ee633d507d4
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-610c1938-7d1a-4f5d-a7c9-a303df67cd19
+      - req-0db12090-8552-44f4-b72f-3ee633d507d4
       Date:
-      - Thu, 03 Jan 2019 19:25:59 GMT
+      - Fri, 04 Jan 2019 16:57:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:59 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:53 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/snapshots/detail?limit=1000&status=available
@@ -5628,27 +5628,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 783e0dd4185f4ef1bbec0dca1a8f1765
+      - a359a67e90b4427b85157b75e0d92575
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-ca8a3f18-a3f9-4d67-a748-67e08f9723b1
+      - req-ca56b1a5-cbfe-498d-8463-8b74bcf3ece5
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-ca8a3f18-a3f9-4d67-a748-67e08f9723b1
+      - req-ca56b1a5-cbfe-498d-8463-8b74bcf3ece5
       Date:
-      - Thu, 03 Jan 2019 19:26:00 GMT
+      - Fri, 04 Jan 2019 16:57:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:00 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:53 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000
@@ -5663,22 +5663,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9ca79dbce6724a63bc5a43a7c7db3c5d
+      - 024e41417f6949cc89281b21234f91b7
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-e75251a4-00ce-43dd-afd7-2c1d2285515a
+      - req-37b587d2-c3c0-400c-9183-0b18e593066f
       Content-Type:
       - application/json
       Content-Length:
       - '2706'
       X-Openstack-Request-Id:
-      - req-e75251a4-00ce-43dd-afd7-2c1d2285515a
+      - req-37b587d2-c3c0-400c-9183-0b18e593066f
       Date:
-      - Thu, 03 Jan 2019 19:26:00 GMT
+      - Fri, 04 Jan 2019 16:57:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=9bb99818-b339-4e31-b87f-e4181ec48acd",
@@ -5711,7 +5711,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-4", "bootable": "true", "created_at":
         "2016-11-11T13:49:53.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:00 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:53 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=9bb99818-b339-4e31-b87f-e4181ec48acd
@@ -5726,22 +5726,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9ca79dbce6724a63bc5a43a7c7db3c5d
+      - 024e41417f6949cc89281b21234f91b7
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-d7ad3afb-9307-40a9-9b5c-0650db75c479
+      - req-2c9625c8-f629-45f3-839d-27f80abb7386
       Content-Type:
       - application/json
       Content-Length:
       - '3284'
       X-Openstack-Request-Id:
-      - req-d7ad3afb-9307-40a9-9b5c-0650db75c479
+      - req-2c9625c8-f629-45f3-839d-27f80abb7386
       Date:
-      - Thu, 03 Jan 2019 19:26:00 GMT
+      - Fri, 04 Jan 2019 16:57:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=2c774148-c11a-434c-aabb-7fa9c82c37ce",
@@ -5782,7 +5782,7 @@ http_interactions:
         "name": "EmsRefreshSpec-Volume-2", "bootable": "false", "created_at": "2016-11-11T13:49:43.000000",
         "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:00 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:53 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=2c774148-c11a-434c-aabb-7fa9c82c37ce
@@ -5797,22 +5797,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9ca79dbce6724a63bc5a43a7c7db3c5d
+      - 024e41417f6949cc89281b21234f91b7
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-4cbbd3fc-4749-46b7-956d-781205d9e773
+      - req-a428836c-fe78-4629-afbf-8a707d4f8db5
       Content-Type:
       - application/json
       Content-Length:
       - '2753'
       X-Openstack-Request-Id:
-      - req-4cbbd3fc-4749-46b7-956d-781205d9e773
+      - req-a428836c-fe78-4629-afbf-8a707d4f8db5
       Date:
-      - Thu, 03 Jan 2019 19:26:00 GMT
+      - Fri, 04 Jan 2019 16:57:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=0a55c0d5-c780-4e7d-9d09-47f5520c7448",
@@ -5846,7 +5846,7 @@ http_interactions:
         "bootable": "false", "created_at": "2016-11-11T13:49:20.000000", "volume_type":
         "iscsi"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:00 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:53 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=0a55c0d5-c780-4e7d-9d09-47f5520c7448
@@ -5861,27 +5861,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9ca79dbce6724a63bc5a43a7c7db3c5d
+      - 024e41417f6949cc89281b21234f91b7
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-e281a432-00d8-4946-ab2c-d3ba4f1b7461
+      - req-f71d3289-e8e8-4f3f-a02b-53185052d145
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-e281a432-00d8-4946-ab2c-d3ba4f1b7461
+      - req-f71d3289-e8e8-4f3f-a02b-53185052d145
       Date:
-      - Thu, 03 Jan 2019 19:26:00 GMT
+      - Fri, 04 Jan 2019 16:57:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:00 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:54 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/volumes/detail?limit=1000
@@ -5896,27 +5896,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7caff75714e24eaf932288c3a2b627c6
+      - 0a614ee4b0fd433588809616606c3097
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-b14d9bf7-81de-412f-96d6-a1bfc22250a8
+      - req-6207c013-8e63-4863-bcdc-5a3f3d0a2b68
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-b14d9bf7-81de-412f-96d6-a1bfc22250a8
+      - req-6207c013-8e63-4863-bcdc-5a3f3d0a2b68
       Date:
-      - Thu, 03 Jan 2019 19:26:00 GMT
+      - Fri, 04 Jan 2019 16:57:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:00 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:54 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/volumes/detail?limit=1000
@@ -5931,27 +5931,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ddb3b8e038164a93a8ea3bc6966bfac1
+      - 850b9cc1260946ba8adf189fd4158dbd
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-b57842d1-ad12-4aff-8c1b-fa3f657e1390
+      - req-d86331c1-e521-45de-a86a-16c7d02ff859
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-b57842d1-ad12-4aff-8c1b-fa3f657e1390
+      - req-d86331c1-e521-45de-a86a-16c7d02ff859
       Date:
-      - Thu, 03 Jan 2019 19:26:01 GMT
+      - Fri, 04 Jan 2019 16:57:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:01 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:54 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/volumes/detail?limit=1000
@@ -5966,27 +5966,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 783e0dd4185f4ef1bbec0dca1a8f1765
+      - a359a67e90b4427b85157b75e0d92575
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-1a08ccf6-1230-4573-a222-580e712689e5
+      - req-e144d98c-277e-4f07-8ab1-516cd60685f3
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-1a08ccf6-1230-4573-a222-580e712689e5
+      - req-e144d98c-277e-4f07-8ab1-516cd60685f3
       Date:
-      - Thu, 03 Jan 2019 19:26:01 GMT
+      - Fri, 04 Jan 2019 16:57:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:01 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:54 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -6004,13 +6004,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:26:02 GMT
+      - Fri, 04 Jan 2019 16:58:00 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-597ee652-e1cf-4f04-bcdb-842409967ff3
+      - req-e9c0de20-88e3-4c63-88cf-cb9e9d82c520
       Content-Length:
       - '4170'
       Connection:
@@ -6019,10 +6019,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:26:02.437476", "expires":
-        "2019-01-03T20:26:02Z", "id": "3d626787e8af4701936909999ee7a135", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:58:00.642552", "expires":
+        "2019-01-04T17:58:00Z", "id": "967d813205b346cc900d9ff1e6a26e29", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["bajuE9jOTC2xolWqVP-25Q"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["YG_xURw2TUKgio6U8MbJ4w"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -6067,7 +6067,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:02 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:00 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -6085,13 +6085,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:26:02 GMT
+      - Fri, 04 Jan 2019 16:58:00 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-0b9143a0-b128-435a-877a-1ba96d4654eb
+      - req-a51656be-d32f-4912-8b29-604a382a3198
       Content-Length:
       - '4170'
       Connection:
@@ -6100,10 +6100,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:26:02.630118", "expires":
-        "2019-01-03T20:26:02Z", "id": "0c68ca26f1c2410583445fc927dc23f1", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:58:00.835145", "expires":
+        "2019-01-04T17:58:00Z", "id": "60fc0d5603144c02b441088d45ba35d5", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["W2OO7UMuTyO5axxoIdCO5g"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["4y6CZwmrRoCHguTey64h4Q"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -6148,7 +6148,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:02 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:00 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/networks
@@ -6163,7 +6163,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0c68ca26f1c2410583445fc927dc23f1
+      - 60fc0d5603144c02b441088d45ba35d5
   response:
     status:
       code: 200
@@ -6174,32 +6174,27 @@ http_interactions:
       Content-Length:
       - '5330'
       X-Openstack-Request-Id:
-      - req-14e8521a-0e09-49e0-a334-060cb7330c13
+      - req-690abfa8-c019-4802-8b8a-07a7c92554d4
       Date:
-      - Thu, 03 Jan 2019 19:26:02 GMT
+      - Fri, 04 Jan 2019 16:58:01 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"networks": [{"status": "ACTIVE", "subnets": ["bb23bb48-804d-4416-bac3-231db23841e8"],
-        "name": "EmsRefreshSpec-NetworkPrivate_2", "provider:physical_network": null,
-        "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
-        0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
-        "id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "provider:segmentation_id":
-        53}, {"status": "ACTIVE", "subnets": ["841b5584-f86f-4abd-9bc2-f445b8bc860b",
-        "39628ee0-d5ff-4a88-ae66-80442e5feefd"], "name": "EmsRefreshSpec-NetworkPrivate_30",
-        "provider:physical_network": null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
-        "vxlan", "id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "provider:segmentation_id":
-        79}, {"status": "ACTIVE", "subnets": ["edfcb49b-e917-4897-b8ae-859ef3dae2de",
-        "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4"], "name": "EmsRefreshSpec-IsolatedNetworkPrivate_2",
-        "provider:physical_network": null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
-        "vxlan", "id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "provider:segmentation_id":
-        57}, {"status": "ACTIVE", "subnets": ["33da95a6-bded-44d8-be36-6cc97f3d72bd"],
+      string: '{"networks": [{"status": "ACTIVE", "subnets": ["33da95a6-bded-44d8-be36-6cc97f3d72bd"],
         "name": "EmsRefreshSpec-NetworkPublic", "provider:physical_network": "public_net_0",
         "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
         0, "router:external": true, "shared": false, "provider:network_type": "flat",
         "id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "provider:segmentation_id":
-        null}, {"status": "ACTIVE", "subnets": ["2092b802-1034-4fb8-9c5e-1ec61d1e463f"],
+        null}, {"status": "ACTIVE", "subnets": ["39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "841b5584-f86f-4abd-9bc2-f445b8bc860b"], "name": "EmsRefreshSpec-NetworkPrivate_30",
+        "provider:physical_network": null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
+        "vxlan", "id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "provider:segmentation_id":
+        79}, {"status": "ACTIVE", "subnets": ["826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
+        "edfcb49b-e917-4897-b8ae-859ef3dae2de"], "name": "EmsRefreshSpec-IsolatedNetworkPrivate_2",
+        "provider:physical_network": null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
+        "vxlan", "id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "provider:segmentation_id":
+        57}, {"status": "ACTIVE", "subnets": ["2092b802-1034-4fb8-9c5e-1ec61d1e463f"],
         "name": "EmsRefreshSpec-NetworkPrivate_20", "provider:physical_network": null,
         "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
         0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
@@ -6239,14 +6234,19 @@ http_interactions:
         null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
         "vxlan", "id": "560b4210-2b5a-4439-8d24-203e09478f48", "provider:segmentation_id":
-        54}, {"status": "ACTIVE", "subnets": ["104c081f-97dd-42b7-8930-98abbd015c74",
+        54}, {"status": "ACTIVE", "subnets": ["bb23bb48-804d-4416-bac3-231db23841e8"],
+        "name": "EmsRefreshSpec-NetworkPrivate_2", "provider:physical_network": null,
+        "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
+        0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
+        "id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "provider:segmentation_id":
+        53}, {"status": "ACTIVE", "subnets": ["104c081f-97dd-42b7-8930-98abbd015c74",
         "d53802a5-f0f6-48ba-9207-dbd9b13acac3"], "name": "EmsRefreshSpec-NetworkPrivate",
         "provider:physical_network": null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
         "vxlan", "id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "provider:segmentation_id":
         14}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:02 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:01 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -6264,13 +6264,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:26:02 GMT
+      - Fri, 04 Jan 2019 16:58:01 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-a9bdd1ef-8c9a-49f7-b1ef-9e6ff0ef8c9f
+      - req-1e081e48-4cc3-4cfe-b134-6805eef67c29
       Content-Length:
       - '4170'
       Connection:
@@ -6279,10 +6279,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:26:03.014029", "expires":
-        "2019-01-03T20:26:02Z", "id": "a063186649bf4a7a82d14f8cecae1eac", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:58:01.200127", "expires":
+        "2019-01-04T17:58:01Z", "id": "6ead7b1586c0449a8afa11ec2fc06f25", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["qKpGBKAvRYOPOKuTy2CfWQ"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["CTtGu-oJT627PfIB3LnLSA"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -6327,7 +6327,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:03 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:01 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -6345,13 +6345,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:26:03 GMT
+      - Fri, 04 Jan 2019 16:58:01 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-5661e1a4-17a6-44a2-b0a2-ccd44a8aa8ec
+      - req-faaa2783-0cf2-4e10-b604-d138efb50121
       Content-Length:
       - '370'
       Connection:
@@ -6360,13 +6360,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:26:03.185720", "expires":
-        "2019-01-03T20:26:03Z", "id": "c341603358ee48859a7f8053c753eff7", "audit_ids":
-        ["73AvFbzoR3WbFy40uU0YVw"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:58:01.362580", "expires":
+        "2019-01-04T17:58:01Z", "id": "ad0f9f5c13834e359430815ad5c7c961", "audit_ids":
+        ["5UhzDIxuTaCOji0cDcY0kw"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:03 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:01 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -6381,20 +6381,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c341603358ee48859a7f8053c753eff7
+      - ad0f9f5c13834e359430815ad5c7c961
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:26:03 GMT
+      - Fri, 04 Jan 2019 16:58:01 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-984838a7-fa02-4f9e-b21a-5c38a7d19ae8
+      - req-b21c0b77-ac11-4f88-83cc-6e57e730ef9a
       Content-Length:
       - '500'
       Connection:
@@ -6411,7 +6411,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:03 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:01 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -6429,13 +6429,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:26:03 GMT
+      - Fri, 04 Jan 2019 16:58:01 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-bba7e057-37c6-4c95-ab23-9549c89760e2
+      - req-cb9debd5-75ca-4cc2-bc52-51cdb2546e94
       Content-Length:
       - '4117'
       Connection:
@@ -6444,10 +6444,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:26:03.508304", "expires":
-        "2019-01-03T20:26:03Z", "id": "2fc95fbde4b74b7cad632821a3d0e5ce", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:58:01.676727", "expires":
+        "2019-01-04T17:58:01Z", "id": "a520637297074c3698d462b0569bdfc6", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["Z8X3vBg0SLiGy7RNHcQs7Q"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["CYyaKiZ7S_qMbaFhsord2g"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -6491,7 +6491,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:03 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:01 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -6509,13 +6509,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:26:03 GMT
+      - Fri, 04 Jan 2019 16:58:01 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-9d749e89-1948-462d-affb-a39fb445b2e1
+      - req-721a9478-5c27-49d0-bad9-a3ff9d0318dd
       Content-Length:
       - '4131'
       Connection:
@@ -6524,10 +6524,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:26:03.694752", "expires":
-        "2019-01-03T20:26:03Z", "id": "96415884d73f481392cca27bcde14283", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:58:01.862721", "expires":
+        "2019-01-04T17:58:01Z", "id": "e4b796a8db794fc18198cdc0ad977221", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["8pZjyk57TXOxXDxMoenjMw"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["Js8PZdyqSvyWy_H-n4zJSg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -6571,7 +6571,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:03 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:01 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -6589,13 +6589,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:26:03 GMT
+      - Fri, 04 Jan 2019 16:58:02 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-332f3f0b-aa00-4bdb-81a7-3db307f6706c
+      - req-062d8b2d-35fa-463c-9da6-4fbf05cf502b
       Content-Length:
       - '4118'
       Connection:
@@ -6604,10 +6604,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:26:03.881787", "expires":
-        "2019-01-03T20:26:03Z", "id": "127fb20841744f22b20d36dfb9b6fb15", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:58:02.053126", "expires":
+        "2019-01-04T17:58:02Z", "id": "2a939c79b7404028a9d57d79a21088ac", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["F3s497vFQzGqSJARohWNjg"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["8VEKPqimRIegrb66RN6nwQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -6651,7 +6651,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:03 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:02 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks?limit=1000&show_nested=true
@@ -6666,7 +6666,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2fc95fbde4b74b7cad632821a3d0e5ce
+      - a520637297074c3698d462b0569bdfc6
   response:
     status:
       code: 200
@@ -6677,9 +6677,9 @@ http_interactions:
       Content-Length:
       - '2559'
       X-Openstack-Request-Id:
-      - req-dcae8bdc-584e-4bd6-91d1-54c06e0d52ef
+      - req-d32e78eb-1e2e-49f8-a2ba-d75b705c80a7
       Date:
-      - Thu, 03 Jan 2019 19:26:04 GMT
+      - Fri, 04 Jan 2019 16:58:02 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": [{"description": "Heat WordPress template to support F20,
@@ -6713,7 +6713,7 @@ http_interactions:
         "rel": "self"}], "updated_time": null, "stack_owner": null, "stack_status":
         "CREATE_COMPLETE", "id": "091e1e54-e01c-4ec5-a0ab-b00bee4d425c"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:04 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:02 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks?limit=1000&marker=091e1e54-e01c-4ec5-a0ab-b00bee4d425c&show_nested=true
@@ -6728,7 +6728,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2fc95fbde4b74b7cad632821a3d0e5ce
+      - a520637297074c3698d462b0569bdfc6
   response:
     status:
       code: 200
@@ -6739,14 +6739,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-b18b21ea-1f0e-4437-8265-9051014354fc
+      - req-2aa8998a-9bda-4607-a1dc-bfd819f7cc2f
       Date:
-      - Thu, 03 Jan 2019 19:26:04 GMT
+      - Fri, 04 Jan 2019 16:58:02 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:04 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:02 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/b458a5c25c3749758f4c0661940b3ba8/stacks?limit=1000&show_nested=true
@@ -6761,7 +6761,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 96415884d73f481392cca27bcde14283
+      - e4b796a8db794fc18198cdc0ad977221
   response:
     status:
       code: 200
@@ -6772,14 +6772,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-2b1829c4-5899-4efc-a8d8-bbf4e5c6e858
+      - req-3993001a-7f88-4752-b51a-e115b618ebc1
       Date:
-      - Thu, 03 Jan 2019 19:26:04 GMT
+      - Fri, 04 Jan 2019 16:58:02 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:04 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:02 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/e54e5c3c19e34720b05661f2ea1ea00a/stacks?limit=1000&show_nested=true
@@ -6794,7 +6794,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a063186649bf4a7a82d14f8cecae1eac
+      - 6ead7b1586c0449a8afa11ec2fc06f25
   response:
     status:
       code: 200
@@ -6805,14 +6805,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-3e4d1214-204b-4e32-9e80-1dd96759836d
+      - req-2953949a-56bc-4556-8708-1b91a78ff948
       Date:
-      - Thu, 03 Jan 2019 19:26:04 GMT
+      - Fri, 04 Jan 2019 16:58:02 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:04 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:02 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/e8f744b1fc6a487681d35fb275252608/stacks?limit=1000&show_nested=true
@@ -6827,7 +6827,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 127fb20841744f22b20d36dfb9b6fb15
+      - 2a939c79b7404028a9d57d79a21088ac
   response:
     status:
       code: 200
@@ -6838,14 +6838,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-6674f446-c7c4-4efd-bff0-f4a4f85c35a8
+      - req-7935468e-09e3-48a5-abd6-f310fb6173b2
       Date:
-      - Thu, 03 Jan 2019 19:26:04 GMT
+      - Fri, 04 Jan 2019 16:58:02 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:04 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:02 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack3/45d2af82-eff9-4483-a1f0-f19c44d96146
@@ -6860,7 +6860,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2fc95fbde4b74b7cad632821a3d0e5ce
+      - a520637297074c3698d462b0569bdfc6
   response:
     status:
       code: 200
@@ -6871,9 +6871,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-17943422-57d7-45c1-942b-f40910dfd453
+      - req-bf78277a-cc3b-491c-a314-17fbed9e9ade
       Date:
-      - Thu, 03 Jan 2019 19:26:05 GMT
+      - Fri, 04 Jan 2019 16:58:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -6900,7 +6900,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:05 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:03 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack2/4cf24b12-29fc-4529-a8ed-6b079dea7c17
@@ -6915,7 +6915,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2fc95fbde4b74b7cad632821a3d0e5ce
+      - a520637297074c3698d462b0569bdfc6
   response:
     status:
       code: 200
@@ -6926,9 +6926,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-86cca94f-e987-472f-9f31-64caa8698b9b
+      - req-3a3ec021-f2a7-416e-bf36-aaa418f91063
       Date:
-      - Thu, 03 Jan 2019 19:26:05 GMT
+      - Fri, 04 Jan 2019 16:58:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -6955,7 +6955,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:05 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:03 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c
@@ -6970,7 +6970,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2fc95fbde4b74b7cad632821a3d0e5ce
+      - a520637297074c3698d462b0569bdfc6
   response:
     status:
       code: 200
@@ -6981,9 +6981,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-667dda65-b819-4ce4-9d51-a0db59230760
+      - req-5ef6ab11-e755-49df-87f5-1dd006a44415
       Date:
-      - Thu, 03 Jan 2019 19:26:05 GMT
+      - Fri, 04 Jan 2019 16:58:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -7010,7 +7010,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:05 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:04 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack3/45d2af82-eff9-4483-a1f0-f19c44d96146/resources
@@ -7025,7 +7025,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2fc95fbde4b74b7cad632821a3d0e5ce
+      - a520637297074c3698d462b0569bdfc6
   response:
     status:
       code: 200
@@ -7036,9 +7036,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-b74b5044-2a8f-4240-9bb4-a6f0e2f01519
+      - req-c1a9fb74-307a-4d51-bab0-edf46605f673
       Date:
-      - Thu, 03 Jan 2019 19:26:05 GMT
+      - Fri, 04 Jan 2019 16:58:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -7050,7 +7050,7 @@ http_interactions:
         changed", "physical_resource_id": "aa5907f3-8209-4dd0-b3ef-600431d85bac",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:05 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:04 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack2/4cf24b12-29fc-4529-a8ed-6b079dea7c17/resources
@@ -7065,7 +7065,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2fc95fbde4b74b7cad632821a3d0e5ce
+      - a520637297074c3698d462b0569bdfc6
   response:
     status:
       code: 200
@@ -7076,9 +7076,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-bdfb5509-dcfd-4453-9c91-b5e23ffbebf4
+      - req-0d368c72-d511-4847-b4f8-eccfa5c995d1
       Date:
-      - Thu, 03 Jan 2019 19:26:05 GMT
+      - Fri, 04 Jan 2019 16:58:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -7090,7 +7090,7 @@ http_interactions:
         changed", "physical_resource_id": "219a737c-b4ad-430d-944a-a92a4834b12d",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:06 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:04 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c/resources
@@ -7105,7 +7105,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2fc95fbde4b74b7cad632821a3d0e5ce
+      - a520637297074c3698d462b0569bdfc6
   response:
     status:
       code: 200
@@ -7116,9 +7116,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-f61fff98-0bde-4a35-b07c-c48fa983c837
+      - req-581ebadc-0678-41b6-9006-af522d160464
       Date:
-      - Thu, 03 Jan 2019 19:26:06 GMT
+      - Fri, 04 Jan 2019 16:58:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -7130,7 +7130,7 @@ http_interactions:
         changed", "physical_resource_id": "b686353f-0da0-48bf-bc35-8ea411a67dfd",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:06 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:04 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -7148,13 +7148,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:26:06 GMT
+      - Fri, 04 Jan 2019 16:58:04 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-43b38b60-9bf8-474b-9e59-ccf38738557e
+      - req-ea1b566b-cbe7-4b40-b86e-553d1632ccbe
       Content-Length:
       - '4117'
       Connection:
@@ -7163,10 +7163,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:26:06.292307", "expires":
-        "2019-01-03T20:26:06Z", "id": "2d8cc04039274191a6523840e6cb7c5d", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:58:04.630787", "expires":
+        "2019-01-04T17:58:04Z", "id": "6f2eb86ec5e5414196d08e40a9b390b2", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["XU5j16DYRtKmHgDhXaVo2w"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["t30WosCzQrqW04yfXj_q4g"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -7210,7 +7210,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:06 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:04 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -7228,13 +7228,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:26:06 GMT
+      - Fri, 04 Jan 2019 16:58:04 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-387410ff-2c26-4711-8368-0a7c6386fee8
+      - req-790c5a99-0eb4-448c-8c8c-d8e3e82a83b9
       Content-Length:
       - '4131'
       Connection:
@@ -7243,10 +7243,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:26:06.482685", "expires":
-        "2019-01-03T20:26:06Z", "id": "f18d0603b6744e0a91128ce16d025d29", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:58:04.826491", "expires":
+        "2019-01-04T17:58:04Z", "id": "5a1255aba0874c1faf9a4fd61b559665", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["4xoZhaV1SDChxx6XWHvOTQ"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["0s-iQAVNTqS3wjoNvEYhkA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -7290,7 +7290,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:06 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:04 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -7308,13 +7308,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:26:06 GMT
+      - Fri, 04 Jan 2019 16:58:04 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-10d98d10-632c-487b-96ce-a5ad852f9cad
+      - req-cfb17086-668a-4d1f-a80b-f1a1a4d8d4c0
       Content-Length:
       - '4118'
       Connection:
@@ -7323,10 +7323,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:26:06.667751", "expires":
-        "2019-01-03T20:26:06Z", "id": "e8d70d727cc74cc9b3ce6241980332d5", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:58:05.022124", "expires":
+        "2019-01-04T17:58:05Z", "id": "68abdb329a8f4548bbaeaed4e794523c", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["sQ2C_BwmSHmIUk364hDzOQ"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["k2UqRlLORUy4GQjKC7-Ckg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -7370,7 +7370,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:06 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:05 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -7385,7 +7385,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2d8cc04039274191a6523840e6cb7c5d
+      - 6f2eb86ec5e5414196d08e40a9b390b2
   response:
     status:
       code: 200
@@ -7396,40 +7396,28 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-990a0dd5-e318-4ba8-8ae5-435f4b523320
+      - req-79ebbf97-49d4-4058-b5ab-21401262f7af
       Date:
-      - Thu, 03 Jan 2019 19:26:06 GMT
+      - Fri, 04 Jan 2019 16:58:05 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
-        true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
@@ -7489,6 +7477,18 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
         "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
         "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
@@ -7502,7 +7502,7 @@ http_interactions:
         4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
         "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:06 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:05 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
@@ -7517,7 +7517,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2d8cc04039274191a6523840e6cb7c5d
+      - 6f2eb86ec5e5414196d08e40a9b390b2
   response:
     status:
       code: 200
@@ -7528,40 +7528,28 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-6f116ee2-4de2-4c58-9dc1-237644059631
+      - req-69033a20-f14b-49e2-a7d0-abf1f612ea57
       Date:
-      - Thu, 03 Jan 2019 19:26:07 GMT
+      - Fri, 04 Jan 2019 16:58:05 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
-        true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
@@ -7621,6 +7609,18 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
         "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
         "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
@@ -7634,7 +7634,7 @@ http_interactions:
         4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
         "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:07 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:05 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -7649,7 +7649,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f18d0603b6744e0a91128ce16d025d29
+      - 5a1255aba0874c1faf9a4fd61b559665
   response:
     status:
       code: 200
@@ -7660,19 +7660,13 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-0ab148bb-98b4-4da2-b808-d3f0fce50fdb
+      - req-732f3bc4-d24b-46d1-887a-566bc4ae9cf6
       Date:
-      - Thu, 03 Jan 2019 19:26:07 GMT
+      - Fri, 04 Jan 2019 16:58:05 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
-        true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp":
+        true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
@@ -7753,6 +7747,12 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
         "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
         "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
@@ -7766,7 +7766,7 @@ http_interactions:
         4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
         "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:07 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:05 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
@@ -7781,7 +7781,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f18d0603b6744e0a91128ce16d025d29
+      - 5a1255aba0874c1faf9a4fd61b559665
   response:
     status:
       code: 200
@@ -7792,40 +7792,28 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-523ae722-c7a1-4e8f-bd24-81aa15e8115e
+      - req-29200f45-2dd7-4d45-8b6b-1c73edc3dfa7
       Date:
-      - Thu, 03 Jan 2019 19:26:07 GMT
+      - Fri, 04 Jan 2019 16:58:05 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
-        true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
@@ -7885,6 +7873,18 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
         "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
         "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
@@ -7898,7 +7898,7 @@ http_interactions:
         4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
         "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:07 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:05 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -7913,7 +7913,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0c68ca26f1c2410583445fc927dc23f1
+      - 60fc0d5603144c02b441088d45ba35d5
   response:
     status:
       code: 200
@@ -7924,12 +7924,161 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-42a50571-9303-4777-bab9-d375250ae634
+      - req-8c51d676-42bf-4243-8f21-3076a5f14e11
       Date:
-      - Thu, 03 Jan 2019 19:26:07 GMT
+      - Fri, 04 Jan 2019 16:58:05 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp":
+        true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Fri, 04 Jan 2019 16:58:06 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 60fc0d5603144c02b441088d45ba35d5
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-7ffb9199-4ef0-4dc1-b082-c873c9d6d043
+      Date:
+      - Fri, 04 Jan 2019 16:58:06 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
@@ -8000,155 +8149,6 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
         "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:07 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 0c68ca26f1c2410583445fc927dc23f1
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-81dd5a77-5f00-40bf-90a1-d150519eb7de
-      Date:
-      - Thu, 03 Jan 2019 19:26:07 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
-        true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
         "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
@@ -8162,403 +8162,7 @@ http_interactions:
         4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
         "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:07 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 0c68ca26f1c2410583445fc927dc23f1
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-f172a87a-26ca-482c-84db-a11df7bf9ba2
-      Date:
-      - Thu, 03 Jan 2019 19:26:07 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:08 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 0c68ca26f1c2410583445fc927dc23f1
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-77ddd97c-f37d-43a8-a20e-51fd7e875271
-      Date:
-      - Thu, 03 Jan 2019 19:26:08 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
-        true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:08 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 0c68ca26f1c2410583445fc927dc23f1
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-0d8b597b-36a5-443f-b8d1-b39d5bcef465
-      Date:
-      - Thu, 03 Jan 2019 19:26:08 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
-        true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:08 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:06 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -8573,7 +8177,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e8d70d727cc74cc9b3ce6241980332d5
+      - 68abdb329a8f4548bbaeaed4e794523c
   response:
     status:
       code: 200
@@ -8584,12 +8188,161 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-5208774a-3fdd-4ecf-938d-ceca0536e54f
+      - req-4a80fd30-7a13-4798-860a-7bdf60ef4ead
       Date:
-      - Thu, 03 Jan 2019 19:26:08 GMT
+      - Fri, 04 Jan 2019 16:58:06 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp":
+        true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Fri, 04 Jan 2019 16:58:06 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 68abdb329a8f4548bbaeaed4e794523c
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-5edb3e2e-f46d-4430-a7c2-c8f93e660a23
+      Date:
+      - Fri, 04 Jan 2019 16:58:06 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
@@ -8660,155 +8413,6 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
         "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:08 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - e8d70d727cc74cc9b3ce6241980332d5
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-c8e61a72-c83b-4d93-8f2c-ea91316d0556
-      Date:
-      - Thu, 03 Jan 2019 19:26:08 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
-        true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
         "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
@@ -8822,667 +8426,7 @@ http_interactions:
         4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
         "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:08 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - e8d70d727cc74cc9b3ce6241980332d5
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-a5ec6218-a94a-4bbe-8fac-e0458a3c5c36
-      Date:
-      - Thu, 03 Jan 2019 19:26:08 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:08 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - e8d70d727cc74cc9b3ce6241980332d5
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-aba16271-969f-4737-8d5e-b3f99eed1441
-      Date:
-      - Thu, 03 Jan 2019 19:26:08 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
-        true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:09 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - e8d70d727cc74cc9b3ce6241980332d5
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-34fa6d9d-3614-4969-ade5-75fb09e0111a
-      Date:
-      - Thu, 03 Jan 2019 19:26:09 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:09 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - e8d70d727cc74cc9b3ce6241980332d5
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-db6c5f20-0e05-46b9-8a55-010066ac5eba
-      Date:
-      - Thu, 03 Jan 2019 19:26:09 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
-        true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:09 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - e8d70d727cc74cc9b3ce6241980332d5
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-f1339d16-0bbf-4286-bb5d-c03fc25fea4e
-      Date:
-      - Thu, 03 Jan 2019 19:26:09 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
-        true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:09 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:06 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?limit=1000
@@ -9497,7 +8441,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2d8cc04039274191a6523840e6cb7c5d
+      - 6f2eb86ec5e5414196d08e40a9b390b2
   response:
     status:
       code: 200
@@ -9508,9 +8452,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-b6ba2836-144b-43a5-8b44-ddd4761c8ffd
+      - req-6952d97e-af01-4374-9d4a-4bfecefbd151
       Date:
-      - Thu, 03 Jan 2019 19:26:09 GMT
+      - Fri, 04 Jan 2019 16:58:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -9552,7 +8496,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:09 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:06 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?limit=1000&marker=ee601a91-f6ac-4a46-a599-87cfd83094a3
@@ -9567,7 +8511,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2d8cc04039274191a6523840e6cb7c5d
+      - 6f2eb86ec5e5414196d08e40a9b390b2
   response:
     status:
       code: 200
@@ -9578,9 +8522,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-0a8dd13a-7398-40dd-81e6-fd1bcda8cfad
+      - req-4baf2948-f76e-4a50-b7a9-7d1264272dcc
       Date:
-      - Thu, 03 Jan 2019 19:26:09 GMT
+      - Fri, 04 Jan 2019 16:58:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -9622,7 +8566,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:09 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:06 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?limit=1000
@@ -9637,7 +8581,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f18d0603b6744e0a91128ce16d025d29
+      - 5a1255aba0874c1faf9a4fd61b559665
   response:
     status:
       code: 200
@@ -9648,9 +8592,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-8c9a8908-b8b6-4504-9a6e-17455897df99
+      - req-f5af8ee1-cf02-4508-a645-36b08d61919a
       Date:
-      - Thu, 03 Jan 2019 19:26:10 GMT
+      - Fri, 04 Jan 2019 16:58:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -9692,7 +8636,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:10 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:06 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?limit=1000&marker=ee601a91-f6ac-4a46-a599-87cfd83094a3
@@ -9707,7 +8651,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f18d0603b6744e0a91128ce16d025d29
+      - 5a1255aba0874c1faf9a4fd61b559665
   response:
     status:
       code: 200
@@ -9718,9 +8662,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-4a8bdcff-ec3b-4cc6-b73f-66d84c2ac77f
+      - req-a72ef3bf-df81-4d03-924f-ebbac76b8e17
       Date:
-      - Thu, 03 Jan 2019 19:26:10 GMT
+      - Fri, 04 Jan 2019 16:58:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -9762,7 +8706,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:10 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:07 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?limit=1000
@@ -9777,7 +8721,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0c68ca26f1c2410583445fc927dc23f1
+      - 60fc0d5603144c02b441088d45ba35d5
   response:
     status:
       code: 200
@@ -9788,9 +8732,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-5ac45fdb-dcd4-4fb6-9adc-93b99bc9a444
+      - req-c51653bf-f230-4753-ad15-b2527e3e763c
       Date:
-      - Thu, 03 Jan 2019 19:26:10 GMT
+      - Fri, 04 Jan 2019 16:58:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -9832,7 +8776,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:10 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:07 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?limit=1000&marker=ee601a91-f6ac-4a46-a599-87cfd83094a3
@@ -9847,7 +8791,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0c68ca26f1c2410583445fc927dc23f1
+      - 60fc0d5603144c02b441088d45ba35d5
   response:
     status:
       code: 200
@@ -9858,9 +8802,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-11d69238-a333-4430-9383-f22e8c16c9a8
+      - req-018735c7-bd22-4d43-a675-230b5e69c8f5
       Date:
-      - Thu, 03 Jan 2019 19:26:10 GMT
+      - Fri, 04 Jan 2019 16:58:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -9902,7 +8846,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:10 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:07 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?limit=1000
@@ -9917,7 +8861,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e8d70d727cc74cc9b3ce6241980332d5
+      - 68abdb329a8f4548bbaeaed4e794523c
   response:
     status:
       code: 200
@@ -9928,9 +8872,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-3479186d-1f7f-4e96-936b-0003c26ed4cb
+      - req-f3cef589-8e17-4264-8eda-f34c5fe07793
       Date:
-      - Thu, 03 Jan 2019 19:26:10 GMT
+      - Fri, 04 Jan 2019 16:58:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -9972,7 +8916,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:10 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:07 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?limit=1000&marker=ee601a91-f6ac-4a46-a599-87cfd83094a3
@@ -9987,7 +8931,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e8d70d727cc74cc9b3ce6241980332d5
+      - 68abdb329a8f4548bbaeaed4e794523c
   response:
     status:
       code: 200
@@ -9998,9 +8942,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-f8642bfb-2571-4650-8905-15cc196db4e8
+      - req-eb29595f-de84-4add-b003-9a67fa978c21
       Date:
-      - Thu, 03 Jan 2019 19:26:10 GMT
+      - Fri, 04 Jan 2019 16:58:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -10042,7 +8986,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:10 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:08 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?limit=1000
@@ -10057,7 +9001,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2d8cc04039274191a6523840e6cb7c5d
+      - 6f2eb86ec5e5414196d08e40a9b390b2
   response:
     status:
       code: 200
@@ -10068,9 +9012,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-c2e9f02f-eccb-4363-8db3-c489fa5549af
+      - req-9db525c1-df22-47a5-b09c-4feeff51a429
       Date:
-      - Thu, 03 Jan 2019 19:26:10 GMT
+      - Fri, 04 Jan 2019 16:58:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -10473,7 +9417,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:10 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:08 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?limit=1000&marker=dee8791c-23b3-4e65-846d-49aeaba18036
@@ -10488,7 +9432,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2d8cc04039274191a6523840e6cb7c5d
+      - 6f2eb86ec5e5414196d08e40a9b390b2
   response:
     status:
       code: 200
@@ -10499,9 +9443,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-dedcac59-bbe1-495d-8ea0-9b2f72b6320e
+      - req-bf38a136-590d-48cf-9093-f92b1c16dd19
       Date:
-      - Thu, 03 Jan 2019 19:26:10 GMT
+      - Fri, 04 Jan 2019 16:58:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -10904,7 +9848,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:10 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:08 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?limit=1000
@@ -10919,7 +9863,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f18d0603b6744e0a91128ce16d025d29
+      - 5a1255aba0874c1faf9a4fd61b559665
   response:
     status:
       code: 200
@@ -10930,9 +9874,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-c401ac2c-b39b-4aa1-aac4-5642122fa384
+      - req-1eb47eb0-5309-4686-8290-a02b78c905b3
       Date:
-      - Thu, 03 Jan 2019 19:26:11 GMT
+      - Fri, 04 Jan 2019 16:58:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -11335,7 +10279,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:11 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:08 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?limit=1000&marker=dee8791c-23b3-4e65-846d-49aeaba18036
@@ -11350,7 +10294,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f18d0603b6744e0a91128ce16d025d29
+      - 5a1255aba0874c1faf9a4fd61b559665
   response:
     status:
       code: 200
@@ -11361,9 +10305,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-291f5f9a-ac23-40ff-b517-6f136d006edc
+      - req-7679fb62-967f-4ed1-8257-1ef093f64647
       Date:
-      - Thu, 03 Jan 2019 19:26:11 GMT
+      - Fri, 04 Jan 2019 16:58:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -11766,7 +10710,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:11 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:08 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?limit=1000
@@ -11781,7 +10725,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0c68ca26f1c2410583445fc927dc23f1
+      - 60fc0d5603144c02b441088d45ba35d5
   response:
     status:
       code: 200
@@ -11792,9 +10736,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-efb6dab8-4350-4649-986e-02057a3ace53
+      - req-d9a4fb68-109a-4b49-a33a-6fbe561a29ea
       Date:
-      - Thu, 03 Jan 2019 19:26:11 GMT
+      - Fri, 04 Jan 2019 16:58:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -12197,7 +11141,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:11 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:09 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?limit=1000&marker=dee8791c-23b3-4e65-846d-49aeaba18036
@@ -12212,7 +11156,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0c68ca26f1c2410583445fc927dc23f1
+      - 60fc0d5603144c02b441088d45ba35d5
   response:
     status:
       code: 200
@@ -12223,9 +11167,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-42023cc6-8a0d-4446-a637-837683403485
+      - req-d1e3a770-5bda-4ea9-9524-ba148bbfda0a
       Date:
-      - Thu, 03 Jan 2019 19:26:11 GMT
+      - Fri, 04 Jan 2019 16:58:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -12628,7 +11572,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:11 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:09 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?limit=1000
@@ -12643,7 +11587,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e8d70d727cc74cc9b3ce6241980332d5
+      - 68abdb329a8f4548bbaeaed4e794523c
   response:
     status:
       code: 200
@@ -12654,9 +11598,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-710edd04-05fb-40c2-b659-c982f815b1fe
+      - req-94b47fa8-0305-421b-8741-24db48fe7e28
       Date:
-      - Thu, 03 Jan 2019 19:26:11 GMT
+      - Fri, 04 Jan 2019 16:58:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -13059,7 +12003,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:11 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:09 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?limit=1000&marker=dee8791c-23b3-4e65-846d-49aeaba18036
@@ -13074,7 +12018,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e8d70d727cc74cc9b3ce6241980332d5
+      - 68abdb329a8f4548bbaeaed4e794523c
   response:
     status:
       code: 200
@@ -13085,9 +12029,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-5931861f-43e4-43bb-b6c1-2a1ab517b403
+      - req-e806e793-2245-4dc5-99ab-d17015dac66e
       Date:
-      - Thu, 03 Jan 2019 19:26:12 GMT
+      - Fri, 04 Jan 2019 16:58:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -13490,7 +12434,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:12 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:09 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?limit=1000
@@ -13505,7 +12449,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2d8cc04039274191a6523840e6cb7c5d
+      - 6f2eb86ec5e5414196d08e40a9b390b2
   response:
     status:
       code: 200
@@ -13516,9 +12460,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-5c7d9240-d46a-4fb8-b464-8a95a8aa48c2
+      - req-da59d94c-74e1-4d29-bc1e-fc1a790a7bd6
       Date:
-      - Thu, 03 Jan 2019 19:26:12 GMT
+      - Fri, 04 Jan 2019 16:58:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -13550,7 +12494,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:12 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:09 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?limit=1000&marker=a41c036a-c34e-454b-851d-5eefd03888cb
@@ -13565,7 +12509,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2d8cc04039274191a6523840e6cb7c5d
+      - 6f2eb86ec5e5414196d08e40a9b390b2
   response:
     status:
       code: 200
@@ -13576,9 +12520,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-e9a5d75a-a5d6-45b6-9c37-3b1a69e3cb0c
+      - req-ea82ead5-de86-4d58-9f29-fd46b9221cee
       Date:
-      - Thu, 03 Jan 2019 19:26:12 GMT
+      - Fri, 04 Jan 2019 16:58:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -13610,7 +12554,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:12 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:09 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?limit=1000
@@ -13625,7 +12569,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f18d0603b6744e0a91128ce16d025d29
+      - 5a1255aba0874c1faf9a4fd61b559665
   response:
     status:
       code: 200
@@ -13636,9 +12580,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-7ca05af6-84bd-4958-ae21-3d4dc9f4b442
+      - req-470570ff-bb55-4466-9c4f-2d485179e13f
       Date:
-      - Thu, 03 Jan 2019 19:26:12 GMT
+      - Fri, 04 Jan 2019 16:58:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -13670,7 +12614,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:12 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:10 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?limit=1000&marker=a41c036a-c34e-454b-851d-5eefd03888cb
@@ -13685,7 +12629,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f18d0603b6744e0a91128ce16d025d29
+      - 5a1255aba0874c1faf9a4fd61b559665
   response:
     status:
       code: 200
@@ -13696,9 +12640,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-ad33dd23-eff2-400c-a532-adb49349ed8e
+      - req-10329a90-510d-4cb4-a339-f17e45425ace
       Date:
-      - Thu, 03 Jan 2019 19:26:12 GMT
+      - Fri, 04 Jan 2019 16:58:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -13730,7 +12674,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:12 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:10 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?limit=1000
@@ -13745,7 +12689,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0c68ca26f1c2410583445fc927dc23f1
+      - 60fc0d5603144c02b441088d45ba35d5
   response:
     status:
       code: 200
@@ -13756,9 +12700,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-78aa3cb0-4d6a-499e-8dee-bf1e8640b405
+      - req-f990d68d-2e23-437b-838d-5ca3698e7a36
       Date:
-      - Thu, 03 Jan 2019 19:26:12 GMT
+      - Fri, 04 Jan 2019 16:58:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -13790,7 +12734,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:12 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:10 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?limit=1000&marker=a41c036a-c34e-454b-851d-5eefd03888cb
@@ -13805,7 +12749,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0c68ca26f1c2410583445fc927dc23f1
+      - 60fc0d5603144c02b441088d45ba35d5
   response:
     status:
       code: 200
@@ -13816,9 +12760,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-03584009-eb3f-4177-b9c6-d64d08583630
+      - req-2fab9a20-e35f-4c91-85f7-ca76009dab46
       Date:
-      - Thu, 03 Jan 2019 19:26:12 GMT
+      - Fri, 04 Jan 2019 16:58:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -13850,7 +12794,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:12 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:10 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?limit=1000
@@ -13865,7 +12809,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e8d70d727cc74cc9b3ce6241980332d5
+      - 68abdb329a8f4548bbaeaed4e794523c
   response:
     status:
       code: 200
@@ -13876,9 +12820,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-07bac652-4c31-484e-bc7c-ba5e48f2511d
+      - req-5a719606-ee7e-4322-9b39-8f5c006dc2fc
       Date:
-      - Thu, 03 Jan 2019 19:26:12 GMT
+      - Fri, 04 Jan 2019 16:58:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -13910,7 +12854,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:12 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:10 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?limit=1000&marker=a41c036a-c34e-454b-851d-5eefd03888cb
@@ -13925,7 +12869,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e8d70d727cc74cc9b3ce6241980332d5
+      - 68abdb329a8f4548bbaeaed4e794523c
   response:
     status:
       code: 200
@@ -13936,9 +12880,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-bb72593e-3d07-40e2-9065-17cfcee3ec85
+      - req-4ca1fa1b-06f8-4ba8-a6ec-55adae1da21f
       Date:
-      - Thu, 03 Jan 2019 19:26:13 GMT
+      - Fri, 04 Jan 2019 16:58:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -13970,7 +12914,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:13 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:10 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000
@@ -13985,7 +12929,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2d8cc04039274191a6523840e6cb7c5d
+      - 6f2eb86ec5e5414196d08e40a9b390b2
   response:
     status:
       code: 200
@@ -13996,9 +12940,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-0c1c375d-ff6f-4bc7-9af5-3ce1976c9b22
+      - req-0aaced1e-ff6c-4d7b-9b8b-ae19e793e34f
       Date:
-      - Thu, 03 Jan 2019 19:26:13 GMT
+      - Fri, 04 Jan 2019 16:58:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef",
@@ -14040,7 +12984,7 @@ http_interactions:
         null, "port_range_min": null, "id": "ff24dfac-169a-4238-b78b-ed1536a0bf06",
         "security_group_id": "5b2b42a6-1271-4c4a-b062-8e8ba299acef"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:13 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:10 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef
@@ -14055,7 +12999,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2d8cc04039274191a6523840e6cb7c5d
+      - 6f2eb86ec5e5414196d08e40a9b390b2
   response:
     status:
       code: 200
@@ -14066,9 +13010,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-de5cdbc6-54a5-4f0f-89f5-ae5a54aec5c3
+      - req-15da64f2-6377-4dce-8b08-50fa1d777f90
       Date:
-      - Thu, 03 Jan 2019 19:26:13 GMT
+      - Fri, 04 Jan 2019 16:58:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab",
@@ -14111,7 +13055,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "c06c0e71-2c18-43a9-ace9-91242f0251e2",
         "security_group_id": "98bfc20c-a897-42c5-b33c-f0d8317667ab"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:13 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:10 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab
@@ -14126,7 +13070,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2d8cc04039274191a6523840e6cb7c5d
+      - 6f2eb86ec5e5414196d08e40a9b390b2
   response:
     status:
       code: 200
@@ -14137,9 +13081,9 @@ http_interactions:
       Content-Length:
       - '2717'
       X-Openstack-Request-Id:
-      - req-97f18b61-b936-4b2e-9b4a-3ad2340aa42e
+      - req-5f8f7614-79f2-4b9f-b608-56793cd6b3d1
       Date:
-      - Thu, 03 Jan 2019 19:26:13 GMT
+      - Fri, 04 Jan 2019 16:58:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4",
@@ -14174,7 +13118,7 @@ http_interactions:
         null, "port_range_min": null, "id": "75924ebc-4758-4042-ad04-4ef3c9189098",
         "security_group_id": "e4836528-d0df-425e-a117-ae8ec6f356d4"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:13 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:11 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4
@@ -14189,7 +13133,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2d8cc04039274191a6523840e6cb7c5d
+      - 6f2eb86ec5e5414196d08e40a9b390b2
   response:
     status:
       code: 200
@@ -14200,9 +13144,9 @@ http_interactions:
       Content-Length:
       - '7080'
       X-Openstack-Request-Id:
-      - req-f75bb88d-2008-4c9c-978f-fedd01a3025f
+      - req-65956b7c-f1db-409e-b0db-347d17fa960a
       Date:
-      - Thu, 03 Jan 2019 19:26:13 GMT
+      - Fri, 04 Jan 2019 16:58:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=fd147cb7-7456-43d9-a01f-c06e21b4e6fb&page_reverse=True",
@@ -14289,7 +13233,7 @@ http_interactions:
         "port_range_max": 80, "port_range_min": 80, "id": "f79f0e32-b186-4778-952e-20827a60ef73",
         "security_group_id": "fd147cb7-7456-43d9-a01f-c06e21b4e6fb"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:13 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:11 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000
@@ -14304,7 +13248,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f18d0603b6744e0a91128ce16d025d29
+      - 5a1255aba0874c1faf9a4fd61b559665
   response:
     status:
       code: 200
@@ -14315,9 +13259,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-d5085fc9-eae5-4407-9eef-a497ddf9bce4
+      - req-0d331c09-79cb-4ef7-b49a-21110208baae
       Date:
-      - Thu, 03 Jan 2019 19:26:13 GMT
+      - Fri, 04 Jan 2019 16:58:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef",
@@ -14359,7 +13303,7 @@ http_interactions:
         null, "port_range_min": null, "id": "ff24dfac-169a-4238-b78b-ed1536a0bf06",
         "security_group_id": "5b2b42a6-1271-4c4a-b062-8e8ba299acef"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:13 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:11 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef
@@ -14374,7 +13318,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f18d0603b6744e0a91128ce16d025d29
+      - 5a1255aba0874c1faf9a4fd61b559665
   response:
     status:
       code: 200
@@ -14385,9 +13329,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-b742d210-84ee-48f5-a2fc-4361c460d5fe
+      - req-1998adb3-1b8d-4b4f-8ee1-4d826cac9303
       Date:
-      - Thu, 03 Jan 2019 19:26:13 GMT
+      - Fri, 04 Jan 2019 16:58:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab",
@@ -14430,7 +13374,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "c06c0e71-2c18-43a9-ace9-91242f0251e2",
         "security_group_id": "98bfc20c-a897-42c5-b33c-f0d8317667ab"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:13 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:11 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab
@@ -14445,7 +13389,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f18d0603b6744e0a91128ce16d025d29
+      - 5a1255aba0874c1faf9a4fd61b559665
   response:
     status:
       code: 200
@@ -14456,9 +13400,9 @@ http_interactions:
       Content-Length:
       - '2717'
       X-Openstack-Request-Id:
-      - req-f45f7c57-e032-48bb-af07-8b13967a8891
+      - req-620b15a1-aa0b-4809-b9c7-76423221bcda
       Date:
-      - Thu, 03 Jan 2019 19:26:13 GMT
+      - Fri, 04 Jan 2019 16:58:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4",
@@ -14493,7 +13437,7 @@ http_interactions:
         null, "port_range_min": null, "id": "75924ebc-4758-4042-ad04-4ef3c9189098",
         "security_group_id": "e4836528-d0df-425e-a117-ae8ec6f356d4"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:13 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:11 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4
@@ -14508,7 +13452,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f18d0603b6744e0a91128ce16d025d29
+      - 5a1255aba0874c1faf9a4fd61b559665
   response:
     status:
       code: 200
@@ -14519,9 +13463,9 @@ http_interactions:
       Content-Length:
       - '7080'
       X-Openstack-Request-Id:
-      - req-d6a32e8d-cb5c-4a1b-bcff-c81ceb568691
+      - req-39de39cf-2855-45f1-8aa5-988b859fb41d
       Date:
-      - Thu, 03 Jan 2019 19:26:13 GMT
+      - Fri, 04 Jan 2019 16:58:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=fd147cb7-7456-43d9-a01f-c06e21b4e6fb&page_reverse=True",
@@ -14608,7 +13552,7 @@ http_interactions:
         "port_range_max": 80, "port_range_min": 80, "id": "f79f0e32-b186-4778-952e-20827a60ef73",
         "security_group_id": "fd147cb7-7456-43d9-a01f-c06e21b4e6fb"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:13 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:11 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000
@@ -14623,7 +13567,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0c68ca26f1c2410583445fc927dc23f1
+      - 60fc0d5603144c02b441088d45ba35d5
   response:
     status:
       code: 200
@@ -14634,9 +13578,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-723c401e-760a-405e-a489-f0150e99f0d6
+      - req-2eeb00a7-e09a-494e-b7a6-e5b6a2e43169
       Date:
-      - Thu, 03 Jan 2019 19:26:14 GMT
+      - Fri, 04 Jan 2019 16:58:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef",
@@ -14678,7 +13622,7 @@ http_interactions:
         null, "port_range_min": null, "id": "ff24dfac-169a-4238-b78b-ed1536a0bf06",
         "security_group_id": "5b2b42a6-1271-4c4a-b062-8e8ba299acef"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:14 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:11 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef
@@ -14693,7 +13637,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0c68ca26f1c2410583445fc927dc23f1
+      - 60fc0d5603144c02b441088d45ba35d5
   response:
     status:
       code: 200
@@ -14704,9 +13648,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-6743007b-1f7f-418b-a7a9-08d7157774fc
+      - req-7809e354-f3fa-4b82-ab90-558623bd2f22
       Date:
-      - Thu, 03 Jan 2019 19:26:14 GMT
+      - Fri, 04 Jan 2019 16:58:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab",
@@ -14749,7 +13693,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "c06c0e71-2c18-43a9-ace9-91242f0251e2",
         "security_group_id": "98bfc20c-a897-42c5-b33c-f0d8317667ab"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:14 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:11 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab
@@ -14764,7 +13708,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0c68ca26f1c2410583445fc927dc23f1
+      - 60fc0d5603144c02b441088d45ba35d5
   response:
     status:
       code: 200
@@ -14775,9 +13719,9 @@ http_interactions:
       Content-Length:
       - '2717'
       X-Openstack-Request-Id:
-      - req-5a67c481-19d5-4d62-a687-80fbd09d8ec5
+      - req-50f399ed-ed50-480e-b1df-e4d0fe2abea6
       Date:
-      - Thu, 03 Jan 2019 19:26:14 GMT
+      - Fri, 04 Jan 2019 16:58:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4",
@@ -14812,7 +13756,7 @@ http_interactions:
         null, "port_range_min": null, "id": "75924ebc-4758-4042-ad04-4ef3c9189098",
         "security_group_id": "e4836528-d0df-425e-a117-ae8ec6f356d4"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:14 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:11 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4
@@ -14827,7 +13771,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0c68ca26f1c2410583445fc927dc23f1
+      - 60fc0d5603144c02b441088d45ba35d5
   response:
     status:
       code: 200
@@ -14838,9 +13782,9 @@ http_interactions:
       Content-Length:
       - '7080'
       X-Openstack-Request-Id:
-      - req-719de4a7-91b6-47dd-b518-33f988054449
+      - req-a522b8c1-6997-4930-ba65-093230a2be59
       Date:
-      - Thu, 03 Jan 2019 19:26:14 GMT
+      - Fri, 04 Jan 2019 16:58:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=fd147cb7-7456-43d9-a01f-c06e21b4e6fb&page_reverse=True",
@@ -14927,7 +13871,7 @@ http_interactions:
         "port_range_max": 80, "port_range_min": 80, "id": "f79f0e32-b186-4778-952e-20827a60ef73",
         "security_group_id": "fd147cb7-7456-43d9-a01f-c06e21b4e6fb"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:14 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:12 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000
@@ -14942,7 +13886,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e8d70d727cc74cc9b3ce6241980332d5
+      - 68abdb329a8f4548bbaeaed4e794523c
   response:
     status:
       code: 200
@@ -14953,9 +13897,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-fd001f5f-7687-4b16-8f3f-1319cd1c33ba
+      - req-f4d86870-12e5-4137-9502-9451e2fc52a9
       Date:
-      - Thu, 03 Jan 2019 19:26:14 GMT
+      - Fri, 04 Jan 2019 16:58:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef",
@@ -14997,7 +13941,7 @@ http_interactions:
         null, "port_range_min": null, "id": "ff24dfac-169a-4238-b78b-ed1536a0bf06",
         "security_group_id": "5b2b42a6-1271-4c4a-b062-8e8ba299acef"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:14 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:12 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef
@@ -15012,7 +13956,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e8d70d727cc74cc9b3ce6241980332d5
+      - 68abdb329a8f4548bbaeaed4e794523c
   response:
     status:
       code: 200
@@ -15023,9 +13967,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-151b342a-e183-4f83-b18a-707f47c5bead
+      - req-9dd16fc8-3da7-45d9-b63b-235129045e11
       Date:
-      - Thu, 03 Jan 2019 19:26:14 GMT
+      - Fri, 04 Jan 2019 16:58:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab",
@@ -15068,7 +14012,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "c06c0e71-2c18-43a9-ace9-91242f0251e2",
         "security_group_id": "98bfc20c-a897-42c5-b33c-f0d8317667ab"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:14 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:12 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab
@@ -15083,7 +14027,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e8d70d727cc74cc9b3ce6241980332d5
+      - 68abdb329a8f4548bbaeaed4e794523c
   response:
     status:
       code: 200
@@ -15094,9 +14038,9 @@ http_interactions:
       Content-Length:
       - '2717'
       X-Openstack-Request-Id:
-      - req-a6bf0a41-6b7a-4248-82b7-153a56dbcb53
+      - req-24202f17-9975-4a12-ba4d-1a6b8e693019
       Date:
-      - Thu, 03 Jan 2019 19:26:14 GMT
+      - Fri, 04 Jan 2019 16:58:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4",
@@ -15131,7 +14075,7 @@ http_interactions:
         null, "port_range_min": null, "id": "75924ebc-4758-4042-ad04-4ef3c9189098",
         "security_group_id": "e4836528-d0df-425e-a117-ae8ec6f356d4"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:14 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:12 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4
@@ -15146,7 +14090,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e8d70d727cc74cc9b3ce6241980332d5
+      - 68abdb329a8f4548bbaeaed4e794523c
   response:
     status:
       code: 200
@@ -15157,9 +14101,9 @@ http_interactions:
       Content-Length:
       - '7080'
       X-Openstack-Request-Id:
-      - req-64ac516d-ca23-49eb-8a15-c9c56f4b8a99
+      - req-90a9ae1f-4566-4a8e-b42a-f15f6b3dbb4e
       Date:
-      - Thu, 03 Jan 2019 19:26:14 GMT
+      - Fri, 04 Jan 2019 16:58:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=fd147cb7-7456-43d9-a01f-c06e21b4e6fb&page_reverse=True",
@@ -15246,7 +14190,7 @@ http_interactions:
         "port_range_max": 80, "port_range_min": 80, "id": "f79f0e32-b186-4778-952e-20827a60ef73",
         "security_group_id": "fd147cb7-7456-43d9-a01f-c06e21b4e6fb"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:14 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:12 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -15264,13 +14208,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:26:15 GMT
+      - Fri, 04 Jan 2019 16:58:13 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-30ff7c77-ab8c-47c9-b6c9-0cb92d4bf4f6
+      - req-a78ad2f4-df09-48e0-86ef-b47258cfd18c
       Content-Length:
       - '4170'
       Connection:
@@ -15279,10 +14223,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:26:15.585342", "expires":
-        "2019-01-03T20:26:15Z", "id": "d8739ec54a394c99a2b93239693cf1f6", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:58:13.187227", "expires":
+        "2019-01-04T17:58:13Z", "id": "9407fa996925498aa857249b75e7bec1", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["RHVSkjqFROaBsTzrcjMWHg"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["1VtWd8ejQZ6jyGValqsiEw"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -15327,7 +14271,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:15 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:13 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -15345,13 +14289,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:26:15 GMT
+      - Fri, 04 Jan 2019 16:58:13 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-59fa7dbe-256f-4141-8016-86d535e51e96
+      - req-7fc67c42-0eb4-4f5b-95d1-840324c4f22b
       Content-Length:
       - '4170'
       Connection:
@@ -15360,10 +14304,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:26:15.784961", "expires":
-        "2019-01-03T20:26:15Z", "id": "b75fd184ff124df38726ddabda5ade95", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:58:13.380931", "expires":
+        "2019-01-04T17:58:13Z", "id": "aa825b7596ec4ff5be84eb91b84b9ef5", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["kPgkA_C3SZCSxZ_E9U6fGg"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["S1uNprYhQe6WHhfuLoAC_g"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -15408,7 +14352,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:15 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:13 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -15426,13 +14370,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:26:15 GMT
+      - Fri, 04 Jan 2019 16:58:13 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-c1038dec-0c10-4a9f-bcb2-78ff255b9701
+      - req-d3b35259-fbbc-4de7-af3e-dd3fc9dbbdff
       Content-Length:
       - '370'
       Connection:
@@ -15441,13 +14385,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:26:15.949284", "expires":
-        "2019-01-03T20:26:15Z", "id": "da63663d3cbe45ffb07bb7a5fb995c07", "audit_ids":
-        ["SGbjo2BEQhq4ymqCVhUCcg"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:58:13.542399", "expires":
+        "2019-01-04T17:58:13Z", "id": "94c070d78ad043b6a8d481a74f9d7293", "audit_ids":
+        ["thbSidNuShaZuWETehzHVA"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:15 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:13 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -15462,20 +14406,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - da63663d3cbe45ffb07bb7a5fb995c07
+      - 94c070d78ad043b6a8d481a74f9d7293
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:26:16 GMT
+      - Fri, 04 Jan 2019 16:58:13 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-33e85b37-9fb7-4a59-aa66-8c181f0f4ea4
+      - req-597f986e-eeca-4868-8613-dec8159b774e
       Content-Length:
       - '500'
       Connection:
@@ -15492,7 +14436,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:16 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:13 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -15510,13 +14454,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:26:16 GMT
+      - Fri, 04 Jan 2019 16:58:13 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-51793494-44d9-45d3-803a-ad759d10456e
+      - req-c800ee4d-11e8-4840-bfe1-17f064ff5f59
       Content-Length:
       - '4117'
       Connection:
@@ -15525,10 +14469,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:26:16.271386", "expires":
-        "2019-01-03T20:26:16Z", "id": "865dd18321b94d7fbabbba754745ea93", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:58:13.880131", "expires":
+        "2019-01-04T17:58:13Z", "id": "7f3a87776bf0407a861a8dcbfd1b4683", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["HbjguA4aSdyXTBXhnsVdmA"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["13B52BiaRSK-90DlM72Dwg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -15572,7 +14516,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:16 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:13 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -15590,13 +14534,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:26:16 GMT
+      - Fri, 04 Jan 2019 16:58:14 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-429eaa72-1359-421c-b130-76ce898eba71
+      - req-5d7fc1e7-85b3-49f7-bf8c-2c04d6890d02
       Content-Length:
       - '4131'
       Connection:
@@ -15605,10 +14549,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:26:16.462448", "expires":
-        "2019-01-03T20:26:16Z", "id": "680b56dee1454cd9af0d2d8c5d0f5e01", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:58:14.069609", "expires":
+        "2019-01-04T17:58:14Z", "id": "194b33def3824e5a971b49904ace153b", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["Ee-WFgKxTQivWJz7ZDEjRQ"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["FTTJKX27QOyTcOv1aXzPPg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -15652,7 +14596,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:16 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:14 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -15670,13 +14614,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:26:16 GMT
+      - Fri, 04 Jan 2019 16:58:14 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-04350c41-cab0-48a5-b66f-aa7bc741e8dc
+      - req-209241ec-5c46-4590-85a5-b1c5e107f48b
       Content-Length:
       - '4118'
       Connection:
@@ -15685,10 +14629,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:26:16.646214", "expires":
-        "2019-01-03T20:26:16Z", "id": "80d7bffc67084c4dad31d20fae8fe4b2", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:58:14.287551", "expires":
+        "2019-01-04T17:58:14Z", "id": "83e6da66a9a54ec98a9a0d9398bc264c", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["WRC9UZY9QgWj_mJZH1oCXg"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["coKRbPS0SM6qJfnKDaLMRA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -15732,7 +14676,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:16 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:14 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000
@@ -15747,22 +14691,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 865dd18321b94d7fbabbba754745ea93
+      - 7f3a87776bf0407a861a8dcbfd1b4683
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-7abf49e0-5e8a-4bdb-a641-0e2861557289
+      - req-f3f7927c-d029-45a1-9136-d4e245cd5093
       Content-Type:
       - application/json
       Content-Length:
       - '2706'
       X-Openstack-Request-Id:
-      - req-7abf49e0-5e8a-4bdb-a641-0e2861557289
+      - req-f3f7927c-d029-45a1-9136-d4e245cd5093
       Date:
-      - Thu, 03 Jan 2019 19:26:16 GMT
+      - Fri, 04 Jan 2019 16:58:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=9bb99818-b339-4e31-b87f-e4181ec48acd",
@@ -15795,7 +14739,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-4", "bootable": "true", "created_at":
         "2016-11-11T13:49:53.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:16 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:14 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=9bb99818-b339-4e31-b87f-e4181ec48acd
@@ -15810,22 +14754,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 865dd18321b94d7fbabbba754745ea93
+      - 7f3a87776bf0407a861a8dcbfd1b4683
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-26d8ea5f-1259-4d68-94c9-766e9eb3f985
+      - req-dc023722-65af-4456-a9e7-bf0383d64d7b
       Content-Type:
       - application/json
       Content-Length:
       - '3284'
       X-Openstack-Request-Id:
-      - req-26d8ea5f-1259-4d68-94c9-766e9eb3f985
+      - req-dc023722-65af-4456-a9e7-bf0383d64d7b
       Date:
-      - Thu, 03 Jan 2019 19:26:17 GMT
+      - Fri, 04 Jan 2019 16:58:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=2c774148-c11a-434c-aabb-7fa9c82c37ce",
@@ -15866,7 +14810,7 @@ http_interactions:
         "name": "EmsRefreshSpec-Volume-2", "bootable": "false", "created_at": "2016-11-11T13:49:43.000000",
         "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:17 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:14 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=2c774148-c11a-434c-aabb-7fa9c82c37ce
@@ -15881,22 +14825,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 865dd18321b94d7fbabbba754745ea93
+      - 7f3a87776bf0407a861a8dcbfd1b4683
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-84d4d7c7-958b-4311-b10f-88057494e8cc
+      - req-3df57ca9-befe-42d8-9f98-bd13ecaf16ea
       Content-Type:
       - application/json
       Content-Length:
       - '2753'
       X-Openstack-Request-Id:
-      - req-84d4d7c7-958b-4311-b10f-88057494e8cc
+      - req-3df57ca9-befe-42d8-9f98-bd13ecaf16ea
       Date:
-      - Thu, 03 Jan 2019 19:26:17 GMT
+      - Fri, 04 Jan 2019 16:58:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=0a55c0d5-c780-4e7d-9d09-47f5520c7448",
@@ -15930,7 +14874,7 @@ http_interactions:
         "bootable": "false", "created_at": "2016-11-11T13:49:20.000000", "volume_type":
         "iscsi"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:17 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:14 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=0a55c0d5-c780-4e7d-9d09-47f5520c7448
@@ -15945,27 +14889,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 865dd18321b94d7fbabbba754745ea93
+      - 7f3a87776bf0407a861a8dcbfd1b4683
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-df038844-575a-4a7f-9e39-9463007e0a21
+      - req-d7e387fa-e068-41d5-972a-a746185d27bf
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-df038844-575a-4a7f-9e39-9463007e0a21
+      - req-d7e387fa-e068-41d5-972a-a746185d27bf
       Date:
-      - Thu, 03 Jan 2019 19:26:17 GMT
+      - Fri, 04 Jan 2019 16:58:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:17 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:15 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/volumes/detail?limit=1000
@@ -15980,27 +14924,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 680b56dee1454cd9af0d2d8c5d0f5e01
+      - 194b33def3824e5a971b49904ace153b
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-f3a43827-e1ff-436c-ba96-ffd34abde6c0
+      - req-5b8e870f-37d9-40d1-839b-28703dac132f
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-f3a43827-e1ff-436c-ba96-ffd34abde6c0
+      - req-5b8e870f-37d9-40d1-839b-28703dac132f
       Date:
-      - Thu, 03 Jan 2019 19:26:17 GMT
+      - Fri, 04 Jan 2019 16:58:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:17 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:15 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/volumes/detail?limit=1000
@@ -16015,27 +14959,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b75fd184ff124df38726ddabda5ade95
+      - aa825b7596ec4ff5be84eb91b84b9ef5
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-b89b4471-d03d-4601-9064-0354d415cfbc
+      - req-62cb09e8-eb39-4e2f-91dc-902e7c40866c
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-b89b4471-d03d-4601-9064-0354d415cfbc
+      - req-62cb09e8-eb39-4e2f-91dc-902e7c40866c
       Date:
-      - Thu, 03 Jan 2019 19:26:17 GMT
+      - Fri, 04 Jan 2019 16:58:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:18 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:15 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/volumes/detail?limit=1000
@@ -16050,27 +14994,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 80d7bffc67084c4dad31d20fae8fe4b2
+      - 83e6da66a9a54ec98a9a0d9398bc264c
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-221500a6-8dce-49c2-9f59-c60ca55b3f07
+      - req-df320aaf-a661-4e6d-93c6-e3c095260f15
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-221500a6-8dce-49c2-9f59-c60ca55b3f07
+      - req-df320aaf-a661-4e6d-93c6-e3c095260f15
       Date:
-      - Thu, 03 Jan 2019 19:26:18 GMT
+      - Fri, 04 Jan 2019 16:58:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:18 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:15 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail
@@ -16085,22 +15029,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 865dd18321b94d7fbabbba754745ea93
+      - 7f3a87776bf0407a861a8dcbfd1b4683
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-5203981e-db01-40f8-8862-51256260e980
+      - req-391614b6-c236-4319-9840-02f9423961f1
       Content-Type:
       - application/json
       Content-Length:
       - '1053'
       X-Openstack-Request-Id:
-      - req-5203981e-db01-40f8-8862-51256260e980
+      - req-391614b6-c236-4319-9840-02f9423961f1
       Date:
-      - Thu, 03 Jan 2019 19:26:18 GMT
+      - Fri, 04 Jan 2019 16:58:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?marker=76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
@@ -16115,7 +15059,7 @@ http_interactions:
         "created_at": "2016-11-11T13:49:36.000000", "size": 1, "id": "76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:18 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:15 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?limit=1000
@@ -16130,22 +15074,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 865dd18321b94d7fbabbba754745ea93
+      - 7f3a87776bf0407a861a8dcbfd1b4683
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-3b948515-1463-4d8b-9ff1-b8e05b495ac6
+      - req-962baff3-1287-446b-95d5-236b1a79d4a6
       Content-Type:
       - application/json
       Content-Length:
       - '1064'
       X-Openstack-Request-Id:
-      - req-3b948515-1463-4d8b-9ff1-b8e05b495ac6
+      - req-962baff3-1287-446b-95d5-236b1a79d4a6
       Date:
-      - Thu, 03 Jan 2019 19:26:18 GMT
+      - Fri, 04 Jan 2019 16:58:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?limit=1000&marker=76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
@@ -16160,7 +15104,7 @@ http_interactions:
         "created_at": "2016-11-11T13:49:36.000000", "size": 1, "id": "76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:18 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:15 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/snapshots/detail
@@ -16175,27 +15119,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 680b56dee1454cd9af0d2d8c5d0f5e01
+      - 194b33def3824e5a971b49904ace153b
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-fbf2de9b-5abb-4a63-87d7-b861505d3b5f
+      - req-ad2a43d5-2c13-4229-bc41-c2b0d551145a
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-fbf2de9b-5abb-4a63-87d7-b861505d3b5f
+      - req-ad2a43d5-2c13-4229-bc41-c2b0d551145a
       Date:
-      - Thu, 03 Jan 2019 19:26:18 GMT
+      - Fri, 04 Jan 2019 16:58:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:18 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:16 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/snapshots/detail?limit=1000
@@ -16210,27 +15154,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 680b56dee1454cd9af0d2d8c5d0f5e01
+      - 194b33def3824e5a971b49904ace153b
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-e1d23291-2cf9-420e-ae2a-fe88ceba083f
+      - req-08cc7355-2dc4-4fae-9962-283301347964
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-e1d23291-2cf9-420e-ae2a-fe88ceba083f
+      - req-08cc7355-2dc4-4fae-9962-283301347964
       Date:
-      - Thu, 03 Jan 2019 19:26:19 GMT
+      - Fri, 04 Jan 2019 16:58:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:19 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:16 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/snapshots/detail
@@ -16245,27 +15189,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b75fd184ff124df38726ddabda5ade95
+      - aa825b7596ec4ff5be84eb91b84b9ef5
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-00a00192-8d35-43c6-af77-92ede07e70b5
+      - req-76f86629-668b-41e2-b1d4-39e39d6cf7b9
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-00a00192-8d35-43c6-af77-92ede07e70b5
+      - req-76f86629-668b-41e2-b1d4-39e39d6cf7b9
       Date:
-      - Thu, 03 Jan 2019 19:26:19 GMT
+      - Fri, 04 Jan 2019 16:58:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:19 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:16 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/snapshots/detail?limit=1000
@@ -16280,27 +15224,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b75fd184ff124df38726ddabda5ade95
+      - aa825b7596ec4ff5be84eb91b84b9ef5
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-60735f59-afe8-4956-b827-f5f5c87a5618
+      - req-337bac36-86bb-471a-8db6-b6e46b842b7c
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-60735f59-afe8-4956-b827-f5f5c87a5618
+      - req-337bac36-86bb-471a-8db6-b6e46b842b7c
       Date:
-      - Thu, 03 Jan 2019 19:26:19 GMT
+      - Fri, 04 Jan 2019 16:58:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:19 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:16 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/snapshots/detail
@@ -16315,27 +15259,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 80d7bffc67084c4dad31d20fae8fe4b2
+      - 83e6da66a9a54ec98a9a0d9398bc264c
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-0a8065d1-20ed-4e2a-b1f8-9b5dace9ad9e
+      - req-9cb275da-6ec0-4302-895c-1508a778db79
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-0a8065d1-20ed-4e2a-b1f8-9b5dace9ad9e
+      - req-9cb275da-6ec0-4302-895c-1508a778db79
       Date:
-      - Thu, 03 Jan 2019 19:26:20 GMT
+      - Fri, 04 Jan 2019 16:58:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:20 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:16 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/snapshots/detail?limit=1000
@@ -16350,27 +15294,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 80d7bffc67084c4dad31d20fae8fe4b2
+      - 83e6da66a9a54ec98a9a0d9398bc264c
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-4cad21c4-cfcc-4bc7-adb0-69ba8024d05b
+      - req-f776e520-7252-4ecb-8a43-9e65dcb98508
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-4cad21c4-cfcc-4bc7-adb0-69ba8024d05b
+      - req-f776e520-7252-4ecb-8a43-9e65dcb98508
       Date:
-      - Thu, 03 Jan 2019 19:26:20 GMT
+      - Fri, 04 Jan 2019 16:58:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:20 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:16 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/backups/detail
@@ -16385,27 +15329,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 865dd18321b94d7fbabbba754745ea93
+      - 7f3a87776bf0407a861a8dcbfd1b4683
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-0487736c-b6e7-4a75-952f-b5c3bf913367
+      - req-8799d713-d4d2-4a79-989a-2d8b7f2ffb4a
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-0487736c-b6e7-4a75-952f-b5c3bf913367
+      - req-8799d713-d4d2-4a79-989a-2d8b7f2ffb4a
       Date:
-      - Thu, 03 Jan 2019 19:26:20 GMT
+      - Fri, 04 Jan 2019 16:58:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:20 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:16 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/backups/detail?limit=1000
@@ -16420,27 +15364,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 865dd18321b94d7fbabbba754745ea93
+      - 7f3a87776bf0407a861a8dcbfd1b4683
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-b541e5ea-9c46-4dc6-a90e-a0022f0fa37e
+      - req-f991f9e2-231a-45c7-b426-da75068d9aa8
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-b541e5ea-9c46-4dc6-a90e-a0022f0fa37e
+      - req-f991f9e2-231a-45c7-b426-da75068d9aa8
       Date:
-      - Thu, 03 Jan 2019 19:26:20 GMT
+      - Fri, 04 Jan 2019 16:58:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:20 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:16 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/backups/detail
@@ -16455,27 +15399,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 680b56dee1454cd9af0d2d8c5d0f5e01
+      - 194b33def3824e5a971b49904ace153b
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-4bb2e7ba-c96c-4231-a633-12d00f1ebce2
+      - req-891a84e2-6c44-45ab-8b7f-7767c0541b9b
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-4bb2e7ba-c96c-4231-a633-12d00f1ebce2
+      - req-891a84e2-6c44-45ab-8b7f-7767c0541b9b
       Date:
-      - Thu, 03 Jan 2019 19:26:20 GMT
+      - Fri, 04 Jan 2019 16:58:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:20 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:17 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/backups/detail?limit=1000
@@ -16490,27 +15434,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 680b56dee1454cd9af0d2d8c5d0f5e01
+      - 194b33def3824e5a971b49904ace153b
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-d495fec3-6d72-4450-b28a-81c3070f703f
+      - req-f90906a3-f388-41d5-9c69-1544b07634a8
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-d495fec3-6d72-4450-b28a-81c3070f703f
+      - req-f90906a3-f388-41d5-9c69-1544b07634a8
       Date:
-      - Thu, 03 Jan 2019 19:26:20 GMT
+      - Fri, 04 Jan 2019 16:58:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:20 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:17 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/backups/detail
@@ -16525,27 +15469,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b75fd184ff124df38726ddabda5ade95
+      - aa825b7596ec4ff5be84eb91b84b9ef5
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-31e663e4-948a-4ee5-8952-0b2f161fd2ad
+      - req-18637745-59bb-4f38-a7ea-dd90049878c8
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-31e663e4-948a-4ee5-8952-0b2f161fd2ad
+      - req-18637745-59bb-4f38-a7ea-dd90049878c8
       Date:
-      - Thu, 03 Jan 2019 19:26:20 GMT
+      - Fri, 04 Jan 2019 16:58:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:20 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:17 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/backups/detail?limit=1000
@@ -16560,27 +15504,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b75fd184ff124df38726ddabda5ade95
+      - aa825b7596ec4ff5be84eb91b84b9ef5
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-fa184df5-e389-4735-b361-77d5f29c66bd
+      - req-98ea9c9c-a5de-462f-a830-7aa9bf4c2727
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-fa184df5-e389-4735-b361-77d5f29c66bd
+      - req-98ea9c9c-a5de-462f-a830-7aa9bf4c2727
       Date:
-      - Thu, 03 Jan 2019 19:26:20 GMT
+      - Fri, 04 Jan 2019 16:58:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:20 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:17 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/backups/detail
@@ -16595,27 +15539,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 80d7bffc67084c4dad31d20fae8fe4b2
+      - 83e6da66a9a54ec98a9a0d9398bc264c
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-c04e0bb9-57c0-46c0-a0d6-5aadebff841e
+      - req-6694f8f3-e02a-47e0-a9af-20f08ba4b51c
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-c04e0bb9-57c0-46c0-a0d6-5aadebff841e
+      - req-6694f8f3-e02a-47e0-a9af-20f08ba4b51c
       Date:
-      - Thu, 03 Jan 2019 19:26:20 GMT
+      - Fri, 04 Jan 2019 16:58:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:20 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:17 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/backups/detail?limit=1000
@@ -16630,27 +15574,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 80d7bffc67084c4dad31d20fae8fe4b2
+      - 83e6da66a9a54ec98a9a0d9398bc264c
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-f8dcbb76-d711-47b4-a72b-6469bc68bc48
+      - req-a3273990-4015-4e6b-baa6-a6f585a73753
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-f8dcbb76-d711-47b4-a72b-6469bc68bc48
+      - req-a3273990-4015-4e6b-baa6-a6f585a73753
       Date:
-      - Thu, 03 Jan 2019 19:26:21 GMT
+      - Fri, 04 Jan 2019 16:58:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:21 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:17 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/types?limit=1000
@@ -16665,22 +15609,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 865dd18321b94d7fbabbba754745ea93
+      - 7f3a87776bf0407a861a8dcbfd1b4683
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-b2a72bc1-c573-48d6-8991-a88032a3e792
+      - req-ea2f0e4a-7604-4b78-9bb6-a938ee7c85cb
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-b2a72bc1-c573-48d6-8991-a88032a3e792
+      - req-ea2f0e4a-7604-4b78-9bb6-a938ee7c85cb
       Date:
-      - Thu, 03 Jan 2019 19:26:21 GMT
+      - Fri, 04 Jan 2019 16:58:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -16692,7 +15636,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:21 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:17 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/types?limit=1000&marker=0d07f8c3-f295-48c7-b632-6b7d8bd860eb
@@ -16707,22 +15651,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 865dd18321b94d7fbabbba754745ea93
+      - 7f3a87776bf0407a861a8dcbfd1b4683
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-661b5b81-5649-4651-b844-0727c2399180
+      - req-fb07edcb-fc37-40a8-8c0c-ccd2874061bb
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-661b5b81-5649-4651-b844-0727c2399180
+      - req-fb07edcb-fc37-40a8-8c0c-ccd2874061bb
       Date:
-      - Thu, 03 Jan 2019 19:26:21 GMT
+      - Fri, 04 Jan 2019 16:58:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -16734,7 +15678,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:21 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:17 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/types?limit=1000
@@ -16749,22 +15693,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 680b56dee1454cd9af0d2d8c5d0f5e01
+      - 194b33def3824e5a971b49904ace153b
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-7274c015-3fa0-4cb9-a8b8-af428432ed13
+      - req-f38df004-a5ac-42df-958d-891be3bb07cd
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-7274c015-3fa0-4cb9-a8b8-af428432ed13
+      - req-f38df004-a5ac-42df-958d-891be3bb07cd
       Date:
-      - Thu, 03 Jan 2019 19:26:21 GMT
+      - Fri, 04 Jan 2019 16:58:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -16776,7 +15720,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:21 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:17 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/types?limit=1000&marker=0d07f8c3-f295-48c7-b632-6b7d8bd860eb
@@ -16791,22 +15735,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 680b56dee1454cd9af0d2d8c5d0f5e01
+      - 194b33def3824e5a971b49904ace153b
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-7b34201b-1ed4-4ad4-aebe-e75b73c798f8
+      - req-791b8342-288a-4b1c-b109-533321fc8ff7
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-7b34201b-1ed4-4ad4-aebe-e75b73c798f8
+      - req-791b8342-288a-4b1c-b109-533321fc8ff7
       Date:
-      - Thu, 03 Jan 2019 19:26:21 GMT
+      - Fri, 04 Jan 2019 16:58:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -16818,7 +15762,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:21 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:17 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/types?limit=1000
@@ -16833,22 +15777,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b75fd184ff124df38726ddabda5ade95
+      - aa825b7596ec4ff5be84eb91b84b9ef5
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-db1f5ca4-f918-4326-84eb-22db4c645171
+      - req-ab9486a4-02eb-42d6-8f3f-63dbf49f150d
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-db1f5ca4-f918-4326-84eb-22db4c645171
+      - req-ab9486a4-02eb-42d6-8f3f-63dbf49f150d
       Date:
-      - Thu, 03 Jan 2019 19:26:21 GMT
+      - Fri, 04 Jan 2019 16:58:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -16860,7 +15804,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:21 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:18 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/types?limit=1000&marker=0d07f8c3-f295-48c7-b632-6b7d8bd860eb
@@ -16875,22 +15819,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b75fd184ff124df38726ddabda5ade95
+      - aa825b7596ec4ff5be84eb91b84b9ef5
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-d0662627-d4ab-4916-93d4-6959e324af69
+      - req-4f8926de-858b-4139-ac8f-1381bda20291
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-d0662627-d4ab-4916-93d4-6959e324af69
+      - req-4f8926de-858b-4139-ac8f-1381bda20291
       Date:
-      - Thu, 03 Jan 2019 19:26:21 GMT
+      - Fri, 04 Jan 2019 16:58:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -16902,7 +15846,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:21 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:18 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/types?limit=1000
@@ -16917,22 +15861,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 80d7bffc67084c4dad31d20fae8fe4b2
+      - 83e6da66a9a54ec98a9a0d9398bc264c
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-e30fd9d1-88da-4e81-a4aa-0a0f3ca9c788
+      - req-1d71d6f5-eeb3-4bb3-be2a-838fa002d5fe
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-e30fd9d1-88da-4e81-a4aa-0a0f3ca9c788
+      - req-1d71d6f5-eeb3-4bb3-be2a-838fa002d5fe
       Date:
-      - Thu, 03 Jan 2019 19:26:21 GMT
+      - Fri, 04 Jan 2019 16:58:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -16944,7 +15888,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:21 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:18 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/types?limit=1000&marker=0d07f8c3-f295-48c7-b632-6b7d8bd860eb
@@ -16959,22 +15903,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 80d7bffc67084c4dad31d20fae8fe4b2
+      - 83e6da66a9a54ec98a9a0d9398bc264c
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-fdb889b4-5298-442c-b8be-5579ab4900b3
+      - req-9b22763c-4d94-44e2-ab71-edbdf42b1b03
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-fdb889b4-5298-442c-b8be-5579ab4900b3
+      - req-9b22763c-4d94-44e2-ab71-edbdf42b1b03
       Date:
-      - Thu, 03 Jan 2019 19:26:21 GMT
+      - Fri, 04 Jan 2019 16:58:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -16986,7 +15930,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:21 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:18 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -17004,13 +15948,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:26:22 GMT
+      - Fri, 04 Jan 2019 16:58:18 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-5a587402-c4a2-413c-b47a-32aa63bf92e8
+      - req-cd2d7166-33bb-46e3-9e96-60d5c8767c80
       Content-Length:
       - '4170'
       Connection:
@@ -17019,10 +15963,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:26:22.148106", "expires":
-        "2019-01-03T20:26:22Z", "id": "10826a0c92494a3691a2dae07d1c3ca5", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:58:18.570708", "expires":
+        "2019-01-04T17:58:18Z", "id": "935896390fa4497a8262d284613dbea6", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["MFef6Cl_QhqUxnXgQtt8gw"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["J4uwaHMeRReTOU08okOZ_g"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -17067,7 +16011,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:22 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:18 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -17085,13 +16029,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:26:22 GMT
+      - Fri, 04 Jan 2019 16:58:18 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-35014c2f-0cbb-4531-b25d-b274a500c048
+      - req-77074917-5587-4c71-b1f5-9550d6df1f8e
       Content-Length:
       - '4170'
       Connection:
@@ -17100,10 +16044,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:26:22.357407", "expires":
-        "2019-01-03T20:26:22Z", "id": "6e5427070b0e4a4390a4cee5a31e7788", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:58:18.766903", "expires":
+        "2019-01-04T17:58:18Z", "id": "ec9da1d4001d4625bf75349fb25d39b0", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["iS9BCFlKQRqLxI61l__QLA"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["NQHFDdQPT6q_dwj82W9sDw"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -17148,7 +16092,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:22 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:18 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -17166,13 +16110,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:26:22 GMT
+      - Fri, 04 Jan 2019 16:58:18 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-206e085a-b903-4b51-9453-8567512eb60a
+      - req-2e63907a-193c-4503-9e44-9c8863c7f44a
       Content-Length:
       - '370'
       Connection:
@@ -17181,13 +16125,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:26:22.516534", "expires":
-        "2019-01-03T20:26:22Z", "id": "36231d8a06a342619bf1b5f446901566", "audit_ids":
-        ["GcXepCUoQleNHyxl_6uhzQ"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:58:18.927523", "expires":
+        "2019-01-04T17:58:18Z", "id": "7ae193b46fbf456ca218728a340fe594", "audit_ids":
+        ["v0m7_JRnTxunDKwYBRJiQg"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:22 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:18 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -17202,20 +16146,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 36231d8a06a342619bf1b5f446901566
+      - 7ae193b46fbf456ca218728a340fe594
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:26:22 GMT
+      - Fri, 04 Jan 2019 16:58:19 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-58730005-f7ec-4aa8-81cd-c2dead179b1e
+      - req-f4780d8b-33cd-47e8-a1f1-b4ab922e08ac
       Content-Length:
       - '500'
       Connection:
@@ -17232,7 +16176,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:22 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:19 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -17250,13 +16194,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:26:22 GMT
+      - Fri, 04 Jan 2019 16:58:19 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-170460e6-d6d6-4b02-91cc-7ebad75d957f
+      - req-7e2ec35d-3399-4cde-be69-1488da4315ad
       Content-Length:
       - '4117'
       Connection:
@@ -17265,10 +16209,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:26:22.844662", "expires":
-        "2019-01-03T20:26:22Z", "id": "3a1293f11e6d42b2baa2ee9677898960", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:58:19.264453", "expires":
+        "2019-01-04T17:58:19Z", "id": "2a206dc2a91943829f0449e499dcf8c8", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["I4lDrWpeTN-SsprdDuytjQ"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["APdXPe0SS0qpZpo8prBvTA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -17312,7 +16256,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:22 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:19 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -17330,13 +16274,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:26:22 GMT
+      - Fri, 04 Jan 2019 16:58:19 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-1f2db8f9-6f5a-4c94-8f40-1b62bccde52c
+      - req-5e9ed7cd-c196-4437-95b5-2e7084cd846d
       Content-Length:
       - '4131'
       Connection:
@@ -17345,10 +16289,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:26:23.040834", "expires":
-        "2019-01-03T20:26:23Z", "id": "fd11330e154a439b9c27ce318608909a", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:58:19.458939", "expires":
+        "2019-01-04T17:58:19Z", "id": "7b1be7904a9040bfbfcfea0fece7f7ba", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["wzcHtAw0QYOMAMt3FISjzw"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["NQL7Bm6bTp23x8MUqZtEpg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -17392,7 +16336,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:23 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:19 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -17410,13 +16354,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:26:23 GMT
+      - Fri, 04 Jan 2019 16:58:19 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-9b06a5a4-8eb8-4743-96c5-4f55dbb065a7
+      - req-5f9cc073-9d6a-47fa-99c2-b3caf344c312
       Content-Length:
       - '4118'
       Connection:
@@ -17425,10 +16369,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:26:23.236856", "expires":
-        "2019-01-03T20:26:23Z", "id": "909269595a284a31837257c1d01b68c5", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:58:19.657868", "expires":
+        "2019-01-04T17:58:19Z", "id": "814c60ccd6f242619c93c7c12b7f4afb", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["jklYh2srTNGiTClPu7y8BA"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["2Jlno3lqSfuDQ0a3Z1d3FQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -17472,7 +16416,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:23 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:19 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/?format=json&limit=1000
@@ -17487,7 +16431,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3a1293f11e6d42b2baa2ee9677898960
+      - 2a206dc2a91943829f0449e499dcf8c8
   response:
     status:
       code: 200
@@ -17516,15 +16460,15 @@ http_interactions:
       X-Account-Project-Domain-Id:
       - default
       X-Trans-Id:
-      - txb89029d71fa74026b2eda-005c2e61df
+      - tx11331fe583214c4f997c4-005c2f90ab
       Date:
-      - Thu, 03 Jan 2019 19:26:23 GMT
+      - Fri, 04 Jan 2019 16:58:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '[{"count": 3, "bytes": 33, "name": "dir_1"}, {"count": 0, "bytes":
         0, "name": "dir_2"}, {"count": 0, "bytes": 0, "name": "dir_3"}]'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:23 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:19 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/?format=json&limit=1000&marker=dir_3
@@ -17539,7 +16483,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3a1293f11e6d42b2baa2ee9677898960
+      - 2a206dc2a91943829f0449e499dcf8c8
   response:
     status:
       code: 200
@@ -17568,14 +16512,14 @@ http_interactions:
       X-Account-Project-Domain-Id:
       - default
       X-Trans-Id:
-      - txdd50c45c47d84ffcbc238-005c2e61df
+      - tx7f2ad5caf92646a593f82-005c2f90ab
       Date:
-      - Thu, 03 Jan 2019 19:26:23 GMT
+      - Fri, 04 Jan 2019 16:58:19 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:23 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:19 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_b458a5c25c3749758f4c0661940b3ba8/?format=json&limit=1000
@@ -17590,7 +16534,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fd11330e154a439b9c27ce318608909a
+      - 7b1be7904a9040bfbfcfea0fece7f7ba
   response:
     status:
       code: 200
@@ -17603,22 +16547,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1546543583.68297'
+      - '1546621100.08024'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1546543583.68297'
+      - '1546621100.08024'
       X-Trans-Id:
-      - tx260da6cb62094c52ab995-005c2e61df
+      - tx3fcc9eb5159a4cf78b85b-005c2f90ac
       Date:
-      - Thu, 03 Jan 2019 19:26:23 GMT
+      - Fri, 04 Jan 2019 16:58:20 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:23 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:20 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_e54e5c3c19e34720b05661f2ea1ea00a/?format=json&limit=1000
@@ -17633,7 +16577,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6e5427070b0e4a4390a4cee5a31e7788
+      - ec9da1d4001d4625bf75349fb25d39b0
   response:
     status:
       code: 200
@@ -17646,22 +16590,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1546543583.89081'
+      - '1546621100.28903'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1546543583.89081'
+      - '1546621100.28903'
       X-Trans-Id:
-      - tx11084ae9e09e42cb91e6e-005c2e61df
+      - txdab8796111d5490a8570c-005c2f90ac
       Date:
-      - Thu, 03 Jan 2019 19:26:23 GMT
+      - Fri, 04 Jan 2019 16:58:20 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:23 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:20 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_e8f744b1fc6a487681d35fb275252608/?format=json&limit=1000
@@ -17676,7 +16620,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 909269595a284a31837257c1d01b68c5
+      - 814c60ccd6f242619c93c7c12b7f4afb
   response:
     status:
       code: 200
@@ -17689,22 +16633,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1546543584.10032'
+      - '1546621100.43978'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1546543584.10032'
+      - '1546621100.43978'
       X-Trans-Id:
-      - tx27ecb57ef06f4c1c864c5-005c2e61df
+      - txf0ceabfb7d014d1aa83e5-005c2f90ac
       Date:
-      - Thu, 03 Jan 2019 19:26:24 GMT
+      - Fri, 04 Jan 2019 16:58:20 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:24 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:20 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/dir_1?format=json
@@ -17719,7 +16663,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3a1293f11e6d42b2baa2ee9677898960
+      - 2a206dc2a91943829f0449e499dcf8c8
   response:
     status:
       code: 200
@@ -17740,9 +16684,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - tx2d1589b981144f8da7cee-005c2e61e0
+      - tx064e9b9c47644fd19ffaa-005c2f90ac
       Date:
-      - Thu, 03 Jan 2019 19:26:24 GMT
+      - Fri, 04 Jan 2019 16:58:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '[{"hash": "61257bf228e2f6802a196c9a460d19a8", "last_modified": "2016-11-11T13:50:03.869630",
@@ -17752,7 +16696,7 @@ http_interactions:
         {"hash": "1727a9b61bddf85bbe7a5710c9f45691", "last_modified": "2016-11-11T13:50:04.495640",
         "bytes": 11, "name": "file_3", "content_type": "application/octet-stream"}]'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:24 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:20 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/dir_2?format=json
@@ -17767,7 +16711,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3a1293f11e6d42b2baa2ee9677898960
+      - 2a206dc2a91943829f0449e499dcf8c8
   response:
     status:
       code: 200
@@ -17788,14 +16732,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - txc1a8138532e84dcc91003-005c2e61e0
+      - tx8a8b6f93f39445a09bf55-005c2f90ac
       Date:
-      - Thu, 03 Jan 2019 19:26:24 GMT
+      - Fri, 04 Jan 2019 16:58:20 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:24 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:20 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/dir_3?format=json
@@ -17810,7 +16754,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3a1293f11e6d42b2baa2ee9677898960
+      - 2a206dc2a91943829f0449e499dcf8c8
   response:
     status:
       code: 200
@@ -17831,14 +16775,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - txe91506a98d944ebd81f73-005c2e61e0
+      - tx4573c350280b49c6a3ece-005c2f90ac
       Date:
-      - Thu, 03 Jan 2019 19:26:24 GMT
+      - Fri, 04 Jan 2019 16:58:20 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:24 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:20 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/networks/20af6027-7aeb-432a-ab3b-d7217faa2f1c
@@ -17853,7 +16797,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 376552830778498eb2217225cf33f31c
+      - 7652a698c18248aa891dbcf62beb1f43
   response:
     status:
       code: 200
@@ -17864,9 +16808,9 @@ http_interactions:
       Content-Length:
       - '409'
       X-Openstack-Request-Id:
-      - req-e1de5977-ae8d-4a5c-af88-d59237325a92
+      - req-4cfc26d9-745e-499d-9a4e-b8c1244d9fb9
       Date:
-      - Thu, 03 Jan 2019 19:26:24 GMT
+      - Fri, 04 Jan 2019 16:58:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"network": {"status": "ACTIVE", "subnets": ["33da95a6-bded-44d8-be36-6cc97f3d72bd"],
@@ -17876,7 +16820,7 @@ http_interactions:
         "id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "provider:segmentation_id":
         null}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:24 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:21 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -17891,7 +16835,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8ebfa48b16c14e85815bba18ad1fac5c
+      - 11754ea894fd4f0a99b6c0ca075ce4e3
   response:
     status:
       code: 200
@@ -17902,144 +16846,29 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-d19f0da5-973a-498a-9dd2-4776d635f38d
+      - req-51b099a4-72e4-46f9-a08c-1cdf52494823
       Date:
-      - Thu, 03 Jan 2019 19:26:24 GMT
+      - Fri, 04 Jan 2019 16:58:21 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
-        true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
         true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:24 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 8ebfa48b16c14e85815bba18ad1fac5c
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-750a929d-93de-4ba8-be97-ae223ebabd3b
-      Date:
-      - Thu, 03 Jan 2019 19:26:25 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
@@ -18110,155 +16939,6 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
         "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:25 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 8ebfa48b16c14e85815bba18ad1fac5c
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-a91d5fd9-b278-410f-8469-7b21e2a4fa21
-      Date:
-      - Thu, 03 Jan 2019 19:26:25 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
-        true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
         "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
@@ -18272,7 +16952,7 @@ http_interactions:
         4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
         "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:25 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:21 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
@@ -18287,7 +16967,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8ebfa48b16c14e85815bba18ad1fac5c
+      - 11754ea894fd4f0a99b6c0ca075ce4e3
   response:
     status:
       code: 200
@@ -18298,408 +16978,29 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-7a0d2e66-659e-4509-b4b7-82f3346432d1
+      - req-d0cc8e05-5cbb-4965-8425-7a1b33be3202
       Date:
-      - Thu, 03 Jan 2019 19:26:25 GMT
+      - Fri, 04 Jan 2019 16:58:21 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
-        true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
         true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:25 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - adadc4eb7ecf4c329792b437f359cae4
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-a933125a-5f05-4f07-ac8a-b1bcd972b684
-      Date:
-      - Thu, 03 Jan 2019 19:26:25 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
-        true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:25 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - adadc4eb7ecf4c329792b437f359cae4
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-a1cf1533-be92-41df-bf19-8ca85ef42eba
-      Date:
-      - Thu, 03 Jan 2019 19:26:25 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
-        true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:25 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 376552830778498eb2217225cf33f31c
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-50d428d1-9d0e-433b-9e6a-fd6d7b82535f
-      Date:
-      - Thu, 03 Jan 2019 19:26:25 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
@@ -18770,155 +17071,6 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
         "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:26 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 376552830778498eb2217225cf33f31c
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-67ddb4ce-5c7d-4de8-9942-63f1255436f7
-      Date:
-      - Thu, 03 Jan 2019 19:26:26 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
-        true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
         "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
@@ -18932,667 +17084,7 @@ http_interactions:
         4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
         "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:26 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 376552830778498eb2217225cf33f31c
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-59ffa47b-6f7e-4222-980b-0638f7696410
-      Date:
-      - Thu, 03 Jan 2019 19:26:26 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:26 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 376552830778498eb2217225cf33f31c
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-3f472c3e-e0d9-4c76-96f4-9ceb5b508d28
-      Date:
-      - Thu, 03 Jan 2019 19:26:26 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
-        true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:26 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 376552830778498eb2217225cf33f31c
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-48879956-d95b-4b64-9612-1359eb52a666
-      Date:
-      - Thu, 03 Jan 2019 19:26:26 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:26 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 376552830778498eb2217225cf33f31c
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-29fa25f8-e5f3-46fb-a005-919d3e68f04e
-      Date:
-      - Thu, 03 Jan 2019 19:26:26 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
-        true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:26 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 376552830778498eb2217225cf33f31c
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-827e2251-eeb2-4282-be84-1c36b8bc5f7c
-      Date:
-      - Thu, 03 Jan 2019 19:26:26 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
-        true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:27 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:21 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -19607,7 +17099,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e0fcb08193154676a894281b6737bf26
+      - e293ae9eb4e44d3dae28f8eef1912c29
   response:
     status:
       code: 200
@@ -19618,19 +17110,13 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-f561d279-34e6-4aec-ab23-76a1a2cb1638
+      - req-80e19137-edc8-4e5c-ad0f-87e7ae111775
       Date:
-      - Thu, 03 Jan 2019 19:26:27 GMT
+      - Fri, 04 Jan 2019 16:58:21 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
-        true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp":
+        true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
@@ -19711,6 +17197,12 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
         "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
         "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
@@ -19724,7 +17216,7 @@ http_interactions:
         4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
         "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:27 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:21 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
@@ -19739,7 +17231,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e0fcb08193154676a894281b6737bf26
+      - e293ae9eb4e44d3dae28f8eef1912c29
   response:
     status:
       code: 200
@@ -19750,19 +17242,541 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-6664c809-f338-4429-b5e2-8440d9185440
+      - req-9ebfce0e-96fe-4c7c-aa49-64bc5085597b
       Date:
-      - Thu, 03 Jan 2019 19:26:27 GMT
+      - Fri, 04 Jan 2019 16:58:21 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
-        true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
         "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
         "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Fri, 04 Jan 2019 16:58:21 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 7652a698c18248aa891dbcf62beb1f43
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-1ab14052-e984-4de1-87c8-55bcd4451563
+      Date:
+      - Fri, 04 Jan 2019 16:58:21 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Fri, 04 Jan 2019 16:58:21 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 7652a698c18248aa891dbcf62beb1f43
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-192c203b-547a-4ac8-8f7e-7a3c30337423
+      Date:
+      - Fri, 04 Jan 2019 16:58:22 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Fri, 04 Jan 2019 16:58:22 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - ce439edfd73d4a4f8827b922fefc45f8
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-e0a8f2fb-4c05-4b7a-a4ca-4abc66cc9afc
+      Date:
+      - Fri, 04 Jan 2019 16:58:22 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Fri, 04 Jan 2019 16:58:22 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - ce439edfd73d4a4f8827b922fefc45f8
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-e919287b-0906-4c10-b001-2dc0d06e5d9a
+      Date:
+      - Fri, 04 Jan 2019 16:58:22 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp":
+        true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
@@ -19843,6 +17857,12 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
         "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
         "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
@@ -19856,5 +17876,5 @@ http_interactions:
         4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
         "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:27 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:22 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_port_targeted_refresh.yml
+++ b/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_port_targeted_refresh.yml
@@ -17,13 +17,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:25:33 GMT
+      - Fri, 04 Jan 2019 16:57:11 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-9fe07695-6037-4943-ac7c-0ffbd2d79a25
+      - req-3d89fb71-de7e-4c37-b81b-cd49e877d1fc
       Content-Length:
       - '4170'
       Connection:
@@ -32,10 +32,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:25:33.094169", "expires":
-        "2019-01-03T20:25:33Z", "id": "78982324d90d444ab853da4ecd4b182f", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:57:11.979305", "expires":
+        "2019-01-04T17:57:11Z", "id": "f7e2399f5e754fbd817a97c71aaa652c", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["2L6HQnh4SYqqBRuqfrFdQg"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["eUHSNlTtQ3Gto1FOqPIexg"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -80,7 +80,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:33 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:12 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -95,7 +95,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 78982324d90d444ab853da4ecd4b182f
+      - f7e2399f5e754fbd817a97c71aaa652c
   response:
     status:
       code: 200
@@ -106,7 +106,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Thu, 03 Jan 2019 19:25:33 GMT
+      - Fri, 04 Jan 2019 16:57:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -115,7 +115,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:33 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:12 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -133,13 +133,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:25:33 GMT
+      - Fri, 04 Jan 2019 16:57:12 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-51a632ce-9dbe-4d72-8b0b-e9c9c8aea8dd
+      - req-f94b40de-dbe9-477c-abfc-b9543df5ae71
       Content-Length:
       - '4170'
       Connection:
@@ -148,10 +148,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:25:33.371083", "expires":
-        "2019-01-03T20:25:33Z", "id": "55f86548f67640fe96e71d17c791fa9a", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:57:12.282151", "expires":
+        "2019-01-04T17:57:12Z", "id": "523283e75c334e719620b7d36cbeac7f", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["w_BrHrWQRMeH6XTT0RvXlw"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["UQMTwICTS0WSE7dmyR7VWQ"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -196,7 +196,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:33 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:12 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -214,13 +214,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:25:33 GMT
+      - Fri, 04 Jan 2019 16:57:12 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-b9e3afb0-71af-4450-965b-ea1ea4be9b74
+      - req-568de171-5bca-4dd4-9140-adaf013f16b2
       Content-Length:
       - '370'
       Connection:
@@ -229,13 +229,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:25:33.535090", "expires":
-        "2019-01-03T20:25:33Z", "id": "bf6a8f8d7772454ead049d6c40073b7e", "audit_ids":
-        ["DQZQAJYPShOGWZdLvVHAmQ"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:57:12.447336", "expires":
+        "2019-01-04T17:57:12Z", "id": "25bebc71f4494b26893c3e39ef566b66", "audit_ids":
+        ["ARocDPogQsuEc0DBAa_xdA"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:33 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:12 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -250,20 +250,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bf6a8f8d7772454ead049d6c40073b7e
+      - 25bebc71f4494b26893c3e39ef566b66
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:25:33 GMT
+      - Fri, 04 Jan 2019 16:57:12 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-33fdf27b-6c61-420f-ba0b-737afe0a8c9c
+      - req-892e1cc9-b6bd-44e7-b211-be77a3fa38fe
       Content-Length:
       - '500'
       Connection:
@@ -280,7 +280,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:33 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:12 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -298,13 +298,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:25:33 GMT
+      - Fri, 04 Jan 2019 16:57:12 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-a1bf0fc2-4eac-44ef-a020-72b62d6f5c64
+      - req-831d50a1-bcd1-42d9-a172-70e8f2f6d39e
       Content-Length:
       - '4117'
       Connection:
@@ -313,10 +313,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:25:33.871376", "expires":
-        "2019-01-03T20:25:33Z", "id": "aca158ef39b04f9fa4d7ce1081c9c644", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:57:12.781460", "expires":
+        "2019-01-04T17:57:12Z", "id": "0e457aafec9b4bda9b5da869d2b04101", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["IERl-kgAQs-oKkIfg4LzJQ"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["5-DWuHwSS7eh_QSObvYjwQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -360,7 +360,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:33 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:12 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -378,13 +378,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:25:34 GMT
+      - Fri, 04 Jan 2019 16:57:12 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-8b0b4439-144d-4719-8060-4cf1f0889a05
+      - req-6479b61e-1cea-41b1-8c84-d1608635356d
       Content-Length:
       - '4131'
       Connection:
@@ -393,10 +393,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:25:34.058443", "expires":
-        "2019-01-03T20:25:34Z", "id": "b03c8990b5794972b049a026da3c8869", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:57:12.971217", "expires":
+        "2019-01-04T17:57:12Z", "id": "d98e65916cef4580a727d62102483988", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["d-nSsWQxTlS-lAtOgz9FCQ"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["7VnLHQUKS2Gp7oB7GSaWFw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -440,7 +440,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:34 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:12 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -458,13 +458,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:25:34 GMT
+      - Fri, 04 Jan 2019 16:57:13 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-37dc7085-4b4b-4984-aec6-37346d0bdae9
+      - req-3aaeb67c-3d18-45a1-b2b3-014729a832f2
       Content-Length:
       - '4118'
       Connection:
@@ -473,10 +473,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:25:34.278374", "expires":
-        "2019-01-03T20:25:34Z", "id": "aa47f48458524feb8a493a79071b3699", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:57:13.161868", "expires":
+        "2019-01-04T17:57:13Z", "id": "b6214a95869b46b4bbbcaa7dfbdab2ea", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["dEfDBnKDRbysMHB3qFEynw"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["9pN8HRMQSHiouqAIFD3yiA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -520,7 +520,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:34 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:13 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -535,7 +535,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - aca158ef39b04f9fa4d7ce1081c9c644
+      - 0e457aafec9b4bda9b5da869d2b04101
   response:
     status:
       code: 200
@@ -546,12 +546,167 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-4266ab8d-8c3a-4b37-a920-7f1ec70e660b
+      - req-c5fe46aa-6692-4941-bff1-95909989d52d
       Date:
-      - Thu, 03 Jan 2019 19:25:34 GMT
+      - Fri, 04 Jan 2019 16:57:13 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Fri, 04 Jan 2019 16:57:13 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 0e457aafec9b4bda9b5da869d2b04101
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-85743797-3a9e-4c80-8653-43316a33ef76
+      Date:
+      - Fri, 04 Jan 2019 16:57:13 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp":
+        true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
@@ -616,161 +771,6 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
         "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:34 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - aca158ef39b04f9fa4d7ce1081c9c644
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-b63ca3b3-29c3-43fe-83cf-b0d43376ad02
-      Date:
-      - Thu, 03 Jan 2019 19:25:34 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
-        true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
         "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
@@ -784,139 +784,7 @@ http_interactions:
         4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
         "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:34 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - aca158ef39b04f9fa4d7ce1081c9c644
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-22c637af-0684-4ac1-85e0-7a8107313d33
-      Date:
-      - Thu, 03 Jan 2019 19:25:34 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
-        true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:34 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:13 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -931,7 +799,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b03c8990b5794972b049a026da3c8869
+      - d98e65916cef4580a727d62102483988
   response:
     status:
       code: 200
@@ -942,13 +810,19 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-179137b1-04ad-4bf6-a9a3-f5e7b7aceb8d
+      - req-25fb8c32-ba5e-4577-825a-dab66c7be80e
       Date:
-      - Thu, 03 Jan 2019 19:25:35 GMT
+      - Fri, 04 Jan 2019 16:57:13 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
-        true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
@@ -1029,26 +903,20 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
         "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:35 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:13 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
@@ -1063,7 +931,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b03c8990b5794972b049a026da3c8869
+      - d98e65916cef4580a727d62102483988
   response:
     status:
       code: 200
@@ -1074,12 +942,167 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-e8f87441-fe39-41cc-94c5-dd9145ac73af
+      - req-6aa52154-cc87-4a55-be1f-cc510b137c60
       Date:
-      - Thu, 03 Jan 2019 19:25:35 GMT
+      - Fri, 04 Jan 2019 16:57:14 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Fri, 04 Jan 2019 16:57:14 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 523283e75c334e719620b7d36cbeac7f
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-cfe768be-adee-44ff-bfbe-97783c1f5acf
+      Date:
+      - Fri, 04 Jan 2019 16:57:14 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp":
+        true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
@@ -1144,6 +1167,62 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
         "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Fri, 04 Jan 2019 16:57:14 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 523283e75c334e719620b7d36cbeac7f
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-f9b9713c-9f2f-4c29-943f-ff2355588fc1
+      Date:
+      - Fri, 04 Jan 2019 16:57:14 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
         "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
@@ -1167,284 +1246,73 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
         "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
         null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:35 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - b03c8990b5794972b049a026da3c8869
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-c0962121-f3c8-4e92-9d11-30a4795c5e2c
-      Date:
-      - Thu, 03 Jan 2019 19:25:35 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
-        true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:35 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - b03c8990b5794972b049a026da3c8869
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-4298e701-67f4-496d-bed8-232b541c354e
-      Date:
-      - Thu, 03 Jan 2019 19:25:35 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
-        true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:35 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:14 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -1459,7 +1327,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 55f86548f67640fe96e71d17c791fa9a
+      - b6214a95869b46b4bbbcaa7dfbdab2ea
   response:
     status:
       code: 200
@@ -1470,19 +1338,13 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-cfe28cc6-42b4-46d1-a4bb-69755e7c7ac8
+      - req-1fc7215b-c1cf-4a35-8e1d-8b09fb96d6e3
       Date:
-      - Thu, 03 Jan 2019 19:25:35 GMT
+      - Fri, 04 Jan 2019 16:57:14 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
-        true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp":
+        true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
@@ -1563,6 +1425,12 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
         "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
         "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
@@ -1576,7 +1444,7 @@ http_interactions:
         4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
         "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:35 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:14 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
@@ -1591,7 +1459,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 55f86548f67640fe96e71d17c791fa9a
+      - b6214a95869b46b4bbbcaa7dfbdab2ea
   response:
     status:
       code: 200
@@ -1602,13 +1470,19 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-3ee2b65d-4788-4bbd-a531-31dbe0f75102
+      - req-3acebebc-bd43-4837-8909-e45128d80462
       Date:
-      - Thu, 03 Jan 2019 19:25:35 GMT
+      - Fri, 04 Jan 2019 16:57:14 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
-        true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
@@ -1689,290 +1563,20 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
         "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:36 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - aa47f48458524feb8a493a79071b3699
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-e72b1bb2-5d05-438b-9b66-ce2fb217fb1e
-      Date:
-      - Thu, 03 Jan 2019 19:25:36 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
-        true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:36 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - aa47f48458524feb8a493a79071b3699
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-7d37630f-f4dd-499f-9334-e2f91779686f
-      Date:
-      - Thu, 03 Jan 2019 19:25:36 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
-        true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:36 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:14 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports/02b5cbb1-6072-429c-b185-89f44b552d40
@@ -1987,7 +1591,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 55f86548f67640fe96e71d17c791fa9a
+      - 523283e75c334e719620b7d36cbeac7f
   response:
     status:
       code: 200
@@ -1998,9 +1602,9 @@ http_interactions:
       Content-Length:
       - '888'
       X-Openstack-Request-Id:
-      - req-f8729db3-77bc-458e-8fe4-3c6ad34a4107
+      - req-a6200c35-bbd8-4e4b-a3fc-ea16c25697bf
       Date:
-      - Thu, 03 Jan 2019 19:25:36 GMT
+      - Fri, 04 Jan 2019 16:57:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"port": {"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -2015,5 +1619,5 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:b5:f7:9c"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:36 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:15 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_router_targeted_refresh.yml
+++ b/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_router_targeted_refresh.yml
@@ -17,13 +17,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:25:22 GMT
+      - Fri, 04 Jan 2019 16:57:21 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-c4b7193d-1e54-411d-8e42-d88664b34693
+      - req-3b5cfe6d-bd47-40fe-b060-858d9d81971d
       Content-Length:
       - '4170'
       Connection:
@@ -32,10 +32,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:25:22.610336", "expires":
-        "2019-01-03T20:25:22Z", "id": "3e4d9e4787b44c2894d1a1fda2267cf5", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:57:21.925145", "expires":
+        "2019-01-04T17:57:21Z", "id": "fdc8677ccb7e4b889c82d8bfaf0cd66e", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["C-RSgc5NR0WTryw1_8cxpg"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["PRpO2JUzTmKY7YfSrzNeVg"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -80,7 +80,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:22 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:21 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -95,7 +95,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3e4d9e4787b44c2894d1a1fda2267cf5
+      - fdc8677ccb7e4b889c82d8bfaf0cd66e
   response:
     status:
       code: 200
@@ -106,7 +106,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Thu, 03 Jan 2019 19:25:22 GMT
+      - Fri, 04 Jan 2019 16:57:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -115,7 +115,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:22 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:22 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -133,13 +133,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:25:22 GMT
+      - Fri, 04 Jan 2019 16:57:22 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-5713ed9c-2143-40d8-b549-e4f342dfc985
+      - req-36f6679e-0a8d-49d9-9b11-e185f44f3d5a
       Content-Length:
       - '4170'
       Connection:
@@ -148,10 +148,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:25:22.893426", "expires":
-        "2019-01-03T20:25:22Z", "id": "adf2a1995506497ab2921e7f79eb995b", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:57:22.210946", "expires":
+        "2019-01-04T17:57:22Z", "id": "af06a1accc9640d69d7a3d75bfe7afd1", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["3krla_44RBya8FTBtw77Bg"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["8CJyJzn6TKqYLQpQxs5XHA"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -196,7 +196,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:22 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:22 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -214,13 +214,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:25:23 GMT
+      - Fri, 04 Jan 2019 16:57:22 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-92c9c661-77ba-4dd3-854c-f4c9c0d7b3ab
+      - req-1daa2351-3f44-4e24-83e4-2e69bf8a8b38
       Content-Length:
       - '370'
       Connection:
@@ -229,13 +229,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:25:23.056507", "expires":
-        "2019-01-03T20:25:23Z", "id": "b196e427395d4ce0bbf02bc3d99db323", "audit_ids":
-        ["6zvdy4DdQ8iOXoDu4FostQ"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:57:22.382992", "expires":
+        "2019-01-04T17:57:22Z", "id": "98104cb1c22f47cfb5fe2e1229621685", "audit_ids":
+        ["aFJrTbG5REK-WkVoEDaNvA"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:23 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:22 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -250,20 +250,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b196e427395d4ce0bbf02bc3d99db323
+      - 98104cb1c22f47cfb5fe2e1229621685
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:25:23 GMT
+      - Fri, 04 Jan 2019 16:57:22 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-37427fef-e862-4cd3-8e56-41ef722f3e7e
+      - req-fefea34d-168c-498e-a7ba-cda664fefd54
       Content-Length:
       - '500'
       Connection:
@@ -280,7 +280,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:23 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:22 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -298,13 +298,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:25:23 GMT
+      - Fri, 04 Jan 2019 16:57:22 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-dd08549c-2ce5-4076-80c8-5f9d14bdb1d5
+      - req-a5d8d811-5683-420f-802c-8763aedacd60
       Content-Length:
       - '4117'
       Connection:
@@ -313,10 +313,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:25:23.387255", "expires":
-        "2019-01-03T20:25:23Z", "id": "02c133ea846e4f26bddc7797d7b33120", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:57:22.704778", "expires":
+        "2019-01-04T17:57:22Z", "id": "4597148df6d04a1cbaf752c5e626161a", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["mPwduXZaRyyW5W8PI28RsA"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["HhyKUM-IRG-isW2lF_3i6Q"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -360,7 +360,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:23 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:22 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -378,13 +378,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:25:23 GMT
+      - Fri, 04 Jan 2019 16:57:22 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-7860153a-19cd-4130-9bae-bff2a1994ab3
+      - req-7ec89757-d3cc-4c5e-98a4-e35f922066ab
       Content-Length:
       - '4131'
       Connection:
@@ -393,10 +393,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:25:23.600136", "expires":
-        "2019-01-03T20:25:23Z", "id": "8bb2e1fa80f64e9b9a0d79231d8a5a62", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:57:22.895599", "expires":
+        "2019-01-04T17:57:22Z", "id": "46552925f5064a67a2fc277242995b2f", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["UuuPopcFT7azsP_Bdb3IMA"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["GQxgNYIzSCi6zTS3Eg4lyw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -440,7 +440,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:23 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:22 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -458,13 +458,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:25:23 GMT
+      - Fri, 04 Jan 2019 16:57:23 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-f243b572-923f-44ca-8bfa-0a6e8dcbdad9
+      - req-5652a67d-775e-4603-b51f-3dab15bdf0d5
       Content-Length:
       - '4118'
       Connection:
@@ -473,10 +473,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:25:23.795678", "expires":
-        "2019-01-03T20:25:23Z", "id": "6a689e07417b4cef8506c28a98e707c1", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:57:23.084916", "expires":
+        "2019-01-04T17:57:23Z", "id": "d9beb107ff6442c9b90bf1692b257a9d", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["FAU3DRD_T_SmoOvCzAWXQw"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["dh6NGn3AQi-WPpiJe_IfhA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -520,7 +520,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:23 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:23 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -535,7 +535,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 02c133ea846e4f26bddc7797d7b33120
+      - 4597148df6d04a1cbaf752c5e626161a
   response:
     status:
       code: 200
@@ -546,19 +546,13 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-dfdcee40-d8d7-4ea2-a342-9d062ca9b96b
+      - req-d0fcdbe4-c9af-44d2-b8ad-b49aa11ade60
       Date:
-      - Thu, 03 Jan 2019 19:25:23 GMT
+      - Fri, 04 Jan 2019 16:57:23 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
-        true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp":
+        true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
@@ -581,505 +575,6 @@ http_interactions:
         "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:24 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 02c133ea846e4f26bddc7797d7b33120
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-b7293e62-a516-4a83-8ba4-ca959a644190
-      Date:
-      - Thu, 03 Jan 2019 19:25:24 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
-        true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:24 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 8bb2e1fa80f64e9b9a0d79231d8a5a62
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-4fe602df-a7b8-4eb6-950c-9ff0ac935c9d
-      Date:
-      - Thu, 03 Jan 2019 19:25:24 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
-        true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:24 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 8bb2e1fa80f64e9b9a0d79231d8a5a62
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-656996ae-a506-41a1-a77d-6a1632cadded
-      Date:
-      - Thu, 03 Jan 2019 19:25:24 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
-        true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:24 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - adf2a1995506497ab2921e7f79eb995b
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-e9977f99-3327-45ad-ba43-b13621c25612
-      Date:
-      - Thu, 03 Jan 2019 19:25:24 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
@@ -1144,161 +639,6 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
         "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:24 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - adf2a1995506497ab2921e7f79eb995b
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-3ba99147-8c72-490a-82a9-4f43fd2130f8
-      Date:
-      - Thu, 03 Jan 2019 19:25:24 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
-        true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
         "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
@@ -1312,7 +652,7 @@ http_interactions:
         4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
         "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:25 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:23 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
@@ -1327,7 +667,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - adf2a1995506497ab2921e7f79eb995b
+      - 4597148df6d04a1cbaf752c5e626161a
   response:
     status:
       code: 200
@@ -1338,13 +678,19 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-4074f3de-d372-4646-b121-a1005de635f6
+      - req-94cf01aa-ab87-4f81-906d-4d178fdb174a
       Date:
-      - Thu, 03 Jan 2019 19:25:25 GMT
+      - Fri, 04 Jan 2019 16:57:23 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
-        true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
@@ -1425,26 +771,20 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
         "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:25 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:23 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -1459,7 +799,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6a689e07417b4cef8506c28a98e707c1
+      - 46552925f5064a67a2fc277242995b2f
   response:
     status:
       code: 200
@@ -1470,12 +810,167 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-e7121f1f-dc31-4166-b3d2-d121f663f02c
+      - req-9f140121-dd3f-419b-8611-94d8f29a4b49
       Date:
-      - Thu, 03 Jan 2019 19:25:25 GMT
+      - Fri, 04 Jan 2019 16:57:23 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Fri, 04 Jan 2019 16:57:23 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 46552925f5064a67a2fc277242995b2f
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-3b78888c-658d-4956-a97e-8811a37aa9e4
+      Date:
+      - Fri, 04 Jan 2019 16:57:23 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp":
+        true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
@@ -1540,161 +1035,6 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
         "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:25 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 6a689e07417b4cef8506c28a98e707c1
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-2b7e5fb0-0572-4f37-b831-b0fe21ccee65
-      Date:
-      - Thu, 03 Jan 2019 19:25:25 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
-        true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
         "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
@@ -1708,10 +1048,10 @@ http_interactions:
         4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
         "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:25 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:23 GMT
 - request:
     method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
     body:
       encoding: US-ASCII
       string: ''
@@ -1723,7 +1063,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6a689e07417b4cef8506c28a98e707c1
+      - af06a1accc9640d69d7a3d75bfe7afd1
   response:
     status:
       code: 200
@@ -1734,65 +1074,12 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-ba45baf8-1a9c-4e2e-b6df-cb4324cc49a9
+      - req-cd8c6b02-a304-4021-81c5-960742b183cb
       Date:
-      - Thu, 03 Jan 2019 19:25:25 GMT
+      - Fri, 04 Jan 2019 16:57:24 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
         true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
@@ -1827,79 +1114,6 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
         "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:25 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 6a689e07417b4cef8506c28a98e707c1
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-7254c326-76e8-4a29-86ee-3f00e90ee115
-      Date:
-      - Thu, 03 Jan 2019 19:25:25 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
-        true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
@@ -1953,26 +1167,20 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
         "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:25 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:24 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
@@ -1987,7 +1195,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6a689e07417b4cef8506c28a98e707c1
+      - af06a1accc9640d69d7a3d75bfe7afd1
   response:
     status:
       code: 200
@@ -1998,13 +1206,19 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-7cc53681-05d0-40e8-a85f-ec048f03d94e
+      - req-535e2ae2-e569-470c-9f9e-3717d7de6129
       Date:
-      - Thu, 03 Jan 2019 19:25:26 GMT
+      - Fri, 04 Jan 2019 16:57:24 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
-        true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
@@ -2085,26 +1299,284 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
         "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Fri, 04 Jan 2019 16:57:24 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - d9beb107ff6442c9b90bf1692b257a9d
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-4d31efe6-5318-41b8-a9de-785436ac780f
+      Date:
+      - Fri, 04 Jan 2019 16:57:24 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
         true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
         "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:26 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:24 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - d9beb107ff6442c9b90bf1692b257a9d
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-8b861409-c400-4827-91c5-73116cd7f29f
+      Date:
+      - Fri, 04 Jan 2019 16:57:24 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Fri, 04 Jan 2019 16:57:24 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers/57e17608-8ac6-44a6-803e-f42ec15e9d1e
@@ -2119,7 +1591,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - adf2a1995506497ab2921e7f79eb995b
+      - af06a1accc9640d69d7a3d75bfe7afd1
   response:
     status:
       code: 200
@@ -2130,9 +1602,9 @@ http_interactions:
       Content-Length:
       - '443'
       X-Openstack-Request-Id:
-      - req-f64ad6f8-96e5-46ca-b78a-be40d3b1548e
+      - req-5befdf5c-1eb3-4ed4-98d2-150847b4e0eb
       Date:
-      - Thu, 03 Jan 2019 19:25:26 GMT
+      - Fri, 04 Jan 2019 16:57:24 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"router": {"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -2141,5 +1613,5 @@ http_interactions:
         "name": "EmsRefreshSpec-Router", "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "distributed": false, "routes": [], "ha": false, "id": "57e17608-8ac6-44a6-803e-f42ec15e9d1e"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:26 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:24 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_stack_targeted_refresh.yml
+++ b/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_stack_targeted_refresh.yml
@@ -17,13 +17,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:26:52 GMT
+      - Fri, 04 Jan 2019 16:56:48 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-4ff24daf-880c-4f57-a917-d1e7c59d9897
+      - req-034a007e-92e5-46d3-8509-a5ee5b14483e
       Content-Length:
       - '4170'
       Connection:
@@ -32,10 +32,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:26:52.457828", "expires":
-        "2019-01-03T20:26:52Z", "id": "ca7fdd27b5d944c2ba83442861323dc1", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:56:48.443318", "expires":
+        "2019-01-04T17:56:48Z", "id": "b9241ec254a446b2ab2f791d1453459b", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["ys0vuXnwRUK2YvZBwS1ZLQ"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["34Sg7cneROKyJiIVdpowyg"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -80,7 +80,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:52 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:48 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -95,7 +95,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ca7fdd27b5d944c2ba83442861323dc1
+      - b9241ec254a446b2ab2f791d1453459b
   response:
     status:
       code: 200
@@ -106,7 +106,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Thu, 03 Jan 2019 19:26:52 GMT
+      - Fri, 04 Jan 2019 16:56:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -115,7 +115,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:52 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:48 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -133,13 +133,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:26:52 GMT
+      - Fri, 04 Jan 2019 16:56:48 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-295b3210-e624-4170-89b9-b2b908fed15c
+      - req-a62c1c9b-cd4b-4b4f-8709-6f48314344fc
       Content-Length:
       - '4170'
       Connection:
@@ -148,10 +148,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:26:52.732967", "expires":
-        "2019-01-03T20:26:52Z", "id": "53b65b1a48b14ef1a135fc71c109d850", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:56:48.722386", "expires":
+        "2019-01-04T17:56:48Z", "id": "f93126356fbe430f9693d000be622912", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["jJb7SAe8RsaB-JyO5F7l_Q"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["xSDmIpeNQdurJpu5Tui9SQ"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -196,7 +196,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:52 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:48 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -211,20 +211,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 53b65b1a48b14ef1a135fc71c109d850
+      - f93126356fbe430f9693d000be622912
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:26:52 GMT
+      - Fri, 04 Jan 2019 16:56:48 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-9f1930e8-8e9f-4329-a60c-356dacb34adc
+      - req-4d4306c1-f94e-453f-aa9f-53dd716fcbd5
       Content-Length:
       - '500'
       Connection:
@@ -241,7 +241,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:52 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:48 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -259,13 +259,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:26:53 GMT
+      - Fri, 04 Jan 2019 16:56:49 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-88849bc4-e84b-4f8d-b9d7-ce9ac29027e2
+      - req-9e1773fe-6d4a-4794-a936-c991437a36ec
       Content-Length:
       - '4117'
       Connection:
@@ -274,10 +274,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:26:53.078854", "expires":
-        "2019-01-03T20:26:53Z", "id": "a246f5ba84a8425e94ce02abffc69838", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:56:49.060049", "expires":
+        "2019-01-04T17:56:49Z", "id": "0317a906b7a34001b8da53b14d9febc6", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["ifFBIABUSTCUZZt9L0LxKQ"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["9gnoF0r1SNOpxET3Yv4ddQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -321,7 +321,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:53 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:49 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks
@@ -336,7 +336,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a246f5ba84a8425e94ce02abffc69838
+      - 0317a906b7a34001b8da53b14d9febc6
   response:
     status:
       code: 200
@@ -347,9 +347,9 @@ http_interactions:
       Content-Length:
       - '2559'
       X-Openstack-Request-Id:
-      - req-263f42b5-9a64-44e2-9fe8-d1048f46a0ea
+      - req-6dcc780c-2e6e-41c1-a3d9-b4b52e04945b
       Date:
-      - Thu, 03 Jan 2019 19:26:53 GMT
+      - Fri, 04 Jan 2019 16:56:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": [{"description": "Heat WordPress template to support F20,
@@ -383,7 +383,7 @@ http_interactions:
         "rel": "self"}], "updated_time": null, "stack_owner": null, "stack_status":
         "CREATE_COMPLETE", "id": "091e1e54-e01c-4ec5-a0ab-b00bee4d425c"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:53 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:49 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c/template
@@ -398,7 +398,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a246f5ba84a8425e94ce02abffc69838
+      - 0317a906b7a34001b8da53b14d9febc6
   response:
     status:
       code: 200
@@ -409,9 +409,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-d5eb58e4-9646-4a8f-80a3-016c4627ce7b
+      - req-b60c9e10-dbed-4c32-847a-3ed97de8a2ff
       Date:
-      - Thu, 03 Jan 2019 19:26:53 GMT
+      - Fri, 04 Jan 2019 16:56:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -467,7 +467,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:53 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:49 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c/resources
@@ -482,7 +482,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a246f5ba84a8425e94ce02abffc69838
+      - 0317a906b7a34001b8da53b14d9febc6
   response:
     status:
       code: 200
@@ -493,9 +493,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-f0c7bcbf-2d1a-4a1f-b097-b27b89735d83
+      - req-5bd16417-efc1-447b-8cf2-44c6899f7b4b
       Date:
-      - Thu, 03 Jan 2019 19:26:53 GMT
+      - Fri, 04 Jan 2019 16:56:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -507,7 +507,7 @@ http_interactions:
         changed", "physical_resource_id": "b686353f-0da0-48bf-bc35-8ea411a67dfd",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:53 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:49 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -525,13 +525,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:26:53 GMT
+      - Fri, 04 Jan 2019 16:56:49 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-c94a6514-05ec-4cd1-bc74-f07582b7613b
+      - req-38ce1b71-fa15-43b7-9e64-701f96e304bd
       Content-Length:
       - '4170'
       Connection:
@@ -540,10 +540,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:26:53.824569", "expires":
-        "2019-01-03T20:26:53Z", "id": "36fb939c9ff84a6cbae9a983915c0f4b", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:56:49.792964", "expires":
+        "2019-01-04T17:56:49Z", "id": "7c25401576c045bbba476d49d7969c58", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["jBfDeH_6QKStXyOCQLszXw"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["uEqCOv-MQ4Gk041I7Ery9w"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -588,7 +588,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:53 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:49 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -606,13 +606,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:26:53 GMT
+      - Fri, 04 Jan 2019 16:56:49 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-91fdda5f-3276-4a93-b2f6-84131e36a3cb
+      - req-bd7fdb09-322f-4aaa-b67a-46b98a4f8793
       Content-Length:
       - '370'
       Connection:
@@ -621,13 +621,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:26:53.979724", "expires":
-        "2019-01-03T20:26:53Z", "id": "975fac3b0937498dadc56450324593c4", "audit_ids":
-        ["IssTVO77SumY6dyHqg49iQ"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:56:49.955424", "expires":
+        "2019-01-04T17:56:49Z", "id": "50cc324449e64005a90470b3222b69da", "audit_ids":
+        ["efDIZ7UUT3GiRXDy_ldHrQ"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:54 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:49 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -642,20 +642,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 975fac3b0937498dadc56450324593c4
+      - 50cc324449e64005a90470b3222b69da
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:26:54 GMT
+      - Fri, 04 Jan 2019 16:56:50 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-33968b67-fcf6-43f6-a6f0-7c90ec7b7218
+      - req-d0b82dc4-661f-44de-9829-884577847a01
       Content-Length:
       - '500'
       Connection:
@@ -672,7 +672,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:54 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:50 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -690,13 +690,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:26:54 GMT
+      - Fri, 04 Jan 2019 16:56:50 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-48dfeae4-6399-4b9f-8387-cd88d46fb688
+      - req-8a0661ae-99c4-4dc9-a142-630562cbb356
       Content-Length:
       - '4117'
       Connection:
@@ -705,10 +705,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:26:54.297691", "expires":
-        "2019-01-03T20:26:54Z", "id": "74f8f7921b66479989abb03433c13e77", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:56:50.280127", "expires":
+        "2019-01-04T17:56:50Z", "id": "886c3221299144cca48af3277130224b", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["S479_g7zTe-XHlonaml5sA"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["AMuS2fdmSFSW7XaZwFJcWw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -752,7 +752,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:54 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:50 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -770,13 +770,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:26:54 GMT
+      - Fri, 04 Jan 2019 16:56:50 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-9701e52f-53cc-49a2-adc8-bfb45e155825
+      - req-734b1462-90a6-4b82-a839-6bfd4525af8e
       Content-Length:
       - '4131'
       Connection:
@@ -785,10 +785,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:26:54.479235", "expires":
-        "2019-01-03T20:26:54Z", "id": "0a3477fb17d5468f862a457456983c76", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:56:50.468014", "expires":
+        "2019-01-04T17:56:50Z", "id": "b111d3d8208746549c18182175a84e10", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["UBJn2le0TJSmVaSbuJieow"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["fCSsNXPwQS-cIV8Mtf3PUQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -832,7 +832,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:54 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:50 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -850,13 +850,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:26:54 GMT
+      - Fri, 04 Jan 2019 16:56:50 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-40802d83-6cd0-4c6d-8495-644e35df5a04
+      - req-2b36515e-cc84-4edc-9114-196024692dae
       Content-Length:
       - '4118'
       Connection:
@@ -865,10 +865,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:26:54.673025", "expires":
-        "2019-01-03T20:26:54Z", "id": "aadeb1f1421b4ca1bf880543e4dc57bd", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:56:50.659280", "expires":
+        "2019-01-04T17:56:50Z", "id": "2ef9b99bcab9419fbb4c7695bbf63ae4", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["RZIJkpGTTuiEWDLeq9C4ig"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["5OQ7-1T8Qv6NWfNQlU-tJA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -912,7 +912,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:54 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:50 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -927,7 +927,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 74f8f7921b66479989abb03433c13e77
+      - 886c3221299144cca48af3277130224b
   response:
     status:
       code: 200
@@ -938,13 +938,19 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-abcfda1d-12da-4889-b155-8674c0096e99
+      - req-51ab3fef-f349-405f-a30c-74f35c2dc177
       Date:
-      - Thu, 03 Jan 2019 19:26:54 GMT
+      - Fri, 04 Jan 2019 16:56:50 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
-        true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
@@ -1025,26 +1031,20 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
         "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:54 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:50 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
@@ -1059,7 +1059,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 74f8f7921b66479989abb03433c13e77
+      - 886c3221299144cca48af3277130224b
   response:
     status:
       code: 200
@@ -1070,13 +1070,19 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-3a63a96f-0df8-4978-b8c1-89a30e02652c
+      - req-932bf650-4e8d-4611-a70f-0df17916142e
       Date:
-      - Thu, 03 Jan 2019 19:26:55 GMT
+      - Fri, 04 Jan 2019 16:56:51 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
-        true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
@@ -1157,26 +1163,20 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
         "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:55 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:51 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -1191,7 +1191,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0a3477fb17d5468f862a457456983c76
+      - b111d3d8208746549c18182175a84e10
   response:
     status:
       code: 200
@@ -1202,12 +1202,167 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-904f73f4-0192-4306-bee5-92e842943a26
+      - req-d3337d2c-378a-4cad-922e-a8ddd4cdd135
       Date:
-      - Thu, 03 Jan 2019 19:26:55 GMT
+      - Fri, 04 Jan 2019 16:56:51 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Fri, 04 Jan 2019 16:56:51 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - b111d3d8208746549c18182175a84e10
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-4966bdbf-72d2-445c-a55f-724e3e52ea22
+      Date:
+      - Fri, 04 Jan 2019 16:56:51 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp":
+        true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
@@ -1272,161 +1427,6 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
         "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:55 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 0a3477fb17d5468f862a457456983c76
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-c0d6a5fd-865d-4f95-bda8-b8a092007fa3
-      Date:
-      - Thu, 03 Jan 2019 19:26:55 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
-        true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
         "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
@@ -1440,10 +1440,10 @@ http_interactions:
         4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
         "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:55 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:51 GMT
 - request:
     method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
     body:
       encoding: US-ASCII
       string: ''
@@ -1455,7 +1455,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0a3477fb17d5468f862a457456983c76
+      - 7c25401576c045bbba476d49d7969c58
   response:
     status:
       code: 200
@@ -1466,65 +1466,12 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-b7a57df2-da97-4ddf-a667-b7110a2e1a8c
+      - req-f4bf6703-1b6f-4e6d-b8bd-ffc1fd8a6e8e
       Date:
-      - Thu, 03 Jan 2019 19:26:55 GMT
+      - Fri, 04 Jan 2019 16:56:51 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
         true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
@@ -1559,79 +1506,6 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
         "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:55 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 0a3477fb17d5468f862a457456983c76
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-3966b35c-4ce0-4e59-924a-cc6aa9773479
-      Date:
-      - Thu, 03 Jan 2019 19:26:55 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
-        true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
@@ -1685,26 +1559,20 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
         "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:55 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:51 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
@@ -1719,7 +1587,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0a3477fb17d5468f862a457456983c76
+      - 7c25401576c045bbba476d49d7969c58
   response:
     status:
       code: 200
@@ -1730,65 +1598,12 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-36e4518d-a3d9-4726-8c8b-319079587da9
+      - req-03ebc9da-e910-49ce-8e1b-4d9d37c84998
       Date:
-      - Thu, 03 Jan 2019 19:26:56 GMT
+      - Fri, 04 Jan 2019 16:56:51 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
         true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
@@ -1823,284 +1638,73 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
         "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
         null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:56 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 0a3477fb17d5468f862a457456983c76
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-3f57cd18-71cd-4e72-bc85-26ef1bf8e19f
-      Date:
-      - Thu, 03 Jan 2019 19:26:56 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
-        true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:56 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 0a3477fb17d5468f862a457456983c76
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-5ba7a2e9-5e89-494c-8b2f-245bda5ad942
-      Date:
-      - Thu, 03 Jan 2019 19:26:56 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
-        true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:56 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:52 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -2115,7 +1719,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 36fb939c9ff84a6cbae9a983915c0f4b
+      - 2ef9b99bcab9419fbb4c7695bbf63ae4
   response:
     status:
       code: 200
@@ -2126,13 +1730,19 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-0c20c589-e18a-48f7-adee-27e78eb35304
+      - req-1ffb1b91-d7e3-4990-b8c8-6df39bd69ca6
       Date:
-      - Thu, 03 Jan 2019 19:26:56 GMT
+      - Fri, 04 Jan 2019 16:56:52 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
-        true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
@@ -2213,26 +1823,20 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
         "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:56 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:52 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
@@ -2247,7 +1851,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 36fb939c9ff84a6cbae9a983915c0f4b
+      - 2ef9b99bcab9419fbb4c7695bbf63ae4
   response:
     status:
       code: 200
@@ -2258,13 +1862,19 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-64da8541-0d54-414e-b173-2a817d84d04d
+      - req-f9dd99c5-5766-4d17-9ddb-a6a41f563cee
       Date:
-      - Thu, 03 Jan 2019 19:26:56 GMT
+      - Fri, 04 Jan 2019 16:56:52 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
-        true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
@@ -2345,288 +1955,18 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
         "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:56 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - aadeb1f1421b4ca1bf880543e4dc57bd
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-b34e47ba-a02b-441e-a072-f632d2f1d0e7
-      Date:
-      - Thu, 03 Jan 2019 19:26:57 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
-        true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:57 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - aadeb1f1421b4ca1bf880543e4dc57bd
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-ffc373a5-73a7-45aa-80a5-c2e062c460f5
-      Date:
-      - Thu, 03 Jan 2019 19:26:57 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
-        true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:57 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:52 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_tenant_targeted_refresh.yml
+++ b/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_tenant_targeted_refresh.yml
@@ -17,13 +17,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:25:37 GMT
+      - Fri, 04 Jan 2019 16:58:23 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-795c4fc5-4124-4b83-97af-a1ae81ae445c
+      - req-2076bd22-5f09-42f6-9e86-7eedd11b6599
       Content-Length:
       - '4170'
       Connection:
@@ -32,10 +32,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:25:37.605265", "expires":
-        "2019-01-03T20:25:37Z", "id": "7617d1d87e554700b6f562fbd3ee6da2", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:58:23.303613", "expires":
+        "2019-01-04T17:58:23Z", "id": "1b69402e585d4dc19936dd4333428931", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["rfBKLlnMRd2Dy6XyqPNeOw"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["QCV74ROARiaYMaQVlOynKQ"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -80,7 +80,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:37 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:23 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -95,7 +95,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7617d1d87e554700b6f562fbd3ee6da2
+      - 1b69402e585d4dc19936dd4333428931
   response:
     status:
       code: 200
@@ -106,7 +106,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Thu, 03 Jan 2019 19:25:37 GMT
+      - Fri, 04 Jan 2019 16:58:23 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -115,7 +115,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:37 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:23 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -133,13 +133,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:25:37 GMT
+      - Fri, 04 Jan 2019 16:58:23 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-3b268eb4-4b85-4a20-8f2c-124d5cff9141
+      - req-32b1b5e8-182e-4302-b3d2-4d1486fba496
       Content-Length:
       - '4170'
       Connection:
@@ -148,10 +148,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:25:37.882807", "expires":
-        "2019-01-03T20:25:37Z", "id": "63d0b3e5991340448dd61bf942e68f52", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:58:23.583236", "expires":
+        "2019-01-04T17:58:23Z", "id": "0b2582341aa042ee8dca9741417738aa", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["6xoBAu0NTme5-pbExY0f3Q"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["67H8N9KOTpmvXbKoRh2u4g"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -196,7 +196,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:37 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:23 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -211,20 +211,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 63d0b3e5991340448dd61bf942e68f52
+      - 0b2582341aa042ee8dca9741417738aa
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:25:38 GMT
+      - Fri, 04 Jan 2019 16:58:23 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-973f66b3-16c7-4b10-9748-4a14ce003310
+      - req-02db13f5-f295-4860-a7b4-09aaf83bf644
       Content-Length:
       - '500'
       Connection:
@@ -241,7 +241,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:38 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:23 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -259,13 +259,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:25:38 GMT
+      - Fri, 04 Jan 2019 16:58:23 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-955e7ff4-3d19-4223-be95-ab7330cb386b
+      - req-afe779e0-3ccf-4fad-95a2-b916cc87e5f6
       Content-Length:
       - '4170'
       Connection:
@@ -274,10 +274,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:25:38.302734", "expires":
-        "2019-01-03T20:25:38Z", "id": "3a09a7b3ae6e483cb1f97c7a6a161e83", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:58:24.018370", "expires":
+        "2019-01-04T17:58:23Z", "id": "c19f980c8b6a400a8c05db4e3aab0461", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["uCWD27kpTHOWNA2vuOZ1EA"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["qVrdw6tfQMqE60-giOKphA"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -322,7 +322,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:38 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:24 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -340,13 +340,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:25:38 GMT
+      - Fri, 04 Jan 2019 16:58:24 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-ee5f696e-3701-468f-bb16-65923dfd8e28
+      - req-1a492551-4934-4e3c-9094-0b40451e8791
       Content-Length:
       - '370'
       Connection:
@@ -355,13 +355,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:25:38.467228", "expires":
-        "2019-01-03T20:25:38Z", "id": "3dac0e69d0c1488b9634a61554fb92ee", "audit_ids":
-        ["M_GPcpwNQ3u-yLDYfltVMA"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:58:24.200167", "expires":
+        "2019-01-04T17:58:24Z", "id": "783c905edce0462687be50b089e18a8b", "audit_ids":
+        ["UaMB8ka4RWe0z4xNCB9Dcg"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:38 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:24 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -376,20 +376,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3dac0e69d0c1488b9634a61554fb92ee
+      - 783c905edce0462687be50b089e18a8b
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:25:38 GMT
+      - Fri, 04 Jan 2019 16:58:24 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-62ef2ec3-f401-4377-97e2-56deacd5761a
+      - req-6adbf85b-2e58-4484-ba5d-7724e9d8c302
       Content-Length:
       - '500'
       Connection:
@@ -406,7 +406,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:38 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:24 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -424,13 +424,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:25:38 GMT
+      - Fri, 04 Jan 2019 16:58:24 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-51e833f2-97bc-4b24-b08f-1a0910eb0096
+      - req-15b5cc8f-848e-47c4-b4f7-370aaf207652
       Content-Length:
       - '4117'
       Connection:
@@ -439,10 +439,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:25:38.806632", "expires":
-        "2019-01-03T20:25:38Z", "id": "d44aae4f2c9b4a93b9bffac9bf1b85a2", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:58:24.536232", "expires":
+        "2019-01-04T17:58:24Z", "id": "379b826d04844c12b189bc1d68f55c66", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["fLXBYN2DQOCMYcotuT7VKQ"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["4PRVcPUYQom2vMoxfrxeAA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -486,7 +486,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:38 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:24 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -504,13 +504,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:25:38 GMT
+      - Fri, 04 Jan 2019 16:58:24 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-babb3c33-a235-4d1d-ab2b-5eac809a61cd
+      - req-e6f83ef7-9f33-4150-bd8d-01ea73c3ad9f
       Content-Length:
       - '4131'
       Connection:
@@ -519,10 +519,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:25:38.995335", "expires":
-        "2019-01-03T20:25:38Z", "id": "a639323598c7434ca0b014bed613f098", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:58:24.723924", "expires":
+        "2019-01-04T17:58:24Z", "id": "dc0ef8dbd1524cd9b221b41862b57f95", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["PHwyGZJBTkqgBaGCg9pKWA"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["PR19zYMTSGmqAU-W4QGMHQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -566,7 +566,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:39 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:24 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -584,13 +584,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:25:39 GMT
+      - Fri, 04 Jan 2019 16:58:24 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-6845004f-87bc-46db-a1dc-6e73b0204e3e
+      - req-7d0e0b11-90f7-456a-9908-a363bfd88abb
       Content-Length:
       - '4118'
       Connection:
@@ -599,10 +599,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:25:39.187619", "expires":
-        "2019-01-03T20:25:39Z", "id": "236d9476cbda45d7b26f9e4d170ba52c", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:58:24.913419", "expires":
+        "2019-01-04T17:58:24Z", "id": "4ff941b948434add8f1fb574e0581a54", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["imYX5JYKQ-uMChabAo8xTg"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["_QzEH_GtQ3yHd0FIypZ9BA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -646,7 +646,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:39 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:24 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -661,7 +661,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d44aae4f2c9b4a93b9bffac9bf1b85a2
+      - 379b826d04844c12b189bc1d68f55c66
   response:
     status:
       code: 200
@@ -672,936 +672,29 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-919de506-7a75-429b-8a79-dbc2ee7eec8b
+      - req-f63e2372-e767-4bef-a13d-e13a098821a4
       Date:
-      - Thu, 03 Jan 2019 19:25:39 GMT
+      - Fri, 04 Jan 2019 16:58:25 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
-        true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
         true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:39 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - d44aae4f2c9b4a93b9bffac9bf1b85a2
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-86148771-c760-486a-9a7d-4a200035f216
-      Date:
-      - Thu, 03 Jan 2019 19:25:39 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
-        true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:39 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - a639323598c7434ca0b014bed613f098
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-ffa5b2d5-7e32-46a7-9a5b-7a9a79352b2f
-      Date:
-      - Thu, 03 Jan 2019 19:25:39 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
-        true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:39 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - a639323598c7434ca0b014bed613f098
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-c6d9fb77-80b5-4c56-9d3f-3a47e6c30dc4
-      Date:
-      - Thu, 03 Jan 2019 19:25:39 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
-        true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:39 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 3a09a7b3ae6e483cb1f97c7a6a161e83
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-59380e7d-43d3-40c7-9cea-5bf445c0567c
-      Date:
-      - Thu, 03 Jan 2019 19:25:40 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
-        true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:40 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 3a09a7b3ae6e483cb1f97c7a6a161e83
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-ad04c859-75fe-4b78-8bbf-651a218d040d
-      Date:
-      - Thu, 03 Jan 2019 19:25:40 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
-        true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:40 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 236d9476cbda45d7b26f9e4d170ba52c
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-7da14e1b-8711-49a7-8c30-d2baed12c099
-      Date:
-      - Thu, 03 Jan 2019 19:25:40 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
-        true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:40 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 236d9476cbda45d7b26f9e4d170ba52c
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-091cdae5-770b-4f77-9eaf-872667c4529d
-      Date:
-      - Thu, 03 Jan 2019 19:25:40 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
@@ -1672,155 +765,6 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
         "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:40 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 236d9476cbda45d7b26f9e4d170ba52c
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-f2677d6d-7a79-4e5e-9f69-666379dce9fd
-      Date:
-      - Thu, 03 Jan 2019 19:25:40 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
-        true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
         "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
@@ -1834,7 +778,7 @@ http_interactions:
         4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
         "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:40 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:25 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
@@ -1849,7 +793,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 236d9476cbda45d7b26f9e4d170ba52c
+      - 379b826d04844c12b189bc1d68f55c66
   response:
     status:
       code: 200
@@ -1860,19 +804,13 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-4b203be2-8f5a-4106-a9ae-9741daa14471
+      - req-a4a81bb8-5d7d-4220-a566-438d9e0c556d
       Date:
-      - Thu, 03 Jan 2019 19:25:41 GMT
+      - Fri, 04 Jan 2019 16:58:25 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
-        true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp":
+        true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
@@ -1953,6 +891,12 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
         "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
         "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
@@ -1966,5 +910,797 @@ http_interactions:
         4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
         "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:41 GMT
+  recorded_at: Fri, 04 Jan 2019 16:58:25 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - dc0ef8dbd1524cd9b221b41862b57f95
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-f31a2124-6afd-40c6-a82f-36648885d81a
+      Date:
+      - Fri, 04 Jan 2019 16:58:25 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Fri, 04 Jan 2019 16:58:25 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - dc0ef8dbd1524cd9b221b41862b57f95
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-8ff72ea1-862e-4cba-9583-684c3887b96c
+      Date:
+      - Fri, 04 Jan 2019 16:58:25 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Fri, 04 Jan 2019 16:58:25 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - c19f980c8b6a400a8c05db4e3aab0461
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-2a5f35e4-efd4-4d54-8e2f-84f29b5651ff
+      Date:
+      - Fri, 04 Jan 2019 16:58:25 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp":
+        true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Fri, 04 Jan 2019 16:58:25 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - c19f980c8b6a400a8c05db4e3aab0461
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-6c061d78-05b3-4a47-a592-df194f3f5e40
+      Date:
+      - Fri, 04 Jan 2019 16:58:26 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Fri, 04 Jan 2019 16:58:26 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 4ff941b948434add8f1fb574e0581a54
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-fbfe9039-2a68-4645-a265-986629d7f5b4
+      Date:
+      - Fri, 04 Jan 2019 16:58:26 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Fri, 04 Jan 2019 16:58:26 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 4ff941b948434add8f1fb574e0581a54
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-0c82c9c2-3f50-4a0c-a7b4-1f0876137e39
+      Date:
+      - Fri, 04 Jan 2019 16:58:26 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp":
+        true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Fri, 04 Jan 2019 16:58:26 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_vm_targeted_refresh.yml
+++ b/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_vm_targeted_refresh.yml
@@ -17,13 +17,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:26:28 GMT
+      - Fri, 04 Jan 2019 16:56:53 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-3c1f436c-5bd7-4166-9775-83463b9534ec
+      - req-5651ae34-08dc-410e-874e-baa6b4a25332
       Content-Length:
       - '4170'
       Connection:
@@ -32,10 +32,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:26:28.211478", "expires":
-        "2019-01-03T20:26:28Z", "id": "31773b1f125449e2ba5204654b9f958f", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:56:53.418690", "expires":
+        "2019-01-04T17:56:53Z", "id": "5df501965aab45d8afca8d01ba39c22d", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["m6TQrRGHQCOiAou3ABpDMA"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["5eGILPSKRTyx3ImS-_mwzQ"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -80,7 +80,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:28 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:53 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -95,7 +95,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 31773b1f125449e2ba5204654b9f958f
+      - 5df501965aab45d8afca8d01ba39c22d
   response:
     status:
       code: 200
@@ -106,7 +106,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Thu, 03 Jan 2019 19:26:28 GMT
+      - Fri, 04 Jan 2019 16:56:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -115,7 +115,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:28 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:53 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/ca4f3a16-bae3-4407-83e9-f77b28af0f2b
@@ -130,7 +130,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 31773b1f125449e2ba5204654b9f958f
+      - 5df501965aab45d8afca8d01ba39c22d
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -143,9 +143,9 @@ http_interactions:
       Content-Length:
       - '2088'
       X-Compute-Request-Id:
-      - req-56296008-6d91-4929-8509-46577580ab61
+      - req-8cdec8ff-73f9-498e-bc52-7dd890dded44
       Date:
-      - Thu, 03 Jan 2019 19:26:28 GMT
+      - Fri, 04 Jan 2019 16:56:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"server": {"status": "ACTIVE", "updated": "2018-10-09T18:40:19Z",
@@ -172,7 +172,7 @@ http_interactions:
         "", "progress": 0, "OS-EXT-STS:power_state": 1, "config_drive": "", "metadata":
         {}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:28 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:53 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/ca4f3a16-bae3-4407-83e9-f77b28af0f2b/os-interface
@@ -187,7 +187,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 31773b1f125449e2ba5204654b9f958f
+      - 5df501965aab45d8afca8d01ba39c22d
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -200,9 +200,9 @@ http_interactions:
       Content-Length:
       - '285'
       X-Compute-Request-Id:
-      - req-64f75cce-3689-4de2-afb6-cb018882094c
+      - req-53a5a944-6477-4121-8bb2-30c33efd61d6
       Date:
-      - Thu, 03 Jan 2019 19:26:28 GMT
+      - Fri, 04 Jan 2019 16:56:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"interfaceAttachments": [{"port_state": "ACTIVE", "fixed_ips": [{"subnet_id":
@@ -210,7 +210,7 @@ http_interactions:
         "dda2ebad-f144-4f63-9a75-cbd4fe25e3e9", "net_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
         "mac_addr": "fa:16:3e:e1:0b:2c"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:28 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:54 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/ca4f3a16-bae3-4407-83e9-f77b28af0f2b/os-security-groups
@@ -225,7 +225,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 31773b1f125449e2ba5204654b9f958f
+      - 5df501965aab45d8afca8d01ba39c22d
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -238,9 +238,9 @@ http_interactions:
       Content-Length:
       - '3931'
       X-Compute-Request-Id:
-      - req-0d145ade-78eb-477c-96aa-9c1cb1222ea0
+      - req-4e0b697f-c96f-4b2f-8372-d97d95b8a5a9
       Date:
-      - Thu, 03 Jan 2019 19:26:29 GMT
+      - Fri, 04 Jan 2019 16:56:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups": [{"rules": [{"from_port": 3, "group": {"tenant_id":
@@ -292,7 +292,7 @@ http_interactions:
         "name": "EmsRefreshSpec-SecurityGroup2", "description": "EmsRefreshSpec-SecurityGroup2
         description"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:29 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:55 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-floating-ips
@@ -307,7 +307,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 31773b1f125449e2ba5204654b9f958f
+      - 5df501965aab45d8afca8d01ba39c22d
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -320,14 +320,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-070436a6-9c7a-4961-97d1-97d4d13c4417
+      - req-4edad6c8-327d-4d6f-924c-2f761c99ea90
       Date:
-      - Thu, 03 Jan 2019 19:26:29 GMT
+      - Fri, 04 Jan 2019 16:56:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:29 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:55 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -345,13 +345,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:26:29 GMT
+      - Fri, 04 Jan 2019 16:56:55 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-72db78e6-6e7b-4cdf-8f09-06398ee8a49f
+      - req-62316508-e994-4b65-a8bd-6d86de266ccb
       Content-Length:
       - '4170'
       Connection:
@@ -360,10 +360,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:26:29.619182", "expires":
-        "2019-01-03T20:26:29Z", "id": "d6a2ddd270fb452f93fc0c5be14cf82d", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:56:55.416189", "expires":
+        "2019-01-04T17:56:55Z", "id": "6055943a72b94605b248692a5c007e89", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["U3MD4xVqQAueLMrMhHv35Q"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["MD5MRUxES5m6LcohhkhduA"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -408,7 +408,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:29 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:55 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?floating_ip_address=172.16.17.4
@@ -423,7 +423,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d6a2ddd270fb452f93fc0c5be14cf82d
+      - 6055943a72b94605b248692a5c007e89
   response:
     status:
       code: 200
@@ -434,9 +434,9 @@ http_interactions:
       Content-Length:
       - '374'
       X-Openstack-Request-Id:
-      - req-5a766e57-c333-42d3-98f1-6173726e193a
+      - req-f04277ce-732d-4f1b-98bf-de7164d87b05
       Date:
-      - Thu, 03 Jan 2019 19:26:29 GMT
+      - Fri, 04 Jan 2019 16:56:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -445,7 +445,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "dda2ebad-f144-4f63-9a75-cbd4fe25e3e9", "id":
         "855b23e7-1ace-4c22-8c02-2160d3cde900"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:29 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:55 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -463,13 +463,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:26:29 GMT
+      - Fri, 04 Jan 2019 16:56:55 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-94d8f65d-9587-4002-9103-b6a645e4906f
+      - req-98154a67-5613-411f-814a-1f45d484b07b
       Content-Length:
       - '4170'
       Connection:
@@ -478,10 +478,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:26:29.963752", "expires":
-        "2019-01-03T20:26:29Z", "id": "9f5f9db5d2684a9589b3ab518897b910", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:56:55.775917", "expires":
+        "2019-01-04T17:56:55Z", "id": "47a74883b6494db09f58e452d3b1e25e", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["eMQRMWneSwSyHJ7QNwg0nQ"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["cJBkPNCoQM6Abplc1J1-9g"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -526,7 +526,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:29 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:55 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -541,20 +541,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9f5f9db5d2684a9589b3ab518897b910
+      - 47a74883b6494db09f58e452d3b1e25e
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:26:30 GMT
+      - Fri, 04 Jan 2019 16:56:55 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-ce635d68-08dd-4f05-827d-869005bb8f4a
+      - req-85f5dbd9-b3fd-45a8-b27d-a56093d012d4
       Content-Length:
       - '500'
       Connection:
@@ -571,7 +571,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:30 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:55 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -589,13 +589,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:26:30 GMT
+      - Fri, 04 Jan 2019 16:56:56 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-48f154b3-65df-437a-af22-c7ec2b504680
+      - req-9d4c5b54-6e9e-43b9-bfb8-621dd5053d92
       Content-Length:
       - '4117'
       Connection:
@@ -604,10 +604,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:26:30.302859", "expires":
-        "2019-01-03T20:26:30Z", "id": "c75b54791e1c4d0ea060fa44ee8e8147", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:56:56.115476", "expires":
+        "2019-01-04T17:56:56Z", "id": "644eeb2758e6479ab5ad426137b806db", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["dppXfd_8S8-DQsD-u5_MPA"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["rtQyzGNkQaWbdK1MwDZhxg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -651,7 +651,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:30 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:56 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/0a55c0d5-c780-4e7d-9d09-47f5520c7448
@@ -666,22 +666,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c75b54791e1c4d0ea060fa44ee8e8147
+      - 644eeb2758e6479ab5ad426137b806db
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-6bd31e2e-ac33-40cb-9ebc-2d23bea872a8
+      - req-424fc52e-96c5-4685-b7a4-f8216d47dbf8
       Content-Type:
       - application/json
       Content-Length:
       - '1406'
       X-Openstack-Request-Id:
-      - req-6bd31e2e-ac33-40cb-9ebc-2d23bea872a8
+      - req-424fc52e-96c5-4685-b7a4-f8216d47dbf8
       Date:
-      - Thu, 03 Jan 2019 19:26:30 GMT
+      - Fri, 04 Jan 2019 16:56:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume": {"migration_status": null, "attachments": [{"server_id":
@@ -702,7 +702,7 @@ http_interactions:
         "bootable": "false", "created_at": "2016-11-11T13:49:20.000000", "volume_type":
         "iscsi"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:30 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:56 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/2c774148-c11a-434c-aabb-7fa9c82c37ce
@@ -717,22 +717,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c75b54791e1c4d0ea060fa44ee8e8147
+      - 644eeb2758e6479ab5ad426137b806db
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-cacf353e-6dcc-4e87-934b-4e5d2ead5f61
+      - req-1eac3ba3-8e46-4c22-a0da-a798b3c8f12b
       Content-Type:
       - application/json
       Content-Length:
       - '1408'
       X-Openstack-Request-Id:
-      - req-cacf353e-6dcc-4e87-934b-4e5d2ead5f61
+      - req-1eac3ba3-8e46-4c22-a0da-a798b3c8f12b
       Date:
-      - Thu, 03 Jan 2019 19:26:30 GMT
+      - Fri, 04 Jan 2019 16:56:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume": {"migration_status": null, "attachments": [{"server_id":
@@ -753,7 +753,7 @@ http_interactions:
         "bootable": "false", "created_at": "2016-11-11T13:49:43.000000", "volume_type":
         "iscsi"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:30 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:56 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/6
@@ -768,7 +768,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 31773b1f125449e2ba5204654b9f958f
+      - 5df501965aab45d8afca8d01ba39c22d
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -781,9 +781,9 @@ http_interactions:
       Content-Length:
       - '433'
       X-Compute-Request-Id:
-      - req-b4848054-37e1-4f69-83d9-ac2a83285a4a
+      - req-1aeb555f-b8be-4afb-9b08-425335639c18
       Date:
-      - Thu, 03 Jan 2019 19:26:30 GMT
+      - Fri, 04 Jan 2019 16:56:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavor": {"name": "m1.ems_refresh_spec", "links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/6",
@@ -792,7 +792,7 @@ http_interactions:
         1, "swap": 512, "os-flavor-access:is_public": true, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         1, "disk": 1, "id": "6"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:30 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:56 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -810,13 +810,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:26:31 GMT
+      - Fri, 04 Jan 2019 16:56:56 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-deec50ff-2098-4583-b7dd-05841a4aae61
+      - req-4f9f1305-f8ab-4a39-a034-7bc40de69feb
       Content-Length:
       - '4170'
       Connection:
@@ -825,10 +825,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:26:31.141763", "expires":
-        "2019-01-03T20:26:31Z", "id": "c80dabb6dab04b98a94dc56e9d02ff3c", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:56:57.054466", "expires":
+        "2019-01-04T17:56:57Z", "id": "2ff82ff7c21842ab8eb8d0023a7614c1", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["8mxg54JqQjW9Wsw_UJbErA"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["ACeo5F9RQf-gag3rfBovuQ"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -873,7 +873,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:31 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:57 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images/bb799f70-5e02-461b-8324-17ee88259c7b
@@ -888,7 +888,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c80dabb6dab04b98a94dc56e9d02ff3c
+      - 2ff82ff7c21842ab8eb8d0023a7614c1
   response:
     status:
       code: 200
@@ -899,9 +899,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-f4e50b46-068f-44cb-b99a-9f4d47ba675a
+      - req-dc2fd489-2d1d-4b97-af77-b35484e0023d
       Date:
-      - Thu, 03 Jan 2019 19:26:31 GMT
+      - Fri, 04 Jan 2019 16:56:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"status": "active", "name": "EmsRefreshSpec-Image", "tags": [], "container_format":
@@ -912,7 +912,7 @@ http_interactions:
         "checksum": "ee1eca47dc88f4879d8a229cc70a07c6", "owner": "69f8f7205ade4aa59084c32c83e60b5a",
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:31 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:57 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -930,13 +930,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:26:31 GMT
+      - Fri, 04 Jan 2019 16:56:57 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-b9b19b8c-d770-4776-9de4-77db7996e775
+      - req-a8494503-4a01-4133-a4fa-73a200b9f69d
       Content-Length:
       - '370'
       Connection:
@@ -945,13 +945,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:26:31.471816", "expires":
-        "2019-01-03T20:26:31Z", "id": "cdf689f708074f64bc43dcad2b2a991c", "audit_ids":
-        ["3ajISnObRXSnkoAsOykv2w"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:56:57.427119", "expires":
+        "2019-01-04T17:56:57Z", "id": "26e74bf4d4304e1ca57bf398800fe3d6", "audit_ids":
+        ["NrNeuVQ9QnGh6CgTe7fT2w"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:31 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:57 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -966,20 +966,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cdf689f708074f64bc43dcad2b2a991c
+      - 26e74bf4d4304e1ca57bf398800fe3d6
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:26:31 GMT
+      - Fri, 04 Jan 2019 16:56:57 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-6cb0d4b3-15c5-4184-9a12-9cdcedd5422f
+      - req-4360d47c-9fac-4cec-b683-cce844a1c41b
       Content-Length:
       - '500'
       Connection:
@@ -996,7 +996,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:31 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:57 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1014,13 +1014,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:26:31 GMT
+      - Fri, 04 Jan 2019 16:56:57 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-29d1afef-75cd-4b62-bdd3-4ee442fb245d
+      - req-c77cc079-dd2b-4480-8e2b-31ac22f6374b
       Content-Length:
       - '4117'
       Connection:
@@ -1029,10 +1029,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:26:31.811246", "expires":
-        "2019-01-03T20:26:31Z", "id": "eca4c6f1ff3e45e6901b20d442827695", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:56:57.758227", "expires":
+        "2019-01-04T17:56:57Z", "id": "1656b3ffa7dd4e419dde1eef905c83f6", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["8xpxob8PRc6rkQljhnFFBA"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["vvQ-NkweQji4I_QV3_uEcw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -1076,7 +1076,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:31 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:57 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -1091,7 +1091,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - eca4c6f1ff3e45e6901b20d442827695
+      - 1656b3ffa7dd4e419dde1eef905c83f6
   response:
     status:
       code: 200
@@ -1102,7 +1102,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Thu, 03 Jan 2019 19:26:31 GMT
+      - Fri, 04 Jan 2019 16:56:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -1111,7 +1111,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:31 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:57 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1129,13 +1129,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:26:32 GMT
+      - Fri, 04 Jan 2019 16:56:57 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-1194fa87-9af8-4b69-8e8b-caeb5c505e58
+      - req-e89e69b2-b17d-41c2-83f4-0b7063359eff
       Content-Length:
       - '4131'
       Connection:
@@ -1144,10 +1144,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:26:32.081167", "expires":
-        "2019-01-03T20:26:32Z", "id": "b49882cd24634dae9641f22bc8762da8", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:56:58.032872", "expires":
+        "2019-01-04T17:56:58Z", "id": "e9e27fbeba79434da2b1c694befe62a3", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["VuL9NSgOQdqDOR1uYoBl_A"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["XfIkTb3VRwarwzx4IKrgkw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -1191,7 +1191,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:32 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:58 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -1206,7 +1206,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b49882cd24634dae9641f22bc8762da8
+      - e9e27fbeba79434da2b1c694befe62a3
   response:
     status:
       code: 200
@@ -1217,7 +1217,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Thu, 03 Jan 2019 19:26:32 GMT
+      - Fri, 04 Jan 2019 16:56:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -1226,7 +1226,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:32 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:58 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1244,13 +1244,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:26:32 GMT
+      - Fri, 04 Jan 2019 16:56:58 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-018db3a0-ac7e-4715-af5e-95612c339a0e
+      - req-249614e9-84c1-487c-ade7-a289773808c3
       Content-Length:
       - '4118'
       Connection:
@@ -1259,10 +1259,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:26:32.362559", "expires":
-        "2019-01-03T20:26:32Z", "id": "04c8c081b43c4d79af888e376e74230c", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:56:58.315195", "expires":
+        "2019-01-04T17:56:58Z", "id": "12f695968ab74cd1a7740cf9867a2a5a", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["izwJKIDIQuCArPXyRI_pAw"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["SKJNUWdXRBiSX4NM5olDlA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -1306,7 +1306,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:32 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:58 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -1321,7 +1321,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 04c8c081b43c4d79af888e376e74230c
+      - 12f695968ab74cd1a7740cf9867a2a5a
   response:
     status:
       code: 200
@@ -1332,7 +1332,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Thu, 03 Jan 2019 19:26:32 GMT
+      - Fri, 04 Jan 2019 16:56:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -1341,7 +1341,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:32 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:58 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-keypairs?limit=1000
@@ -1356,7 +1356,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - eca4c6f1ff3e45e6901b20d442827695
+      - 1656b3ffa7dd4e419dde1eef905c83f6
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1369,9 +1369,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-20cc6d7b-e2d1-4358-b519-42131e537305
+      - req-0737dd74-21f5-483d-a85c-8559725c9d30
       Date:
-      - Thu, 03 Jan 2019 19:26:32 GMT
+      - Fri, 04 Jan 2019 16:56:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -1381,7 +1381,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:32 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:58 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -1396,7 +1396,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - eca4c6f1ff3e45e6901b20d442827695
+      - 1656b3ffa7dd4e419dde1eef905c83f6
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1409,9 +1409,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-fdfca415-99ce-4734-97e2-5332eb24c61a
+      - req-39ba7a7f-6283-4e47-8afd-bc67853a8c5e
       Date:
-      - Thu, 03 Jan 2019 19:26:32 GMT
+      - Fri, 04 Jan 2019 16:56:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -1421,7 +1421,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:32 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:58 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8/os-keypairs?limit=1000
@@ -1436,7 +1436,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b49882cd24634dae9641f22bc8762da8
+      - e9e27fbeba79434da2b1c694befe62a3
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1449,9 +1449,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-7da978de-9f94-4fc4-8d94-55b4586c4deb
+      - req-dc4e0d1f-a735-452b-94f5-f36ef415f049
       Date:
-      - Thu, 03 Jan 2019 19:26:32 GMT
+      - Fri, 04 Jan 2019 16:56:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -1461,7 +1461,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:32 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:58 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -1476,7 +1476,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b49882cd24634dae9641f22bc8762da8
+      - e9e27fbeba79434da2b1c694befe62a3
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1489,9 +1489,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-29ee1900-654a-44ff-80cd-f9802fea0cbe
+      - req-d03b61c2-eb2e-4721-8bf8-af21ab0e4f98
       Date:
-      - Thu, 03 Jan 2019 19:26:32 GMT
+      - Fri, 04 Jan 2019 16:56:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -1501,7 +1501,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:32 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:58 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-keypairs?limit=1000
@@ -1516,7 +1516,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 31773b1f125449e2ba5204654b9f958f
+      - 5df501965aab45d8afca8d01ba39c22d
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1529,9 +1529,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-5f57a190-144a-4d1c-a693-35ce50f63a53
+      - req-839e481f-612f-417f-af21-55bdf191532b
       Date:
-      - Thu, 03 Jan 2019 19:26:33 GMT
+      - Fri, 04 Jan 2019 16:56:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -1541,7 +1541,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:33 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:59 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -1556,7 +1556,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 31773b1f125449e2ba5204654b9f958f
+      - 5df501965aab45d8afca8d01ba39c22d
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1569,9 +1569,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-79e29040-0466-4cb0-a474-01f4e6d8664a
+      - req-912db514-cce8-4642-afb8-f7c8ae2f18bf
       Date:
-      - Thu, 03 Jan 2019 19:26:33 GMT
+      - Fri, 04 Jan 2019 16:56:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -1581,7 +1581,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:33 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:59 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608/os-keypairs?limit=1000
@@ -1596,7 +1596,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 04c8c081b43c4d79af888e376e74230c
+      - 12f695968ab74cd1a7740cf9867a2a5a
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1609,9 +1609,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-ee53089b-369b-4520-b31d-29cb9899b934
+      - req-c10f2d37-a719-4d3a-956d-7218cad270a2
       Date:
-      - Thu, 03 Jan 2019 19:26:33 GMT
+      - Fri, 04 Jan 2019 16:56:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -1621,7 +1621,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:33 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:59 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -1636,7 +1636,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 04c8c081b43c4d79af888e376e74230c
+      - 12f695968ab74cd1a7740cf9867a2a5a
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1649,9 +1649,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-da17401c-1ce6-47e1-9ac4-07e555eb69c3
+      - req-339ab1e6-bcad-4459-aced-3880fcc153f2
       Date:
-      - Thu, 03 Jan 2019 19:26:33 GMT
+      - Fri, 04 Jan 2019 16:56:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -1661,7 +1661,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:33 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:59 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/6
@@ -1676,7 +1676,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 31773b1f125449e2ba5204654b9f958f
+      - 5df501965aab45d8afca8d01ba39c22d
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1689,9 +1689,9 @@ http_interactions:
       Content-Length:
       - '433'
       X-Compute-Request-Id:
-      - req-e103ea76-d688-44aa-bb02-6e3f27236d48
+      - req-f84c5cae-91e1-4a72-a391-e91dfd57bdce
       Date:
-      - Thu, 03 Jan 2019 19:26:33 GMT
+      - Fri, 04 Jan 2019 16:56:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavor": {"name": "m1.ems_refresh_spec", "links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/6",
@@ -1700,7 +1700,7 @@ http_interactions:
         1, "swap": 512, "os-flavor-access:is_public": true, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         1, "disk": 1, "id": "6"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:33 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:59 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/ca4f3a16-bae3-4407-83e9-f77b28af0f2b/os-volume_attachments
@@ -1715,7 +1715,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 31773b1f125449e2ba5204654b9f958f
+      - 5df501965aab45d8afca8d01ba39c22d
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1728,15 +1728,15 @@ http_interactions:
       Content-Length:
       - '197'
       X-Compute-Request-Id:
-      - req-3c08aab6-57bc-47a7-9f3f-15d32f8fdbdb
+      - req-1cb01dd9-8736-442c-8914-fc3b9a67335c
       Date:
-      - Thu, 03 Jan 2019 19:26:33 GMT
+      - Fri, 04 Jan 2019 16:56:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumeAttachments": [{"device": "/dev/vdd", "serverId": "ca4f3a16-bae3-4407-83e9-f77b28af0f2b",
         "id": "0a55c0d5-c780-4e7d-9d09-47f5520c7448", "volumeId": "0a55c0d5-c780-4e7d-9d09-47f5520c7448"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:33 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:59 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/networks/c0e8e42b-005e-4183-8f25-fa91b3e441c1
@@ -1751,7 +1751,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d6a2ddd270fb452f93fc0c5be14cf82d
+      - 6055943a72b94605b248692a5c007e89
   response:
     status:
       code: 200
@@ -1762,9 +1762,9 @@ http_interactions:
       Content-Length:
       - '440'
       X-Openstack-Request-Id:
-      - req-0e292ed5-8014-4522-a8d5-4f3e759af903
+      - req-43562c85-79a2-43cd-925a-1b0f930b24e7
       Date:
-      - Thu, 03 Jan 2019 19:26:33 GMT
+      - Fri, 04 Jan 2019 16:56:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"network": {"status": "ACTIVE", "subnets": ["104c081f-97dd-42b7-8930-98abbd015c74",
@@ -1774,7 +1774,7 @@ http_interactions:
         "vxlan", "id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "provider:segmentation_id":
         14}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:33 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:59 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/networks/20af6027-7aeb-432a-ab3b-d7217faa2f1c
@@ -1789,7 +1789,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d6a2ddd270fb452f93fc0c5be14cf82d
+      - 6055943a72b94605b248692a5c007e89
   response:
     status:
       code: 200
@@ -1800,9 +1800,9 @@ http_interactions:
       Content-Length:
       - '409'
       X-Openstack-Request-Id:
-      - req-75d07ddd-5f75-4caf-a5c3-60a993abae57
+      - req-56ad3e8d-9f87-4230-bfe2-597858ec8a19
       Date:
-      - Thu, 03 Jan 2019 19:26:33 GMT
+      - Fri, 04 Jan 2019 16:56:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"network": {"status": "ACTIVE", "subnets": ["33da95a6-bded-44d8-be36-6cc97f3d72bd"],
@@ -1812,7 +1812,7 @@ http_interactions:
         "id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "provider:segmentation_id":
         null}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:33 GMT
+  recorded_at: Fri, 04 Jan 2019 16:56:59 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1830,13 +1830,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:26:34 GMT
+      - Fri, 04 Jan 2019 16:57:00 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-b7584f49-b2a8-4862-81f2-645dbcb05c1c
+      - req-fdc943df-e36d-4871-8b6d-c41eece2b5f0
       Content-Length:
       - '4117'
       Connection:
@@ -1845,10 +1845,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:26:34.118158", "expires":
-        "2019-01-03T20:26:34Z", "id": "1c239488911f49378d86a0f60cf89077", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:57:00.107759", "expires":
+        "2019-01-04T17:57:00Z", "id": "2bf2e6c8e107429494762e878d48ecf3", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["6w8lwPS_Qf6Wr5uPT8MM0A"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["lT62gEWwS3OQ2f2CF9ViEw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -1892,7 +1892,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:34 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:00 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1910,13 +1910,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:26:39 GMT
+      - Fri, 04 Jan 2019 16:57:00 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-ff59740b-f83f-4479-9fd7-532418864ec8
+      - req-ab3b8422-a3ba-41f1-9a3a-b09c848d0a13
       Content-Length:
       - '4131'
       Connection:
@@ -1925,10 +1925,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:26:39.461643", "expires":
-        "2019-01-03T20:26:39Z", "id": "c97bac23e36a43f0a202f37d82711ae7", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:57:00.301846", "expires":
+        "2019-01-04T17:57:00Z", "id": "6dd06f801c354fd7be26d17aa8860095", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["xoLTVaQhRNiFLPzmcU19kw"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["tw9qn1ZeRIGtpS0UriuljQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -1972,7 +1972,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:39 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:00 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1990,13 +1990,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:26:39 GMT
+      - Fri, 04 Jan 2019 16:57:00 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-2e3c9f53-cdcd-4bf6-9145-c61bc54a4a04
+      - req-3ca97681-697d-4de6-aac7-6d87c8b9388b
       Content-Length:
       - '4118'
       Connection:
@@ -2005,10 +2005,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:26:39.667498", "expires":
-        "2019-01-03T20:26:39Z", "id": "aaf73829d98345eea24d237f74299387", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:57:00.488576", "expires":
+        "2019-01-04T17:57:00Z", "id": "d680d0edbd174e398c354ed3f5241eb9", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["p8IbgZY8SQ2xIxvfr0WEqw"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["bBuLsUGiRnCxGXNdR9Nrog"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -2052,7 +2052,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:39 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:00 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -2067,7 +2067,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1c239488911f49378d86a0f60cf89077
+      - 2bf2e6c8e107429494762e878d48ecf3
   response:
     status:
       code: 200
@@ -2078,329 +2078,12 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-f09c5683-a91a-43a2-909b-aeb7b5d17df6
+      - req-30a2cc8d-b0e5-49e5-8d19-f5b373cecdb7
       Date:
-      - Thu, 03 Jan 2019 19:26:39 GMT
+      - Fri, 04 Jan 2019 16:57:00 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
-        true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:39 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 1c239488911f49378d86a0f60cf89077
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-6fba40e4-74f5-4028-9a94-3e0bccb00fc3
-      Date:
-      - Thu, 03 Jan 2019 19:26:40 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
-        true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:40 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - c97bac23e36a43f0a202f37d82711ae7
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-b483a6b8-027f-47b7-926a-3380dcf3d092
-      Date:
-      - Thu, 03 Jan 2019 19:26:40 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
         true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
@@ -2435,79 +2118,6 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
         "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:40 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - c97bac23e36a43f0a202f37d82711ae7
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-fad716f1-63b8-4d5b-91f9-fcbb5d8352e9
-      Date:
-      - Thu, 03 Jan 2019 19:26:40 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
-        true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
@@ -2561,26 +2171,20 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
         "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:40 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:00 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
@@ -2595,7 +2199,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c97bac23e36a43f0a202f37d82711ae7
+      - 2bf2e6c8e107429494762e878d48ecf3
   response:
     status:
       code: 200
@@ -2606,65 +2210,12 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-ec844471-4586-498a-b949-f1fc2ce8901e
+      - req-61049342-3441-4387-b238-8745b2707791
       Date:
-      - Thu, 03 Jan 2019 19:26:40 GMT
+      - Fri, 04 Jan 2019 16:57:00 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
         true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
@@ -2699,812 +2250,73 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
         "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
         null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:40 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - c97bac23e36a43f0a202f37d82711ae7
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-a22f7ec3-2156-4dc7-b5f3-b954d6f78046
-      Date:
-      - Thu, 03 Jan 2019 19:26:40 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
-        true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:40 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - c97bac23e36a43f0a202f37d82711ae7
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-6b15b52e-23ec-4b8f-8a30-ede606098af4
-      Date:
-      - Thu, 03 Jan 2019 19:26:40 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:41 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - c97bac23e36a43f0a202f37d82711ae7
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-2d1de31d-89e7-41e8-990b-950f01a3a326
-      Date:
-      - Thu, 03 Jan 2019 19:26:41 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
-        true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:41 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - c97bac23e36a43f0a202f37d82711ae7
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-d5b9f9f0-d218-436a-88c9-295ff04fd58d
-      Date:
-      - Thu, 03 Jan 2019 19:26:41 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:41 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - c97bac23e36a43f0a202f37d82711ae7
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-6b9251b7-cd3e-4bbe-b208-6dc65e3bc2a0
-      Date:
-      - Thu, 03 Jan 2019 19:26:41 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
-        true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:41 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - c97bac23e36a43f0a202f37d82711ae7
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-85ed7e61-2ac3-4550-b6d1-a06d2da428ab
-      Date:
-      - Thu, 03 Jan 2019 19:26:41 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
-        true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:41 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:00 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -3519,7 +2331,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d6a2ddd270fb452f93fc0c5be14cf82d
+      - 6dd06f801c354fd7be26d17aa8860095
   response:
     status:
       code: 200
@@ -3530,13 +2342,19 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-e8f88c41-ff83-4266-bb0b-e21340b6b131
+      - req-ea6a5aa0-2e99-4e15-a671-cf4d48a6c7fc
       Date:
-      - Thu, 03 Jan 2019 19:26:41 GMT
+      - Fri, 04 Jan 2019 16:57:01 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
-        true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
@@ -3617,26 +2435,20 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
         "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:41 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:01 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
@@ -3651,7 +2463,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d6a2ddd270fb452f93fc0c5be14cf82d
+      - 6dd06f801c354fd7be26d17aa8860095
   response:
     status:
       code: 200
@@ -3662,13 +2474,19 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-38b1cb83-9d45-4488-b5ad-b2a1986b562b
+      - req-73e80895-0a63-4011-8354-47a01aa84f7d
       Date:
-      - Thu, 03 Jan 2019 19:26:42 GMT
+      - Fri, 04 Jan 2019 16:57:01 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
-        true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
@@ -3749,26 +2567,20 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
         "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:42 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:01 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -3783,7 +2595,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - aaf73829d98345eea24d237f74299387
+      - 6055943a72b94605b248692a5c007e89
   response:
     status:
       code: 200
@@ -3794,13 +2606,19 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-2c2cd34b-9569-4dd8-be52-b9d687e789b9
+      - req-ff9ed287-dd41-4064-bc96-5aff607ecc56
       Date:
-      - Thu, 03 Jan 2019 19:26:42 GMT
+      - Fri, 04 Jan 2019 16:57:01 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
-        true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
@@ -3881,26 +2699,20 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
         "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:42 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:01 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
@@ -3915,7 +2727,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - aaf73829d98345eea24d237f74299387
+      - 6055943a72b94605b248692a5c007e89
   response:
     status:
       code: 200
@@ -3926,13 +2738,19 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-c635673c-22d8-49c6-b0b2-9dbfc600e2be
+      - req-1b9c722a-e9fd-4c10-9464-ba8a6c98dc81
       Date:
-      - Thu, 03 Jan 2019 19:26:42 GMT
+      - Fri, 04 Jan 2019 16:57:01 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
-        true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
@@ -4013,26 +2831,284 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
         "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Fri, 04 Jan 2019 16:57:01 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - d680d0edbd174e398c354ed3f5241eb9
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-5ffd8a06-99ce-4947-871a-cc1cc0654c88
+      Date:
+      - Fri, 04 Jan 2019 16:57:01 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
         true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
         "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:42 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:01 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - d680d0edbd174e398c354ed3f5241eb9
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-c205cf8f-c2ea-4838-a11b-1398c76f9443
+      Date:
+      - Fri, 04 Jan 2019 16:57:01 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Fri, 04 Jan 2019 16:57:02 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports/dda2ebad-f144-4f63-9a75-cbd4fe25e3e9
@@ -4047,7 +3123,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d6a2ddd270fb452f93fc0c5be14cf82d
+      - 6055943a72b94605b248692a5c007e89
   response:
     status:
       code: 200
@@ -4058,9 +3134,9 @@ http_interactions:
       Content-Length:
       - '954'
       X-Openstack-Request-Id:
-      - req-55f54d67-565c-4c6d-9213-b3d17f887124
+      - req-83deceb6-6674-4b1c-884f-51b73e0743d1
       Date:
-      - Thu, 03 Jan 2019 19:26:42 GMT
+      - Fri, 04 Jan 2019 16:57:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"port": {"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -4075,7 +3151,7 @@ http_interactions:
         true}, "binding:vnic_type": "normal", "binding:vif_type": "ovs", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "mac_address": "fa:16:3e:e1:0b:2c"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:42 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:03 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?device_id=57e17608-8ac6-44a6-803e-f42ec15e9d1e&limit=1000
@@ -4090,7 +3166,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1c239488911f49378d86a0f60cf89077
+      - 2bf2e6c8e107429494762e878d48ecf3
   response:
     status:
       code: 200
@@ -4101,9 +3177,9 @@ http_interactions:
       Content-Length:
       - '2617'
       X-Openstack-Request-Id:
-      - req-03c55dd2-dfdc-494e-964c-f64afa606663
+      - req-fb7904c2-c8ee-49f7-ba3b-0ed0bbacd030
       Date:
-      - Thu, 03 Jan 2019 19:26:42 GMT
+      - Fri, 04 Jan 2019 16:57:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -4139,7 +3215,7 @@ http_interactions:
         {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
         "binding:vif_type": "ovs", "tenant_id": "", "mac_address": "fa:16:3e:2e:66:be"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:42 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:03 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?device_id=57e17608-8ac6-44a6-803e-f42ec15e9d1e&limit=1000&marker=9330caba-d3ec-4675-b68a-b80fffae6365
@@ -4154,7 +3230,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1c239488911f49378d86a0f60cf89077
+      - 2bf2e6c8e107429494762e878d48ecf3
   response:
     status:
       code: 200
@@ -4165,9 +3241,9 @@ http_interactions:
       Content-Length:
       - '2617'
       X-Openstack-Request-Id:
-      - req-8f91f466-0667-453c-a576-c0ec291272a8
+      - req-1149379a-f334-4b8c-a161-9a58d96159ef
       Date:
-      - Thu, 03 Jan 2019 19:26:42 GMT
+      - Fri, 04 Jan 2019 16:57:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -4203,7 +3279,7 @@ http_interactions:
         {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
         "binding:vif_type": "ovs", "tenant_id": "", "mac_address": "fa:16:3e:2e:66:be"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:42 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:03 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?device_id=57e17608-8ac6-44a6-803e-f42ec15e9d1e&limit=1000
@@ -4218,7 +3294,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c97bac23e36a43f0a202f37d82711ae7
+      - 6dd06f801c354fd7be26d17aa8860095
   response:
     status:
       code: 200
@@ -4229,9 +3305,9 @@ http_interactions:
       Content-Length:
       - '2617'
       X-Openstack-Request-Id:
-      - req-92409b3a-7d4d-441b-8fbe-6fc3b6bfb4b0
+      - req-bf03197a-bd06-49e5-9992-9d2f55d9295d
       Date:
-      - Thu, 03 Jan 2019 19:26:42 GMT
+      - Fri, 04 Jan 2019 16:57:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -4267,7 +3343,7 @@ http_interactions:
         {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
         "binding:vif_type": "ovs", "tenant_id": "", "mac_address": "fa:16:3e:2e:66:be"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:42 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:03 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?device_id=57e17608-8ac6-44a6-803e-f42ec15e9d1e&limit=1000&marker=9330caba-d3ec-4675-b68a-b80fffae6365
@@ -4282,7 +3358,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c97bac23e36a43f0a202f37d82711ae7
+      - 6dd06f801c354fd7be26d17aa8860095
   response:
     status:
       code: 200
@@ -4293,9 +3369,9 @@ http_interactions:
       Content-Length:
       - '2617'
       X-Openstack-Request-Id:
-      - req-a7125f79-25cc-4c18-9e40-4dc37ce9b259
+      - req-aab23741-4deb-4783-8bcc-32bed9b2eb1b
       Date:
-      - Thu, 03 Jan 2019 19:26:43 GMT
+      - Fri, 04 Jan 2019 16:57:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -4331,7 +3407,7 @@ http_interactions:
         {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
         "binding:vif_type": "ovs", "tenant_id": "", "mac_address": "fa:16:3e:2e:66:be"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:43 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:03 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?device_id=57e17608-8ac6-44a6-803e-f42ec15e9d1e&limit=1000
@@ -4346,7 +3422,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d6a2ddd270fb452f93fc0c5be14cf82d
+      - 6055943a72b94605b248692a5c007e89
   response:
     status:
       code: 200
@@ -4357,9 +3433,9 @@ http_interactions:
       Content-Length:
       - '2617'
       X-Openstack-Request-Id:
-      - req-b656ec21-85a2-4cff-babc-2c3534fc98eb
+      - req-a6b8cb34-6534-4f5c-98bf-07c7ad49c897
       Date:
-      - Thu, 03 Jan 2019 19:26:43 GMT
+      - Fri, 04 Jan 2019 16:57:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -4395,7 +3471,7 @@ http_interactions:
         {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
         "binding:vif_type": "ovs", "tenant_id": "", "mac_address": "fa:16:3e:2e:66:be"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:43 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:03 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?device_id=57e17608-8ac6-44a6-803e-f42ec15e9d1e&limit=1000&marker=9330caba-d3ec-4675-b68a-b80fffae6365
@@ -4410,7 +3486,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d6a2ddd270fb452f93fc0c5be14cf82d
+      - 6055943a72b94605b248692a5c007e89
   response:
     status:
       code: 200
@@ -4421,9 +3497,9 @@ http_interactions:
       Content-Length:
       - '2617'
       X-Openstack-Request-Id:
-      - req-d8da85c7-54d7-46ae-b51d-6f9e3a9620d6
+      - req-2e04dc03-de32-4ffd-b313-871bdafc2798
       Date:
-      - Thu, 03 Jan 2019 19:26:43 GMT
+      - Fri, 04 Jan 2019 16:57:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -4459,7 +3535,7 @@ http_interactions:
         {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
         "binding:vif_type": "ovs", "tenant_id": "", "mac_address": "fa:16:3e:2e:66:be"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:43 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:03 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?device_id=57e17608-8ac6-44a6-803e-f42ec15e9d1e&limit=1000
@@ -4474,7 +3550,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - aaf73829d98345eea24d237f74299387
+      - d680d0edbd174e398c354ed3f5241eb9
   response:
     status:
       code: 200
@@ -4485,9 +3561,9 @@ http_interactions:
       Content-Length:
       - '2617'
       X-Openstack-Request-Id:
-      - req-586ccec3-9a06-4bdc-97c6-0f3843732ac4
+      - req-e2f0bf37-5983-4713-a058-9442650837dc
       Date:
-      - Thu, 03 Jan 2019 19:26:43 GMT
+      - Fri, 04 Jan 2019 16:57:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -4523,7 +3599,7 @@ http_interactions:
         {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
         "binding:vif_type": "ovs", "tenant_id": "", "mac_address": "fa:16:3e:2e:66:be"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:43 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:04 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?device_id=57e17608-8ac6-44a6-803e-f42ec15e9d1e&limit=1000&marker=9330caba-d3ec-4675-b68a-b80fffae6365
@@ -4538,7 +3614,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - aaf73829d98345eea24d237f74299387
+      - d680d0edbd174e398c354ed3f5241eb9
   response:
     status:
       code: 200
@@ -4549,9 +3625,9 @@ http_interactions:
       Content-Length:
       - '2617'
       X-Openstack-Request-Id:
-      - req-5d09742d-39b0-4526-9348-9800f84a8685
+      - req-4a502c50-bd18-4958-b3b6-a87bb056f65e
       Date:
-      - Thu, 03 Jan 2019 19:26:43 GMT
+      - Fri, 04 Jan 2019 16:57:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -4587,7 +3663,7 @@ http_interactions:
         {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
         "binding:vif_type": "ovs", "tenant_id": "", "mac_address": "fa:16:3e:2e:66:be"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:43 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:04 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers/57e17608-8ac6-44a6-803e-f42ec15e9d1e
@@ -4602,7 +3678,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d6a2ddd270fb452f93fc0c5be14cf82d
+      - 6055943a72b94605b248692a5c007e89
   response:
     status:
       code: 200
@@ -4613,9 +3689,9 @@ http_interactions:
       Content-Length:
       - '443'
       X-Openstack-Request-Id:
-      - req-9384f433-c6e9-4ebf-ae44-6c9ce01401e1
+      - req-ea6627b2-f94a-48fe-9b0d-2c220a1c4748
       Date:
-      - Thu, 03 Jan 2019 19:26:43 GMT
+      - Fri, 04 Jan 2019 16:57:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"router": {"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -4624,7 +3700,7 @@ http_interactions:
         "name": "EmsRefreshSpec-Router", "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "distributed": false, "routes": [], "ha": false, "id": "57e17608-8ac6-44a6-803e-f42ec15e9d1e"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:43 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:04 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups/fd147cb7-7456-43d9-a01f-c06e21b4e6fb
@@ -4639,7 +3715,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d6a2ddd270fb452f93fc0c5be14cf82d
+      - 6055943a72b94605b248692a5c007e89
   response:
     status:
       code: 200
@@ -4650,9 +3726,9 @@ http_interactions:
       Content-Length:
       - '6900'
       X-Openstack-Request-Id:
-      - req-b61c0056-14eb-4465-8200-1cf41cfbcd2b
+      - req-b2ad0a36-89a6-4b7a-91ca-b166607c611b
       Date:
-      - Thu, 03 Jan 2019 19:26:43 GMT
+      - Fri, 04 Jan 2019 16:57:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_group": {"tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
@@ -4738,7 +3814,7 @@ http_interactions:
         "port_range_max": 80, "port_range_min": 80, "id": "f79f0e32-b186-4778-952e-20827a60ef73",
         "security_group_id": "fd147cb7-7456-43d9-a01f-c06e21b4e6fb"}], "name": "EmsRefreshSpec-SecurityGroup"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:43 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:04 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups/e4836528-d0df-425e-a117-ae8ec6f356d4
@@ -4753,7 +3829,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d6a2ddd270fb452f93fc0c5be14cf82d
+      - 6055943a72b94605b248692a5c007e89
   response:
     status:
       code: 200
@@ -4764,9 +3840,9 @@ http_interactions:
       Content-Length:
       - '880'
       X-Openstack-Request-Id:
-      - req-bad496b3-040e-416d-b9b0-36367d8ec01a
+      - req-1f0f2616-bfff-4d6f-829c-16236f7329ce
       Date:
-      - Thu, 03 Jan 2019 19:26:43 GMT
+      - Fri, 04 Jan 2019 16:57:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_group": {"tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
@@ -4780,7 +3856,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "75924ebc-4758-4042-ad04-4ef3c9189098",
         "security_group_id": "e4836528-d0df-425e-a117-ae8ec6f356d4"}], "name": "EmsRefreshSpec-SecurityGroup2"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:43 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:04 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/ca4f3a16-bae3-4407-83e9-f77b28af0f2b
@@ -4795,7 +3871,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 31773b1f125449e2ba5204654b9f958f
+      - 5df501965aab45d8afca8d01ba39c22d
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4808,9 +3884,9 @@ http_interactions:
       Content-Length:
       - '2088'
       X-Compute-Request-Id:
-      - req-a08c5c14-ef34-4c81-bfd4-e0a41bcd13cb
+      - req-028df71a-d450-4b07-be8d-6847fc558ff8
       Date:
-      - Thu, 03 Jan 2019 19:26:44 GMT
+      - Fri, 04 Jan 2019 16:57:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"server": {"status": "ACTIVE", "updated": "2018-10-09T18:40:19Z",
@@ -4837,7 +3913,7 @@ http_interactions:
         "", "progress": 0, "OS-EXT-STS:power_state": 1, "config_drive": "", "metadata":
         {}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:44 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:05 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/ca4f3a16-bae3-4407-83e9-f77b28af0f2b/os-interface
@@ -4852,7 +3928,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 31773b1f125449e2ba5204654b9f958f
+      - 5df501965aab45d8afca8d01ba39c22d
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4865,9 +3941,9 @@ http_interactions:
       Content-Length:
       - '285'
       X-Compute-Request-Id:
-      - req-d163e46f-cf18-44ff-9135-46f2dbbcdc18
+      - req-b5dd3ac1-634e-4757-b22e-e0e6496d266e
       Date:
-      - Thu, 03 Jan 2019 19:26:44 GMT
+      - Fri, 04 Jan 2019 16:57:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"interfaceAttachments": [{"port_state": "ACTIVE", "fixed_ips": [{"subnet_id":
@@ -4875,7 +3951,7 @@ http_interactions:
         "dda2ebad-f144-4f63-9a75-cbd4fe25e3e9", "net_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
         "mac_addr": "fa:16:3e:e1:0b:2c"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:44 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:05 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/ca4f3a16-bae3-4407-83e9-f77b28af0f2b/os-security-groups
@@ -4890,7 +3966,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 31773b1f125449e2ba5204654b9f958f
+      - 5df501965aab45d8afca8d01ba39c22d
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4903,9 +3979,9 @@ http_interactions:
       Content-Length:
       - '3931'
       X-Compute-Request-Id:
-      - req-a5f41124-5f75-4539-bbbe-cbc4230fa364
+      - req-5b3a474c-40cc-45d3-94d5-1e9d98e72b19
       Date:
-      - Thu, 03 Jan 2019 19:26:45 GMT
+      - Fri, 04 Jan 2019 16:57:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups": [{"rules": [{"from_port": 3, "group": {"tenant_id":
@@ -4957,7 +4033,7 @@ http_interactions:
         "name": "EmsRefreshSpec-SecurityGroup2", "description": "EmsRefreshSpec-SecurityGroup2
         description"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:45 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:06 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-floating-ips
@@ -4972,7 +4048,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 31773b1f125449e2ba5204654b9f958f
+      - 5df501965aab45d8afca8d01ba39c22d
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4985,14 +4061,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-ecccaac4-4a16-44e5-8115-1cdf59101a17
+      - req-4199b7df-3b50-4d51-a68e-48c327303a96
       Date:
-      - Thu, 03 Jan 2019 19:26:45 GMT
+      - Fri, 04 Jan 2019 16:57:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:45 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:06 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?floating_ip_address=172.16.17.4
@@ -5007,7 +4083,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d6a2ddd270fb452f93fc0c5be14cf82d
+      - 6055943a72b94605b248692a5c007e89
   response:
     status:
       code: 200
@@ -5018,9 +4094,9 @@ http_interactions:
       Content-Length:
       - '374'
       X-Openstack-Request-Id:
-      - req-13af1db7-3911-4430-a170-b6b2bef07c64
+      - req-5242cb66-2a56-473c-983c-78c4fc65ebfb
       Date:
-      - Thu, 03 Jan 2019 19:26:45 GMT
+      - Fri, 04 Jan 2019 16:57:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -5029,7 +4105,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "dda2ebad-f144-4f63-9a75-cbd4fe25e3e9", "id":
         "855b23e7-1ace-4c22-8c02-2160d3cde900"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:45 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:06 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips/855b23e7-1ace-4c22-8c02-2160d3cde900
@@ -5044,7 +4120,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d6a2ddd270fb452f93fc0c5be14cf82d
+      - 6055943a72b94605b248692a5c007e89
   response:
     status:
       code: 200
@@ -5055,9 +4131,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Openstack-Request-Id:
-      - req-6c9863eb-a131-406c-b297-60b99d4e2264
+      - req-157ec51a-5d31-40a7-a5b8-dff2709e71bd
       Date:
-      - Thu, 03 Jan 2019 19:26:45 GMT
+      - Fri, 04 Jan 2019 16:57:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingip": {"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -5066,7 +4142,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "dda2ebad-f144-4f63-9a75-cbd4fe25e3e9", "id":
         "855b23e7-1ace-4c22-8c02-2160d3cde900"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:45 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:06 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -5081,20 +4157,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9f5f9db5d2684a9589b3ab518897b910
+      - 47a74883b6494db09f58e452d3b1e25e
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:26:45 GMT
+      - Fri, 04 Jan 2019 16:57:06 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-127e6633-7ebf-4f2b-af28-e98084223ee3
+      - req-06f5b750-ba22-4c08-af46-3e0d94c7d0bb
       Content-Length:
       - '500'
       Connection:
@@ -5111,7 +4187,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:45 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:06 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/0a55c0d5-c780-4e7d-9d09-47f5520c7448
@@ -5126,22 +4202,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c75b54791e1c4d0ea060fa44ee8e8147
+      - 644eeb2758e6479ab5ad426137b806db
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-451255bf-9b94-4392-8c84-b8a016ab8a1f
+      - req-a9e77b32-27b1-4a33-a9e7-30bf7acc4248
       Content-Type:
       - application/json
       Content-Length:
       - '1406'
       X-Openstack-Request-Id:
-      - req-451255bf-9b94-4392-8c84-b8a016ab8a1f
+      - req-a9e77b32-27b1-4a33-a9e7-30bf7acc4248
       Date:
-      - Thu, 03 Jan 2019 19:26:46 GMT
+      - Fri, 04 Jan 2019 16:57:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume": {"migration_status": null, "attachments": [{"server_id":
@@ -5162,7 +4238,7 @@ http_interactions:
         "bootable": "false", "created_at": "2016-11-11T13:49:20.000000", "volume_type":
         "iscsi"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:46 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:06 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/2c774148-c11a-434c-aabb-7fa9c82c37ce
@@ -5177,22 +4253,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c75b54791e1c4d0ea060fa44ee8e8147
+      - 644eeb2758e6479ab5ad426137b806db
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-1033e620-957e-46c5-9b41-8d5ea5ebacf1
+      - req-70dfa0b8-61cd-4b56-af51-1d1d5fc4d17e
       Content-Type:
       - application/json
       Content-Length:
       - '1408'
       X-Openstack-Request-Id:
-      - req-1033e620-957e-46c5-9b41-8d5ea5ebacf1
+      - req-70dfa0b8-61cd-4b56-af51-1d1d5fc4d17e
       Date:
-      - Thu, 03 Jan 2019 19:26:46 GMT
+      - Fri, 04 Jan 2019 16:57:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume": {"migration_status": null, "attachments": [{"server_id":
@@ -5213,7 +4289,7 @@ http_interactions:
         "bootable": "false", "created_at": "2016-11-11T13:49:43.000000", "volume_type":
         "iscsi"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:46 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:06 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/6
@@ -5228,7 +4304,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 31773b1f125449e2ba5204654b9f958f
+      - 5df501965aab45d8afca8d01ba39c22d
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5241,9 +4317,9 @@ http_interactions:
       Content-Length:
       - '433'
       X-Compute-Request-Id:
-      - req-df2ea5b8-3037-4632-aa89-50437ad1934e
+      - req-32237dda-539a-44d7-b054-d42ebd9d151b
       Date:
-      - Thu, 03 Jan 2019 19:26:46 GMT
+      - Fri, 04 Jan 2019 16:57:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavor": {"name": "m1.ems_refresh_spec", "links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/6",
@@ -5252,7 +4328,7 @@ http_interactions:
         1, "swap": 512, "os-flavor-access:is_public": true, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         1, "disk": 1, "id": "6"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:46 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:07 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images/bb799f70-5e02-461b-8324-17ee88259c7b
@@ -5267,7 +4343,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c80dabb6dab04b98a94dc56e9d02ff3c
+      - 2ff82ff7c21842ab8eb8d0023a7614c1
   response:
     status:
       code: 200
@@ -5278,9 +4354,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-dd76299e-d1b3-448b-b92b-b84cc2d0f825
+      - req-f435b0b6-0a17-40f9-b4ec-a6db88dd91cd
       Date:
-      - Thu, 03 Jan 2019 19:26:46 GMT
+      - Fri, 04 Jan 2019 16:57:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"status": "active", "name": "EmsRefreshSpec-Image", "tags": [], "container_format":
@@ -5291,7 +4367,7 @@ http_interactions:
         "checksum": "ee1eca47dc88f4879d8a229cc70a07c6", "owner": "69f8f7205ade4aa59084c32c83e60b5a",
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:46 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:07 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-keypairs?limit=1000
@@ -5306,7 +4382,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - eca4c6f1ff3e45e6901b20d442827695
+      - 1656b3ffa7dd4e419dde1eef905c83f6
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5319,9 +4395,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-7a58d30b-6b4c-4216-a4d1-e938a5fc547f
+      - req-38a509ea-eebc-45d8-97d3-4fd39122338a
       Date:
-      - Thu, 03 Jan 2019 19:26:46 GMT
+      - Fri, 04 Jan 2019 16:57:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -5331,7 +4407,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:46 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:07 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -5346,7 +4422,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - eca4c6f1ff3e45e6901b20d442827695
+      - 1656b3ffa7dd4e419dde1eef905c83f6
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5359,9 +4435,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-e07d0542-9374-486c-8a24-dcf784a44cc9
+      - req-98ac03ea-e86d-4f6f-90f0-4c34ce1c1f78
       Date:
-      - Thu, 03 Jan 2019 19:26:46 GMT
+      - Fri, 04 Jan 2019 16:57:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -5371,7 +4447,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:46 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:07 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8/os-keypairs?limit=1000
@@ -5386,7 +4462,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b49882cd24634dae9641f22bc8762da8
+      - e9e27fbeba79434da2b1c694befe62a3
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5399,9 +4475,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-60ae2f1e-d935-45d1-8563-06bcaf3ea2b4
+      - req-d2d91e66-b9a3-4946-808a-197120dcc0e9
       Date:
-      - Thu, 03 Jan 2019 19:26:46 GMT
+      - Fri, 04 Jan 2019 16:57:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -5411,7 +4487,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:46 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:07 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -5426,7 +4502,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b49882cd24634dae9641f22bc8762da8
+      - e9e27fbeba79434da2b1c694befe62a3
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5439,9 +4515,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-4d9e6e91-c0a6-4b1a-becc-05cc460bd53c
+      - req-fccf208a-4715-43ea-bcd9-c5330b19e47d
       Date:
-      - Thu, 03 Jan 2019 19:26:47 GMT
+      - Fri, 04 Jan 2019 16:57:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -5451,7 +4527,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:47 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:07 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-keypairs?limit=1000
@@ -5466,7 +4542,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 31773b1f125449e2ba5204654b9f958f
+      - 5df501965aab45d8afca8d01ba39c22d
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5479,9 +4555,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-416cd94a-9875-4c27-8cea-4a2a1886715a
+      - req-39c96eb9-8b78-44a6-982a-a203799fcf16
       Date:
-      - Thu, 03 Jan 2019 19:26:47 GMT
+      - Fri, 04 Jan 2019 16:57:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -5491,7 +4567,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:47 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:07 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -5506,7 +4582,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 31773b1f125449e2ba5204654b9f958f
+      - 5df501965aab45d8afca8d01ba39c22d
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5519,9 +4595,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-9584611a-b9d3-4ba1-8d89-9c7a1c74fd32
+      - req-e83db464-5794-4ce3-9bdb-6bafc55895c5
       Date:
-      - Thu, 03 Jan 2019 19:26:47 GMT
+      - Fri, 04 Jan 2019 16:57:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -5531,7 +4607,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:47 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:07 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608/os-keypairs?limit=1000
@@ -5546,7 +4622,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 04c8c081b43c4d79af888e376e74230c
+      - 12f695968ab74cd1a7740cf9867a2a5a
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5559,9 +4635,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-5531ca5f-05cc-485c-80fe-c3a1e10015b5
+      - req-47b66431-dd24-4b4d-93ea-c3ad21462a8f
       Date:
-      - Thu, 03 Jan 2019 19:26:47 GMT
+      - Fri, 04 Jan 2019 16:57:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -5571,7 +4647,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:47 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:07 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -5586,7 +4662,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 04c8c081b43c4d79af888e376e74230c
+      - 12f695968ab74cd1a7740cf9867a2a5a
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5599,9 +4675,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-74c3a1ff-00e4-4f34-b089-4d61fcb5fd4a
+      - req-73230dbf-7bef-4b71-82c7-469a15929fe4
       Date:
-      - Thu, 03 Jan 2019 19:26:47 GMT
+      - Fri, 04 Jan 2019 16:57:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -5611,7 +4687,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:47 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:08 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/6
@@ -5626,7 +4702,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 31773b1f125449e2ba5204654b9f958f
+      - 5df501965aab45d8afca8d01ba39c22d
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5639,9 +4715,9 @@ http_interactions:
       Content-Length:
       - '433'
       X-Compute-Request-Id:
-      - req-33597e11-b2b3-4bb8-9df3-4280c98483dd
+      - req-2396cf61-e77a-400a-bb7d-f5d50c866801
       Date:
-      - Thu, 03 Jan 2019 19:26:47 GMT
+      - Fri, 04 Jan 2019 16:57:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavor": {"name": "m1.ems_refresh_spec", "links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/6",
@@ -5650,7 +4726,7 @@ http_interactions:
         1, "swap": 512, "os-flavor-access:is_public": true, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         1, "disk": 1, "id": "6"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:47 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:08 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/ca4f3a16-bae3-4407-83e9-f77b28af0f2b/os-volume_attachments
@@ -5665,7 +4741,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 31773b1f125449e2ba5204654b9f958f
+      - 5df501965aab45d8afca8d01ba39c22d
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5678,15 +4754,15 @@ http_interactions:
       Content-Length:
       - '197'
       X-Compute-Request-Id:
-      - req-2ec69342-792e-4513-9277-d250ac10ad96
+      - req-e7820094-534c-407b-9cfc-643a0224e87b
       Date:
-      - Thu, 03 Jan 2019 19:26:47 GMT
+      - Fri, 04 Jan 2019 16:57:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumeAttachments": [{"device": "/dev/vdd", "serverId": "ca4f3a16-bae3-4407-83e9-f77b28af0f2b",
         "id": "0a55c0d5-c780-4e7d-9d09-47f5520c7448", "volumeId": "0a55c0d5-c780-4e7d-9d09-47f5520c7448"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:47 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:08 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/networks/c0e8e42b-005e-4183-8f25-fa91b3e441c1
@@ -5701,7 +4777,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d6a2ddd270fb452f93fc0c5be14cf82d
+      - 6055943a72b94605b248692a5c007e89
   response:
     status:
       code: 200
@@ -5712,19 +4788,19 @@ http_interactions:
       Content-Length:
       - '440'
       X-Openstack-Request-Id:
-      - req-6904b1fb-4e65-495a-916e-0275c62829d9
+      - req-52303f4a-1c0a-48ab-acae-638cb9b4fb87
       Date:
-      - Thu, 03 Jan 2019 19:26:47 GMT
+      - Fri, 04 Jan 2019 16:57:08 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"network": {"status": "ACTIVE", "subnets": ["d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "104c081f-97dd-42b7-8930-98abbd015c74"], "name": "EmsRefreshSpec-NetworkPrivate",
+      string: '{"network": {"status": "ACTIVE", "subnets": ["104c081f-97dd-42b7-8930-98abbd015c74",
+        "d53802a5-f0f6-48ba-9207-dbd9b13acac3"], "name": "EmsRefreshSpec-NetworkPrivate",
         "provider:physical_network": null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
         "vxlan", "id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "provider:segmentation_id":
         14}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:47 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:08 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/networks/20af6027-7aeb-432a-ab3b-d7217faa2f1c
@@ -5739,7 +4815,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d6a2ddd270fb452f93fc0c5be14cf82d
+      - 6055943a72b94605b248692a5c007e89
   response:
     status:
       code: 200
@@ -5750,9 +4826,9 @@ http_interactions:
       Content-Length:
       - '409'
       X-Openstack-Request-Id:
-      - req-0a1a3cad-b0e2-4cee-8a34-d761a517f815
+      - req-fe6cb237-06d3-4359-96e0-426bde64b5a7
       Date:
-      - Thu, 03 Jan 2019 19:26:47 GMT
+      - Fri, 04 Jan 2019 16:57:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"network": {"status": "ACTIVE", "subnets": ["33da95a6-bded-44d8-be36-6cc97f3d72bd"],
@@ -5762,7 +4838,7 @@ http_interactions:
         "id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "provider:segmentation_id":
         null}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:47 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:08 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -5777,7 +4853,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1c239488911f49378d86a0f60cf89077
+      - 2bf2e6c8e107429494762e878d48ecf3
   response:
     status:
       code: 200
@@ -5788,13 +4864,19 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-622053a1-72cf-42f9-91ec-360d03bd9de3
+      - req-367d396d-e301-4cbb-9c01-569f8b24d6dc
       Date:
-      - Thu, 03 Jan 2019 19:26:47 GMT
+      - Fri, 04 Jan 2019 16:57:08 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
-        true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
@@ -5875,26 +4957,20 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
         "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:48 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:08 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
@@ -5909,7 +4985,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1c239488911f49378d86a0f60cf89077
+      - 2bf2e6c8e107429494762e878d48ecf3
   response:
     status:
       code: 200
@@ -5920,12 +4996,695 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-f8cc6a59-a8bf-4567-917b-dc866dbac5f7
+      - req-565e17ac-4c1c-4b1b-8056-94063f677d05
       Date:
-      - Thu, 03 Jan 2019 19:26:48 GMT
+      - Fri, 04 Jan 2019 16:57:08 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Fri, 04 Jan 2019 16:57:08 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 6dd06f801c354fd7be26d17aa8860095
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-bfdfca1b-f7f6-47c6-afbd-1b802039b147
+      Date:
+      - Fri, 04 Jan 2019 16:57:08 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Fri, 04 Jan 2019 16:57:08 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 6dd06f801c354fd7be26d17aa8860095
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-1610e45d-2a82-40e3-a2ac-b7edae52cacf
+      Date:
+      - Fri, 04 Jan 2019 16:57:09 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Fri, 04 Jan 2019 16:57:09 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 6055943a72b94605b248692a5c007e89
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-534ec940-862d-4d5f-8ec9-0aa84288597a
+      Date:
+      - Fri, 04 Jan 2019 16:57:09 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Fri, 04 Jan 2019 16:57:09 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 6055943a72b94605b248692a5c007e89
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-7f8914c3-10a3-4195-8bde-c98023c332a2
+      Date:
+      - Fri, 04 Jan 2019 16:57:09 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Fri, 04 Jan 2019 16:57:09 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - d680d0edbd174e398c354ed3f5241eb9
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-fc64b774-a109-42e1-bece-9108f55e3f48
+      Date:
+      - Fri, 04 Jan 2019 16:57:09 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp":
+        true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
@@ -5990,161 +5749,6 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
         "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:48 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 1c239488911f49378d86a0f60cf89077
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-bb512260-36f3-4a70-9f62-3df9c6b5ccf9
-      Date:
-      - Thu, 03 Jan 2019 19:26:48 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
-        true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
         "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
@@ -6158,7 +5762,7 @@ http_interactions:
         4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
         "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:48 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:09 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
@@ -6173,7 +5777,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1c239488911f49378d86a0f60cf89077
+      - d680d0edbd174e398c354ed3f5241eb9
   response:
     status:
       code: 200
@@ -6184,197 +5788,12 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-5bd31493-ce9c-43d7-928f-d6e9a34b9099
+      - req-3d812789-6986-40bf-9523-8bb7b57e9982
       Date:
-      - Thu, 03 Jan 2019 19:26:48 GMT
+      - Fri, 04 Jan 2019 16:57:09 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
-        true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:48 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - c97bac23e36a43f0a202f37d82711ae7
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-753b7edf-baf5-4be5-aa9a-9155630df672
-      Date:
-      - Thu, 03 Jan 2019 19:26:48 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
         true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
@@ -6409,1340 +5828,73 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
         "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
         null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:48 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - c97bac23e36a43f0a202f37d82711ae7
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-eb23e892-bd16-464e-b042-a5535435ce5f
-      Date:
-      - Thu, 03 Jan 2019 19:26:48 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
-        true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:48 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - c97bac23e36a43f0a202f37d82711ae7
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-52330089-1513-4777-8c5d-9837d23952f2
-      Date:
-      - Thu, 03 Jan 2019 19:26:48 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:49 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - c97bac23e36a43f0a202f37d82711ae7
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-8b560ace-391b-4611-b774-f24cd3266e21
-      Date:
-      - Thu, 03 Jan 2019 19:26:49 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
-        true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:49 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - c97bac23e36a43f0a202f37d82711ae7
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-60bef187-b371-4e2c-b4e2-c86876448e99
-      Date:
-      - Thu, 03 Jan 2019 19:26:49 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:49 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - c97bac23e36a43f0a202f37d82711ae7
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-719aa719-1e3c-4cee-bde1-03d636c6dc54
-      Date:
-      - Thu, 03 Jan 2019 19:26:49 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
-        true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:49 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - c97bac23e36a43f0a202f37d82711ae7
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-37b04d92-2a1f-4e48-b698-99901197bf63
-      Date:
-      - Thu, 03 Jan 2019 19:26:49 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
-        true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:49 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - d6a2ddd270fb452f93fc0c5be14cf82d
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-14af0e33-71df-4963-8530-e1aff9444cbe
-      Date:
-      - Thu, 03 Jan 2019 19:26:49 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
-        true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:49 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - d6a2ddd270fb452f93fc0c5be14cf82d
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-7886051a-c802-4816-9e74-75f9b8d969fd
-      Date:
-      - Thu, 03 Jan 2019 19:26:49 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
-        true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:49 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - aaf73829d98345eea24d237f74299387
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-b2075c21-c466-4c69-8dfe-261a99f63acc
-      Date:
-      - Thu, 03 Jan 2019 19:26:50 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
-        true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:50 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - aaf73829d98345eea24d237f74299387
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-6cb0216c-171c-48ce-b62a-13d7946e9dff
-      Date:
-      - Thu, 03 Jan 2019 19:26:50 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
-        true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:50 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:09 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports/dda2ebad-f144-4f63-9a75-cbd4fe25e3e9
@@ -7757,7 +5909,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d6a2ddd270fb452f93fc0c5be14cf82d
+      - 6055943a72b94605b248692a5c007e89
   response:
     status:
       code: 200
@@ -7768,9 +5920,9 @@ http_interactions:
       Content-Length:
       - '954'
       X-Openstack-Request-Id:
-      - req-e2acbb2e-2ab8-427f-9b54-77293d53782f
+      - req-732b294f-9f0f-4582-b3b4-4b0147be961e
       Date:
-      - Thu, 03 Jan 2019 19:26:50 GMT
+      - Fri, 04 Jan 2019 16:57:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"port": {"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -7785,7 +5937,7 @@ http_interactions:
         true}, "binding:vnic_type": "normal", "binding:vif_type": "ovs", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "mac_address": "fa:16:3e:e1:0b:2c"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:50 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:09 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?device_id=57e17608-8ac6-44a6-803e-f42ec15e9d1e&limit=1000
@@ -7800,7 +5952,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1c239488911f49378d86a0f60cf89077
+      - 2bf2e6c8e107429494762e878d48ecf3
   response:
     status:
       code: 200
@@ -7811,9 +5963,9 @@ http_interactions:
       Content-Length:
       - '2617'
       X-Openstack-Request-Id:
-      - req-e4b2c0be-e518-4823-8a9f-73989c934d9f
+      - req-2463d140-3fbb-43d6-b18b-0aa57d2da506
       Date:
-      - Thu, 03 Jan 2019 19:26:50 GMT
+      - Fri, 04 Jan 2019 16:57:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -7849,7 +6001,7 @@ http_interactions:
         {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
         "binding:vif_type": "ovs", "tenant_id": "", "mac_address": "fa:16:3e:2e:66:be"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:50 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:10 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?device_id=57e17608-8ac6-44a6-803e-f42ec15e9d1e&limit=1000&marker=9330caba-d3ec-4675-b68a-b80fffae6365
@@ -7864,7 +6016,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1c239488911f49378d86a0f60cf89077
+      - 2bf2e6c8e107429494762e878d48ecf3
   response:
     status:
       code: 200
@@ -7875,9 +6027,9 @@ http_interactions:
       Content-Length:
       - '2617'
       X-Openstack-Request-Id:
-      - req-46c2a53c-51d7-4bd3-94d3-3c2023f301c4
+      - req-666f1ab6-9026-40db-8b2f-7303f7ec7e78
       Date:
-      - Thu, 03 Jan 2019 19:26:50 GMT
+      - Fri, 04 Jan 2019 16:57:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -7913,7 +6065,7 @@ http_interactions:
         {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
         "binding:vif_type": "ovs", "tenant_id": "", "mac_address": "fa:16:3e:2e:66:be"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:50 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:10 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?device_id=57e17608-8ac6-44a6-803e-f42ec15e9d1e&limit=1000
@@ -7928,7 +6080,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c97bac23e36a43f0a202f37d82711ae7
+      - 6dd06f801c354fd7be26d17aa8860095
   response:
     status:
       code: 200
@@ -7939,9 +6091,9 @@ http_interactions:
       Content-Length:
       - '2617'
       X-Openstack-Request-Id:
-      - req-30a6d260-68d6-4b40-9479-cd5a97856266
+      - req-27b3b7c0-b113-45c4-8d40-a58dbd32235c
       Date:
-      - Thu, 03 Jan 2019 19:26:50 GMT
+      - Fri, 04 Jan 2019 16:57:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -7977,7 +6129,7 @@ http_interactions:
         {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
         "binding:vif_type": "ovs", "tenant_id": "", "mac_address": "fa:16:3e:2e:66:be"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:50 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:10 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?device_id=57e17608-8ac6-44a6-803e-f42ec15e9d1e&limit=1000&marker=9330caba-d3ec-4675-b68a-b80fffae6365
@@ -7992,7 +6144,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c97bac23e36a43f0a202f37d82711ae7
+      - 6dd06f801c354fd7be26d17aa8860095
   response:
     status:
       code: 200
@@ -8003,9 +6155,9 @@ http_interactions:
       Content-Length:
       - '2617'
       X-Openstack-Request-Id:
-      - req-38acf938-b1b3-45d2-a66e-638faf60fc4d
+      - req-62afa530-98e3-4e41-9cf8-60ccc26302a0
       Date:
-      - Thu, 03 Jan 2019 19:26:50 GMT
+      - Fri, 04 Jan 2019 16:57:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -8041,7 +6193,7 @@ http_interactions:
         {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
         "binding:vif_type": "ovs", "tenant_id": "", "mac_address": "fa:16:3e:2e:66:be"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:50 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:10 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?device_id=57e17608-8ac6-44a6-803e-f42ec15e9d1e&limit=1000
@@ -8056,7 +6208,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d6a2ddd270fb452f93fc0c5be14cf82d
+      - 6055943a72b94605b248692a5c007e89
   response:
     status:
       code: 200
@@ -8067,9 +6219,9 @@ http_interactions:
       Content-Length:
       - '2617'
       X-Openstack-Request-Id:
-      - req-30d5d53e-d6be-4060-811a-221c431b019f
+      - req-48051be4-09ec-4dfc-a784-a52fa4c34dd0
       Date:
-      - Thu, 03 Jan 2019 19:26:50 GMT
+      - Fri, 04 Jan 2019 16:57:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -8105,7 +6257,7 @@ http_interactions:
         {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
         "binding:vif_type": "ovs", "tenant_id": "", "mac_address": "fa:16:3e:2e:66:be"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:51 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:10 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?device_id=57e17608-8ac6-44a6-803e-f42ec15e9d1e&limit=1000&marker=9330caba-d3ec-4675-b68a-b80fffae6365
@@ -8120,7 +6272,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d6a2ddd270fb452f93fc0c5be14cf82d
+      - 6055943a72b94605b248692a5c007e89
   response:
     status:
       code: 200
@@ -8131,9 +6283,9 @@ http_interactions:
       Content-Length:
       - '2617'
       X-Openstack-Request-Id:
-      - req-7957e9db-90c2-4e66-bdbf-b26e8a02f856
+      - req-8686becb-6d67-485c-8707-44fdf653d3fd
       Date:
-      - Thu, 03 Jan 2019 19:26:51 GMT
+      - Fri, 04 Jan 2019 16:57:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -8169,7 +6321,7 @@ http_interactions:
         {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
         "binding:vif_type": "ovs", "tenant_id": "", "mac_address": "fa:16:3e:2e:66:be"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:51 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:10 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?device_id=57e17608-8ac6-44a6-803e-f42ec15e9d1e&limit=1000
@@ -8184,7 +6336,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - aaf73829d98345eea24d237f74299387
+      - d680d0edbd174e398c354ed3f5241eb9
   response:
     status:
       code: 200
@@ -8195,9 +6347,9 @@ http_interactions:
       Content-Length:
       - '2617'
       X-Openstack-Request-Id:
-      - req-3d8ec566-5739-40f8-8894-364af1ac012c
+      - req-d88990e1-ea31-4ae6-9f6f-a15e6b34b47b
       Date:
-      - Thu, 03 Jan 2019 19:26:51 GMT
+      - Fri, 04 Jan 2019 16:57:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -8233,7 +6385,7 @@ http_interactions:
         {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
         "binding:vif_type": "ovs", "tenant_id": "", "mac_address": "fa:16:3e:2e:66:be"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:51 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:10 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?device_id=57e17608-8ac6-44a6-803e-f42ec15e9d1e&limit=1000&marker=9330caba-d3ec-4675-b68a-b80fffae6365
@@ -8248,7 +6400,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - aaf73829d98345eea24d237f74299387
+      - d680d0edbd174e398c354ed3f5241eb9
   response:
     status:
       code: 200
@@ -8259,9 +6411,9 @@ http_interactions:
       Content-Length:
       - '2617'
       X-Openstack-Request-Id:
-      - req-44605044-2515-4a2e-ac6c-02906629bd1a
+      - req-37c3b7a7-7da9-499e-a273-0a4f3bfff16a
       Date:
-      - Thu, 03 Jan 2019 19:26:51 GMT
+      - Fri, 04 Jan 2019 16:57:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -8297,7 +6449,7 @@ http_interactions:
         {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
         "binding:vif_type": "ovs", "tenant_id": "", "mac_address": "fa:16:3e:2e:66:be"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:51 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:10 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers/57e17608-8ac6-44a6-803e-f42ec15e9d1e
@@ -8312,7 +6464,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d6a2ddd270fb452f93fc0c5be14cf82d
+      - 6055943a72b94605b248692a5c007e89
   response:
     status:
       code: 200
@@ -8323,9 +6475,9 @@ http_interactions:
       Content-Length:
       - '443'
       X-Openstack-Request-Id:
-      - req-0b3b4859-8d0e-48ab-8e02-979b3b35c4f0
+      - req-e39a827c-9263-4f11-a163-1d730692ac84
       Date:
-      - Thu, 03 Jan 2019 19:26:51 GMT
+      - Fri, 04 Jan 2019 16:57:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"router": {"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -8334,7 +6486,7 @@ http_interactions:
         "name": "EmsRefreshSpec-Router", "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "distributed": false, "routes": [], "ha": false, "id": "57e17608-8ac6-44a6-803e-f42ec15e9d1e"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:51 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:10 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups/fd147cb7-7456-43d9-a01f-c06e21b4e6fb
@@ -8349,7 +6501,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d6a2ddd270fb452f93fc0c5be14cf82d
+      - 6055943a72b94605b248692a5c007e89
   response:
     status:
       code: 200
@@ -8360,9 +6512,9 @@ http_interactions:
       Content-Length:
       - '6900'
       X-Openstack-Request-Id:
-      - req-f64b3bb3-4854-4321-a94b-012902ff05f4
+      - req-8376aebf-ab86-4124-ac52-de0190fca6e4
       Date:
-      - Thu, 03 Jan 2019 19:26:51 GMT
+      - Fri, 04 Jan 2019 16:57:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_group": {"tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
@@ -8448,7 +6600,7 @@ http_interactions:
         "port_range_max": 80, "port_range_min": 80, "id": "f79f0e32-b186-4778-952e-20827a60ef73",
         "security_group_id": "fd147cb7-7456-43d9-a01f-c06e21b4e6fb"}], "name": "EmsRefreshSpec-SecurityGroup"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:51 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:11 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups/e4836528-d0df-425e-a117-ae8ec6f356d4
@@ -8463,7 +6615,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d6a2ddd270fb452f93fc0c5be14cf82d
+      - 6055943a72b94605b248692a5c007e89
   response:
     status:
       code: 200
@@ -8474,9 +6626,9 @@ http_interactions:
       Content-Length:
       - '880'
       X-Openstack-Request-Id:
-      - req-2d02b24d-625e-40d2-8e84-d0a74169acd0
+      - req-d1b052f7-3a1c-4c06-8474-c7aa568015c8
       Date:
-      - Thu, 03 Jan 2019 19:26:51 GMT
+      - Fri, 04 Jan 2019 16:57:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_group": {"tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
@@ -8490,5 +6642,5 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "75924ebc-4758-4042-ad04-4ef3c9189098",
         "security_group_id": "e4836528-d0df-425e-a117-ae8ec6f356d4"}], "name": "EmsRefreshSpec-SecurityGroup2"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:26:51 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:11 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_volume_targeted_refresh.yml
+++ b/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_volume_targeted_refresh.yml
@@ -17,13 +17,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:25:27 GMT
+      - Fri, 04 Jan 2019 16:57:15 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-f2b1dea1-011b-4cc5-a8c1-a0be52f0dc2a
+      - req-d10eff87-e49d-4d56-b975-2a4452dae0dd
       Content-Length:
       - '4170'
       Connection:
@@ -32,10 +32,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:25:27.249970", "expires":
-        "2019-01-03T20:25:27Z", "id": "864cb9b831ed40658d42697cd2601af1", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:57:16.047567", "expires":
+        "2019-01-04T17:57:16Z", "id": "9777e27c286e43bcae2c9e8160f9f963", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["Ti7NcKNLRci60OIt72wUKA"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["GqtwGhnQS72Dq27eJav7bg"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -80,7 +80,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:27 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:16 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -95,7 +95,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 864cb9b831ed40658d42697cd2601af1
+      - 9777e27c286e43bcae2c9e8160f9f963
   response:
     status:
       code: 200
@@ -106,7 +106,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Thu, 03 Jan 2019 19:25:27 GMT
+      - Fri, 04 Jan 2019 16:57:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -115,7 +115,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:27 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:16 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -133,13 +133,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:25:27 GMT
+      - Fri, 04 Jan 2019 16:57:16 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-e20b8c49-0b1d-4fc6-b4fd-adc6a9c265c3
+      - req-bc0da6de-f111-4681-a1cc-f197d6be1caa
       Content-Length:
       - '4170'
       Connection:
@@ -148,10 +148,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:25:27.554709", "expires":
-        "2019-01-03T20:25:27Z", "id": "20af143ab34e4939829721f2d0cd0cca", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:57:16.329394", "expires":
+        "2019-01-04T17:57:16Z", "id": "2263f80f35c34e02873cdaab041682ea", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["j7tkpOoDSSuEMjtDE4Owmw"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["CN3_ONf6S-22kaM68y7RsQ"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -196,7 +196,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:27 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:16 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/volumes/0a55c0d5-c780-4e7d-9d09-47f5520c7448
@@ -211,22 +211,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 20af143ab34e4939829721f2d0cd0cca
+      - 2263f80f35c34e02873cdaab041682ea
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-416d117b-3b62-45a1-b2e8-8e93bd85178a
+      - req-0d12fc08-5036-475d-adbf-90d288586643
       Content-Type:
       - application/json
       Content-Length:
       - '1406'
       X-Openstack-Request-Id:
-      - req-416d117b-3b62-45a1-b2e8-8e93bd85178a
+      - req-0d12fc08-5036-475d-adbf-90d288586643
       Date:
-      - Thu, 03 Jan 2019 19:25:27 GMT
+      - Fri, 04 Jan 2019 16:57:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume": {"migration_status": null, "attachments": [{"server_id":
@@ -247,7 +247,7 @@ http_interactions:
         "bootable": "false", "created_at": "2016-11-11T13:49:20.000000", "volume_type":
         "iscsi"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:27 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:16 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/ca4f3a16-bae3-4407-83e9-f77b28af0f2b
@@ -262,7 +262,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 864cb9b831ed40658d42697cd2601af1
+      - 9777e27c286e43bcae2c9e8160f9f963
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -275,9 +275,9 @@ http_interactions:
       Content-Length:
       - '2088'
       X-Compute-Request-Id:
-      - req-c94b9777-44a2-4210-9137-92d9546c3679
+      - req-24eeb196-25b6-46dd-a8d6-33effe9f5579
       Date:
-      - Thu, 03 Jan 2019 19:25:28 GMT
+      - Fri, 04 Jan 2019 16:57:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"server": {"status": "ACTIVE", "updated": "2018-10-09T18:40:19Z",
@@ -304,7 +304,7 @@ http_interactions:
         "", "progress": 0, "OS-EXT-STS:power_state": 1, "config_drive": "", "metadata":
         {}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:28 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:17 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/6
@@ -319,7 +319,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 864cb9b831ed40658d42697cd2601af1
+      - 9777e27c286e43bcae2c9e8160f9f963
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -332,9 +332,9 @@ http_interactions:
       Content-Length:
       - '433'
       X-Compute-Request-Id:
-      - req-a01b81f1-5a73-4329-888c-e45633b47004
+      - req-5c7dd2ed-7616-464f-afe4-d4d781556374
       Date:
-      - Thu, 03 Jan 2019 19:25:28 GMT
+      - Fri, 04 Jan 2019 16:57:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavor": {"name": "m1.ems_refresh_spec", "links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/6",
@@ -343,7 +343,7 @@ http_interactions:
         1, "swap": 512, "os-flavor-access:is_public": true, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         1, "disk": 1, "id": "6"}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:28 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:17 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -361,13 +361,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:25:28 GMT
+      - Fri, 04 Jan 2019 16:57:17 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-cfb84615-0b69-4964-932f-eacd8b1d568e
+      - req-4e8381a3-6e9a-4dd0-817c-0390ea35fdb8
       Content-Length:
       - '4170'
       Connection:
@@ -376,10 +376,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:25:28.608023", "expires":
-        "2019-01-03T20:25:28Z", "id": "9905cc4ba181407ea20fbb97cec4851a", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:57:17.441465", "expires":
+        "2019-01-04T17:57:17Z", "id": "ab3f68d1ac744ad8ba955ae75f3d36db", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["VdLoK5MGRbW_WJjr-1Lysw"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["mSrff-FnQ5CMO_kERwP4SA"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -424,7 +424,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:28 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:17 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -439,20 +439,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9905cc4ba181407ea20fbb97cec4851a
+      - ab3f68d1ac744ad8ba955ae75f3d36db
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:25:28 GMT
+      - Fri, 04 Jan 2019 16:57:17 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-5fa1264e-d50a-4e23-8f08-2d5d8ae766ba
+      - req-978146ae-0318-4c8b-8b3f-6e60365688e7
       Content-Length:
       - '500'
       Connection:
@@ -469,7 +469,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:28 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:17 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/ca4f3a16-bae3-4407-83e9-f77b28af0f2b/os-volume_attachments
@@ -484,7 +484,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 864cb9b831ed40658d42697cd2601af1
+      - 9777e27c286e43bcae2c9e8160f9f963
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -497,15 +497,15 @@ http_interactions:
       Content-Length:
       - '197'
       X-Compute-Request-Id:
-      - req-acc1eeac-3803-4aa8-98ae-bcae126ebd88
+      - req-50c798b6-9450-4351-8cc2-5e78e15d61a2
       Date:
-      - Thu, 03 Jan 2019 19:25:28 GMT
+      - Fri, 04 Jan 2019 16:57:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumeAttachments": [{"device": "/dev/vdd", "serverId": "ca4f3a16-bae3-4407-83e9-f77b28af0f2b",
         "id": "0a55c0d5-c780-4e7d-9d09-47f5520c7448", "volumeId": "0a55c0d5-c780-4e7d-9d09-47f5520c7448"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:28 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:17 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -523,13 +523,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:25:29 GMT
+      - Fri, 04 Jan 2019 16:57:17 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-09f7f36c-90ce-4790-a4f8-fbc6d3035126
+      - req-2bef7f73-e9a6-4e91-84be-c6010c7b7663
       Content-Length:
       - '4170'
       Connection:
@@ -538,10 +538,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:25:29.077387", "expires":
-        "2019-01-03T20:25:29Z", "id": "4522aa3dc6ec4a55a8cf296af0228efe", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:57:17.980272", "expires":
+        "2019-01-04T17:57:17Z", "id": "b90a8bc3132644249774c75c80c5629d", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["WIz_T_ElQzGEFnPV77C70Q"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["fDOBwCtWTzqoTKtrxSJARw"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -586,7 +586,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:29 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:18 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -604,13 +604,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:25:29 GMT
+      - Fri, 04 Jan 2019 16:57:18 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-d05062db-d76a-40d9-ac72-f941ece513cb
+      - req-114ba238-1e30-48af-8dfd-551d1cf64e95
       Content-Length:
       - '370'
       Connection:
@@ -619,13 +619,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:25:29.249441", "expires":
-        "2019-01-03T20:25:29Z", "id": "36b8da5f39eb460f9d23f3cea645a8f2", "audit_ids":
-        ["SUpy01-rQSmj6OTwUWSrUQ"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:57:18.144481", "expires":
+        "2019-01-04T17:57:18Z", "id": "545706aa1f0e4a389470d4a1e90c8056", "audit_ids":
+        ["lH6JKOdiR46NaH61yhNVJA"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:29 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:18 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -640,20 +640,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 36b8da5f39eb460f9d23f3cea645a8f2
+      - 545706aa1f0e4a389470d4a1e90c8056
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:25:29 GMT
+      - Fri, 04 Jan 2019 16:57:18 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-b108f8b9-5cfc-439a-9929-c2354f27ee14
+      - req-90ad0d05-57af-49dc-bb4f-a2c21f045eb3
       Content-Length:
       - '500'
       Connection:
@@ -670,7 +670,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:29 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:18 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -688,13 +688,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:25:29 GMT
+      - Fri, 04 Jan 2019 16:57:18 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-2ef5e082-d8ab-4423-87c1-7a9d83f9f0b2
+      - req-840409da-23dd-45e7-807f-10697035b187
       Content-Length:
       - '4117'
       Connection:
@@ -703,10 +703,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:25:29.612172", "expires":
-        "2019-01-03T20:25:29Z", "id": "5c8492ae62374704943b1dcafd978397", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:57:18.471011", "expires":
+        "2019-01-04T17:57:18Z", "id": "aa51dab66be94bdbb85298016a850b80", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["inX98rFzSxGy-HvngJlX2A"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["zSea2HkmT_2MHaZU-rMA5g"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -750,7 +750,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:29 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:18 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -768,13 +768,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:25:29 GMT
+      - Fri, 04 Jan 2019 16:57:18 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-826a2710-db31-4e97-9e60-62dedd78af12
+      - req-bc0c4942-82f4-43b4-a466-bcd999a7795b
       Content-Length:
       - '4131'
       Connection:
@@ -783,10 +783,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:25:29.803332", "expires":
-        "2019-01-03T20:25:29Z", "id": "0c00eec2cb2748b5b43818a878781863", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:57:18.660743", "expires":
+        "2019-01-04T17:57:18Z", "id": "42e8984104a94205a825bb7fd5952afe", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["ysgmoEgFR5KtpPXFRjQi9Q"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["qvxe1JqRSGu5CcfWv33WeQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -830,7 +830,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:29 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:18 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -848,13 +848,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Jan 2019 19:25:29 GMT
+      - Fri, 04 Jan 2019 16:57:18 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-958e5cb4-e15f-4e11-8588-bb59af210836
+      - req-0f01880c-09c6-4ea8-933b-b2a7dc8bb1d7
       Content-Length:
       - '4118'
       Connection:
@@ -863,10 +863,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-03T19:25:29.994385", "expires":
-        "2019-01-03T20:25:29Z", "id": "f5dda95192f6431c98493a096de488c3", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-01-04T16:57:18.850500", "expires":
+        "2019-01-04T17:57:18Z", "id": "db6c19041baa4dee8399248f229a2d9e", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["JI0Yq4uZQXK5llFx0GMuAw"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["IZWMXRr-T0KsNEZYkXgV1Q"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -910,7 +910,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:30 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:18 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -925,7 +925,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5c8492ae62374704943b1dcafd978397
+      - aa51dab66be94bdbb85298016a850b80
   response:
     status:
       code: 200
@@ -936,13 +936,19 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-674e180e-624b-4721-9d66-46a8a60c230f
+      - req-30b1bab1-cd87-4e1a-ba07-f2b88b759b20
       Date:
-      - Thu, 03 Jan 2019 19:25:30 GMT
+      - Fri, 04 Jan 2019 16:57:19 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
-        true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
@@ -1023,26 +1029,20 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
         "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:30 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:19 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
@@ -1057,7 +1057,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5c8492ae62374704943b1dcafd978397
+      - aa51dab66be94bdbb85298016a850b80
   response:
     status:
       code: 200
@@ -1068,13 +1068,19 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-0354d3c4-ad13-41de-94ba-d96c89ba5643
+      - req-c94212fd-7981-445a-bc5f-d1064a55e3c1
       Date:
-      - Thu, 03 Jan 2019 19:25:30 GMT
+      - Fri, 04 Jan 2019 16:57:19 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
-        true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
@@ -1155,26 +1161,20 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
         "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:30 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:19 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -1189,7 +1189,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0c00eec2cb2748b5b43818a878781863
+      - 42e8984104a94205a825bb7fd5952afe
   response:
     status:
       code: 200
@@ -1200,19 +1200,13 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-d1b798fe-d1fb-4b0c-851b-eb228a8c8b77
+      - req-4928f542-0d1f-41a0-aa25-fb06c074b1e7
       Date:
-      - Thu, 03 Jan 2019 19:25:30 GMT
+      - Fri, 04 Jan 2019 16:57:19 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
-        true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp":
+        true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
@@ -1235,505 +1229,6 @@ http_interactions:
         "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:30 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 0c00eec2cb2748b5b43818a878781863
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-54612450-a0a5-493a-8b3e-e8b0dd5b5e44
-      Date:
-      - Thu, 03 Jan 2019 19:25:30 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
-        true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:30 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 4522aa3dc6ec4a55a8cf296af0228efe
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-b81e9107-7417-40af-8ae4-a277f84f5ac0
-      Date:
-      - Thu, 03 Jan 2019 19:25:30 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
-        true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:31 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 4522aa3dc6ec4a55a8cf296af0228efe
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-9fb19ed6-a9bc-4e7b-8150-0418b68ebb41
-      Date:
-      - Thu, 03 Jan 2019 19:25:31 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
-        true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:31 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - f5dda95192f6431c98493a096de488c3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-83210ace-7432-488f-8795-c4f63ad295ab
-      Date:
-      - Thu, 03 Jan 2019 19:25:31 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
@@ -1798,161 +1293,6 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
         "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:31 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - f5dda95192f6431c98493a096de488c3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-faec57f5-41f5-40d6-8a86-2a6054195572
-      Date:
-      - Thu, 03 Jan 2019 19:25:31 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
-        true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
         "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
@@ -1966,7 +1306,7 @@ http_interactions:
         4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
         "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:31 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:19 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
@@ -1981,7 +1321,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f5dda95192f6431c98493a096de488c3
+      - 42e8984104a94205a825bb7fd5952afe
   response:
     status:
       code: 200
@@ -1992,13 +1332,19 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-00f09e8f-ccaa-43c0-8048-79b0864c942a
+      - req-bd6a3cc2-a18a-4e34-9d6d-78a7fe143167
       Date:
-      - Thu, 03 Jan 2019 19:25:31 GMT
+      - Fri, 04 Jan 2019 16:57:19 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp":
-        true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
@@ -2079,12 +1425,138 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
         "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Fri, 04 Jan 2019 16:57:19 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - b90a8bc3132644249774c75c80c5629d
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-3df4ddc1-2f83-4eb4-b66d-991decbf3e75
+      Date:
+      - Fri, 04 Jan 2019 16:57:19 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp":
+        true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
         true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
         "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
         "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
@@ -2098,5 +1570,401 @@ http_interactions:
         4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
         "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Thu, 03 Jan 2019 19:25:31 GMT
+  recorded_at: Fri, 04 Jan 2019 16:57:20 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - b90a8bc3132644249774c75c80c5629d
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-7cbf0597-9be3-4933-895a-03bae64d3832
+      Date:
+      - Fri, 04 Jan 2019 16:57:20 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Fri, 04 Jan 2019 16:57:20 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - db6c19041baa4dee8399248f229a2d9e
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-80a50cb3-2f41-4563-8674-657da5884bd0
+      Date:
+      - Fri, 04 Jan 2019 16:57:20 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Fri, 04 Jan 2019 16:57:20 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - db6c19041baa4dee8399248f229a2d9e
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-6f0181ce-2f45-4a06-a59e-f3d94ff64bdb
+      Date:
+      - Fri, 04 Jan 2019 16:57:20 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Fri, 04 Jan 2019 16:57:20 GMT
 recorded_with: VCR 3.0.3


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1662126 by ensuring that the reference cache is refreshed before collecting tenants during a targeted refresh. 