### PR TITLE
[WIP] Add graph refresh for undercloud

### DIFF
--- a/app/models/manageiq/providers/openstack/inventory/collector.rb
+++ b/app/models/manageiq/providers/openstack/inventory/collector.rb
@@ -3,6 +3,7 @@ class ManageIQ::Providers::Openstack::Inventory::Collector < ManageIQ::Providers
   include Vmdb::Logging
 
   require_nested :CloudManager
+  require_nested :InfraManager
   require_nested :NetworkManager
   require_nested :StorageManager
   require_nested :TargetCollection
@@ -14,7 +15,6 @@ class ManageIQ::Providers::Openstack::Inventory::Collector < ManageIQ::Providers
   attr_reader :host_aggregates
   attr_reader :key_pairs
   attr_reader :miq_templates
-  attr_reader :orchestration_stacks
   attr_reader :quotas
   attr_reader :vms
   attr_reader :vnfs
@@ -30,6 +30,12 @@ class ManageIQ::Providers::Openstack::Inventory::Collector < ManageIQ::Providers
   attr_reader :cloud_volume_snapshots
   attr_reader :cloud_volume_backups
   attr_reader :cloud_volume_types
+  attr_reader :hosts
+  attr_reader :object_store
+  attr_reader :stack_server_resources
+  attr_reader :stack_server_resource_types
+  attr_reader :stack_resource_groups
+  attr_reader :stack_resources
 
   def initialize(_manager, _target)
     super
@@ -38,33 +44,43 @@ class ManageIQ::Providers::Openstack::Inventory::Collector < ManageIQ::Providers
   end
 
   def initialize_inventory_sources
+    # common
+    @images                      = []
+    @orchestration_stacks        = nil
+    @tenants                     = []
     # cloud
-    @availability_zones        = []
-    @cloud_services            = []
-    @tenants                   = []
-    @flavors                   = []
-    @host_aggregates           = []
-    @key_pairs                 = []
-    @images                    = []
-    @orchestration_stacks      = nil
-    @quotas                    = []
-    @vms                       = []
-    @vnfs                      = []
-    @vnfds                     = []
-    @volume_templates          = []
-    @volume_snapshot_templates = []
+    @availability_zones          = []
+    @cloud_services              = []
+    @flavors                     = []
+    @host_aggregates             = []
+    @key_pairs                   = []
+    @quotas                      = []
+    @vms                         = []
+    @vnfs                        = []
+    @vnfds                       = []
+    @volume_templates            = []
+    @volume_snapshot_templates   = []
+    # infra
+    @hosts                       = []
+    @servers                     = []
+    @object_store                = []
+    @stack_server_resources      = []
+    @stack_server_resource_types = []
+    @stack_resource_groups       = nil
+    @stack_resources             = []
+    @root_stacks                 = []
     # network
-    @cloud_networks            = []
-    @cloud_subnets             = []
-    @floating_ips              = []
-    @network_ports             = []
-    @network_routers           = []
-    @security_groups           = []
+    @cloud_networks              = []
+    @cloud_subnets               = []
+    @floating_ips                = []
+    @network_ports               = []
+    @network_routers             = []
+    @security_groups             = []
     # cinder
-    @cloud_volumes             = []
-    @cloud_volume_snapshots    = []
-    @cloud_volume_backups      = []
-    @cloud_volume_types        = []
+    @cloud_volumes               = []
+    @cloud_volume_snapshots      = []
+    @cloud_volume_backups        = []
+    @cloud_volume_types          = []
   end
 
   def connection
@@ -98,5 +114,71 @@ class ManageIQ::Providers::Openstack::Inventory::Collector < ManageIQ::Providers
 
   def orchestration_service
     @orchestration_service ||= manager.openstack_handle.detect_orchestration_service
+  end
+
+  def baremetal_service
+    @baremetal_service ||= manager.openstack_handle.detect_baremetal_service
+  end
+
+  def storage_service
+    @storage_service ||= manager.openstack_handle.detect_storage_service
+  end
+
+  def introspection_service
+    @introspection_service ||= manager.openstack_handle.detect_introspection_service
+  end
+
+  def images
+    return @images if @images.any?
+    @images = if openstack_admin?
+                image_service.images_with_pagination_loop
+              else
+                image_service.handled_list(:images)
+              end
+  end
+
+  def orchestration_stacks(show_nested = true)
+    return orchestration_stacks_with_nested if show_nested
+    orchestration_stacks_without_nested
+  end
+
+  def orchestration_stacks_with_nested
+    @orchestration_stacks_with_nested ||= load_stacks
+  end
+
+  def orchestration_stacks_without_nested
+    @orchestration_stacks_without_nested ||= load_stacks(false)
+  end
+
+  def load_stacks(show_nested = true)
+    return [] unless orchestration_service
+    # TODO(lsmola) We need a support of GET /{tenant_id}/stacks/detail in FOG, it was implemented here
+    # https://review.openstack.org/#/c/35034/, but never documented in API reference, so right now we
+    # can't get list of detailed stacks in one API call.
+    if openstack_heat_global_admin?
+      orchestration_service.handled_list(:stacks, {:show_nested => show_nested, :global_tenant => true}, true).collect(&:details)
+    else
+      orchestration_service.handled_list(:stacks, :show_nested => show_nested).collect(&:details)
+    end
+  rescue Excon::Errors::Forbidden
+    # Orchestration service is detected but not open to the user
+    _log.warn("Skip refreshing stacks because the user cannot access the orchestration service")
+    []
+  end
+
+  def orchestration_outputs(stack)
+    safe_list { stack.outputs }
+  end
+
+  def orchestration_parameters(stack)
+    safe_list { stack.parameters }
+  end
+
+  def orchestration_resources(stack)
+    safe_list { stack.resources }
+  end
+
+  def orchestration_template(stack)
+    safe_call { stack.template }
   end
 end

