### PR TITLE
Read back to catch events that may have reached Panko out of order

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -22,6 +22,7 @@
       :read_timeout: 60
     :blacklisted_event_names: []
     :event_handling:
+      :event_backread_seconds: 15
       :event_groups:
         :addition:
           :critical:

--- a/spec/models/manageiq/providers/openstack/cloud_manager/event_target_parser_spec.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/event_target_parser_spec.rb
@@ -74,6 +74,16 @@ describe ManageIQ::Providers::Openstack::CloudManager::EventTargetParser do
         )
       )
     end
+
+    it "doesn't create duplicate events" do
+      create_ems_event("compute.instance.create.start", "service" => "compute")
+      # these two should have identical timestamps, event_types, and ems_ids,
+      # so they are probably duplicate events. As such, only one EmsEvent
+      # should be created.
+      create_ems_event("compute.instance.create.end", "service" => "compute")
+      create_ems_event("compute.instance.create.end", "service" => "compute")
+      expect(EmsEvent.all.count).to eq(2)
+    end
   end
 
   def target_references(parsed_targets)


### PR DESCRIPTION
Adds a setting to specify the number of seconds prior to the last received event to query Panko for events, so as to help catch events that may have arrived in Panko out of order.