### PR TITLE
Bug 1664888: Warn, but still allow infra without ironic

### DIFF
--- a/app/models/manageiq/providers/openstack/infra_manager.rb
+++ b/app/models/manageiq/providers/openstack/infra_manager.rb
@@ -200,7 +200,8 @@ class ManageIQ::Providers::Openstack::InfraManager < ManageIQ::Providers::InfraM
       error_message = task.message
     end
 
-    [error_message.blank?, error_message]
+    # Don't fail if ironic isn't found, but provide warning message for user.
+    [(error_message.blank? || error_message[0, 9] == "Baremetal"), error_message]
   end
 
   # For infra, validate primary endpoint *and* verify presence of ironic
@@ -209,7 +210,7 @@ class ManageIQ::Providers::Openstack::InfraManager < ManageIQ::Providers::InfraM
       begin
         !!raw_connect(*params, "Baremetal")
       rescue MiqException::ServiceNotAvailable
-        raise MiqException::ServiceNotAvailable, "Baremetal service not found. Not an OpenStack Infrastructure provider."
+        raise MiqException::ServiceNotAvailable, "Baremetal(Ironic) service not found. Some infrastructure features may be disabled."
       end
     end
   end

--- a/app/models/manageiq/providers/openstack/infra_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/openstack/infra_manager/refresh_parser.rb
@@ -47,8 +47,9 @@ module ManageIQ
           raise MiqException::MiqOpenstackGlanceServiceMissing, "Required service Glance is missing in the catalog."
         end
 
+        # log a warning but don't fail on missing Ironicggg
         unless @baremetal_service
-          raise MiqException::MiqOpenstackIronicServiceMissing, "Required service Ironic is missing in the catalog."
+          _log.warn "Ironic service is missing in the catalog. No host data will be synced."
         end
       end
 
@@ -119,7 +120,7 @@ module ManageIQ
       end
 
       def hosts
-        @hosts ||= uniques(@baremetal_service.handled_list(:nodes))
+        @hosts ||= @baremetal_service && uniques(@baremetal_service.handled_list(:nodes))
       end
 
       def clouds


### PR DESCRIPTION
fixes https://bugzilla.redhat.com/show_bug.cgi?id=1664888

This commit changes the validation to warn but not fail for
infra providers without Ironic. In addition, refresh no longer
fails if ironic is missing -- it just logs a warning instead.