--- a/app/models/manageiq/providers/openstack/inventory/collector/infra_manager.rb
+++ b/app/models/manageiq/providers/openstack/inventory/collector/infra_manager.rb
@@ -1,0 +1,103 @@
+class ManageIQ::Providers::Openstack::Inventory::Collector::InfraManager < ManageIQ::Providers::Openstack::Inventory::Collector
+  include ManageIQ::Providers::Openstack::Inventory::Collector::HelperMethods
+
+  def servers
+    return @servers if @servers.any?
+    @servers = uniques(connection.handled_list(:servers))
+  end
+
+  def hosts
+    return @hosts if @hosts.any?
+    @hosts = uniques(baremetal_service.handled_list(:nodes))
+  end
+
+  def servers_by_id
+    @servers_by_id ||= servers.index_by(&:id)
+  end
+
+  def object_store
+    return if storage_service.blank? || storage_service.name != :swift
+    @object_store ||= storage_service.handled_list(:directories)
+  end
+
+  def get_introspection_details(host_uuid)
+    return {} unless introspection_service
+    begin
+      introspection_service.get_introspection_details(host_uuid).body
+    rescue
+      # introspection data not available
+      {}
+    end
+  end
+
+  def tenants
+    return @tenants if @tenants.any?
+    @tenants = manager.openstack_handle.tenants
+  end
+
+  def root_stacks
+    return @root_stacks if @root_stacks.any?
+    @root_stacks = uniques(orchestration_stacks(false))
+  end
+
+  def stack_server_resources
+    return @stack_server_resources if @stack_server_resources.any?
+    @stack_server_resources = filter_stack_resources_by_resource_type(stack_server_resource_types)
+  end
+
+  def stack_server_resource_types
+    return @stack_server_resource_types if @stack_server_resource_types.any?
+    @stack_server_resource_types = ["OS::TripleO::Server", "OS::Nova::Server"]
+    @stack_server_resource_types += stack_resource_groups.map { |rg| "OS::TripleO::" + rg["resource_name"] + "Server" }
+  end
+
+  def filter_stack_resources_by_resource_type(resource_type_list)
+    resources = []
+    root_stacks.each do |stack|
+      # Filtering just server resources which is important to us for getting Purpose of the node
+      # (compute, controller, etc.).
+      resources += stack_resources_by_depth(stack).select do |x|
+        resource_type_list.include?(x["resource_type"])
+      end
+    end
+    resources
+  end
+
+  def stack_resource_groups
+    @stack_resource_groups ||= filter_stack_resources_by_resource_type(["OS::Heat::ResourceGroup"])
+  end
+
+  def stack_resources_by_depth(stack)
+    # TODO(lsmola) loading this from already obtained nested stack hierarchy will be more effective. This is one
+    # extra API call. But we will need to change order of loading, so we have all resources first.
+    @stack_resources ||= @orchestration_service.list_resources(:stack => stack, :nested_depth => 2).body['resources']
+  end
+
+  def cloud_ems_hosts_attributes
+    clouds = @manager.provider.try(:cloud_ems)
+
+    hosts_attributes = []
+    return hosts_attributes unless clouds
+    clouds.each do |cloud_ems|
+      compute_hosts = nil
+      begin
+        cloud_ems.with_provider_connection do |connection|
+          compute_hosts = connection.hosts.select { |x| x.service_name == "compute" }
+        end
+      rescue => err
+        _log.error("Error Class=#{err.class.name}, Message=#{err.message}")
+        _log.error(err.backtrace.join("\n"))
+        # Just log the error and continue the refresh, we don't want error in cloud side to affect infra refresh
+        next
+      end
+
+      compute_hosts.each do |compute_host|
+        # We need to take correct zone id from correct provider, since the zone name can be the same
+        # across providers
+        availability_zone_id = cloud_ems.availability_zones.find_by(:name => compute_host.zone).try(:id)
+        hosts_attributes << {:host_name => compute_host.host_name, :availability_zone_id => availability_zone_id}
+      end
+    end
+    hosts_attributes
+  end
+end

--- a/app/models/manageiq/providers/openstack/inventory/parser.rb
+++ b/app/models/manageiq/providers/openstack/inventory/parser.rb
@@ -1,5 +1,6 @@
 class ManageIQ::Providers::Openstack::Inventory::Parser < ManageIQ::Providers::Inventory::Parser
   require_nested :CloudManager
+  require_nested :InfraManager
   require_nested :NetworkManager
   require_nested :StorageManager
 end

--- a/app/models/manageiq/providers/openstack/inventory/parser/cloud_manager.rb
+++ b/app/models/manageiq/providers/openstack/inventory/parser/cloud_manager.rb
@@ -1,14 +1,15 @@
 class ManageIQ::Providers::Openstack::Inventory::Parser::CloudManager < ManageIQ::Providers::Openstack::Inventory::Parser
   include ManageIQ::Providers::Openstack::RefreshParserCommon::HelperMethods
   include ManageIQ::Providers::Openstack::RefreshParserCommon::Images
+  include ManageIQ::Providers::Openstack::Inventory::Parser::CommonMethods
 
   def parse
     availability_zones
     cloud_services
     flavors
-    miq_templates
+    miq_templates("ManageIQ::Providers::Openstack::CloudManager::Template")
     key_pairs
-    orchestration_stacks
+    orchestration_stacks("ManageIQ::Providers::Openstack::CloudManager::OrchestrationStack")
     quotas
     vms
     cloud_tenants
@@ -75,21 +76,6 @@ class ManageIQ::Providers::Openstack::Inventory::Parser::CloudManager < ManageIQ
       cloud_service.host = host
       cloud_service.system_service = system_service
       cloud_service.availability_zone = persister.availability_zones.lazy_find(s.zone)
