### PR TITLE
Add ConversionHost and ServiceTemplateTransformationPlan subclasses

### DIFF
--- a/app/models/manageiq/providers/openstack/cloud_manager/conversion_host.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/conversion_host.rb
@@ -1,0 +1,2 @@
+class ManageIQ::Providers::Openstack::CloudManager::ConversionHost < ::ConversionHost
+end

--- a/app/models/manageiq/providers/openstack/cloud_manager/service_template_transformation_plan.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/service_template_transformation_plan.rb
@@ -1,0 +1,2 @@
+class ManageIQ::Providers::Openstack::CloudManager::ServiceTemplateTransformationPlan < ::ServiceTemplateTransformationPlan
+end


### PR DESCRIPTION
For the V2V effort, we will want subclasses for both the ConversionHost and ServiceTemplateTransformationPlan models. For now these are just stubs, but the plan is to add additional logic in the future.

For the ConversionHost model, this will likely contain provider-specific authentication code. At the moment, we have some ugly provider-specific code baked into the core ConversionHost model, which I would like to polymorphosize.

For the ServiceTemplateTransformationPlan model, this will contain provider-specific mapping validation code.

Both underlying tables (conversion_hosts and service_templates) are already setup for STI.

See also: https://github.com/ManageIQ/manageiq-providers-ovirt/pull/339