-    end
-  end
-
-  def cloud_tenants
-    collector.tenants.each do |t|
-      tenant = persister.cloud_tenants.find_or_build(t.id)
-      tenant.name = t.name
-      tenant.description = t.description
-      tenant.enabled = t.enabled
-      tenant.ems_ref = t.id
-      tenant.parent = if t.try(:parent_id).blank?
-                        nil
-                      else
-                        persister.cloud_tenants.lazy_find(t.try(:parent_id))
-                      end
     end
   end
 
@@ -169,129 +155,6 @@ class ManageIQ::Providers::Openstack::Inventory::Parser::CloudManager < ManageIQ
         quota.value = value
         quota.cloud_tenant = persister.cloud_tenants.lazy_find(q["tenant_id"])
       end
-    end
-  end
-
-  def miq_templates
-    collector.images.each do |i|
-      parent_server_uid = parse_image_parent_id(i)
-      image = persister.miq_templates.find_or_build(i.id)
-      image.type = "ManageIQ::Providers::Openstack::CloudManager::Template"
-      image.uid_ems = i.id
-      image.name = i.name.blank? ? i.id.to_s : i.name
-      image.vendor = "openstack"
-      image.raw_power_state = "never"
-      image.template = true
-      image.publicly_available = public_image?(i)
-      image.cloud_tenants = image_tenants(i)
-      image.location = "unknown"
-      image.cloud_tenant = persister.cloud_tenants.lazy_find(i.owner) if i.owner
-      image.genealogy_parent = persister.vms.lazy_find(parent_server_uid) unless parent_server_uid.nil?
-
-      guest_os = OperatingSystem.normalize_os_name(i.try(:os_distro) || 'unknown')
-
-      hardware = persister.hardwares.find_or_build(image)
-      hardware.vm_or_template = image
-      hardware.guest_os = guest_os
-      hardware.bitness = image_architecture(i)
-      hardware.disk_size_minimum = (i.min_disk * 1.gigabyte)
-      hardware.memory_mb_minimum = i.min_ram
-      hardware.root_device_type = i.disk_format
-      hardware.size_on_disk = i.size
-      hardware.virtualization_type = i.properties.try(:[], 'hypervisor_type') || i.attributes['hypervisor_type']
-
-      operating_system = persister.operating_systems.find_or_build(image)
-      operating_system.vm_or_template = image
-      operating_system.product_name = guest_os
-      operating_system.distribution = i.try(:os_distro)
-      operating_system.version = i.try(:os_version)
-    end
-  end
-
-  def orchestration_stack_resources(stack, stack_inventory_object)
-    raw_resources = collector.orchestration_resources(stack)
-    # reject resources that don't have a physical resource id, because that
-    # means they failed to be successfully created
-    raw_resources.reject! { |r| r.physical_resource_id.blank? }
-    raw_resources.each do |resource|
-      uid = resource.physical_resource_id
-      o = persister.orchestration_stacks_resources.find_or_build(uid)
-      o.ems_ref = uid
-      o.logical_resource = resource.logical_resource_id
-      o.physical_resource = resource.physical_resource_id
-      o.resource_category = resource.resource_type
-      o.resource_status = resource.resource_status
-      o.resource_status_reason = resource.resource_status_reason
-      o.last_updated = resource.updated_time
-      o.stack = stack_inventory_object
-
-      # in some cases, a stack resource may refer to a physical resource
-      # that doesn't exist. check that the physical resource actually exists
-      # so that find_or_build doesn't produce an "empty" vm.
-      if collector.vms_by_id.key?(uid)
-        s = persister.vms.find_or_build(uid)
-        s.orchestration_stack = persister.orchestration_stacks.lazy_find(stack.id)
-      end
-    end
-  end
-
-  def orchestration_stack_parameters(stack, stack_inventory_object)
-    collector.orchestration_parameters(stack).each do |param_key, param_val|
-      uid = compose_ems_ref(stack.id, param_key)
-      o = persister.orchestration_stacks_parameters.find_or_build(uid)
-      o.ems_ref = uid
-      o.name = param_key
-      o.value = param_val
-      o.stack = stack_inventory_object
-    end
-  end
-
-  def orchestration_stack_outputs(stack, stack_inventory_object)
-    collector.orchestration_outputs(stack).each do |output|
-      uid = compose_ems_ref(stack.id, output['output_key'])
-      o = persister.orchestration_stacks_outputs.find_or_build(uid)
-      o.ems_ref = uid
-      o.key = output['output_key']
-      o.value = output['output_value']
-      o.description = output['description']
-      o.stack = stack_inventory_object
-    end
-  end
-
-  def orchestration_template(stack)
-    template = collector.orchestration_template(stack)
-    if template
-      o = persister.orchestration_templates.find_or_build(stack.id)
-      o.type = "ManageIQ::Providers::Openstack::CloudManager::OrchestrationTemplate"
-      o.name = stack.stack_name
-      o.description = stack.template.description
-      o.content = stack.template.content
-      o.orderable = false
-      o
-    end
-  end
-
-  def orchestration_stacks
-    collector.orchestration_stacks.each do |stack|
-      o = persister.orchestration_stacks.find_or_build(stack.id.to_s)
-      o.type = "ManageIQ::Providers::Openstack::CloudManager::OrchestrationStack"
-      o.name = stack.stack_name
-      o.description = stack.description
-      o.status = stack.stack_status
-      o.status_reason = stack.stack_status_reason
-      o.parent = persister.orchestration_stacks.lazy_find(stack.parent)
-      o.orchestration_template = orchestration_template(stack)
-      # stack parameters can miss tenant_id, so we make admin default tenant
-      tenant_id = if stack.parameters && stack.parameters["OS::project_id"]
-                    stack.parameters["OS::project_id"]
-                  else
-                    stack.service.current_tenant["id"]
-                  end
-      o.cloud_tenant = persister.cloud_tenants.lazy_find(tenant_id)
-
-      orchestration_stack_resources(stack, o)
-      orchestration_stack_outputs(stack, o)
-      orchestration_stack_parameters(stack, o)
     end
   end
 
@@ -462,59 +325,13 @@ class ManageIQ::Providers::Openstack::Inventory::Parser::CloudManager < ManageIQ
     disk
   end
 
-  # Compose an ems_ref combining some existing keys
-  def compose_ems_ref(*keys)
-    keys.join('_')
-  end
-
-  # Identify whether the given image is publicly available
-  def public_image?(image)
-    # Glance v1
-    return image.is_public if image.respond_to?(:is_public)
-    # Glance v2
-    image.visibility != 'private' if image.respond_to?(:visibility)
-  end
-
-  # Identify whether the given image has a 32 or 64 bit architecture
-  def image_architecture(image)
-    architecture = image.properties.try(:[], 'architecture') || image.attributes['architecture']
-    return nil if architecture.blank?
-    # Just simple name to bits, x86_64 will be the most used, we should probably support displaying of
-    # architecture name
-    architecture.include?("64") ? 64 : 32
-  end
-
-  # Identify the id of the parent of this image.
-  def parse_image_parent_id(image)
-    if collector.image_service.name == :glance
-      # What version of openstack is this glance v1 on some old openstack version?
-      return image.copy_from["id"] if image.respond_to?(:copy_from) && image.copy_from
-      # Glance V2
-      return image.instance_uuid if image.respond_to?(:instance_uuid)
-      # Glance V1
-      image.properties.try(:[], 'instance_uuid')
-    elsif image.server
-      # Probably nova images?
-      image.server["id"]
+  def find_resource(uid, stack_id)
+    # in some cases, a stack resource may refer to a physical resource
+    # that doesn't exist. check that the physical resource actually exists
+    # so that find_or_build doesn't produce an "empty" vm.
+    if collector.vms_by_id.key?(uid)
+      s = persister.vms.find_or_build(uid)
+      s.orchestration_stack = persister.orchestration_stacks.lazy_find(stack_id)
     end
-  end
-
-  def image_tenants(image)
-    tenants = []
-    if public_image?(image)
-      # For public image we will fill a relation to all tenants,
-      # since calling the members api for a public image throws a 403.
-      collector.tenants.each do |t|
-        tenants << persister.cloud_tenants.lazy_find(t.id)
-      end
-    else
-      # Add owner of the image
-      tenants << persister.cloud_tenants.lazy_find(image.owner) if image.owner
-      # TODO: Glance v2 doesn't support members for "private" images, implement `members` for "shared" images later
-      if image.respond_to?(:is_public) && (members = image.members).any?
-        tenants += members.map { |x| persister.cloud_tenants.lazy_find(x['member_id']) }
-      end
-    end
-    tenants
   end
 end

--- a/app/models/manageiq/providers/openstack/inventory/parser/common_methods.rb
+++ b/app/models/manageiq/providers/openstack/inventory/parser/common_methods.rb
@@ -1,0 +1,181 @@
+module ManageIQ::Providers::Openstack::Inventory::Parser::CommonMethods
+  def miq_templates(type)
+    collector.images.each do |i|
+      parent_server_uid = parse_image_parent_id(i)
+      image = persister.miq_templates.find_or_build(i.id)
+      image.type = type
+      image.uid_ems = i.id
+      image.name = i.name.presence || i.id.to_s
+      image.vendor = "openstack"
+      image.raw_power_state = "never"
+      image.template = true
+      image.publicly_available = public_image?(i)
+      image.cloud_tenants = image_tenants(i)
+      image.location = "unknown"
+      image.cloud_tenant = persister.cloud_tenants.lazy_find(i.owner) if i.owner
+      image.genealogy_parent = persister.vms.lazy_find(parent_server_uid) unless parent_server_uid.nil?
+
+      guest_os = OperatingSystem.normalize_os_name(i.try(:os_distro) || 'unknown')
+
+      hardware = persister.hardwares.find_or_build(image)
+      hardware.vm_or_template = image
+      hardware.guest_os = guest_os
+      hardware.bitness = image_architecture(i)
+      hardware.disk_size_minimum = (i.min_disk * 1.gigabyte)
+      hardware.memory_mb_minimum = i.min_ram
+      hardware.root_device_type = i.disk_format
+      hardware.size_on_disk = i.size
+      hardware.virtualization_type = i.properties.try(:[], 'hypervisor_type') || i.attributes['hypervisor_type']
+
+      operating_system = persister.operating_systems.find_or_build(image)
+      operating_system.vm_or_template = image
+      operating_system.product_name = guest_os
+      operating_system.distribution = i.try(:os_distro)
+      operating_system.version = i.try(:os_version)
+    end
+  end
+
+  def orchestration_stacks(type)
+    collector.orchestration_stacks.each do |stack|
+      o = persister.orchestration_stacks.find_or_build(stack.id.to_s)
+      o.type = type
+      o.name = stack.stack_name
+      o.description = stack.description
+      o.status = stack.stack_status
+      o.status_reason = stack.stack_status_reason
+      o.parent = persister.orchestration_stacks.lazy_find(stack.parent)
+      o.orchestration_template = orchestration_template(stack, type)
+      o.cloud_tenant = persister.cloud_tenants.lazy_find(stack.service.current_tenant["id"])
+      orchestration_stack_resources(stack, o)
+      orchestration_stack_outputs(stack, o)
+      orchestration_stack_parameters(stack, o)
+    end
+  end
+
+  def orchestration_template(stack, type)
+    template = collector.orchestration_template(stack)
+    if template
+      o = persister.orchestration_templates.find_or_build(stack.id)
+      o.type = type
+      o.name = stack.stack_name
+      o.description = stack.template.description
+      o.content = stack.template.content
+      o.orderable = false
+      o
+    end
+  end
+
+  def orchestration_stack_resources(stack, stack_inventory_object)
+    raw_resources = collector.orchestration_resources(stack)
+    # reject resources that don't have a physical resource id, because that
+    # means they failedq to be successfully created
+    raw_resources.reject! { |r| r.physical_resource_id.blank? }
+    raw_resources.each do |resource|
+      uid = resource.physical_resource_id
+      o = persister.orchestration_stacks_resources.find_or_build(uid)
+      o.ems_ref = uid
+      o.logical_resource = resource.logical_resource_id
+      o.physical_resource = resource.physical_resource_id
+      o.resource_category = resource.resource_type
+      o.resource_status = resource.resource_status
+      o.resource_status_reason = resource.resource_status_reason
+      o.last_updated = resource.updated_time
+      o.stack = stack_inventory_object
+      find_resource(uid, stack.id)
+    end
+  end
+
+  def orchestration_stack_parameters(stack, stack_inventory_object)
+    collector.orchestration_parameters(stack).each do |param_key, param_val|
+      uid = compose_ems_ref(stack.id, param_key)
+      o = persister.orchestration_stacks_parameters.find_or_build(uid)
+      o.ems_ref = uid
+      o.name = param_key
+      o.value = param_val
+      o.stack = stack_inventory_object
+    end
+  end
+
+  def orchestration_stack_outputs(stack, stack_inventory_object)
+    collector.orchestration_outputs(stack).each do |output|
+      uid = compose_ems_ref(stack.id, output['output_key'])
+      o = persister.orchestration_stacks_outputs.find_or_build(uid)
+      o.ems_ref = uid
+      o.key = output['output_key']
+      o.value = output['output_value']
+      o.description = output['description']
+      o.stack = stack_inventory_object
+    end
+  end
+
+  def cloud_tenants
+    collector.tenants.each do |t|
+      tenant = persister.cloud_tenants.find_or_build(t.id)
+      tenant.name = t.name
+      tenant.description = t.description
+      tenant.enabled = t.enabled
+      tenant.ems_ref = t.id
+      tenant.parent = if t.try(:parent_id).blank?
+                        nil
+                      else
+                        persister.cloud_tenants.lazy_find(t.try(:parent_id))
+                      end
+    end
+  end
+
+  # Compose an ems_ref combining some existing keys
+  def compose_ems_ref(*keys)
+    keys.join('_')
+  end
+
+  # Identify whether the given image is publicly available
+  def public_image?(image)
+    # Glance v1
+    return image.is_public if image.respond_to?(:is_public)
+    # Glance v2
+    image.visibility != 'private' if image.respond_to?(:visibility)
+  end
+
+  # Identify whether the given image has a 32 or 64 bit architecture
+  def image_architecture(image)
+    architecture = image.properties.try(:[], 'architecture') || image.attributes['architecture']
+    return nil if architecture.blank?
+    # Just simple name to bits, x86_64 will be the most used, we should probably support displaying of
+    # architecture name
+    architecture.include?("64") ? 64 : 32
+  end
+
+  # Identify the id of the parent of this image.
+  def parse_image_parent_id(image)
+    if collector.image_service.name == :glance
+      # What version of openstack is this glance v1 on some old openstack version?
+      return image.copy_from["id"] if image.respond_to?(:copy_from) && image.copy_from
+      # Glance V2
+      return image.instance_uuid if image.respond_to?(:instance_uuid)
+      # Glance V1
+      image.properties.try(:[], 'instance_uuid')
+    elsif image.server
+      # Probably nova images?
+      image.server["id"]
+    end
+  end
+
+  def image_tenants(image)
+    tenants = []
+    if public_image?(image)
+      # For public image we will fill a relation to all tenants,
+      # since calling the members api for a public image throws a 403.
+      collector.tenants.each do |t|
+        tenants << persister.cloud_tenants.lazy_find(t.id)
+      end
+    else
+      # Add owner of the image
+      tenants << persister.cloud_tenants.lazy_find(image.owner) if image.owner
+      # TODO: Glance v2 doesn't support members for "private" images, implement `members` for "shared" images later
+      if image.respond_to?(:is_public) && (members = image.members).any?
+        tenants += members.map { |x| persister.cloud_tenants.lazy_find(x['member_id']) }
+      end
+    end
+    tenants
+  end
+end

--- a/app/models/manageiq/providers/openstack/inventory/parser/infra_manager.rb
+++ b/app/models/manageiq/providers/openstack/inventory/parser/infra_manager.rb
@@ -1,0 +1,258 @@
+class ManageIQ::Providers::Openstack::Inventory::Parser::InfraManager < ManageIQ::Providers::Openstack::Inventory::Parser
+  include ManageIQ::Providers::Openstack::RefreshParserCommon::HelperMethods
+  include ManageIQ::Providers::Openstack::RefreshParserCommon::Images
+  include ManageIQ::Providers::Openstack::Inventory::Parser::CommonMethods
+
+  def parse
+    object_store
+    hosts
+    clusters
+    cloud_tenants
+    miq_templates("ManageIQ::Providers::Openstack::InfraManager::Template")
+    orchestration_stacks("ManageIQ::Providers::Openstack::InfraManager::OrchestrationStack")
+  end
+
+  def object_store
+    collector.object_store.each do |dir|
+      container_uid          = "#{dir.project.id}/#{dir.key}"
+      container              = persister.cloud_object_store_containers.find_or_build(container_uid)
+      container.ems_ref      = container_uid
+      container.key          = dir.key
+      container.object_count = dir.count
+      container.bytes        = dir.bytes
+      container.cloud_tenant = persister.cloud_tenants.lazy_find(dir.project.id)
+
+      dir.files.each do |obj|
+        file_uid                             = obj.key
+        file                                 = persister.cloud_object_store_objects.find_or_build(file_uid)
+        file.ems_ref                         = file_uid
+        file.etag                            = obj.etag
+        file.last_modified                   = obj.last_modified
+        file.content_length                  = obj.content_length
+        file.key                             = obj.key
+        file.content_type                    = obj.content_type
+        file.cloud_object_store_container    = container
+        file.cloud_tenant                    = persister.cloud_tenants.lazy_find(obj.project.id) if obj.project
+      end
+    end
+  end
+
+  def hosts
+    # Servers contains assigned IP address of hosts, there can be only
+    # one nova server per host, only if the host is provisioned.
+    indexed_servers = {}
+    collector.servers.each { |s| indexed_servers[s.id] = s }
+    # Indexed Heat resources, we are interested only in OS::Nova::Server/OS::TripleO::Server
+    indexed_resources = {}
+    collector.stack_server_resources.each { |p| indexed_resources[p['physical_resource_id']] = p }
+
+    collector.hosts.each do |h|
+      uid                   = h.uuid
+      host                  = persister.hosts.find_or_build(uid)
+      name                  = identify_host_name(indexed_resources, h.instance_uuid, uid)
+      ip_address            = identify_primary_ip_address(indexed_servers, h.instance_uuid)
+      hostname              = ip_address
+      introspection_details = collector.get_introspection_details(h.uuid)
+      extra_attributes      = get_extra_attributes(introspection_details)
+      hypervisor_hostname   = identify_hypervisor_hostname(indexed_servers, h)
+
+      # Get the cloud_host_attributes by hypervisor hostname, only compute hosts can get this
+      cloud_host_attributes = collector.cloud_ems_hosts_attributes.select do |x|
+        hypervisor_hostname && x[:host_name].include?(hypervisor_hostname.downcase)
+      end
+      cloud_host_attributes = cloud_host_attributes.first if cloud_host_attributes
+
+      host.name                     = name
+      host.type                     = 'ManageIQ::Providers::Openstack::InfraManager::Host'
+      host.uid_ems                  = uid
+      host.ems_ref                  = uid
+      host.ems_ref_obj              = h.instance_uuid
+      operating_system              = persister.operating_systems.find_or_build(host)
+      operating_system.product_name = 'linux'
+      host.operating_system         = operating_system
+      host.vmm_vendor               = 'redhat'
+      host.vmm_product              = identify_product(indexed_resources, h.instance_uuid)
+      # Can't get this from ironic, maybe from Glance metadata, when it will be there, or image fleecing?
+      host.vmm_version              = nil
+      host.ipaddress                = ip_address
+      host.hostname                 = hostname
+      host.mac_address              = identify_primary_mac_address(indexed_servers, h.instance_uuid)
+      host.ipmi_address             = identify_ipmi_address(h)
+      host.power_state              = lookup_power_state(host.power_state)
+      host.connection_state         = lookup_connection_state(host.power_state)
+      host.maintenance              = h.maintenance
+      host.maintenance_reason       = h.maintenance_reason
+      host.hardware                 = process_host_hardware(h, host, introspection_details, extra_attributes)
+      host.hypervisor_hostname      = hypervisor_hostname
+      host.service_tag              = extra_attributes.fetch_path('system', 'product', 'serial')
+      host.availability_zone_id     = cloud_host_attributes.try(:[], :availability_zone_id)
+    end
+  end
+
+  def clusters
+    clusters, cluster_host_mapping = clusters_and_host_mapping
+    clusters.each do |c|
+      name            = c[:name]
+      uid             = c[:uid]
+      cluster         = persister.ems_clusters.find_or_build(uid)
+      cluster.ems_ref = uid
+      cluster.uid_ems = uid
+      cluster.name    = name
+      cluster.type    = 'ManageIQ::Providers::Openstack::InfraManager::EmsCluster'
+    end
+
+    cluster_host_mapping.each do |host_ems_ref, cluster_ems_ref|
+      host = persister.hosts.find_or_build(host_ems_ref)
+      host.ems_cluster = persister.ems_clusters.lazy_find(cluster_ems_ref)
+    end
+  end
+
+  def identify_host_name(indexed_resources, instance_uuid, uid)
+    purpose = get_purpose(indexed_resources, instance_uuid)
+    return uid unless purpose
+    "#{uid} (#{purpose})"
+  end
+
+  def identify_product(indexed_resources, instance_uuid)
+    purpose = get_purpose(indexed_resources, instance_uuid)
+    return nil unless purpose
+    if purpose == 'NovaCompute'
+      'rhel (Nova Compute hypervisor)'
+    else
+      "rhel (No hypervisor, Host Type is #{purpose})"
+    end
+  end
+
+  def get_purpose(indexed_resources, instance_uuid)
+    indexed_resources.fetch_path(instance_uuid, 'resource_name')
+  end
+
+  def identify_primary_ip_address(indexed_servers, instance_uuid)
+    server_address(indexed_servers[instance_uuid], 'addr')
+  end
+
+  def identify_primary_mac_address(indexed_servers, instance_uuid)
+    server_address(indexed_servers[instance_uuid], 'OS-EXT-IPS-MAC:mac_addr')
+  end
+
+  def identify_hypervisor_hostname(indexed_servers, instance_uuid)
+    indexed_servers.fetch_path(instance_uuid).try(:name)
+  end
+
+  def server_address(server, key)
+    # TODO(lsmola) Nova is missing information which address is primary now,
+    # so just taking first. We need to figure out how to identify it if
+    # there are multiple.
+    server&.addresses&.fetch_path('ctlplane', 0, key)
+  end
+
+  def identify_ipmi_address(host)
+    host.driver_info["ipmi_address"]
+  end
+
+  def lookup_power_state(power_state_input)
+    case power_state_input
+    when "power on"               then "on"
+    when "power off", "rebooting" then "off"
+    else                               "unknown"
+    end
+  end
+
+  def lookup_connection_state(power_state_input)
+    case power_state_input
+    when "power on"               then "connected"
+    when "power off", "rebooting" then "disconnected"
+    else                               "disconnected"
+    end
+  end
+
+  def process_host_hardware(host, host_inventory, introspection_details, extra_attributes)
+    hardware = persister.hardwares.find_or_build(host_inventory)
+
+    cpu_sockets          = extra_attributes.fetch_path('cpu', 'physical', 'number').to_i
+    cpu_total_cores      = extra_attributes.fetch_path('cpu', 'logical', 'number').to_i
+    cpu_cores_per_socket = cpu_sockets.positive? ? cpu_total_cores / cpu_sockets : 0
+    cpu_speed            = introspection_details.fetch_path('inventory', 'cpu', 'frequency').to_i
+
+    hardware.memory_mb            = host.properties['memory_mb']
+    hardware.disk_capacity        = host.properties['local_gb']
+    hardware.cpu_total_cores      = cpu_total_cores
+    hardware.cpu_sockets          = cpu_sockets
+    hardware.cpu_cores_per_socket = cpu_cores_per_socket
+    hardware.cpu_speed            = cpu_speed
+    hardware.cpu_type             = extra_attributes.fetch_path('cpu', 'physical_0', 'version')
+    hardware.manufacturer         = extra_attributes.fetch_path('system', 'product', 'vendor')
+    hardware.model                = extra_attributes.fetch_path('system', 'product', 'name')
+    hardware.number_of_nics       = extra_attributes.fetch_path('network').try(:keys).try(:count).to_i
+    hardware.bios                 = extra_attributes.fetch_path('firmware', 'bios', 'version')
+    # Can't get these 2 from ironic, maybe from Glance metadata, when it will be there, or image fleecing?
+    hardware.guest_os_full_name   = nil
+    hardware.guest_os             = nil
+    hardware.disks                = process_host_hardware_disks(hardware, extra_attributes)
+    hardware.introspected         = introspection_details.present?
+    # fog-openstack baremetal service defaults to Ironic API v1.1.
+    # In version 1.1 "available" is shown as null in JSON. It is correctly
+    # shown as "available" starting with version 1.2.
+    # This may need to change once this issue is addressed:
+    # https://github.com/fog/fog-openstack/issues/197
+    hardware.provision_state      = host.provision_state.nil? ? "available" : host.provision_state
+
+    hardware
+  end
+
+  def get_extra_attributes(introspection_details)
+    return {} if introspection_details.blank? || introspection_details["extra"].nil?
+    introspection_details["extra"]
+  end
+
+  def process_host_hardware_disks(hardware, extra_attributes)
+    return [] if extra_attributes.nil? || (disks = extra_attributes.fetch_path('disk')).blank?
+    inventory_disks = []
+
+    disks.keys.delete_if { |x| x.include?('{') || x == 'logical' }.map do |d|
+      # Logical index contains number of logical disks
+      # TODO(lsmola) For now ignoring smart data, that are in format e.g. sda{cciss,1}, we need to design
+      # how to represent RAID
+      # Convert the disk size from GB to B
+      disk                 = persister.disks.find_or_build_by(:hardware => hardware, :device_name => d)
+      disk_size            = disks.fetch_path(d, 'size').to_i * 1_024**3
+      disk.device_type     = 'disk'
+      disk.controller_type = 'scsi'
+      disk.present         = true
+      disk.filename        = disks.fetch_path(d, 'id') || disks.fetch_path(d, 'scsi-id')
+      disk.location        = d
+      disk.size            = disk_size
+      disk.disk_type       = nil
+      disk.mode            = 'persistent'
+      inventory_disks << disk
+    end
+
+    inventory_disks
+  end
+
+  def clusters_and_host_mapping
+    clusters = []
+    cluster_host_mapping = {}
+    orchestration_stacks = collector.orchestration_stacks
+    orchestration_stacks&.each do |stack|
+      uid = stack.parent
+      next unless uid
+
+      nova_server = stack.resources.detect do |r|
+        collector.stack_server_resource_types.include?(r.resource_type)
+      end
+      next unless nova_server
+
+      host = collector.hosts.find { |h| h.instance_uuid == nova_server.physical_resource_id }
+      cluster_host_mapping[host.uuid] = uid
+
+      name = collector.orchestration_stacks.find { |s| s.id == stack.parent }.stack_name
+      clusters << {:name => name, :uid => uid}
+    end
+    return clusters.uniq, cluster_host_mapping
+  end
+
+  def find_resource(_uid, _stack_id)
+    nil
+  end
+end

--- a/app/models/manageiq/providers/openstack/inventory/persister.rb
+++ b/app/models/manageiq/providers/openstack/inventory/persister.rb
@@ -1,5 +1,6 @@
 class ManageIQ::Providers::Openstack::Inventory::Persister < ManageIQ::Providers::Inventory::Persister
   require_nested :CloudManager
+  require_nested :InfraManager
   require_nested :NetworkManager
   require_nested :StorageManager
   require_nested :TargetCollection

--- a/app/models/manageiq/providers/openstack/inventory/persister/definitions/cloud_collections.rb
+++ b/app/models/manageiq/providers/openstack/inventory/persister/definitions/cloud_collections.rb
@@ -38,7 +38,7 @@ module ManageIQ::Providers::Openstack::Inventory::Persister::Definitions::CloudC
       add_collection(cloud, name)
     end
 
-    add_orchestration_templates
+    add_orchestration_templates(cloud)
 
     # Custom processing of Ancestry
     add_collection(cloud, :vm_and_miq_template_ancestry)
@@ -116,9 +116,9 @@ module ManageIQ::Providers::Openstack::Inventory::Persister::Definitions::CloudC
     end
   end
 
-  def add_orchestration_templates
-    add_collection(cloud, :orchestration_templates) do |builder|
-      builder.add_properties(:model_class => ::OrchestrationTemplate)
+  def add_orchestration_stack_ancestry
+    add_collection(cloud, :orchestration_stack_ancestry) do |builder|
+      builder.remove_dependency_attributes(:orchestration_stacks_resources) unless targeted?
     end
   end
 
@@ -135,12 +135,6 @@ module ManageIQ::Providers::Openstack::Inventory::Persister::Definitions::CloudC
         builder.add_properties(:targeted => false)
       end
       builder.add_default_values(:resource => manager)
-    end
-  end
-
-  def add_orchestration_stack_ancestry
-    add_collection(cloud, :orchestration_stack_ancestry) do |builder|
-      builder.remove_dependency_attributes(:orchestration_stacks_resources) unless targeted?
     end
   end
 
@@ -174,15 +168,6 @@ module ManageIQ::Providers::Openstack::Inventory::Persister::Definitions::CloudC
           )
         end
       )
-    end
-  end
-
-  protected
-
-  # Shortcut for better code readability
-  def add_orchestration_stacks_with_ems_param
-    add_orchestration_stacks do |builder|
-      builder.add_default_values(:ems_id => manager.id)
     end
   end
 end

--- a/app/models/manageiq/providers/openstack/inventory/persister/definitions/infra_collections.rb
+++ b/app/models/manageiq/providers/openstack/inventory/persister/definitions/infra_collections.rb
@@ -1,0 +1,81 @@
+module ManageIQ::Providers::Openstack::Inventory::Persister::Definitions::InfraCollections
+  extend ActiveSupport::Concern
+
+  include ManageIQ::Providers::Openstack::Inventory::Persister::Definitions::Utils
+
+  def initialize_infra_inventory_collections
+    add_miq_templates
+
+    add_object_store
+
+    add_hosts
+
+    add_orchestration_stacks_with_ems_param
+
+    %i(hardwares
+       operating_systems
+       disks
+       orchestration_stacks_resources
+       orchestration_stacks_outputs
+       orchestration_stacks_parameters).each do |name|
+
+      add_collection(infra, name)
+    end
+
+    add_clusters
+
+    add_orchestration_templates(infra)
+
+    add_cloud_tenants
+  end
+
+  # --- IC groups definitions ---
+
+  def add_vms
+    add_collection_with_ems_param(cloud, :vms) do |builder|
+      builder.add_properties(:model_class => ManageIQ::Providers::Openstack::InfraManager::Vm)
+    end
+  end
+
+  def add_miq_templates
+    add_collection(infra, :miq_templates) do |builder|
+      builder.add_properties(:model_class => ::MiqTemplate)
+
+      builder.add_default_values(:ems_id => manager.id)
+
+      # Extra added to automatic attr ibutes
+      builder.add_inventory_attributes(%i(cloud_tenant cloud_tenants))
+    end
+  end
+
+  def add_hosts
+    add_collection_with_ems_param(infra, :hosts) do |builder|
+      builder.add_properties(:model_class => ManageIQ::Providers::Openstack::InfraManager::Host)
+    end
+  end
+
+  def add_object_store
+    %i(cloud_object_store_objects
+       cloud_object_store_containers).each do |name|
+      add_collection(infra, name)
+    end
+  end
+
+  def add_orchestration_stacks(extra_properties = {})
+    add_collection(cloud, :orchestration_stacks, extra_properties) do |builder|
+      yield builder if block_given?
+    end
+  end
+
+  def add_clusters
+    add_collection_with_ems_param(infra, :ems_clusters) do |builder|
+      builder.add_properties(:model_class => ManageIQ::Providers::Openstack::InfraManager::EmsCluster)
+    end
+  end
+
+  def add_cloud_tenants
+    add_collection_with_ems_param(cloud, :cloud_tenants) do |builder|
+      builder.add_properties(:model_class => ManageIQ::Providers::Openstack::InfraManager::CloudTenant)
+    end
+  end
+end

--- a/app/models/manageiq/providers/openstack/inventory/persister/definitions/utils.rb
+++ b/app/models/manageiq/providers/openstack/inventory/persister/definitions/utils.rb
@@ -20,4 +20,17 @@ module ManageIQ::Providers::Openstack::Inventory::Persister::Definitions::Utils
     ems = targeted? ? manager.network_manager : manager
     builder.add_default_values(:ems_id => ems.id)
   end
+
+  def add_orchestration_templates(type)
+    add_collection(type, :orchestration_templates) do |builder|
+      builder.add_properties(:model_class => ::OrchestrationTemplate)
+    end
+  end
+
+  # Shortcut for better code readability
+  def add_orchestration_stacks_with_ems_param
+    add_orchestration_stacks do |builder|
+      builder.add_default_values(:ems_id => manager.id)
+    end
+  end
 end

--- a/app/models/manageiq/providers/openstack/inventory/persister/infra_manager.rb
+++ b/app/models/manageiq/providers/openstack/inventory/persister/infra_manager.rb
@@ -1,0 +1,7 @@
+class ManageIQ::Providers::Openstack::Inventory::Persister::InfraManager < ManageIQ::Providers::Openstack::Inventory::Persister
+  include ManageIQ::Providers::Openstack::Inventory::Persister::Definitions::InfraCollections
+
+  def initialize_inventory_collections
+    initialize_infra_inventory_collections
+  end
+end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -15,6 +15,9 @@
     :is_admin: false
     :inventory_object_refresh: true
     :allow_targeted_refresh: true
+  :openstack_infra:
+    :is_admin: false
+    :inventory_object_refresh: true
 :ems:
   :ems_openstack:
     :excon:


### PR DESCRIPTION
This PR adds graph refresh to undercloud. Part of logic was moved from old refresh parser. Work is still in progress and don't have tests now.

When I try to run refresh from rails console, I'm getting this error 
```ManageIQ::Providers::BaseManager::Refresher::PartialRefreshError: undefined method `cloud_object_store_objects' for #<ManageIQ::Providers::Openstack::InfraManager:0x007fe839098660>
from /.../manageiq/app/models/manageiq/providers/base_manager/refresher.rb:67:in `refresh'```
And I can't find what did I miss.
@aufi @mansam Can I have your review, please ?
https://bugzilla.redhat.com/show_bug.cgi?id=1662904